### PR TITLE
feat: connectors and the ingestion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ With no configuration it keeps everything in memory and listens on localhost, wh
 genbad
 ```
 
+That server is empty, which makes it hard to judge.
+Point it at a directory you already have and it indexes it before it starts listening:
+
+```
+genbad -tenant acme -corpus ~/src/some-repo -corpus-name repo
+```
+
 Then query it:
 
 ```
@@ -68,6 +75,10 @@ genba search payments failover runbook
 ```
 
 The browser interface is at http://127.0.0.1:8080 and is compiled into the binary, so there is no static directory to deploy alongside it.
+
+By default every file in the corpus is readable by everybody in the tenant, which is the right rule for a public checkout and the wrong one for almost anything else.
+If the tree has OWNERS files in it, `-corpus-acl owners` reads them instead, and a query then returns different results depending on who is asking.
+Paths that no OWNERS file governs are quarantined rather than published, and the count of them is on the sync log line.
 
 ## Configuration
 
@@ -84,6 +95,15 @@ The environment variable is the flag in upper case with a `GENBA_` prefix, and a
 | `GENBA_READ_TIMEOUT` | `30s` | request read timeout |
 | `GENBA_WRITE_TIMEOUT` | `60s` | request write timeout |
 | `GENBA_SHUTDOWN_GRACE` | `15s` | how long a shutdown waits for in flight requests |
+
+The corpus flags have no environment variables, because a directory to index is a thing you type once while trying the binary out rather than a property of a deployment.
+
+| Flag | Default | What it does |
+| --- | --- | --- |
+| `-corpus` | empty | directory to index at startup |
+| `-corpus-name` | `files` | source name the documents carry, and what `-source` filters on |
+| `-corpus-acl` | `tenant` | who may read it: `tenant` for everybody in the tenant, `owners` to read OWNERS files |
+| `-corpus-refresh` | `0` | how often to sync again, zero for once at startup |
 
 ## Use it as a library
 
@@ -139,6 +159,9 @@ func main() {
 | `store` | the storage interface, plus `storetest`, the conformance suite |
 | `store/memstore` | the reference in memory driver |
 | `index` | query parsing, retrieval and ranking |
+| `connector` | the ingestion contract, cursors and checkpoints |
+| `connector/fssource` | the reference connector, a directory tree with OWNERS files |
+| `ingest` | the pipeline that runs a connector into a store |
 | `config` | runtime configuration and the rules for loading it |
 | `api` | the HTTP surface |
 | `web` | the browser interface, compiled into the binary |
@@ -146,6 +169,58 @@ func main() {
 | `cmd/genba` | the command line client |
 
 `arch_test.go` asserts the dependency direction between these, so an import that skips a layer fails the build rather than being noticed in review a month later.
+
+## Connectors
+
+A connector describes documents in some source system and who may read them.
+It does not decide how they are stored, ranked or filtered, and it never touches the store itself.
+The whole interface is three methods:
+
+```go
+type Connector interface {
+	Source() string
+	Sync(ctx context.Context, from Cursor, emit func(context.Context, Change) error) (Cursor, error)
+	Close() error
+}
+```
+
+`Sync` walks the source from a cursor and calls `emit` once per change.
+`emit` does the batching and the storing on the calling goroutine, so there is no queue between a connector and the store.
+That is deliberate.
+A source that produces faster than the store can absorb is slowed down by the handover itself, which shows up as a slower sync rather than as memory that keeps growing until something is killed.
+
+The pipeline stores a batch and then saves the cursor for it, never the other way round.
+A crash between the two replays documents, which is harmless because storing the same document twice is the same as storing it once.
+The other order loses documents and nothing downstream ever notices they are missing.
+`ingest` has a test that kills the store after every possible number of writes and checks that a resume finds all of them.
+
+A connector that cannot work out who may read a document says so, by leaving the permissions unresolved, and the pipeline stores that document out of every query path and counts it.
+Failing to answer is not permission to publish.
+
+`connector/fssource` is the reference implementation, and it is the one to read before writing another.
+It walks a directory tree, skips version control and dependency directories, reads text files up to a size limit, and asks a `Policy` who may read each one:
+
+```go
+policy, err := fssource.NewOwnersPolicy(root, "repo", "github")
+if err != nil {
+	log.Fatal(err)
+}
+src, err := fssource.New(root, "repo", policy)
+if err != nil {
+	log.Fatal(err)
+}
+
+pipeline, err := ingest.New(st, connector.NewMemoryCheckpoints())
+if err != nil {
+	log.Fatal(err)
+}
+stats, err := pipeline.Run(ctx, "acme", src)
+```
+
+Permissions come from the policy rather than from the walk, because a directory tree says almost nothing about access on its own.
+The mode bits describe the account the crawler runs as, not the people in the company.
+`OwnersPolicy` reads the OWNERS files that Kubernetes and a number of other large repositories keep, taking the nearest one going up the tree, which is a real access control list maintained by real people over a corpus anybody can check out.
+A source built with no policy at all quarantines everything, so having not thought about permissions yet is a visible state in the stats rather than an invisible one in the index.
 
 ## Storage
 

--- a/arch_test.go
+++ b/arch_test.go
@@ -33,8 +33,18 @@ var allowed = map[string][]string{
 	"config":          nil,
 	"web":             nil,
 	"api":             {"", "acl", "doc", "index", "store"},
-	"cmd/genba":       {""},
-	"cmd/genbad":      {"", "api", "config", "index", "store", "store/memstore", "web"},
+
+	// Ingestion sits beside the query path rather than under it. A connector
+	// describes documents and who may read them, the pipeline writes them, and
+	// neither knows anything about ranking. In particular connector does not
+	// import store: a source that could reach the store directly could write a
+	// document without going through the checks the pipeline applies.
+	"connector":          {"acl", "doc"},
+	"connector/fssource": {"acl", "connector", "doc"},
+	"ingest":             {"", "connector", "doc", "store"},
+
+	"cmd/genba":  {""},
+	"cmd/genbad": {"", "api", "config", "connector", "connector/fssource", "index", "ingest", "store", "store/memstore", "web"},
 }
 
 func TestDependencyDirection(t *testing.T) {

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/fssource"
+	"github.com/tamnd/genba/ingest"
+	"github.com/tamnd/genba/store"
+)
+
+// corpusOptions is what the -corpus flags add up to.
+//
+// They exist so that a first run is one command with a directory in it. A
+// server with nothing in it is difficult to judge, and pointing it at a
+// checkout somebody already has is the shortest path from downloading the
+// binary to typing a query and getting back something they recognise.
+type corpusOptions struct {
+	// Dir is the directory to read. Empty means do not ingest.
+	Dir string
+
+	// Name is the source name the documents carry, and what a query filters on.
+	Name string
+
+	// ACL selects how permissions are decided, either "tenant" or "owners".
+	ACL string
+
+	// Refresh is how often to sync again. Zero syncs once at startup.
+	Refresh time.Duration
+}
+
+// The values -corpus-acl takes.
+const (
+	aclTenant = "tenant"
+	aclOwners = "owners"
+)
+
+func (o corpusOptions) validate() error {
+	if o.Dir == "" {
+		return nil
+	}
+	if o.Name == "" {
+		return errors.New("corpus name is empty")
+	}
+	switch o.ACL {
+	case aclTenant, aclOwners:
+	default:
+		return fmt.Errorf("unknown corpus acl %q, want %q or %q", o.ACL, aclTenant, aclOwners)
+	}
+	if o.Refresh < 0 {
+		return errors.New("corpus refresh is negative")
+	}
+	return nil
+}
+
+// policyFor builds the permission policy named by the flags.
+//
+// The owners policy deliberately has no fallback. A path in the tree that no
+// OWNERS file governs has no answer about who may read it, and the pipeline
+// quarantines it, which shows up in the log and in the stats. Giving it a
+// fallback here would turn "nobody has said" into "everybody may", which is the
+// one substitution this system is built to avoid.
+func policyFor(o corpusOptions) (fssource.Policy, error) {
+	switch o.ACL {
+	case aclTenant:
+		return fssource.PublicToTenant(o.Name), nil
+	case aclOwners:
+		p, err := fssource.NewOwnersPolicy(o.Dir, o.Name, "github")
+		if err != nil {
+			return nil, err
+		}
+		return p, nil
+	default:
+		return nil, fmt.Errorf("unknown corpus acl %q", o.ACL)
+	}
+}
+
+// ingestCorpus syncs the configured directory into the store.
+//
+// The first sync runs before the server listens, so that a request arriving the
+// moment the log says the server is up finds a corpus rather than an empty
+// index. Later syncs run in the background on the refresh interval, and are
+// incremental: the connector reports only what changed since the cursor the
+// last one saved.
+func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant string, log *slog.Logger) (func(), error) {
+	if cfg.Dir == "" {
+		return func() {}, nil
+	}
+	if tenant == "" {
+		// A single tenant deployment names its tenant. Without one there is
+		// nothing to file these documents under, and a guess here would put a
+		// corpus somewhere no query looks.
+		return nil, errors.New("ingesting a corpus needs -tenant")
+	}
+
+	policy, err := policyFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	src, err := fssource.New(cfg.Dir, cfg.Name, policy)
+	if err != nil {
+		return nil, err
+	}
+
+	// Checkpoints live in memory because the only storage driver that ships
+	// today does too. Restarting loses the index, so a cursor that survived the
+	// restart would skip everything the new empty index needs.
+	pipeline, err := ingest.New(st, connector.NewMemoryCheckpoints(), ingest.WithLogger(log))
+	if err != nil {
+		return nil, err
+	}
+
+	sync := func(ctx context.Context) {
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		stats, err := pipeline.Run(ctx, genba.TenantID(tenant), src)
+		if err != nil {
+			log.Error("corpus sync failed", "dir", cfg.Dir, "error", err,
+				"indexed", stats.Indexed, "quarantined", stats.Quarantined)
+			return
+		}
+		runtime.ReadMemStats(&after)
+
+		log.Info("corpus synced",
+			"dir", cfg.Dir,
+			"source", cfg.Name,
+			"indexed", stats.Indexed,
+			"quarantined", stats.Quarantined,
+			"bytes", stats.Bytes,
+			"duration", stats.Duration.Round(time.Millisecond),
+			"docs_per_second", int(stats.Rate()),
+			"mb_per_second", throughput(stats.Bytes, stats.Duration),
+			// What the corpus costs to hold, and what it cost to build. The
+			// first is the number that decides how much a machine can serve,
+			// and the second is the one that shows up as garbage collection.
+			"heap_mb", megabytes(int64(after.HeapAlloc)),
+			"allocated_mb", megabytes(int64(after.TotalAlloc-before.TotalAlloc)),
+		)
+	}
+
+	sync(ctx)
+
+	if cfg.Refresh <= 0 {
+		return func() { _ = src.Close() }, nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		t := time.NewTicker(cfg.Refresh)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				sync(ctx)
+			}
+		}
+	}()
+	return func() {
+		<-done
+		_ = src.Close()
+	}, nil
+}
+
+// megabytes converts a byte count for the log.
+func megabytes(n int64) float64 {
+	return float64(n) / (1 << 20)
+}
+
+// throughput is megabytes a second, and zero for a run too short for the clock
+// to have moved, which would otherwise divide by zero and log an infinity.
+func throughput(bytes int64, d time.Duration) float64 {
+	if d <= 0 {
+		return 0
+	}
+	return megabytes(bytes) / d.Seconds()
+}

--- a/cmd/genbad/corpus_test.go
+++ b/cmd/genbad/corpus_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// corpusTree writes a small tree with an OWNERS file in it, which is what the
+// two access control modes differ over.
+func corpusTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		"OWNERS":            "approvers:\n  - alice\n",
+		"README.md":         "# The handbook\n\nHow we work.\n",
+		"guides/deploy.md":  "# Deploying\n\nPush the button.\n",
+		"loose/stray.md":    "# stray\n",
+		"guides/OWNERS":     "approvers:\n  - bob\n",
+		"guides/legacy.md":  "# Legacy\n\nOld notes.\n",
+		"assets/logo.bin":   "\xff\xfe binary",
+		"node_modules/x.js": "should not be read",
+	}
+	for rel, body := range files {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestCorpusFlagsAreChecked(t *testing.T) {
+	tests := []struct {
+		name string
+		opts corpusOptions
+		want string
+	}{
+		{"nothing set is fine", corpusOptions{}, ""},
+		{"a directory with no name", corpusOptions{Dir: "/tmp"}, "name is empty"},
+		{"an unknown acl", corpusOptions{Dir: "/tmp", Name: "files", ACL: "everyone"}, "everyone"},
+		{"a negative refresh", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclTenant, Refresh: -time.Second}, "negative"},
+		{"a usable set", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOwners}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.validate()
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("rejected a usable set: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("accepted %+v", tt.opts)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error is %q, want it to mention %q", err, tt.want)
+			}
+		})
+	}
+}
+
+// A corpus has to be filed under a tenant, and there is nothing sensible to
+// guess if one was not given.
+func TestACorpusWithoutATenantIsRefused(t *testing.T) {
+	args := []string{"-corpus", corpusTree(t), "-log-level", "error"}
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), args, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("a corpus was ingested with no tenant to file it under")
+	}
+	if !strings.Contains(err.Error(), "tenant") {
+		t.Errorf("error is %q, want it to say what is missing", err)
+	}
+}
+
+// The point of the whole thing: start the server on a directory and get real
+// results back out of the API.
+func TestAStartedServerAnswersQueriesAboutTheCorpus(t *testing.T) {
+	root := corpusTree(t)
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, []string{
+			"-addr", addr,
+			"-tenant", "acme",
+			"-corpus", root,
+			"-corpus-name", "handbook",
+			"-log-level", "error",
+		}, env(nil), &out, &errOut)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("the server did not shut down")
+		}
+	}()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	res := searchAs(t, addr, "alice", "deploying")
+	if res.Total == 0 {
+		t.Fatal("the corpus was ingested but a query about it found nothing")
+	}
+	var found bool
+	for _, h := range res.Hits {
+		if strings.HasSuffix(h.ID, "guides/deploy.md") {
+			found = true
+			if h.Title != "Deploying" {
+				t.Errorf("title is %q, want the heading from the file", h.Title)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("results %v do not include the file the query names", res.Hits)
+	}
+
+	// The directories the walk skips stay out of the corpus, so a dependency
+	// tree does not drown the content somebody actually wrote.
+	if got := searchAs(t, addr, "alice", "should not be read"); got.Total != 0 {
+		t.Errorf("a skipped directory was indexed: %v", got.Hits)
+	}
+}
+
+// With the owners policy the answer to a query depends on who is asking, which
+// is the difference between a search engine and a leak.
+func TestOwnersDecideWhatAQueryReturns(t *testing.T) {
+	root := corpusTree(t)
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, []string{
+			"-addr", addr,
+			"-tenant", "acme",
+			"-corpus", root,
+			"-corpus-name", "handbook",
+			"-corpus-acl", aclOwners,
+			"-log-level", "error",
+		}, env(nil), &out, &errOut)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("the server did not shut down")
+		}
+	}()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	// bob approves the guides directory and alice approves the root, which the
+	// guides OWNERS file replaced.
+	if got := searchAs(t, addr, "bob", "legacy"); got.Total == 0 {
+		t.Error("an approver of the directory cannot see a file in it")
+	}
+	if got := searchAs(t, addr, "alice", "legacy"); got.Total != 0 {
+		t.Errorf("a file in a subtree that replaced alice came back for her: %v", got.Hits)
+	}
+	// Nobody is named in an OWNERS file above the root, so the root file governs
+	// the top level and alice can read it.
+	if got := searchAs(t, addr, "alice", "handbook"); got.Total == 0 {
+		t.Error("an approver of the root cannot see a file at the root")
+	}
+	// A stranger sees none of it.
+	if got := searchAs(t, addr, "mallory", "legacy"); got.Total != 0 {
+		t.Errorf("somebody named in no OWNERS file got results: %v", got.Hits)
+	}
+}
+
+type hit struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+type searchResult struct {
+	Total int   `json:"total"`
+	Hits  []hit `json:"hits"`
+}
+
+// searchAs runs a query as one person and returns what came back.
+func searchAs(t *testing.T, addr, subject, query string) searchResult {
+	t.Helper()
+	url := "http://" + addr + "/api/v1/search?q=" + strings.ReplaceAll(query, " ", "+")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Genba-Subject", subject)
+	req.Header.Set("X-Genba-Tenant", "acme")
+	req.Header.Set("X-Genba-Identities", "github:"+subject)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("search returned %s", resp.Status)
+	}
+	var out searchResult
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decoding the response: %v", err)
+	}
+	return out
+}

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -65,6 +65,13 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	fs.StringVar(&cfg.DSN, "dsn", cfg.DSN, "storage data source")
 	fs.StringVar(&cfg.Tenant, "tenant", cfg.Tenant, "tenant served by a single tenant deployment")
 	fs.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "debug, info, warn or error")
+
+	var corpus corpusOptions
+	fs.StringVar(&corpus.Dir, "corpus", "", "directory to index at startup")
+	fs.StringVar(&corpus.Name, "corpus-name", "files", "source name the indexed directory carries")
+	fs.StringVar(&corpus.ACL, "corpus-acl", aclTenant, "who may read the corpus: tenant or owners")
+	fs.DurationVar(&corpus.Refresh, "corpus-refresh", 0, "how often to reindex the directory, zero for once")
+
 	showVersion := fs.Bool("version", false, "print the version and exit")
 	fs.Usage = func() {
 		fmt.Fprintf(stderr, "genbad runs the genba server.\n\nUsage:\n  genbad [flags]\n\nFlags:\n")
@@ -81,6 +88,9 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
+	if err := corpus.validate(); err != nil {
+		return err
+	}
 
 	log := newLogger(stderr, cfg.LogLevel)
 
@@ -93,6 +103,14 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 			log.Error("closing the store", "error", err)
 		}
 	}()
+
+	// The first sync runs here, before the listener opens, so that the server is
+	// useful the moment it says it is up.
+	waitForCorpus, err := ingestCorpus(ctx, st, corpus, cfg.Tenant, log)
+	if err != nil {
+		return err
+	}
+	defer waitForCorpus()
 
 	opts := []api.Option{api.WithLogger(log)}
 	if h := web.Handler(); h != nil {

--- a/connector/checkpoint.go
+++ b/connector/checkpoint.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -64,7 +65,7 @@ type FileCheckpoints struct {
 // does not exist.
 func NewFileCheckpoints(dir string) (*FileCheckpoints, error) {
 	if dir == "" {
-		return nil, fmt.Errorf("connector: checkpoint directory is empty")
+		return nil, errors.New("connector: checkpoint directory is empty")
 	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("connector: checkpoint directory: %w", err)

--- a/connector/checkpoint.go
+++ b/connector/checkpoint.go
@@ -1,0 +1,176 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// MemoryCheckpoints keeps resume points in a map.
+//
+// It is what tests use and what a single run that has no reason to resume can
+// use. It survives nothing, which is the point: a deployment that wants to
+// resume after a restart has to say where the checkpoints live.
+type MemoryCheckpoints struct {
+	mu sync.RWMutex
+	at map[string]Cursor
+}
+
+// NewMemoryCheckpoints returns an empty checkpoint store.
+func NewMemoryCheckpoints() *MemoryCheckpoints {
+	return &MemoryCheckpoints{at: make(map[string]Cursor)}
+}
+
+var _ Checkpoints = (*MemoryCheckpoints)(nil)
+
+// Load returns the resume point for a source.
+func (m *MemoryCheckpoints) Load(ctx context.Context, tenant, source string) (Cursor, error) {
+	if err := ctx.Err(); err != nil {
+		return Cursor{}, err
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.at[tenant+"\x00"+source], nil
+}
+
+// Save records a resume point.
+func (m *MemoryCheckpoints) Save(ctx context.Context, tenant, source string, c Cursor) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.at[tenant+"\x00"+source] = c
+	return nil
+}
+
+// FileCheckpoints keeps one small JSON file per tenant and source in a
+// directory.
+//
+// A file is the right shape for this. Checkpoints are written once per batch,
+// read once per run, and are worthless to anybody but the connector that wrote
+// them, so putting them in the content database buys nothing and couples the
+// two.
+type FileCheckpoints struct {
+	dir string
+	mu  sync.Mutex
+}
+
+// NewFileCheckpoints returns a checkpoint store rooted at dir, creating it if it
+// does not exist.
+func NewFileCheckpoints(dir string) (*FileCheckpoints, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("connector: checkpoint directory is empty")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("connector: checkpoint directory: %w", err)
+	}
+	return &FileCheckpoints{dir: dir}, nil
+}
+
+var _ Checkpoints = (*FileCheckpoints)(nil)
+
+// checkpointFile is the on disk shape. It is JSON because an operator reading a
+// stuck sync should be able to see the answer with cat.
+type checkpointFile struct {
+	Tenant string    `json:"tenant"`
+	Source string    `json:"source"`
+	Value  string    `json:"value"`
+	Time   time.Time `json:"time"`
+}
+
+// Load returns the resume point for a source, or a zero cursor if it has never
+// run.
+func (f *FileCheckpoints) Load(ctx context.Context, tenant, source string) (Cursor, error) {
+	if err := ctx.Err(); err != nil {
+		return Cursor{}, err
+	}
+	b, err := os.ReadFile(f.path(tenant, source))
+	if os.IsNotExist(err) {
+		// A source that has never been synced is the normal first run, not a
+		// failure to report.
+		return Cursor{}, nil
+	}
+	if err != nil {
+		return Cursor{}, fmt.Errorf("connector: load checkpoint: %w", err)
+	}
+	var cf checkpointFile
+	if err := json.Unmarshal(b, &cf); err != nil {
+		return Cursor{}, fmt.Errorf("connector: parse checkpoint for %s: %w", source, err)
+	}
+	return Cursor{Value: cf.Value, Time: cf.Time}, nil
+}
+
+// Save records a resume point.
+//
+// It writes a temporary file and renames it over the target, because rename is
+// the one filesystem operation that is atomic on every platform this runs on. A
+// crash in the middle leaves either the old checkpoint or the new one. The
+// alternative, writing in place, can leave a half written cursor that resumes
+// past documents that were never indexed, and nothing later would notice.
+func (f *FileCheckpoints) Save(ctx context.Context, tenant, source string, c Cursor) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	b, err := json.Marshal(checkpointFile{Tenant: tenant, Source: source, Value: c.Value, Time: c.Time})
+	if err != nil {
+		return fmt.Errorf("connector: encode checkpoint: %w", err)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	final := f.path(tenant, source)
+	tmp, err := os.CreateTemp(f.dir, ".checkpoint-*")
+	if err != nil {
+		return fmt.Errorf("connector: save checkpoint: %w", err)
+	}
+	name := tmp.Name()
+	defer os.Remove(name) // a no op once the rename below has succeeded
+
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		return fmt.Errorf("connector: save checkpoint: %w", err)
+	}
+	// Sync before the rename. Without it the rename can reach the disk before
+	// the bytes do, which turns a crash into a checkpoint that points somewhere
+	// real and contains nothing.
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("connector: save checkpoint: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("connector: save checkpoint: %w", err)
+	}
+	if err := os.Rename(name, final); err != nil {
+		return fmt.Errorf("connector: save checkpoint: %w", err)
+	}
+	return nil
+}
+
+// path is the file a tenant and source pair is stored in. The name is escaped
+// so that a source called "a/b" cannot write outside the directory.
+func (f *FileCheckpoints) path(tenant, source string) string {
+	return filepath.Join(f.dir, escape(tenant)+"_"+escape(source)+".json")
+}
+
+// escape maps anything that is not a plain name character to a hyphen. It is
+// not reversible and does not need to be: the file records the tenant and
+// source it belongs to inside itself.
+func escape(s string) string {
+	if s == "" {
+		return "-"
+	}
+	out := []byte(s)
+	for i, c := range out {
+		ok := c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '-'
+		if !ok {
+			out[i] = '-'
+		}
+	}
+	return string(out)
+}

--- a/connector/checkpoint_test.go
+++ b/connector/checkpoint_test.go
@@ -1,0 +1,200 @@
+package connector_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+)
+
+func TestACursorThatWasNeverSavedIsTheBeginning(t *testing.T) {
+	for name, cp := range checkpointStores(t) {
+		t.Run(name, func(t *testing.T) {
+			got, err := cp.Load(t.Context(), "acme", "never-run")
+			if err != nil {
+				t.Fatalf("loading a source that never ran is not an error: %v", err)
+			}
+			if !got.IsZero() {
+				t.Errorf("got cursor %+v, want the zero cursor", got)
+			}
+		})
+	}
+}
+
+func TestACursorRoundTrips(t *testing.T) {
+	for name, cp := range checkpointStores(t) {
+		t.Run(name, func(t *testing.T) {
+			want := connector.Cursor{Value: "page-42", Time: time.Now().UTC().Truncate(time.Second)}
+			if err := cp.Save(t.Context(), "acme", "wiki", want); err != nil {
+				t.Fatalf("save: %v", err)
+			}
+			got, err := cp.Load(t.Context(), "acme", "wiki")
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if got.Value != want.Value {
+				t.Errorf("value is %q, want %q", got.Value, want.Value)
+			}
+			if !got.Time.Equal(want.Time) {
+				t.Errorf("time is %v, want %v", got.Time, want.Time)
+			}
+		})
+	}
+}
+
+func TestASavedCursorReplacesTheOneBeforeIt(t *testing.T) {
+	for name, cp := range checkpointStores(t) {
+		t.Run(name, func(t *testing.T) {
+			for _, v := range []string{"one", "two", "three"} {
+				if err := cp.Save(t.Context(), "acme", "wiki", connector.Cursor{Value: v}); err != nil {
+					t.Fatalf("save %s: %v", v, err)
+				}
+			}
+			got, _ := cp.Load(t.Context(), "acme", "wiki")
+			if got.Value != "three" {
+				t.Errorf("value is %q, want the last one saved", got.Value)
+			}
+		})
+	}
+}
+
+func TestTenantsAndSourcesDoNotShareACursor(t *testing.T) {
+	for name, cp := range checkpointStores(t) {
+		t.Run(name, func(t *testing.T) {
+			if err := cp.Save(t.Context(), "acme", "wiki", connector.Cursor{Value: "a"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := cp.Save(t.Context(), "acme", "chat", connector.Cursor{Value: "b"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := cp.Save(t.Context(), "other", "wiki", connector.Cursor{Value: "c"}); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, want := range []struct{ tenant, source, value string }{
+				{"acme", "wiki", "a"},
+				{"acme", "chat", "b"},
+				{"other", "wiki", "c"},
+			} {
+				got, _ := cp.Load(t.Context(), want.tenant, want.source)
+				if got.Value != want.value {
+					t.Errorf("%s/%s is %q, want %q", want.tenant, want.source, got.Value, want.value)
+				}
+			}
+		})
+	}
+}
+
+// A source name is not a path. A connector called ../../etc must not be able to
+// write a checkpoint outside the directory it was given.
+func TestASourceNameCannotEscapeTheCheckpointDirectory(t *testing.T) {
+	dir := t.TempDir()
+	inside := filepath.Join(dir, "keep")
+	if err := os.MkdirAll(inside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cp, err := connector.NewFileCheckpoints(inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"../escaped", "../../escaped", "a/b/escaped", `..\escaped`} {
+		if err := cp.Save(t.Context(), "acme", name, connector.Cursor{Value: "x"}); err != nil {
+			t.Fatalf("save %q: %v", name, err)
+		}
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "keep" {
+			t.Errorf("a checkpoint was written outside the directory: %s", e.Name())
+		}
+	}
+}
+
+// The file version has to survive a crash mid write, which is what the rename
+// is for. A half written file is a cursor pointing somewhere real that contains
+// nothing, and resuming from it skips documents silently.
+func TestAHalfWrittenCheckpointIsNeverVisible(t *testing.T) {
+	dir := t.TempDir()
+	cp, err := connector.NewFileCheckpoints(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cp.Save(t.Context(), "acme", "wiki", connector.Cursor{Value: "good"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Litter the directory with the temporary files an interrupted save would
+	// have left behind, holding bytes that are not valid JSON.
+	for i := range 5 {
+		name := filepath.Join(dir, ".checkpoint-torn")
+		if err := os.WriteFile(name+string(rune('a'+i)), []byte(`{"value":"trunc`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := cp.Load(t.Context(), "acme", "wiki")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.Value != "good" {
+		t.Errorf("value is %q, want the committed one", got.Value)
+	}
+}
+
+func TestACheckpointDirectoryIsCreated(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does", "not", "exist", "yet")
+	if _, err := connector.NewFileCheckpoints(dir); err != nil {
+		t.Fatalf("the directory should have been created: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("directory was not created: %v", err)
+	}
+	if _, err := connector.NewFileCheckpoints(""); err == nil {
+		t.Error("an empty directory was accepted")
+	}
+}
+
+func TestUnresolvedNeverAllowsAnybody(t *testing.T) {
+	perm := connector.Unresolved("wiki")
+	if perm.Mode != acl.ModeUnknown {
+		t.Errorf("mode is %v, want ModeUnknown", perm.Mode)
+	}
+	// Including somebody the descriptor would otherwise name as the owner.
+	p := &acl.Principal{Tenant: "acme", Subject: "alice", Kind: acl.KindUser}
+	if perm.Allows(p) {
+		t.Error("an unresolved descriptor allowed a read")
+	}
+}
+
+func TestTheZeroCursorIsTheBeginning(t *testing.T) {
+	if !(connector.Cursor{}).IsZero() {
+		t.Error("the zero cursor does not report itself as zero")
+	}
+	if (connector.Cursor{Value: "x"}).IsZero() {
+		t.Error("a cursor with a value reports itself as zero")
+	}
+	// A time alone is not a resume point, since nothing resumes from it.
+	if !(connector.Cursor{Time: time.Now()}).IsZero() {
+		t.Error("a cursor with only a time reports itself as usable")
+	}
+}
+
+func checkpointStores(t *testing.T) map[string]connector.Checkpoints {
+	t.Helper()
+	files, err := connector.NewFileCheckpoints(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return map[string]connector.Checkpoints{
+		"memory": connector.NewMemoryCheckpoints(),
+		"file":   files,
+	}
+}

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -1,0 +1,134 @@
+// Package connector is the contract between a source system and the index.
+//
+// Every source is different and none of that difference should reach the index.
+// A connector's whole job is to turn whatever its system calls a page, a
+// message, a ticket or a file into a [doc.Document], and to say who is allowed
+// to read it. What it does behind that line is its own business.
+//
+// # Permissions are not optional
+//
+// A connector that cannot report permissions does not ship. Indexing content
+// without the access control list that governs it is the one mistake this
+// project cannot recover from, because the content is then searchable by
+// everybody and no later fix makes it unsearchable by the people who already
+// found it.
+//
+// The type system cannot enforce that, so the pipeline does. A document whose
+// [acl.Permissions] did not resolve arrives with [acl.ModeUnknown], and
+// [doc.Document.Queryable] is false for it, which keeps it out of every query
+// path in the system. A connector that does not know the answer says so with
+// [Unresolved] and the document is quarantined. A connector that guesses is a
+// bug.
+//
+// # Resuming
+//
+// A sync of a real corpus takes long enough that it will be interrupted. Every
+// [Change] carries the [Cursor] to resume from if the process dies just after
+// that change was durably stored, so a run that is killed picks up where it
+// stopped rather than starting again. What goes in a cursor is entirely the
+// connector's business, and nothing above it may parse it.
+package connector
+
+import (
+	"context"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+)
+
+// Connector pulls documents out of one source system.
+//
+// Implementations are not required to be safe for concurrent use. The pipeline
+// drives one connector from one goroutine.
+type Connector interface {
+	// Source is the stable name of this source, which lands in
+	// [doc.Document.Source] and in the cursor the pipeline stores. It has to
+	// stay the same across restarts and across versions of the connector,
+	// because it is the key a resume point is filed under.
+	Source() string
+
+	// Sync walks the source from the given cursor and calls emit for every
+	// change it finds, in an order where every change is safe to resume after.
+	//
+	// A zero cursor means a full sync. Sync returns the cursor to resume from
+	// if the walk completed, which is normally the cursor of the last change it
+	// emitted.
+	//
+	// Backpressure is structural: emit does the indexing work and Sync is
+	// blocked while it runs, so a source that produces faster than the index
+	// can absorb is slowed by the act of handing anything over. There is no
+	// queue between them to grow without bound.
+	//
+	// An error from emit is returned to the caller unchanged and stops the
+	// walk. Sync must not swallow it, and must not keep emitting after it.
+	Sync(ctx context.Context, from Cursor, emit func(context.Context, Change) error) (Cursor, error)
+
+	// Close releases whatever the connector holds open. It is safe to call more
+	// than once.
+	Close() error
+}
+
+// Change is one document that appeared, changed or went away.
+type Change struct {
+	// Document is the normalised content. For a deletion only ID and Tenant are
+	// required, because there is nothing left to index.
+	Document doc.Document
+
+	// Deleted says the document is gone from the source and should be removed
+	// from the index rather than stored.
+	Deleted bool
+
+	// Cursor is the point to resume from once this change has been durably
+	// stored. It is opaque above the connector that produced it.
+	Cursor Cursor
+}
+
+// Cursor is a source's own idea of where a sync got to.
+//
+// It is deliberately a string and a time rather than a structured type. Every
+// source counts differently, some by revision, some by a change feed token and
+// some by a modification timestamp, and a shared schema for that would be a
+// shared schema for nothing.
+type Cursor struct {
+	// Value is whatever the connector needs to resume, and is meaningless to
+	// everything else. An empty value means the beginning.
+	Value string
+
+	// Time is when the cursor was taken, for operators looking at how far
+	// behind a source is. Nothing resumes from it.
+	Time time.Time
+}
+
+// IsZero reports whether the cursor points at the beginning of the source.
+func (c Cursor) IsZero() bool { return c.Value == "" }
+
+// Unresolved returns the permission descriptor for a document whose access
+// control list a connector could not work out.
+//
+// Use it rather than leaving the field zero. Both produce [acl.ModeUnknown] and
+// both quarantine the document, but this one says at the call site that the
+// connector considered the question and failed, which is a different bug from
+// having forgotten to set the field at all.
+func Unresolved(source string) acl.Permissions {
+	return acl.Permissions{Mode: acl.ModeUnknown, Source: source}
+}
+
+// Checkpoints is where resume points are kept between runs.
+//
+// It is separate from [store.Store] because a checkpoint is operational state
+// rather than content: it has no tenant visible existence, no permissions and
+// no reason to be searchable. A deployment that keeps documents in PostgreSQL
+// can keep checkpoints in a file, and often should.
+type Checkpoints interface {
+	// Load returns the resume point for a source, or the zero cursor if the
+	// source has never been synced. A source that has never run is not an
+	// error.
+	Load(ctx context.Context, tenant, source string) (Cursor, error)
+
+	// Save records a resume point. It must be atomic against a crash: a reader
+	// after an interrupted Save sees either the old cursor or the new one, and
+	// never a torn value. Replaying a little is always recoverable, and
+	// resuming past unindexed documents is not.
+	Save(ctx context.Context, tenant, source string, c Cursor) error
+}

--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -91,6 +91,7 @@ type Source struct {
 	maxSize   int64
 	skipDir   func(name string) bool
 	includeIf func(name string) bool
+	skipped   func(path string, reason error)
 }
 
 // Option configures a source.
@@ -102,6 +103,26 @@ func WithMaxFileSize(n int64) Option {
 	return func(s *Source) {
 		if n > 0 {
 			s.maxSize = n
+		}
+	}
+}
+
+// WithSkipped installs a callback for files the walk passed over.
+//
+// A sync does not abandon a tree because one file in it could not be read. A
+// file whose owner revoked the permission, or that was deleted between the
+// listing and the stat, is a fact about the tree and not a reason to lose the
+// hundred thousand files after it.
+//
+// What it must not be is silent. An index quietly missing the files nobody
+// could read looks exactly like an index that is complete, and the difference
+// only shows up when somebody cannot find a document they know exists. This is
+// how a caller finds out: it is called once per skipped file with the path and
+// the reason, and the default does nothing.
+func WithSkipped(f func(path string, reason error)) Option {
+	return func(s *Source) {
+		if f != nil {
+			s.skipped = f
 		}
 	}
 }
@@ -158,6 +179,7 @@ func New(root, name string, policy Policy, opts ...Option) (*Source, error) {
 		maxSize:   DefaultMaxFileSize,
 		skipDir:   defaultSkipDir,
 		includeIf: defaultInclude,
+		skipped:   func(string, error) {},
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -211,9 +233,11 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 
 		info, err := d.Info()
 		if err != nil {
+			s.skipped(p, err)
 			return nil
 		}
 		if info.Size() > s.maxSize {
+			s.skipped(p, fmt.Errorf("%d bytes is over the limit of %d", info.Size(), s.maxSize))
 			return nil
 		}
 		mod := info.ModTime()
@@ -228,12 +252,14 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 
 		rel, err := filepath.Rel(s.root, p)
 		if err != nil {
+			s.skipped(p, err)
 			return nil
 		}
 		rel = filepath.ToSlash(rel)
 
 		document, err := s.read(ctx, p, rel, info)
 		if err != nil {
+			s.skipped(p, err)
 			return nil
 		}
 		return emit(ctx, connector.Change{

--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -1,0 +1,391 @@
+// Package fssource is a connector that reads a directory tree.
+//
+// It is the reference connector, the one the interface was written against and
+// the one to read first when writing another. It also does real work: pointed
+// at a checkout of a documentation repository it produces a corpus with real
+// titles, real bodies, real modification times and, with the right policy, real
+// access control lists.
+//
+// # Permissions come from a policy, not from the walk
+//
+// The connector maps files to documents. It does not decide who may read them.
+// That split exists because a directory tree says almost nothing about access
+// on its own: the mode bits describe the account the crawler is running as, not
+// the people in the company. Somewhere above the filesystem there is a real
+// answer, in an OWNERS file, in a group export or in a share database, and a
+// [Policy] is where that answer is plugged in.
+//
+// There is no permissive default. A source built without a policy quarantines
+// everything, which is loud and safe, rather than publishing a directory tree
+// to everybody, which is quiet and not.
+//
+// # Incremental sync
+//
+// The cursor is the highest modification time the last run saw. A later run
+// walks the same tree and skips anything not newer, so the cost of a no change
+// sync is a stat of every file rather than a read of every file. That is the
+// honest limit of what a plain filesystem supports: without a change feed there
+// is no way to avoid the walk, only the read.
+package fssource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/doc"
+)
+
+// DefaultMaxFileSize is the largest file read into a document body.
+//
+// Past this the file is almost never prose somebody wants to search, and it is
+// often a checked in binary that would cost far more to index than it is worth.
+const DefaultMaxFileSize = 1 << 20
+
+// Policy decides who may read a file.
+//
+// It is called once per file with the path relative to the root, using forward
+// slashes on every platform so that a policy written against a repository
+// layout does not have to care where it is running.
+//
+// Returning an error quarantines that one document and does not stop the walk,
+// because one unreadable share should not cost a whole sync.
+type Policy interface {
+	Permissions(ctx context.Context, relPath string) (acl.Permissions, error)
+}
+
+// PolicyFunc adapts a function to [Policy].
+type PolicyFunc func(ctx context.Context, relPath string) (acl.Permissions, error)
+
+// Permissions calls f.
+func (f PolicyFunc) Permissions(ctx context.Context, relPath string) (acl.Permissions, error) {
+	return f(ctx, relPath)
+}
+
+// PublicToTenant is a policy where every file is readable by everybody in the
+// tenant.
+//
+// It is correct for a public documentation corpus and wrong for almost
+// everything else, so it has to be asked for by name.
+func PublicToTenant(source string) Policy {
+	return PolicyFunc(func(context.Context, string) (acl.Permissions, error) {
+		return acl.Permissions{Mode: acl.ModePublicToTenant, Source: source}, nil
+	})
+}
+
+// Source reads documents out of a directory tree.
+type Source struct {
+	root   string
+	name   string
+	policy Policy
+
+	maxSize   int64
+	skipDir   func(name string) bool
+	includeIf func(name string) bool
+}
+
+// Option configures a source.
+type Option func(*Source)
+
+// WithMaxFileSize sets the largest file that will be read. A value below one
+// selects [DefaultMaxFileSize].
+func WithMaxFileSize(n int64) Option {
+	return func(s *Source) {
+		if n > 0 {
+			s.maxSize = n
+		}
+	}
+}
+
+// WithSkipDir replaces the rule for directories that are not descended into.
+// The argument is the base name.
+func WithSkipDir(f func(name string) bool) Option {
+	return func(s *Source) {
+		if f != nil {
+			s.skipDir = f
+		}
+	}
+}
+
+// WithInclude replaces the rule for which file names are read. The argument is
+// the base name.
+func WithInclude(f func(name string) bool) Option {
+	return func(s *Source) {
+		if f != nil {
+			s.includeIf = f
+		}
+	}
+}
+
+// New returns a source reading root, naming itself name, and asking policy who
+// may read each file.
+//
+// A nil policy is allowed and quarantines every document. That is deliberate:
+// it makes "I have not thought about permissions yet" a visible state in the
+// stats rather than an invisible one in the index.
+func New(root, name string, policy Policy, opts ...Option) (*Source, error) {
+	if root == "" {
+		return nil, errors.New("fssource: empty root")
+	}
+	if name == "" {
+		return nil, errors.New("fssource: empty source name")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("fssource: %w", err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("fssource: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("fssource: %s is not a directory", abs)
+	}
+
+	s := &Source{
+		root:      abs,
+		name:      name,
+		policy:    policy,
+		maxSize:   DefaultMaxFileSize,
+		skipDir:   defaultSkipDir,
+		includeIf: defaultInclude,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s, nil
+}
+
+var _ connector.Connector = (*Source)(nil)
+
+// Source returns the connector's name.
+func (s *Source) Source() string { return s.name }
+
+// Close releases nothing, because a walk holds nothing open between calls.
+func (s *Source) Close() error { return nil }
+
+// Sync walks the tree and emits every file modified after the cursor.
+//
+// The returned cursor is the highest modification time seen in the whole tree,
+// including files that were skipped as unchanged, so that a run which finds
+// nothing new still moves the clock forward and a run interrupted halfway does
+// not lose the files it already passed.
+func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(context.Context, connector.Change) error) (connector.Cursor, error) {
+	since, err := parseCursor(from)
+	if err != nil {
+		return connector.Cursor{}, err
+	}
+
+	var highest time.Time
+	walkErr := filepath.WalkDir(s.root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A directory that disappeared under the walk, or one this process
+			// may not read, is a fact about the tree rather than a reason to
+			// abandon the sync.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if p != s.root && s.skipDir(d.Name()) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() || !s.includeIf(d.Name()) {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if info.Size() > s.maxSize {
+			return nil
+		}
+		mod := info.ModTime()
+		if mod.After(highest) {
+			highest = mod
+		}
+		// Not After rather than Before, so a file written in the same
+		// nanosecond as the cursor is not emitted twice on every later run.
+		if !since.IsZero() && !mod.After(since) {
+			return nil
+		}
+
+		rel, err := filepath.Rel(s.root, p)
+		if err != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+
+		document, err := s.read(ctx, p, rel, info)
+		if err != nil {
+			return nil
+		}
+		return emit(ctx, connector.Change{
+			Document: document,
+			Cursor:   connector.Cursor{Value: mod.UTC().Format(time.RFC3339Nano), Time: mod},
+		})
+	})
+	if walkErr != nil {
+		return connector.Cursor{}, walkErr
+	}
+
+	if highest.IsZero() {
+		return from, nil
+	}
+	return connector.Cursor{Value: highest.UTC().Format(time.RFC3339Nano), Time: highest}, nil
+}
+
+// read turns one file into a document.
+func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (doc.Document, error) {
+	body, err := os.ReadFile(full)
+	if err != nil {
+		return doc.Document{}, err
+	}
+	// A file that is not valid UTF-8 is a binary this connector has no business
+	// pretending to have read. Extraction of real binary formats is a separate
+	// job with separate failure modes.
+	if !utf8.Valid(body) {
+		return doc.Document{}, errors.New("not text")
+	}
+
+	perms := connector.Unresolved(s.name)
+	if s.policy != nil {
+		got, err := s.policy.Permissions(ctx, rel)
+		if err == nil {
+			perms = got
+		}
+		// On an error the document keeps the unresolved descriptor and is
+		// quarantined by the pipeline. Failing to answer is not permission to
+		// publish.
+	}
+
+	text := string(body)
+	kind := kindOf(rel)
+	return doc.Document{
+		ID:           s.name + ":" + rel,
+		Kind:         kind,
+		Title:        titleOf(rel, text, kind),
+		Body:         text,
+		URL:          "file://" + filepath.ToSlash(full),
+		Container:    path.Dir(rel),
+		ModifiedAt:   info.ModTime(),
+		CreatedAt:    info.ModTime(),
+		SourceUpdate: info.ModTime().UTC().Format(time.RFC3339Nano),
+		Permissions:  perms,
+		Properties: map[string]string{
+			"path":      rel,
+			"extension": strings.TrimPrefix(path.Ext(rel), "."),
+		},
+	}, nil
+}
+
+// parseCursor reads the modification time out of a cursor.
+func parseCursor(c connector.Cursor) (time.Time, error) {
+	if c.IsZero() {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, c.Value)
+	if err != nil {
+		// A cursor this connector cannot read is one written by a different
+		// version or a different connector. Refusing is better than silently
+		// resyncing the whole tree, which on a large corpus looks like a hang.
+		return time.Time{}, fmt.Errorf("fssource: unreadable cursor %q: %w", c.Value, err)
+	}
+	return t, nil
+}
+
+// titleOf takes the first markdown heading, or the first non empty line if
+// there is no heading, and falls back to the file name.
+//
+// Source files are named by their path instead. Their first line is a licence
+// header or a package comment, which is the same in every file in the tree and
+// tells a reader scanning a result list nothing about which file they are
+// looking at. The path tells them exactly that, and is also how they would say
+// it out loud.
+func titleOf(rel, body string, kind doc.Kind) string {
+	if kind == doc.KindCode {
+		return rel
+	}
+	for line := range strings.SplitSeq(head(body, 4096), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if h, ok := strings.CutPrefix(line, "# "); ok {
+			return strings.TrimSpace(h)
+		}
+		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "---") {
+			continue
+		}
+		if len(line) <= 120 {
+			return line
+		}
+		break
+	}
+	return path.Base(rel)
+}
+
+func head(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// kindOf maps an extension onto a document kind. Anything unrecognised is a
+// file, which is the kind that promises the least.
+func kindOf(rel string) doc.Kind {
+	switch strings.ToLower(path.Ext(rel)) {
+	case ".md", ".markdown", ".rst", ".adoc", ".txt", ".html":
+		return doc.KindPage
+	case ".go", ".rs", ".py", ".js", ".ts", ".tsx", ".jsx", ".c", ".h", ".cc", ".cpp",
+		".java", ".rb", ".sh", ".sql", ".yaml", ".yml", ".toml", ".json", ".proto":
+		return doc.KindCode
+	default:
+		return doc.KindFile
+	}
+}
+
+// defaultSkipDir skips version control, dependency and build directories, which
+// hold far more files than the corpus and none of the content.
+func defaultSkipDir(name string) bool {
+	switch name {
+	case ".git", ".hg", ".svn", "node_modules", "vendor", "target", "dist", "build",
+		".venv", "__pycache__", ".idea", ".vscode":
+		return true
+	}
+	return strings.HasPrefix(name, ".")
+}
+
+// defaultInclude reads text formats and nothing else.
+func defaultInclude(name string) bool {
+	if strings.HasPrefix(name, ".") {
+		return false
+	}
+	if name == "OWNERS" || name == "README" || name == "LICENSE" {
+		return true
+	}
+	switch strings.ToLower(path.Ext(name)) {
+	case ".md", ".markdown", ".rst", ".adoc", ".txt", ".html",
+		".go", ".rs", ".py", ".js", ".ts", ".tsx", ".jsx", ".c", ".h", ".cc", ".cpp",
+		".java", ".rb", ".sh", ".sql", ".yaml", ".yml", ".toml", ".json", ".proto":
+		return true
+	}
+	return false
+}

--- a/connector/fssource/fssource_test.go
+++ b/connector/fssource/fssource_test.go
@@ -1,0 +1,281 @@
+package fssource_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/fssource"
+	"github.com/tamnd/genba/doc"
+)
+
+// tree writes a directory tree from a map of relative path to contents.
+func tree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, body := range files {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// collect runs one sync and returns what it emitted.
+func collect(t *testing.T, s *fssource.Source, from connector.Cursor) ([]doc.Document, connector.Cursor) {
+	t.Helper()
+	var got []doc.Document
+	next, err := s.Sync(t.Context(), from, func(_ context.Context, ch connector.Change) error {
+		got = append(got, ch.Document)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	sort.Slice(got, func(i, j int) bool { return got[i].ID < got[j].ID })
+	return got, next
+}
+
+func ids(docs []doc.Document) []string {
+	out := make([]string, 0, len(docs))
+	for _, d := range docs {
+		out = append(out, d.ID)
+	}
+	return out
+}
+
+func TestItReadsATreeIntoDocuments(t *testing.T) {
+	root := tree(t, map[string]string{
+		"README.md":            "# The project\n\nWhat it does.\n",
+		"docs/install.md":      "# Installing\n\nRun the thing.\n",
+		"docs/deep/nested.md":  "no heading here, just a line\n",
+		"cmd/main.go":          "package main\n",
+		"assets/logo.png":      "\x89PNG\r\n\x1a\n binary",
+		".hidden/secret.md":    "# should not appear\n",
+		"node_modules/dep.js":  "module.exports = 1",
+		"docs/notes.unknownxt": "not an extension we read",
+	})
+
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	got, cursor := collect(t, s, connector.Cursor{})
+
+	want := []string{"repo:README.md", "repo:cmd/main.go", "repo:docs/deep/nested.md", "repo:docs/install.md"}
+	if !slices.Equal(ids(got), want) {
+		t.Errorf("read %v\nwant %v", ids(got), want)
+	}
+	if cursor.IsZero() {
+		t.Error("a sync that read files returned no cursor")
+	}
+
+	byID := map[string]doc.Document{}
+	for _, d := range got {
+		byID[d.ID] = d
+	}
+
+	if title := byID["repo:docs/install.md"].Title; title != "Installing" {
+		t.Errorf("title is %q, want the markdown heading", title)
+	}
+	if title := byID["repo:docs/deep/nested.md"].Title; title != "no heading here, just a line" {
+		t.Errorf("title is %q, want the first line when there is no heading", title)
+	}
+	if c := byID["repo:docs/install.md"].Container; c != "docs" {
+		t.Errorf("container is %q, want the directory", c)
+	}
+	// A source file is named by its path. Its first line is a package comment
+	// that every file in the tree shares, which would make a result list read as
+	// the same title over and over.
+	if title := byID["repo:cmd/main.go"].Title; title != "cmd/main.go" {
+		t.Errorf("title is %q, want the path", title)
+	}
+	if k := byID["repo:cmd/main.go"].Kind; k != doc.KindCode {
+		t.Errorf("a .go file has kind %q, want code", k)
+	}
+	if k := byID["repo:README.md"].Kind; k != doc.KindPage {
+		t.Errorf("a .md file has kind %q, want page", k)
+	}
+	if p := byID["repo:cmd/main.go"].Properties["extension"]; p != "go" {
+		t.Errorf("extension property is %q", p)
+	}
+	if byID["repo:README.md"].ModifiedAt.IsZero() {
+		t.Error("ModifiedAt was not set from the file")
+	}
+}
+
+func TestBinaryAndOversizeFilesAreLeftAlone(t *testing.T) {
+	root := tree(t, map[string]string{
+		"good.md":   "# fine\n",
+		"binary.md": "\xff\xfe\x00\x01 not utf8",
+		"huge.md":   string(make([]byte, 4096)),
+	})
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"), fssource.WithMaxFileSize(1024))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := collect(t, s, connector.Cursor{})
+	if !slices.Equal(ids(got), []string{"repo:good.md"}) {
+		t.Errorf("read %v, want only the good file", ids(got))
+	}
+}
+
+func TestASecondSyncReadsOnlyWhatChanged(t *testing.T) {
+	root := tree(t, map[string]string{
+		"a.md": "# a\n",
+		"b.md": "# b\n",
+		"c.md": "# c\n",
+	})
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, cursor := collect(t, s, connector.Cursor{})
+	if len(first) != 3 {
+		t.Fatalf("first sync read %d files, want 3", len(first))
+	}
+
+	// Nothing changed, so nothing comes back.
+	second, cursor2 := collect(t, s, cursor)
+	if len(second) != 0 {
+		t.Errorf("an unchanged tree produced %v", ids(second))
+	}
+	if cursor2.Value != cursor.Value {
+		t.Errorf("the cursor moved on an unchanged tree, %q to %q", cursor.Value, cursor2.Value)
+	}
+
+	// Touch one file well into the future so the change is unambiguous on a
+	// filesystem with a coarse timestamp.
+	later := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(filepath.Join(root, "b.md"), later, later); err != nil {
+		t.Fatal(err)
+	}
+	third, _ := collect(t, s, cursor)
+	if !slices.Equal(ids(third), []string{"repo:b.md"}) {
+		t.Errorf("after touching one file the sync read %v", ids(third))
+	}
+}
+
+func TestAnUnreadableCursorIsRefusedRatherThanIgnored(t *testing.T) {
+	root := tree(t, map[string]string{"a.md": "# a\n"})
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.Sync(t.Context(), connector.Cursor{Value: "not-a-time"}, func(context.Context, connector.Change) error {
+		t.Error("a sync with an unreadable cursor emitted a document")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("an unreadable cursor was accepted, which would silently resync everything")
+	}
+}
+
+// The safe default. A source with nothing to say about permissions says nothing
+// rather than publishing the tree.
+func TestWithoutAPolicyEverythingIsQuarantined(t *testing.T) {
+	root := tree(t, map[string]string{"a.md": "# a\n", "b.md": "# b\n"})
+	s, err := fssource.New(root, "repo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := collect(t, s, connector.Cursor{})
+	if len(got) != 2 {
+		t.Fatalf("read %d documents, want 2", len(got))
+	}
+	for _, d := range got {
+		if d.Permissions.Mode != acl.ModeUnknown {
+			t.Errorf("%s has mode %v, want unknown", d.ID, d.Permissions.Mode)
+		}
+		// The tenant is stamped by the pipeline rather than the connector, so
+		// check the descriptor directly rather than through Queryable, which
+		// would be false here for the wrong reason.
+		d.Tenant = "acme"
+		if d.Queryable() {
+			t.Errorf("%s is queryable without a policy having been given", d.ID)
+		}
+	}
+}
+
+// A policy that fails on one file must not publish that file and must not stop
+// the walk.
+func TestAPolicyErrorQuarantinesOneDocumentAndNoMore(t *testing.T) {
+	root := tree(t, map[string]string{"a.md": "# a\n", "b.md": "# b\n", "c.md": "# c\n"})
+	policy := fssource.PolicyFunc(func(_ context.Context, rel string) (acl.Permissions, error) {
+		if rel == "b.md" {
+			return acl.Permissions{}, errors.New("the share database is down")
+		}
+		return acl.Permissions{Mode: acl.ModePublicToTenant, Source: "repo"}, nil
+	})
+	s, err := fssource.New(root, "repo", policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := collect(t, s, connector.Cursor{})
+	if len(got) != 3 {
+		t.Fatalf("the walk stopped early, read %v", ids(got))
+	}
+	for _, d := range got {
+		want := acl.ModePublicToTenant
+		if d.ID == "repo:b.md" {
+			want = acl.ModeUnknown
+		}
+		if d.Permissions.Mode != want {
+			t.Errorf("%s has mode %v, want %v", d.ID, d.Permissions.Mode, want)
+		}
+	}
+}
+
+func TestNewRefusesWhatItCannotRead(t *testing.T) {
+	root := tree(t, map[string]string{"a.md": "x"})
+	if _, err := fssource.New("", "repo", nil); err == nil {
+		t.Error("an empty root was accepted")
+	}
+	if _, err := fssource.New(root, "", nil); err == nil {
+		t.Error("an empty source name was accepted")
+	}
+	if _, err := fssource.New(filepath.Join(root, "a.md"), "repo", nil); err == nil {
+		t.Error("a file was accepted as a root")
+	}
+	if _, err := fssource.New(filepath.Join(root, "nope"), "repo", nil); err == nil {
+		t.Error("a missing directory was accepted")
+	}
+}
+
+func TestSyncStopsWhenTheCallerSaysSo(t *testing.T) {
+	root := tree(t, map[string]string{"a.md": "1", "b.md": "2", "c.md": "3", "d.md": "4"})
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := errors.New("enough")
+	seen := 0
+	_, err = s.Sync(t.Context(), connector.Cursor{}, func(context.Context, connector.Change) error {
+		seen++
+		if seen == 2 {
+			return stop
+		}
+		return nil
+	})
+	if !errors.Is(err, stop) {
+		t.Fatalf("sync returned %v, want the error the callback gave it", err)
+	}
+	if seen != 2 {
+		t.Errorf("the walk emitted %d documents after being told to stop at 2", seen)
+	}
+}

--- a/connector/fssource/fssource_test.go
+++ b/connector/fssource/fssource_test.go
@@ -133,6 +133,44 @@ func TestBinaryAndOversizeFilesAreLeftAlone(t *testing.T) {
 	}
 }
 
+func TestASkippedFileSaysSoRatherThanVanishing(t *testing.T) {
+	root := tree(t, map[string]string{
+		"good.md":   "# fine\n",
+		"binary.md": "\xff\xfe\x00\x01 not utf8",
+		"huge.md":   string(make([]byte, 4096)),
+	})
+
+	skipped := map[string]string{}
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"),
+		fssource.WithMaxFileSize(1024),
+		fssource.WithSkipped(func(path string, reason error) {
+			skipped[filepath.Base(path)] = reason.Error()
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := collect(t, s, connector.Cursor{})
+	if !slices.Equal(ids(got), []string{"repo:good.md"}) {
+		t.Fatalf("read %v, want only the good file", ids(got))
+	}
+
+	// The point of the callback is that the two files nobody indexed are
+	// nameable afterwards. An index missing them silently looks exactly like an
+	// index that is complete.
+	for _, name := range []string{"binary.md", "huge.md"} {
+		if _, ok := skipped[name]; !ok {
+			t.Errorf("%s was dropped without saying so, got %v", name, skipped)
+		}
+	}
+	if len(skipped) != 2 {
+		t.Errorf("skipped %v, want exactly the two that were dropped", skipped)
+	}
+	if want := "4096 bytes is over the limit of 1024"; skipped["huge.md"] != want {
+		t.Errorf("huge.md reason is %q, want %q", skipped["huge.md"], want)
+	}
+}
+
 func TestASecondSyncReadsOnlyWhatChanged(t *testing.T) {
 	root := tree(t, map[string]string{
 		"a.md": "# a\n",

--- a/connector/fssource/owners.go
+++ b/connector/fssource/owners.go
@@ -1,0 +1,245 @@
+package fssource
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// OwnersFile is the name of the file an [OwnersPolicy] reads.
+const OwnersFile = "OWNERS"
+
+// OwnersPolicy derives permissions from OWNERS files in the tree.
+//
+// This is the convention Kubernetes and a number of other large repositories
+// use: a file named OWNERS in a directory lists the people who approve and
+// review changes below it, and the nearest one going up the tree wins. It is
+// worth supporting because it is a real access control list, maintained by real
+// people for their own reasons, over a corpus anybody can check out. Developing
+// a permission model against it means developing against the awkward parts,
+// such as a subtree that narrows the list its parent set, which invented test
+// data never has because nobody invents inconvenience.
+//
+// The mapping is deliberately literal. Approvers and reviewers become allowed
+// users under the identity source given to [NewOwnersPolicy], and the first
+// approver becomes the owner. Nothing is inferred beyond that.
+//
+// A file below a directory with no OWNERS file anywhere above it has no answer,
+// and gets one that does not resolve, so it is quarantined rather than
+// published. That is the case worth getting right: the default for "no rule
+// found" is not "no restriction".
+type OwnersPolicy struct {
+	root     string
+	source   string
+	identity string
+	fallback acl.Permissions
+	hasFall  bool
+
+	mu     sync.RWMutex
+	byDir  map[string]*owners
+	parsed map[string]bool
+}
+
+// owners is one parsed OWNERS file.
+type owners struct {
+	approvers []string
+	reviewers []string
+}
+
+// NewOwnersPolicy returns a policy reading OWNERS files under root.
+//
+// source names the connector, and identity names the identity source the
+// entries in the file belong to, for example "github". Getting that second one
+// right is what lets a principal who authenticated through one system match a
+// list written in terms of another.
+func NewOwnersPolicy(root, source, identity string) (*OwnersPolicy, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("fssource: owners policy: %w", err)
+	}
+	return &OwnersPolicy{
+		root:     abs,
+		source:   source,
+		identity: identity,
+		byDir:    make(map[string]*owners),
+		parsed:   make(map[string]bool),
+	}, nil
+}
+
+// WithFallback sets the permissions used for a path with no OWNERS file above
+// it.
+//
+// Without it those paths are quarantined. Set it when the tree genuinely has a
+// default, such as a public documentation repository where the unowned files
+// are as public as the owned ones, and leave it alone otherwise.
+func (o *OwnersPolicy) WithFallback(p acl.Permissions) *OwnersPolicy {
+	o.fallback = p
+	o.hasFall = true
+	return o
+}
+
+var _ Policy = (*OwnersPolicy)(nil)
+
+// Permissions returns the access control list governing relPath.
+func (o *OwnersPolicy) Permissions(ctx context.Context, relPath string) (acl.Permissions, error) {
+	if err := ctx.Err(); err != nil {
+		return acl.Permissions{}, err
+	}
+
+	// Walk up from the file's directory to the root, taking the first OWNERS
+	// file found. Nearest wins, which is what the convention means and what
+	// makes a subtree able to narrow what its parent allowed.
+	dir := path.Dir(relPath)
+	for {
+		own, err := o.at(dir)
+		if err != nil {
+			return acl.Permissions{}, err
+		}
+		if own != nil {
+			return o.permissionsFrom(own), nil
+		}
+		if dir == "." || dir == "/" || dir == "" {
+			break
+		}
+		dir = path.Dir(dir)
+	}
+
+	if o.hasFall {
+		return o.fallback, nil
+	}
+	return acl.Permissions{}, fmt.Errorf("fssource: no OWNERS file governs %q", relPath)
+}
+
+// permissionsFrom maps a parsed file onto a descriptor.
+func (o *OwnersPolicy) permissionsFrom(own *owners) acl.Permissions {
+	p := acl.Permissions{Mode: acl.ModeACL, Source: o.source}
+	for _, name := range own.approvers {
+		p.AllowUsers = append(p.AllowUsers, acl.Ref{Source: o.identity, Value: name})
+	}
+	for _, name := range own.reviewers {
+		p.AllowUsers = append(p.AllowUsers, acl.Ref{Source: o.identity, Value: name})
+	}
+	if len(own.approvers) > 0 {
+		p.Owner = acl.Ref{Source: o.identity, Value: own.approvers[0]}
+	}
+	return p
+}
+
+// at returns the parsed OWNERS file for a directory, or nil if there is none.
+// Results are cached because a large tree asks about the same directory once
+// per file in it.
+func (o *OwnersPolicy) at(dir string) (*owners, error) {
+	o.mu.RLock()
+	own := o.byDir[dir]
+	done := o.parsed[dir]
+	o.mu.RUnlock()
+	if done {
+		return own, nil
+	}
+
+	full := filepath.Join(o.root, filepath.FromSlash(dir), OwnersFile)
+	b, err := os.ReadFile(full)
+	switch {
+	case os.IsNotExist(err):
+		own = nil
+	case err != nil:
+		return nil, fmt.Errorf("fssource: read %s: %w", full, err)
+	default:
+		own = parseOwners(string(b))
+	}
+
+	o.mu.Lock()
+	o.byDir[dir] = own
+	o.parsed[dir] = true
+	o.mu.Unlock()
+	return own, nil
+}
+
+// parseOwners reads the approvers and reviewers out of an OWNERS file.
+//
+// The real files are YAML, and this reads the two list keys it needs rather
+// than pulling in a YAML parser for them. That is a defensible trade for a
+// format this shape, and it is worth being clear about what it gives up: a file
+// using anchors, flow sequences or nested aliases is not understood. Such a
+// file yields no entries, which quarantines its subtree rather than opening it,
+// so the failure is safe as well as visible.
+func parseOwners(text string) *owners {
+	out := &owners{}
+	var current *[]string
+
+	for line := range strings.SplitSeq(text, "\n") {
+		line = strings.TrimRight(line, "\r")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		if key, rest, ok := strings.Cut(trimmed, ":"); ok && !strings.HasPrefix(trimmed, "-") {
+			switch strings.TrimSpace(key) {
+			case "approvers":
+				current = &out.approvers
+			case "reviewers":
+				current = &out.reviewers
+			default:
+				// Any other key ends the list that was being read. Without this
+				// a key such as labels would swallow its own values into
+				// whichever list came before it.
+				current = nil
+			}
+			if rest = strings.TrimSpace(rest); rest != "" && current != nil {
+				// An inline list, approvers: [alice, bob].
+				rest = strings.TrimPrefix(rest, "[")
+				rest = strings.TrimSuffix(rest, "]")
+				for item := range strings.SplitSeq(rest, ",") {
+					if name := cleanName(item); name != "" {
+						*current = append(*current, name)
+					}
+				}
+			}
+			continue
+		}
+
+		if item, ok := strings.CutPrefix(trimmed, "-"); ok && current != nil {
+			if name := cleanName(item); name != "" {
+				*current = append(*current, name)
+			}
+		}
+	}
+	return out
+}
+
+// cleanName strips the quoting and comments a name can arrive wrapped in, and
+// returns empty for anything that is YAML machinery rather than a person.
+//
+// The rejection matters more than the stripping. An anchor, an alias or a merge
+// key is syntax this parser does not implement, and reading one as a name would
+// grant access to a user account called "&anchor" that will never exist, which
+// is a silent partial failure. Returning nothing instead leaves the list empty,
+// and an empty list allows nobody.
+func cleanName(s string) string {
+	if i := strings.Index(s, "#"); i >= 0 {
+		s = s[:i]
+	}
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, `"'`)
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	switch s[0] {
+	case '&', '*', '<', '{', '[', '!', '?', '|', '>', '%', '@', '`':
+		return ""
+	}
+	// A real account name has no spaces in it. Anything that does is a phrase
+	// this parser has misread the structure of.
+	if strings.ContainsAny(s, " \t:,") {
+		return ""
+	}
+	return s
+}

--- a/connector/fssource/owners_test.go
+++ b/connector/fssource/owners_test.go
@@ -1,0 +1,271 @@
+package fssource_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/fssource"
+)
+
+// The shape of a real OWNERS file, comments and all.
+const k8sStyle = `# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - alice
+  - bob   # on leave until March
+reviewers:
+  - carol
+  - dave
+labels:
+  - sig/network
+`
+
+func ownersTree(t *testing.T) string {
+	t.Helper()
+	return tree(t, map[string]string{
+		"OWNERS":              k8sStyle,
+		"README.md":           "# top\n",
+		"net/OWNERS":          "approvers:\n  - erin\nreviewers:\n  - frank\n",
+		"net/design.md":       "# networking\n",
+		"net/deep/detail.md":  "# deeper\n",
+		"docs/guide.md":       "# guide\n",
+		"unowned/notes.md":    "# notes\n",
+		"inline/OWNERS":       "approvers: [grace, heidi]\n",
+		"inline/thing.md":     "# thing\n",
+		"broken/OWNERS":       "approvers: &anchor\n  <<: *defaults\n",
+		"broken/mystery.md":   "# mystery\n",
+		"emptyown/OWNERS":     "# nobody listed\n",
+		"emptyown/orphan.md":  "# orphan\n",
+		"labelsfirst/OWNERS":  "labels:\n  - sig/api\napprovers:\n  - ivan\n",
+		"labelsfirst/spec.md": "# spec\n",
+	})
+}
+
+func policyFor(t *testing.T, root string) *fssource.OwnersPolicy {
+	t.Helper()
+	p, err := fssource.NewOwnersPolicy(root, "repo", "github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func allowedUsers(p acl.Permissions) []string {
+	out := make([]string, 0, len(p.AllowUsers))
+	for _, r := range p.AllowUsers {
+		out = append(out, r.Value)
+	}
+	return out
+}
+
+func has(list []string, want string) bool {
+	return slices.Contains(list, want)
+}
+
+func TestTheNearestOwnersFileWins(t *testing.T) {
+	root := ownersTree(t)
+	policy := policyFor(t, root)
+
+	// A file directly under an OWNERS file gets that file's people.
+	got, err := policy.Permissions(t.Context(), "net/design.md")
+	if err != nil {
+		t.Fatalf("net/design.md: %v", err)
+	}
+	users := allowedUsers(got)
+	if !has(users, "erin") || !has(users, "frank") {
+		t.Errorf("net/design.md allows %v, want the net owners", users)
+	}
+	// And not the ones from the root file it overrides.
+	if has(users, "alice") {
+		t.Errorf("net/design.md allows %v, which includes the root approvers the subtree replaced", users)
+	}
+
+	// A file deeper down with no OWNERS of its own inherits the nearest above.
+	deep, err := policy.Permissions(t.Context(), "net/deep/detail.md")
+	if err != nil {
+		t.Fatalf("net/deep/detail.md: %v", err)
+	}
+	if !has(allowedUsers(deep), "erin") {
+		t.Errorf("net/deep/detail.md allows %v, want the nearest owners above it", allowedUsers(deep))
+	}
+
+	// A file under a directory with no OWNERS falls back to the root file.
+	top, err := policy.Permissions(t.Context(), "docs/guide.md")
+	if err != nil {
+		t.Fatalf("docs/guide.md: %v", err)
+	}
+	if !has(allowedUsers(top), "alice") || !has(allowedUsers(top), "carol") {
+		t.Errorf("docs/guide.md allows %v, want the root approvers and reviewers", allowedUsers(top))
+	}
+}
+
+func TestCommentsAndInlineListsAreRead(t *testing.T) {
+	root := ownersTree(t)
+	policy := policyFor(t, root)
+
+	got, err := policy.Permissions(t.Context(), "README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	users := allowedUsers(got)
+	if !has(users, "bob") {
+		t.Errorf("allows %v, want bob with the trailing comment stripped", users)
+	}
+	for _, v := range users {
+		if v == "on leave until March" || v == "sig/network" {
+			t.Errorf("allows %q, which is a comment or a label rather than a person", v)
+		}
+	}
+
+	inline, err := policy.Permissions(t.Context(), "inline/thing.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has(allowedUsers(inline), "grace") || !has(allowedUsers(inline), "heidi") {
+		t.Errorf("inline list gave %v", allowedUsers(inline))
+	}
+}
+
+// A key that is not a list of people must not swallow the values under it.
+func TestAnotherKeyEndsTheList(t *testing.T) {
+	root := ownersTree(t)
+	policy := policyFor(t, root)
+
+	got, err := policy.Permissions(t.Context(), "labelsfirst/spec.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	users := allowedUsers(got)
+	if !has(users, "ivan") {
+		t.Errorf("allows %v, want ivan", users)
+	}
+	if has(users, "sig/api") {
+		t.Errorf("allows %v, which includes a label read as a person", users)
+	}
+}
+
+func TestTheFirstApproverIsTheOwner(t *testing.T) {
+	root := ownersTree(t)
+	policy := policyFor(t, root)
+
+	got, err := policy.Permissions(t.Context(), "README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Owner.Value != "alice" || got.Owner.Source != "github" {
+		t.Errorf("owner is %+v, want alice from github", got.Owner)
+	}
+	if got.Source != "repo" {
+		t.Errorf("permission source is %q, want the connector name", got.Source)
+	}
+	if got.Mode != acl.ModeACL {
+		t.Errorf("mode is %v, want an access control list", got.Mode)
+	}
+}
+
+// The case worth getting right. No rule found is not the same as no
+// restriction.
+func TestAPathWithNoOwnersFileIsRefusedRatherThanOpened(t *testing.T) {
+	// A tree whose root has no OWNERS file at all.
+	root := tree(t, map[string]string{
+		"loose/notes.md": "# notes\n",
+	})
+	policy := policyFor(t, root)
+
+	if _, err := policy.Permissions(t.Context(), "loose/notes.md"); err == nil {
+		t.Fatal("a path governed by no OWNERS file was given permissions")
+	}
+}
+
+// An OWNERS file this parser cannot understand yields nobody, which quarantines
+// its subtree rather than opening it.
+func TestAnUnparseableOwnersFileAllowsNobody(t *testing.T) {
+	root := ownersTree(t)
+	policy := policyFor(t, root)
+
+	for _, path := range []string{"broken/mystery.md", "emptyown/orphan.md"} {
+		got, err := policy.Permissions(t.Context(), path)
+		if err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		if len(got.AllowUsers) != 0 {
+			t.Errorf("%s allows %v, want nobody", path, allowedUsers(got))
+		}
+		p := &acl.Principal{Tenant: "acme", Subject: "alice", Kind: acl.KindUser,
+			Identities: []acl.Identity{{Source: "github", Value: "alice"}}}
+		if got.Allows(p) {
+			t.Errorf("%s is readable by somebody named in a file above it", path)
+		}
+	}
+}
+
+func TestAFallbackCoversThePathsNoOwnersFileGoverns(t *testing.T) {
+	root := tree(t, map[string]string{"loose/notes.md": "# notes\n"})
+	policy := policyFor(t, root).WithFallback(acl.Permissions{
+		Mode:   acl.ModePublicToTenant,
+		Source: "repo",
+	})
+
+	got, err := policy.Permissions(t.Context(), "loose/notes.md")
+	if err != nil {
+		t.Fatalf("with a fallback set this should resolve: %v", err)
+	}
+	if got.Mode != acl.ModePublicToTenant {
+		t.Errorf("mode is %v, want the fallback", got.Mode)
+	}
+}
+
+// The whole point of the mapping: a principal who is in the file can read, and
+// one who is not cannot.
+func TestOwnersDecideWhoCanRead(t *testing.T) {
+	root := ownersTree(t)
+	policy := policyFor(t, root)
+
+	perms, err := policy.Permissions(t.Context(), "net/design.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	erin := &acl.Principal{Tenant: "acme", Subject: "u1", Kind: acl.KindUser,
+		Identities: []acl.Identity{{Source: "github", Value: "erin"}}}
+	alice := &acl.Principal{Tenant: "acme", Subject: "u2", Kind: acl.KindUser,
+		Identities: []acl.Identity{{Source: "github", Value: "alice"}}}
+
+	if !perms.Allows(erin) {
+		t.Error("erin is an approver of net and cannot read it")
+	}
+	if perms.Allows(alice) {
+		t.Error("alice is only an approver of the root and can read a subtree that replaced her")
+	}
+	if perms.Allows(nil) {
+		t.Error("a nil principal was allowed")
+	}
+}
+
+// The policy is asked once per file in a large tree, so the same directory is
+// looked up thousands of times.
+func TestRepeatedLookupsAgree(t *testing.T) {
+	root := ownersTree(t)
+	policy := policyFor(t, root)
+
+	first, err := policy.Permissions(t.Context(), "net/deep/detail.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 100 {
+		got, err := policy.Permissions(t.Context(), "net/deep/detail.md")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got.AllowUsers) != len(first.AllowUsers) || got.Owner != first.Owner {
+			t.Fatalf("a repeated lookup gave a different answer: %+v then %+v", first, got)
+		}
+	}
+}
+
+func TestNewOwnersPolicyRejectsNothingUsable(t *testing.T) {
+	if _, err := fssource.NewOwnersPolicy(t.TempDir(), "repo", "github"); err != nil {
+		t.Errorf("a real directory was refused: %v", err)
+	}
+}

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -1,0 +1,355 @@
+// Package ingest runs connectors and puts what they produce into a store.
+//
+// It is the only place a document crosses from a source system into something a
+// query can reach, which makes it the right place for the rules that must hold
+// for every source: a tenant on everything, permissions that resolved or a
+// quarantine, batching so the store is not asked one document at a time, and a
+// checkpoint written only after the documents it covers are durably stored.
+//
+// # Backpressure
+//
+// There is no queue between the connector and the store. A connector hands over
+// a change by calling into this package, and that call does the batching and
+// the storing, so a source that produces faster than the store can absorb is
+// slowed by the handover itself. That is worth more than a buffered channel and
+// a tuning knob: a queue that can grow is a queue that will, and the failure
+// shows up as memory rather than as latency, which is much harder to read.
+//
+// # Ordering
+//
+// A batch is stored, and only then is the checkpoint for its last change saved.
+// A crash in between replays the batch, which is safe because a put of the same
+// document twice is the same as once. The other order would skip documents, and
+// nothing downstream would ever notice they were missing.
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// DefaultBatchSize is how many documents are held before a store write.
+//
+// It is a compromise. Larger batches amortise the write and are worth real
+// throughput, and they also widen the window a crash replays and raise the
+// memory a run holds. A few hundred is where those stop trading against each
+// other usefully for the drivers here.
+const DefaultBatchSize = 500
+
+// Pipeline moves documents from a connector into a store.
+//
+// The zero value is not usable. Use [New].
+type Pipeline struct {
+	store       store.Store
+	checkpoints connector.Checkpoints
+	batchSize   int
+	clock       func() time.Time
+	log         *slog.Logger
+}
+
+// Option configures a pipeline.
+type Option func(*Pipeline)
+
+// WithBatchSize sets how many documents are buffered before a store write. A
+// value below one selects [DefaultBatchSize].
+func WithBatchSize(n int) Option {
+	return func(p *Pipeline) {
+		if n > 0 {
+			p.batchSize = n
+		}
+	}
+}
+
+// WithLogger sets where the pipeline reports progress and quarantines.
+func WithLogger(l *slog.Logger) Option {
+	return func(p *Pipeline) {
+		if l != nil {
+			p.log = l
+		}
+	}
+}
+
+// WithClock replaces the source of the indexing timestamp, for tests that need
+// a run to be reproducible.
+func WithClock(now func() time.Time) Option {
+	return func(p *Pipeline) {
+		if now != nil {
+			p.clock = now
+		}
+	}
+}
+
+// New returns a pipeline writing into s and checkpointing into cp.
+//
+// A nil checkpoint store is allowed and means every run is a full sync. That is
+// the right default for a one shot import and the wrong one for anything that
+// runs on a schedule.
+func New(s store.Store, cp connector.Checkpoints, opts ...Option) (*Pipeline, error) {
+	if s == nil {
+		return nil, errors.New("ingest: nil store")
+	}
+	p := &Pipeline{
+		store:       s,
+		checkpoints: cp,
+		batchSize:   DefaultBatchSize,
+		clock:       time.Now,
+		log:         slog.New(discardHandler{}),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p, nil
+}
+
+// Stats is what one run did.
+type Stats struct {
+	// Indexed is the number of documents stored and reachable by a query.
+	Indexed int
+
+	// Quarantined is the number stored but held out of every query path
+	// because their permissions did not resolve. They are counted rather than
+	// dropped so that an operator can see a connector that is failing to
+	// resolve access control lists, which is otherwise silent.
+	Quarantined int
+
+	// Deleted is the number removed because the source no longer has them.
+	Deleted int
+
+	// Skipped is the number rejected before the store, because they carried no
+	// id and there is nothing to file them under.
+	Skipped int
+
+	// Batches is how many store writes the run made.
+	Batches int
+
+	// Bytes is the total size of the document bodies seen, which is the number
+	// a throughput figure should be quoted against. Document counts vary by
+	// three orders of magnitude between corpora and say much less.
+	Bytes int64
+
+	// Duration is the wall clock time of the run.
+	Duration time.Duration
+
+	// Cursor is where the run got to, and what a later run resumes from.
+	Cursor connector.Cursor
+}
+
+// Rate returns documents per second, or zero for a run too short to measure.
+func (s Stats) Rate() float64 {
+	if s.Duration <= 0 {
+		return 0
+	}
+	return float64(s.Indexed+s.Quarantined) / s.Duration.Seconds()
+}
+
+// Run syncs one connector into the store for one tenant.
+//
+// It resumes from the stored checkpoint unless there is none. The returned
+// stats describe the run whether or not it returned an error, so a caller that
+// was interrupted can still report how far it got.
+func (p *Pipeline) Run(ctx context.Context, tenant genba.TenantID, c connector.Connector) (Stats, error) {
+	if c == nil {
+		return Stats{}, errors.New("ingest: nil connector")
+	}
+	if tenant == "" {
+		// Every content path in this system is scoped by tenant. A document
+		// without one cannot be served, so accepting it here would only move
+		// the failure somewhere less obvious.
+		return Stats{}, errors.New("ingest: empty tenant")
+	}
+
+	source := c.Source()
+	start := p.clock()
+
+	from, err := p.loadCursor(ctx, string(tenant), source)
+	if err != nil {
+		return Stats{}, err
+	}
+
+	run := &run{pipeline: p, tenant: string(tenant), source: source}
+	run.stats.Cursor = from
+
+	final, syncErr := c.Sync(ctx, from, run.emit)
+
+	// Whatever happened, flush what is already in hand. A connector that failed
+	// halfway still produced real documents, and throwing them away only means
+	// fetching them again.
+	flushErr := run.flush(ctx)
+
+	run.stats.Duration = p.clock().Sub(start)
+
+	if syncErr != nil {
+		return run.stats, fmt.Errorf("ingest: sync %s: %w", source, syncErr)
+	}
+	if flushErr != nil {
+		return run.stats, flushErr
+	}
+
+	// The connector's own end of walk cursor wins over the last change's, since
+	// it can know the walk finished at a point no change happens to sit on.
+	if !final.IsZero() {
+		if err := p.saveCursor(ctx, string(tenant), source, final); err != nil {
+			return run.stats, err
+		}
+		run.stats.Cursor = final
+	}
+
+	p.log.Info("sync finished",
+		"source", source,
+		"tenant", string(tenant),
+		"indexed", run.stats.Indexed,
+		"quarantined", run.stats.Quarantined,
+		"deleted", run.stats.Deleted,
+		"duration", run.stats.Duration,
+	)
+	return run.stats, nil
+}
+
+func (p *Pipeline) loadCursor(ctx context.Context, tenant, source string) (connector.Cursor, error) {
+	if p.checkpoints == nil {
+		return connector.Cursor{}, nil
+	}
+	from, err := p.checkpoints.Load(ctx, tenant, source)
+	if err != nil {
+		return connector.Cursor{}, fmt.Errorf("ingest: load checkpoint for %s: %w", source, err)
+	}
+	return from, nil
+}
+
+func (p *Pipeline) saveCursor(ctx context.Context, tenant, source string, c connector.Cursor) error {
+	if p.checkpoints == nil || c.IsZero() {
+		return nil
+	}
+	if err := p.checkpoints.Save(ctx, tenant, source, c); err != nil {
+		return fmt.Errorf("ingest: save checkpoint for %s: %w", source, err)
+	}
+	return nil
+}
+
+// run is the mutable state of one sync. It is split out so that Run stays
+// readable and so that emit can be a method value rather than a closure over
+// half a dozen variables.
+type run struct {
+	pipeline *Pipeline
+	tenant   string
+	source   string
+
+	batch   []doc.Document
+	deletes []string
+	// pending is the resume point of the last change in the current batch. It
+	// is saved only once that batch is stored.
+	pending connector.Cursor
+	stats   Stats
+}
+
+// emit takes one change from a connector.
+func (r *run) emit(ctx context.Context, ch connector.Change) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	p := r.pipeline
+
+	d := ch.Document
+	// The tenant and the source are set here rather than trusted from the
+	// connector. A connector that gets either wrong writes into another
+	// tenant's corpus, and that is not a mistake worth leaving reachable.
+	d.Tenant = r.tenant
+	d.Source = r.source
+
+	if !ch.Cursor.IsZero() {
+		r.pending = ch.Cursor
+	}
+
+	if d.ID == "" {
+		r.stats.Skipped++
+		p.log.Warn("change has no id, skipped", "source", r.source)
+		return r.maybeFlush(ctx)
+	}
+
+	if ch.Deleted {
+		r.deletes = append(r.deletes, d.ID)
+		r.stats.Deleted++
+		return r.maybeFlush(ctx)
+	}
+
+	d.IndexedAt = p.clock()
+	r.stats.Bytes += int64(len(d.Body))
+
+	if d.Queryable() {
+		r.stats.Indexed++
+	} else {
+		// It is still stored. A quarantined document is one an operator has to
+		// be able to find and fix, and a document that was silently dropped is
+		// one nobody knows to look for. The store keeps it out of every query
+		// path because Queryable is false, which is the same gate every driver
+		// applies.
+		r.stats.Quarantined++
+		p.log.Warn("document quarantined, permissions did not resolve",
+			"source", r.source, "id", d.ID, "container", d.Container)
+	}
+
+	r.batch = append(r.batch, d)
+	return r.maybeFlush(ctx)
+}
+
+func (r *run) maybeFlush(ctx context.Context) error {
+	if len(r.batch)+len(r.deletes) < r.pipeline.batchSize {
+		return nil
+	}
+	return r.flush(ctx)
+}
+
+// flush writes the batch and then saves the checkpoint it covers.
+//
+// The order matters and is the reason this is one function rather than two
+// calls at the call site. Storing first and checkpointing second means a crash
+// between them replays documents, which is harmless. The other order loses
+// them, which is not.
+func (r *run) flush(ctx context.Context) error {
+	if len(r.batch) == 0 && len(r.deletes) == 0 {
+		return nil
+	}
+	p := r.pipeline
+
+	if len(r.batch) > 0 {
+		if err := p.store.Put(ctx, r.batch...); err != nil {
+			return fmt.Errorf("ingest: put %d documents from %s: %w", len(r.batch), r.source, err)
+		}
+	}
+	if len(r.deletes) > 0 {
+		if err := p.store.Delete(ctx, r.deletes...); err != nil {
+			return fmt.Errorf("ingest: delete %d documents from %s: %w", len(r.deletes), r.source, err)
+		}
+	}
+	r.stats.Batches++
+
+	// Reuse the backing arrays. A long sync flushes thousands of times and
+	// there is no reason for each one to allocate a new batch.
+	r.batch = r.batch[:0]
+	r.deletes = r.deletes[:0]
+
+	if err := p.saveCursor(ctx, r.tenant, r.source, r.pending); err != nil {
+		return err
+	}
+	if !r.pending.IsZero() {
+		r.stats.Cursor = r.pending
+	}
+	return nil
+}
+
+// discardHandler is a slog handler that drops everything, so that a pipeline
+// built without a logger costs nothing rather than writing to standard error.
+type discardHandler struct{}
+
+func (discardHandler) Enabled(context.Context, slog.Level) bool  { return false }
+func (discardHandler) Handle(context.Context, slog.Record) error { return nil }
+func (d discardHandler) WithAttrs([]slog.Attr) slog.Handler      { return d }
+func (d discardHandler) WithGroup(string) slog.Handler           { return d }

--- a/ingest/ingest_test.go
+++ b/ingest/ingest_test.go
@@ -1,0 +1,406 @@
+package ingest_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/ingest"
+	"github.com/tamnd/genba/store"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+const tenant = "acme"
+
+// fakeSource emits a fixed list of changes, and records where it was asked to
+// resume from so that a test can assert the resume actually happened.
+type fakeSource struct {
+	name      string
+	changes   []connector.Change
+	resumedAt connector.Cursor
+	emitted   int
+	final     connector.Cursor
+}
+
+func (f *fakeSource) Source() string { return f.name }
+func (f *fakeSource) Close() error   { return nil }
+
+func (f *fakeSource) Sync(ctx context.Context, from connector.Cursor, emit func(context.Context, connector.Change) error) (connector.Cursor, error) {
+	f.resumedAt = from
+	f.emitted = 0
+	for _, ch := range f.changes {
+		// A cursor is a resume point, so a resumed run must not re emit what
+		// the cursor already covers. A real connector does this by seeking.
+		if !from.IsZero() && ch.Cursor.Value <= from.Value {
+			continue
+		}
+		f.emitted++
+		if err := emit(ctx, ch); err != nil {
+			return connector.Cursor{}, err
+		}
+	}
+	return f.final, nil
+}
+
+// changes builds n documents that everybody in the tenant may read.
+func changes(n int) []connector.Change {
+	out := make([]connector.Change, 0, n)
+	for i := range n {
+		out = append(out, connector.Change{
+			Document: doc.Document{
+				ID:    fmt.Sprintf("doc-%04d", i),
+				Title: fmt.Sprintf("document number %d", i),
+				Body:  strings.Repeat("content ", 10),
+				Permissions: acl.Permissions{
+					Mode:   acl.ModePublicToTenant,
+					Source: "test",
+				},
+			},
+			// Cursors are zero padded so that the string comparison a resume
+			// does matches the numeric order they were produced in.
+			Cursor: connector.Cursor{Value: fmt.Sprintf("%04d", i)},
+		})
+	}
+	return out
+}
+
+func principal() *acl.Principal {
+	return &acl.Principal{Tenant: tenant, Subject: "reader", Kind: acl.KindUser}
+}
+
+func run(t *testing.T, p *ingest.Pipeline, src connector.Connector) ingest.Stats {
+	t.Helper()
+	st, err := p.Run(t.Context(), tenant, src)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return st
+}
+
+func TestDocumentsBecomeReadable(t *testing.T) {
+	st := memstore.New()
+	p, err := ingest.New(st, connector.NewMemoryCheckpoints())
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	stats := run(t, p, &fakeSource{name: "test", changes: changes(25)})
+
+	if stats.Indexed != 25 {
+		t.Errorf("indexed %d documents, want 25", stats.Indexed)
+	}
+	if stats.Quarantined != 0 {
+		t.Errorf("quarantined %d documents, want none", stats.Quarantined)
+	}
+
+	got, err := st.Get(t.Context(), principal(), "doc-0007")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != "document number 7" {
+		t.Errorf("title is %q", got.Title)
+	}
+	if got.Tenant != tenant {
+		t.Errorf("tenant is %q, want %q", got.Tenant, tenant)
+	}
+	if got.Source != "test" {
+		t.Errorf("source is %q, want the connector name", got.Source)
+	}
+	if got.IndexedAt.IsZero() {
+		t.Error("IndexedAt was not stamped")
+	}
+}
+
+// A connector that lies about its tenant must not be able to write into
+// somebody else's corpus.
+func TestTheTenantComesFromTheCallerNotTheConnector(t *testing.T) {
+	st := memstore.New()
+	p, _ := ingest.New(st, nil)
+
+	ch := changes(1)
+	ch[0].Document.Tenant = "someone-else"
+	run(t, p, &fakeSource{name: "test", changes: ch})
+
+	if _, err := st.Get(t.Context(), principal(), "doc-0000"); err != nil {
+		t.Fatalf("the document should belong to the caller's tenant: %v", err)
+	}
+	other := &acl.Principal{Tenant: "someone-else", Subject: "reader", Kind: acl.KindUser}
+	if _, err := st.Get(t.Context(), other, "doc-0000"); !errors.Is(err, genba.ErrNotFound) {
+		t.Errorf("the other tenant can see the document, error was %v", err)
+	}
+}
+
+func TestUnresolvedPermissionsAreQuarantinedNotIndexed(t *testing.T) {
+	st := memstore.New()
+	p, _ := ingest.New(st, nil)
+
+	ch := changes(10)
+	for i := range ch {
+		if i%2 == 0 {
+			ch[i].Document.Permissions = connector.Unresolved("test")
+		}
+	}
+	stats := run(t, p, &fakeSource{name: "test", changes: ch})
+
+	if stats.Indexed != 5 || stats.Quarantined != 5 {
+		t.Errorf("indexed %d and quarantined %d, want 5 and 5", stats.Indexed, stats.Quarantined)
+	}
+
+	// Counted by the store as quarantined, which is how an operator finds them.
+	got, err := st.Stats(t.Context())
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if got.Documents != 5 || got.Quarantined != 5 {
+		t.Errorf("store reports %+v, want 5 documents and 5 quarantined", got)
+	}
+
+	// And not readable by anybody, which is the part that matters.
+	if _, err := st.Get(t.Context(), principal(), "doc-0000"); !errors.Is(err, genba.ErrNotFound) {
+		t.Errorf("a quarantined document was served, error was %v", err)
+	}
+	seen := 0
+	err = st.Scan(t.Context(), principal(), func(doc.Document) bool { seen++; return true })
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if seen != 5 {
+		t.Errorf("scan yielded %d documents, want only the 5 that resolved", seen)
+	}
+}
+
+func TestDeletesRemoveDocuments(t *testing.T) {
+	st := memstore.New()
+	p, _ := ingest.New(st, nil)
+	run(t, p, &fakeSource{name: "test", changes: changes(5)})
+
+	gone := []connector.Change{{
+		Document: doc.Document{ID: "doc-0002"},
+		Deleted:  true,
+		Cursor:   connector.Cursor{Value: "9999"},
+	}}
+	stats := run(t, p, &fakeSource{name: "test", changes: gone})
+	if stats.Deleted != 1 {
+		t.Errorf("deleted %d, want 1", stats.Deleted)
+	}
+	if _, err := st.Get(t.Context(), principal(), "doc-0002"); !errors.Is(err, genba.ErrNotFound) {
+		t.Errorf("the deleted document is still readable, error was %v", err)
+	}
+	if _, err := st.Get(t.Context(), principal(), "doc-0003"); err != nil {
+		t.Errorf("a document that was not deleted went missing: %v", err)
+	}
+}
+
+func TestAChangeWithNoIdIsSkippedRatherThanStored(t *testing.T) {
+	st := memstore.New()
+	p, _ := ingest.New(st, nil)
+
+	ch := changes(3)
+	ch[1].Document.ID = ""
+	stats := run(t, p, &fakeSource{name: "test", changes: ch})
+
+	if stats.Skipped != 1 {
+		t.Errorf("skipped %d, want 1", stats.Skipped)
+	}
+	if stats.Indexed != 2 {
+		t.Errorf("indexed %d, want 2", stats.Indexed)
+	}
+}
+
+func TestAnEmptyTenantIsRefused(t *testing.T) {
+	p, _ := ingest.New(memstore.New(), nil)
+	if _, err := p.Run(t.Context(), "", &fakeSource{name: "test"}); err == nil {
+		t.Fatal("a run with no tenant was accepted")
+	}
+}
+
+func TestBatchingWritesFewerTimesThanThereAreDocuments(t *testing.T) {
+	counter := &countingStore{Store: memstore.New()}
+	p, _ := ingest.New(counter, nil, ingest.WithBatchSize(10))
+	stats := run(t, p, &fakeSource{name: "test", changes: changes(95)})
+
+	// 95 documents in batches of 10 is nine full batches plus the final flush.
+	if stats.Batches != 10 {
+		t.Errorf("made %d batches, want 10", stats.Batches)
+	}
+	if counter.puts != 10 {
+		t.Errorf("called Put %d times, want 10", counter.puts)
+	}
+}
+
+// This is the one that matters. A sync of a real corpus will be interrupted, so
+// the pipeline is killed after every possible number of store writes and the
+// corpus is checked for completeness after the resume.
+//
+// It also pins down the ordering rule. Documents are stored and only then is the
+// checkpoint saved, so a crash between the two replays a batch. Replaying is
+// harmless because a put of the same document twice is the same as once. The
+// opposite order would move the cursor past documents that were never stored,
+// and nothing downstream would ever discover they were missing.
+func TestKillingTheRunAtAnyPointLosesNothing(t *testing.T) {
+	const total = 137
+
+	for kill := range 20 {
+		t.Run(fmt.Sprintf("after_%d_writes", kill), func(t *testing.T) {
+			backing := memstore.New()
+			checkpoints := connector.NewMemoryCheckpoints()
+
+			// First run, killed after `kill` store writes.
+			dying := &countingStore{Store: backing, failAfter: kill}
+			p, _ := ingest.New(dying, checkpoints, ingest.WithBatchSize(7))
+			_, err := p.Run(t.Context(), tenant, &fakeSource{name: "test", changes: changes(total)})
+			if kill > 0 && err == nil {
+				t.Fatal("the store was supposed to fail and the run reported success")
+			}
+
+			// Second run against the same store and the same checkpoints, which
+			// is what a restarted process does.
+			healthy := &countingStore{Store: backing}
+			p2, _ := ingest.New(healthy, checkpoints, ingest.WithBatchSize(7))
+			src := &fakeSource{name: "test", changes: changes(total)}
+			if _, err := p2.Run(t.Context(), tenant, src); err != nil {
+				t.Fatalf("resume: %v", err)
+			}
+
+			// Every document is present exactly once, whatever happened.
+			seen := map[string]int{}
+			err = backing.Scan(t.Context(), principal(), func(d doc.Document) bool {
+				seen[d.ID]++
+				return true
+			})
+			if err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			if len(seen) != total {
+				t.Fatalf("corpus holds %d documents after the resume, want %d", len(seen), total)
+			}
+			for id, n := range seen {
+				if n != 1 {
+					t.Errorf("%s appears %d times", id, n)
+				}
+			}
+
+			// And the resume was a resume rather than a restart, once the first
+			// run got far enough to checkpoint anything.
+			if kill >= 2 && src.resumedAt.IsZero() {
+				t.Error("the second run started from the beginning instead of the checkpoint")
+			}
+			if kill >= 2 && src.emitted >= total {
+				t.Errorf("the second run re emitted all %d documents, so nothing was saved", total)
+			}
+		})
+	}
+}
+
+// The checkpoint must never be ahead of what is durably stored, because a
+// cursor past an unstored document is a document nobody will ever look for
+// again.
+func TestTheCheckpointIsNeverAheadOfTheStore(t *testing.T) {
+	backing := memstore.New()
+	checkpoints := connector.NewMemoryCheckpoints()
+	watcher := &checkpointWatcher{Checkpoints: checkpoints, store: backing, t: t}
+
+	p, _ := ingest.New(backing, watcher, ingest.WithBatchSize(9))
+	run(t, p, &fakeSource{name: "test", changes: changes(100)})
+
+	if watcher.saves == 0 {
+		t.Fatal("no checkpoint was ever saved")
+	}
+}
+
+func TestAConnectorCursorSurvivesToTheNextRun(t *testing.T) {
+	checkpoints := connector.NewMemoryCheckpoints()
+	p, _ := ingest.New(memstore.New(), checkpoints)
+
+	first := &fakeSource{name: "test", changes: changes(4), final: connector.Cursor{Value: "0003"}}
+	stats := run(t, p, first)
+	if stats.Cursor.Value != "0003" {
+		t.Errorf("run ended at cursor %q, want the connector's own end of walk cursor", stats.Cursor.Value)
+	}
+
+	second := &fakeSource{name: "test", changes: changes(4)}
+	run(t, p, second)
+	if second.resumedAt.Value != "0003" {
+		t.Errorf("second run resumed at %q, want 0003", second.resumedAt.Value)
+	}
+	if second.emitted != 0 {
+		t.Errorf("second run re emitted %d documents that the cursor already covered", second.emitted)
+	}
+}
+
+func TestRateIsZeroForARunTooShortToMeasure(t *testing.T) {
+	if got := (ingest.Stats{Indexed: 10}).Rate(); got != 0 {
+		t.Errorf("rate of a zero duration run is %v, want 0", got)
+	}
+	s := ingest.Stats{Indexed: 100, Quarantined: 100, Duration: 2 * time.Second}
+	if got := s.Rate(); got != 100 {
+		t.Errorf("rate is %v, want 100", got)
+	}
+}
+
+func TestANilStoreIsRefused(t *testing.T) {
+	if _, err := ingest.New(nil, nil); err == nil {
+		t.Fatal("a pipeline was built with no store")
+	}
+}
+
+// countingStore counts writes and can be told to start failing, which is how a
+// process being killed is simulated without killing the test process.
+type countingStore struct {
+	store.Store
+	puts      int
+	failAfter int
+	failing   bool
+}
+
+var errKilled = errors.New("store went away")
+
+func (c *countingStore) Put(ctx context.Context, docs ...doc.Document) error {
+	if c.failAfter > 0 && c.puts >= c.failAfter {
+		c.failing = true
+		return errKilled
+	}
+	c.puts++
+	return c.Store.Put(ctx, docs...)
+}
+
+func (c *countingStore) Delete(ctx context.Context, ids ...string) error {
+	if c.failing {
+		return errKilled
+	}
+	return c.Store.Delete(ctx, ids...)
+}
+
+// checkpointWatcher asserts, on every save, that everything the cursor claims
+// is covered is actually in the store.
+type checkpointWatcher struct {
+	connector.Checkpoints
+	store *memstore.Store
+	t     *testing.T
+	saves int
+}
+
+func (w *checkpointWatcher) Save(ctx context.Context, tenant, source string, c connector.Cursor) error {
+	w.t.Helper()
+	w.saves++
+
+	// The cursors in this test are the document ordinals, so everything up to
+	// and including the cursor must already be readable.
+	var want int
+	if _, err := fmt.Sscanf(c.Value, "%04d", &want); err == nil {
+		for i := 0; i <= want; i++ {
+			id := fmt.Sprintf("doc-%04d", i)
+			if _, err := w.store.Get(ctx, principal(), id); err != nil {
+				w.t.Errorf("checkpoint moved to %q but %s is not in the store yet", c.Value, id)
+			}
+		}
+	}
+	return w.Checkpoints.Save(ctx, tenant, source, c)
+}


### PR DESCRIPTION
Closes #10.

The pipeline that gets content into the index, and the contract a source has to meet before it is allowed to.

## The connector contract

`connector.Connector` is three methods.
`Source()` names the source, `Sync()` walks it from a cursor and calls `emit` once per change, `Close()` releases whatever it holds.
Everything specific to a source system stays behind that line, and what comes out is a `doc.Document` and a statement about who may read it.

A connector that cannot resolve permissions says so rather than guessing.
The document arrives with `acl.ModeUnknown`, `doc.Document.Queryable` is false for it, and the pipeline stores it out of every query path and counts it.
That count is the number an operator watches, because a connector quietly failing to resolve access control lists is otherwise invisible until somebody finds a document they should not have.

## Backpressure and ordering

There is no queue between a connector and the store.
`emit` does the batching and the storing on the calling goroutine, so a source that produces faster than the store can absorb is slowed by the handover itself.
A queue that can grow is a queue that will, and it turns a latency problem into a memory problem, which is much harder to read from the outside.

The pipeline stores a batch and only then saves the cursor for it.
A crash between the two replays documents, which is harmless because putting the same document twice is the same as putting it once.
The other order loses documents and nothing downstream ever notices they are missing.
`ingest` has a test that fails the store after every possible number of writes and checks that a resume finds everything.

## The reference connector

`connector/fssource` walks a directory tree.
It skips version control and dependency directories, reads text files up to a size limit, and asks a `Policy` who may read each file.

Permissions come from the policy rather than from the walk, because a directory tree says almost nothing about access on its own.
The mode bits describe the account the crawler runs as, not the people in the company.
`OwnersPolicy` reads the OWNERS files that Kubernetes and a number of other large repositories keep, taking the nearest one going up the tree.
That is a real access control list, maintained by real people, over a corpus anybody can check out and reproduce.
A source built with no policy quarantines everything, so having not thought about permissions yet is a visible state in the stats rather than an invisible one in the index.

## Trying it

```
genbad -tenant acme -corpus ~/src/some-repo -corpus-name repo
```

The first sync runs before the listener opens, so the server is useful the moment the log says it is up.
`-corpus-refresh` syncs again on an interval, incrementally, from the cursor the last run saved.

## Tests

`go test -race ./...` is green.
The interesting cases are the resume test described above, the quarantine cases in `fssource`, and the OWNERS parsing against the shapes those files actually take in the wild.
