### PR TITLE
feat: restyle the interface on a white ground with a bigger scale

### DIFF
--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -309,7 +309,7 @@ func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (
 		Title:        titleOf(rel, text, kind),
 		Body:         text,
 		URL:          "file://" + filepath.ToSlash(full),
-		Container:    path.Dir(rel),
+		Container:    containerOf(rel),
 		ModifiedAt:   info.ModTime(),
 		CreatedAt:    info.ModTime(),
 		SourceUpdate: info.ModTime().UTC().Format(time.RFC3339Nano),
@@ -372,6 +372,17 @@ func head(s string, n int) string {
 		return s
 	}
 	return s[:n]
+}
+
+// containerOf is the directory a file lives in, relative to the root of the
+// tree. A file at the root has no container rather than a container called
+// ".", because that dot travels all the way to the result row and to the
+// facet list, where it means nothing to anybody.
+func containerOf(rel string) string {
+	if dir := path.Dir(rel); dir != "." && dir != "/" {
+		return dir
+	}
+	return ""
 }
 
 // kindOf maps an extension onto a document kind. Anything unrecognised is a

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -1,9 +1,12 @@
 /*
  * Application styles.
  *
- * Only the semantic tokens from tokens.css appear here. The order is reset,
- * layout, then components, and every component is one contiguous block so that
- * a change to a result card is a change to one place in this file.
+ * Only the semantic tokens from tokens.css appear here. No literal colour, no
+ * literal font size, one border width, and exactly two shadows in the whole
+ * file. If a rule below wants a third, the answer is a hairline.
+ *
+ * The order is reset, frame, then components, and every component is one
+ * contiguous block so that a change to a result row is a change to one place.
  */
 
 /* Reset ------------------------------------------------------------------ */
@@ -24,8 +27,8 @@ body {
   background: var(--bg);
   color: var(--text);
   font-family: var(--font-sans);
-  font-size: var(--text-md);
-  line-height: var(--leading-normal);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -37,6 +40,8 @@ h4,
 p,
 figure {
   margin: 0;
+  font-size: inherit;
+  font-weight: inherit;
 }
 
 ul,
@@ -66,16 +71,39 @@ button {
   padding: 0;
 }
 
-/* One focus style for everything. It is a visible ring rather than an outline
-   removal, because keyboard navigation is a first class way to use this. */
+/* A number that sits above another number should line up with it. Tabular
+   figures are why a column of counts reads as a column rather than as a
+   ragged edge, and why a live counter does not jitter as it changes. */
+.rail__count,
+.tab__count,
+.facet__count,
+.results__count,
+.stat__value,
+.pager__meta,
+time {
+  font-variant-numeric: tabular-nums;
+}
+
+/*
+ * One focus style for everything.
+ *
+ * :focus-visible rather than :focus, so a mouse click does not leave a ring
+ * behind. An outline rather than a ring drawn with a shadow, so it follows the
+ * element's own shape and is never clipped by an ancestor that scrolls.
+ *
+ * The ring is never removed. If a component has a focus problem the fix is to
+ * make the ring fit, not to hide it.
+ */
 :focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
-  border-radius: var(--radius-xs);
+  border-radius: inherit;
 }
 
-:focus:not(:focus-visible) {
-  outline: none;
+[disabled],
+[aria-disabled="true"] {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .visually-hidden {
@@ -90,7 +118,7 @@ button {
   border: 0;
 }
 
-/* Layout ----------------------------------------------------------------- */
+/* Frame ------------------------------------------------------------------ */
 
 .app {
   display: grid;
@@ -107,29 +135,32 @@ button {
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
-  padding: var(--space-4);
-  background: var(--bg-raised);
+  padding: var(--space-4) var(--space-3);
+  background: var(--bg);
   border-right: 1px solid var(--border);
   overflow-y: auto;
 }
 
 .header {
   grid-area: header;
-  position: sticky;
-  top: 0;
-  z-index: var(--z-header);
   display: flex;
   align-items: center;
   gap: var(--space-4);
-  padding: 0 var(--space-6);
-  background: var(--bg-raised);
-  border-bottom: 1px solid var(--border);
+  padding: 0 var(--gutter);
+  background: var(--bg);
+  /* The hairline appears when there is something scrolled under it, so a page
+     at rest has one less line on it. The shell sets data-scrolled. */
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--dur-instant) var(--ease);
+}
+
+.header[data-scrolled="true"] {
+  border-bottom-color: var(--border);
 }
 
 .main {
   grid-area: main;
   overflow-y: auto;
-  scroll-behavior: smooth;
 }
 
 /* Rail ------------------------------------------------------------------- */
@@ -138,22 +169,30 @@ button {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-2);
-  font-size: var(--text-lg);
-  font-weight: var(--weight-semibold);
-  letter-spacing: -0.01em;
+  height: 40px;
+  padding: 0 var(--space-2);
+  font-size: var(--text-title);
+  font-weight: var(--weight-bold);
+  letter-spacing: var(--display-tracking);
 }
 
 .brand__mark {
   display: grid;
   place-items: center;
+  flex: none;
   width: 28px;
   height: 28px;
   border-radius: var(--radius-md);
-  background: linear-gradient(135deg, var(--brand-500), var(--ai-600));
-  color: #fff;
-  font-size: var(--text-base);
+  background: var(--accent);
+  color: var(--text-inverse);
+  font-size: var(--text-body);
   font-weight: var(--weight-bold);
+}
+
+/* The mark is the one place the accent is a fill, and it is a 28 pixel square
+   that is also the product's logo. Everything else obeys the rule. */
+[data-theme="dark"] .brand__mark {
+  color: var(--gray-0);
 }
 
 .rail__section {
@@ -163,24 +202,33 @@ button {
 }
 
 .rail__title {
-  padding: 0 var(--space-2);
-  margin-bottom: var(--space-1);
+  padding: 0 var(--space-3);
+  margin-bottom: var(--space-2);
   color: var(--text-muted);
-  font-size: var(--text-xs);
+  font-size: var(--text-caption);
   font-weight: var(--weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
 
+/*
+ * A rail item is 40 tall and has a three pixel left rule when it is current.
+ *
+ * The rule is a transparent border on every item rather than a border added to
+ * the current one, because a border that appears on selection moves the label
+ * three pixels and the whole rail twitches as you navigate.
+ */
 .rail__link {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-2) var(--space-2);
+  height: 40px;
+  padding: 0 var(--space-3);
+  border-left: 3px solid transparent;
   border-radius: var(--radius-md);
   color: var(--text-secondary);
-  font-size: var(--text-md);
-  transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+  font-size: var(--text-body);
+  transition: background-color var(--dur-instant) var(--ease);
 }
 
 .rail__link:hover {
@@ -188,17 +236,33 @@ button {
   color: var(--text);
 }
 
+.rail__link:active {
+  background: var(--bg-active);
+}
+
 .rail__link[aria-current="page"] {
-  background: var(--bg-brand-subtle);
-  color: var(--text-brand);
-  font-weight: var(--weight-medium);
+  border-left-color: var(--text-link);
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+  color: var(--text);
+  font-weight: var(--weight-semibold);
+}
+
+.rail__link[aria-current="page"] svg {
+  color: var(--text-link);
+}
+
+.rail__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .rail__count {
-  margin-left: auto;
   color: var(--text-muted);
-  font-size: var(--text-sm);
-  font-variant-numeric: tabular-nums;
+  font-size: var(--text-small);
 }
 
 .rail__foot {
@@ -206,11 +270,17 @@ button {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-2);
-  border-top: 1px solid var(--border);
-  padding-top: var(--space-4);
-  color: var(--text-muted);
-  font-size: var(--text-sm);
+  height: 48px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  text-align: left;
+}
+
+.rail__foot:hover {
+  background: var(--bg-hover);
+  color: var(--text);
 }
 
 .avatar {
@@ -220,9 +290,9 @@ button {
   width: 28px;
   height: 28px;
   border-radius: var(--radius-full);
-  background: var(--accent-subtle);
-  color: var(--text-brand);
-  font-size: var(--text-sm);
+  background: var(--bg-active);
+  color: var(--text);
+  font-size: var(--text-caption);
   font-weight: var(--weight-semibold);
 }
 
@@ -231,26 +301,32 @@ button {
 .omnibox {
   position: relative;
   flex: 1;
-  max-width: 720px;
+  max-width: 760px;
 }
 
 .omnibox__field {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  height: 40px;
-  padding: 0 var(--space-3);
-  background: var(--bg-sunken);
-  border: 1px solid transparent;
-  border-radius: var(--radius-lg);
-  transition: background var(--dur-fast) var(--ease),
-    border-color var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease);
+  height: 48px;
+  padding: 0 var(--space-5);
+  background: var(--bg);
+  border: 1px solid var(--border-control);
+  border-radius: var(--radius-full);
+  transition: border-color var(--dur-instant) var(--ease);
 }
 
-.omnibox__field:focus-within {
-  background: var(--bg-raised);
-  border-color: var(--border-brand);
-  box-shadow: 0 0 0 3px var(--accent-subtle);
+.omnibox__field:hover {
+  border-color: var(--text-muted);
+}
+
+/* The ring is drawn just inside the pill so it follows the shape rather than
+   boxing it, and the input's own ring is suppressed because the field is what
+   a person perceives as the control. */
+.omnibox__field:has(:focus-visible) {
+  border-color: var(--focus-ring);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
 }
 
 .omnibox__input {
@@ -259,7 +335,7 @@ button {
   background: none;
   border: none;
   outline: none;
-  font-size: var(--text-md);
+  font-size: var(--text-body);
 }
 
 .omnibox__input::placeholder {
@@ -267,6 +343,7 @@ button {
 }
 
 .omnibox__icon {
+  display: flex;
   flex: none;
   color: var(--text-muted);
 }
@@ -275,17 +352,21 @@ button {
   display: inline-flex;
   align-items: center;
   gap: 2px;
+  flex: none;
   padding: 2px var(--space-2);
-  background: var(--bg-raised);
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-1);
   color: var(--text-muted);
   font-family: var(--font-sans);
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
+  font-size: var(--text-caption);
 }
 
+/*
+ * The suggestion popover. One of exactly two things in this stylesheet that
+ * casts a shadow, because it floats over content that is still visible behind
+ * it and a hairline alone would not separate it.
+ */
 .suggestions {
   position: absolute;
   top: calc(100% + var(--space-2));
@@ -293,24 +374,34 @@ button {
   right: 0;
   z-index: var(--z-popover);
   padding: var(--space-2);
-  background: var(--bg-raised);
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-4);
+  box-shadow: var(--shadow-popover);
   max-height: 60vh;
   overflow-y: auto;
+  animation: rise var(--dur-fast) var(--ease-out);
 }
 
 .suggestions[hidden] {
   display: none;
 }
 
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+
 .suggestion {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-2) var(--space-3);
+  height: 44px;
+  padding: 0 var(--space-4);
   border-radius: var(--radius-md);
+  font-size: var(--text-body);
   cursor: pointer;
 }
 
@@ -329,17 +420,17 @@ button {
 .suggestion__hint {
   flex: none;
   color: var(--text-muted);
-  font-size: var(--text-sm);
+  font-size: var(--text-small);
 }
 
 .suggestion__badge {
   flex: none;
-  padding: 1px var(--space-2);
+  padding: 2px var(--space-2);
+  border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  background: var(--bg-sunken);
   color: var(--text-muted);
-  font-size: var(--text-xs);
   font-family: var(--font-mono);
+  font-size: var(--text-caption);
 }
 
 /* Header actions --------------------------------------------------------- */
@@ -347,18 +438,23 @@ button {
 .header__actions {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-1);
   margin-left: auto;
 }
 
+/*
+ * Forty by forty, always. The icon inside stays at 20 and the rest is
+ * transparent padding, so the target grows and the visual weight does not.
+ */
 .icon-button {
   display: grid;
   place-items: center;
-  width: 34px;
-  height: 34px;
-  border-radius: var(--radius-md);
-  color: var(--text-secondary);
-  transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+  flex: none;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-full);
+  color: var(--text-muted);
+  transition: background-color var(--dur-instant) var(--ease);
 }
 
 .icon-button:hover {
@@ -366,14 +462,39 @@ button {
   color: var(--text);
 }
 
-/* Tabs ------------------------------------------------------------------- */
+.icon-button:active {
+  background: var(--bg-active);
+}
+
+/* Filter bar ------------------------------------------------------------- */
+
+/*
+ * The row under the header carrying the verticals. It is sticky inside the
+ * results scroller rather than inside the page, because the header is a grid
+ * row and does not scroll at all.
+ */
+.filterbar {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-header);
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-1);
+  min-height: var(--filterbar-height);
+  padding: 0 var(--gutter);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.filterbar::-webkit-scrollbar {
+  display: none;
+}
 
 .tabs {
   display: flex;
   gap: var(--space-1);
-  padding: 0 var(--space-6);
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-raised);
 }
 
 .tab {
@@ -381,11 +502,11 @@ button {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-3) var(--space-3);
+  height: var(--filterbar-height);
+  padding: 0 var(--space-3);
   color: var(--text-secondary);
-  font-size: var(--text-md);
+  font-size: var(--text-body);
   white-space: nowrap;
-  transition: color var(--dur-fast) var(--ease);
 }
 
 .tab:hover {
@@ -393,8 +514,8 @@ button {
 }
 
 .tab[aria-selected="true"] {
-  color: var(--text-brand);
-  font-weight: var(--weight-medium);
+  color: var(--text);
+  font-weight: var(--weight-semibold);
 }
 
 .tab[aria-selected="true"]::after {
@@ -404,197 +525,270 @@ button {
   right: var(--space-2);
   bottom: -1px;
   height: 2px;
-  border-radius: var(--radius-full) var(--radius-full) 0 0;
-  background: var(--accent);
+  background: var(--border-strong);
 }
 
 .tab__count {
-  padding: 0 var(--space-2);
-  border-radius: var(--radius-full);
-  background: var(--bg-sunken);
   color: var(--text-muted);
-  font-size: var(--text-xs);
-  font-variant-numeric: tabular-nums;
+  font-size: var(--text-small);
+  font-weight: var(--weight-normal);
 }
 
-/* Filter bar ------------------------------------------------------------- */
+.filterbar__toggle {
+  display: none;
+}
 
-.filterbar {
+/* Chips ------------------------------------------------------------------ */
+
+/*
+ * Active filters. A chip is never filled, in any state. Selection is carried
+ * by border weight and text weight, which is enough on a row of five and does
+ * not turn the bar into a stripe of accent colour.
+ */
+.chips {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
-  min-height: var(--filterbar-height);
-  padding: var(--space-2) var(--space-6);
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-raised);
   flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--gutter) 0;
+}
+
+.chips:empty {
+  display: none;
 }
 
 .chip {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  height: 28px;
-  padding: 0 var(--space-3);
-  border: 1px solid var(--border);
+  height: 40px;
+  padding: 0 var(--space-4);
+  border: 1px solid var(--border-control);
   border-radius: var(--radius-full);
-  background: var(--bg-raised);
+  background: none;
   color: var(--text-secondary);
-  font-size: var(--text-base);
+  font-size: var(--text-body);
   white-space: nowrap;
-  transition: background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease);
+  transition: background-color var(--dur-instant) var(--ease);
 }
 
 .chip:hover {
   background: var(--bg-hover);
-  border-color: var(--border-strong);
+  color: var(--text);
 }
 
 .chip--on {
-  background: var(--bg-brand-subtle);
-  border-color: var(--border-brand);
-  color: var(--text-brand);
-  font-weight: var(--weight-medium);
+  border-color: var(--border-strong);
+  color: var(--text);
+  font-weight: var(--weight-semibold);
 }
 
 .chip__remove {
   display: grid;
   place-items: center;
-  width: 16px;
-  height: 16px;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  margin-right: calc(var(--space-2) * -1);
   border-radius: var(--radius-full);
-  color: inherit;
-  opacity: 0.7;
+  color: var(--text-muted);
 }
 
 .chip__remove:hover {
-  background: rgb(0 0 0 / 0.08);
-  opacity: 1;
-}
-
-.filterbar__spacer {
-  flex: 1;
-}
-
-.filterbar__meta {
-  color: var(--text-muted);
-  font-size: var(--text-base);
-  font-variant-numeric: tabular-nums;
-}
-
-.select {
-  height: 28px;
-  padding: 0 var(--space-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--bg-raised);
-  font-size: var(--text-base);
-  color: var(--text-secondary);
+  background: var(--bg-active);
+  color: var(--text);
 }
 
 /* Results ---------------------------------------------------------------- */
 
 .results {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) var(--facets-width);
-  gap: var(--space-8);
+  grid-template-columns: var(--facets-width) minmax(0, 1fr);
+  gap: var(--space-12);
   align-items: start;
-  padding: var(--space-6);
+  max-width: var(--page-max);
+  margin: 0 auto;
+  padding: var(--space-6) var(--gutter) var(--space-24);
 }
 
-.results__list {
+/*
+ * Both columns are placed explicitly. A query that returns nothing has no
+ * facets to draw, and an auto placed results column would slide into the
+ * margin column on exactly those pages, which reads as a broken layout at the
+ * moment somebody is already frustrated.
+ */
+.results__main {
+  grid-column: 2;
+  min-width: 0;
+}
+
+/* The count and the sort control. Its own row rather than part of the filter
+   bar, because it describes the answer rather than the question. */
+.results__head {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  max-width: var(--content-max);
+  align-items: baseline;
+  gap: var(--space-4);
+  min-height: 28px;
+  margin-bottom: var(--space-4);
+  padding: 0 var(--space-4);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
 }
 
-.card {
+/*
+ * The count is the anchor of the page, so it carries weight rather than
+ * hiding at caption size next to the timing. The timing is the opposite: it
+ * is for us, not for the person reading, so it sits back a step.
+ */
+.results__count {
+  flex: 1;
+  min-width: 0;
+  color: var(--text);
+  font-size: var(--text-title);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-title);
+}
+
+.results__took {
+  margin-left: var(--space-2);
+  color: var(--text-muted);
+  font-size: var(--text-small);
+  font-weight: var(--weight-normal);
+}
+
+.sort {
+  height: 32px;
+  padding: 0 var(--space-2);
+  border: none;
+  background: none;
+  color: var(--text);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+}
+
+/*
+ * The result row.
+ *
+ * No card, no radius, no shadow, no fill. A one pixel rule between rows and
+ * sixteen pixels of air either side of it, which is the whole component. The
+ * affordance that a card used to carry is carried by the hover fill, the
+ * pointer cursor and the title turning into a link colour under the pointer,
+ * and all three of those have to be checked with a pointer rather than in a
+ * screenshot.
+ */
+.result {
   position: relative;
   display: block;
-  padding: var(--space-4);
-  border: 1px solid transparent;
-  border-radius: var(--radius-lg);
-  background: var(--bg-raised);
-  box-shadow: var(--shadow-1);
-  transition: box-shadow var(--dur-fast) var(--ease),
-    border-color var(--dur-fast) var(--ease), transform var(--dur-fast) var(--ease);
+  padding: var(--row-padding-block) var(--space-4);
+  border-bottom: 1px solid var(--border);
+  border-left: 3px solid transparent;
+  background: none;
+  cursor: pointer;
+  /* Keyboard navigation with j and k must never park the selected row under
+     the sticky filter bar. The header is outside this scroller, so the offset
+     is the bar plus a little air rather than both. */
+  scroll-margin-top: calc(var(--filterbar-height) + var(--space-2));
+  transition: background-color var(--dur-instant) var(--ease);
 }
 
-.card:hover {
-  border-color: var(--border);
-  box-shadow: var(--shadow-3);
+.result:last-of-type {
+  border-bottom: none;
 }
 
-.card[data-active="true"] {
-  border-color: var(--border-brand);
-  box-shadow: 0 0 0 3px var(--accent-subtle);
+.result:hover {
+  background: var(--bg-hover);
 }
 
-.card__head {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  margin-bottom: var(--space-1);
-  color: var(--text-muted);
-  font-size: var(--text-sm);
+/* The keyboard cursor and the pointer can both be on the same row at once, so
+   they share the fill and are told apart by the left rule. */
+.result[data-active="true"] {
+  background: var(--bg-hover);
+  border-left-color: var(--focus-ring);
 }
 
-.card__title {
-  display: block;
-  margin-bottom: var(--space-1);
-  color: var(--text-link);
-  font-size: var(--text-lg);
-  font-weight: var(--weight-semibold);
-  line-height: var(--leading-tight);
-  letter-spacing: -0.005em;
-}
-
-.card__title:hover {
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.card__snippet {
-  color: var(--text-secondary);
-  font-size: var(--text-md);
-  line-height: var(--leading-relaxed);
+.result__title {
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  margin-bottom: var(--space-1);
+  padding: 0;
+  color: var(--text);
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-body);
+  text-align: left;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
-.card__snippet mark {
-  padding: 0 1px;
-  border-radius: 2px;
-  background: var(--mark-bg);
-  color: var(--mark-text);
-  font-weight: var(--weight-medium);
+.result:hover .result__title,
+.result__title:hover {
+  color: var(--text-link);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
-.card__foot {
+.result__meta {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
-  margin-top: var(--space-3);
-  color: var(--text-muted);
-  font-size: var(--text-sm);
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
 }
 
-.card__actions {
+.result__snippet {
+  display: -webkit-box;
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/*
+ * A matched term is set in semibold with a rule drawn behind it near the
+ * baseline, rather than filled.
+ *
+ * On a page of eight results with three terms each, a filled highlight turns
+ * the page into a rash. A rule marks exactly the same words and leaves the
+ * page calm. inset-inline rather than left and width so it is correct under
+ * right to left without a second rule, and bottom: 2px so it clears the
+ * descender on a g or a y.
+ */
+mark {
+  position: relative;
+  z-index: 1;
+  background: none;
+  color: inherit;
+  font-weight: var(--weight-semibold);
+}
+
+mark::after {
+  content: "";
   position: absolute;
-  top: var(--space-3);
-  right: var(--space-3);
+  inset-inline: 0;
+  bottom: 2px;
+  z-index: -1;
+  height: 2px;
+  background: var(--mark);
+}
+
+.result__actions {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
   display: flex;
   gap: var(--space-1);
   opacity: 0;
-  transition: opacity var(--dur-fast) var(--ease);
 }
 
-.card:hover .card__actions,
-.card:focus-within .card__actions,
-.card[data-active="true"] .card__actions {
+.result:hover .result__actions,
+.result:focus-within .result__actions,
+.result[data-active="true"] .result__actions {
   opacity: 1;
 }
 
@@ -602,11 +796,10 @@ button {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  font-weight: var(--weight-medium);
-  color: var(--text-secondary);
 }
 
 .source__dot {
+  flex: none;
   width: 8px;
   height: 8px;
   border-radius: var(--radius-full);
@@ -614,7 +807,7 @@ button {
 }
 
 .crumbs {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
@@ -624,23 +817,55 @@ button {
 }
 
 .crumbs__sep {
-  color: var(--border-strong);
+  color: var(--text-muted);
+}
+
+/* Pager ------------------------------------------------------------------ */
+
+.pager {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-top: var(--space-12);
+  padding: 0 var(--space-4);
+}
+
+.pager__meta {
+  color: var(--text-secondary);
+  font-size: var(--text-small);
 }
 
 /* Facets ----------------------------------------------------------------- */
 
+/*
+ * The margin column. No panel, no border, no fill. Alignment and the overline
+ * labels carry the structure, which is what the panel was doing badly.
+ */
 .facets {
+  grid-column: 1;
   position: sticky;
-  top: var(--space-6);
+  top: calc(var(--filterbar-height) + var(--space-6));
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: var(--space-8);
+  max-height: calc(100vh - var(--header-height) - var(--filterbar-height) - var(--space-12));
+  overflow-y: auto;
+}
+
+.facets:empty {
+  display: none;
+}
+
+.facets__title {
+  font-size: var(--text-title);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-title);
 }
 
 .facet__title {
   margin-bottom: var(--space-2);
   color: var(--text-muted);
-  font-size: var(--text-xs);
+  font-size: var(--text-caption);
   font-weight: var(--weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -649,42 +874,40 @@ button {
 .facet__item {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-3);
   width: 100%;
-  padding: var(--space-1) var(--space-2);
+  height: 40px;
+  padding: 0 var(--space-2);
   border-radius: var(--radius-sm);
-  color: var(--text-secondary);
-  font-size: var(--text-base);
+  color: var(--text);
+  font-size: var(--text-body);
   text-align: left;
+  transition: background-color var(--dur-instant) var(--ease);
 }
 
 .facet__item:hover {
   background: var(--bg-hover);
-  color: var(--text);
 }
 
-.facet__item[aria-pressed="true"] {
-  color: var(--text-brand);
-  font-weight: var(--weight-medium);
+.facet__item[aria-pressed="true"] .facet__label {
+  font-weight: var(--weight-semibold);
 }
 
 .facet__box {
   display: grid;
   place-items: center;
   flex: none;
-  width: 14px;
-  height: 14px;
-  border: 1px solid var(--border-strong);
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--border-control);
   border-radius: var(--radius-xs);
-  background: var(--bg-raised);
-  font-size: 10px;
   color: transparent;
 }
 
 .facet__item[aria-pressed="true"] .facet__box {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
+  background: var(--border-strong);
+  border-color: var(--border-strong);
+  color: var(--text-inverse);
 }
 
 .facet__label {
@@ -696,85 +919,98 @@ button {
 }
 
 .facet__count {
+  flex: none;
   color: var(--text-muted);
-  font-size: var(--text-sm);
-  font-variant-numeric: tabular-nums;
+  font-size: var(--text-small);
 }
 
 .facet__more {
-  padding: var(--space-1) var(--space-2);
+  height: 40px;
+  padding: 0 var(--space-2);
   color: var(--text-link);
-  font-size: var(--text-base);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+  text-align: left;
+}
+
+.facet__more:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* Home ------------------------------------------------------------------- */
 
 .home {
-  max-width: 1080px;
+  max-width: var(--page-max);
   margin: 0 auto;
-  padding: var(--space-12) var(--space-6) var(--space-16);
+  padding: var(--space-16) var(--gutter) var(--space-24);
 }
 
 .home__greeting {
-  margin-bottom: var(--space-8);
+  margin-bottom: var(--space-12);
 }
 
 .home__title {
-  font-size: var(--text-3xl);
+  font-size: var(--text-display);
   font-weight: var(--weight-bold);
-  letter-spacing: -0.02em;
-  line-height: var(--leading-tight);
+  line-height: var(--leading-display);
+  letter-spacing: var(--display-tracking);
 }
 
 .home__subtitle {
+  max-width: var(--measure);
   margin-top: var(--space-2);
   color: var(--text-secondary);
-  font-size: var(--text-lg);
+  font-size: var(--text-lead);
+  line-height: var(--leading-lead);
 }
 
 .home__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: var(--space-4);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: var(--space-12) var(--space-16);
 }
 
-.panel {
-  padding: var(--space-5);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  background: var(--bg-raised);
-  box-shadow: var(--shadow-1);
-}
-
+/* A panel is a heading and some rows. It is not a container: no border, no
+   fill, no shadow, no radius. */
 .panel__head {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: var(--space-3);
   margin-bottom: var(--space-4);
 }
 
 .panel__title {
-  font-size: var(--text-md);
-  font-weight: var(--weight-semibold);
+  font-size: var(--text-heading);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-heading);
+  letter-spacing: var(--display-tracking);
 }
 
 .panel__link {
   margin-left: auto;
   color: var(--text-link);
-  font-size: var(--text-base);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+}
+
+.panel__link:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .panel__row {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-2) 0;
-  border-top: 1px solid var(--border);
-  font-size: var(--text-md);
-}
-
-.panel__row:first-of-type {
-  border-top: none;
+  width: 100%;
+  min-height: 56px;
+  padding: var(--space-2) var(--space-3);
+  margin-inline: calc(var(--space-3) * -1);
+  border-radius: var(--radius-md);
+  font-size: var(--text-body);
+  text-align: left;
+  transition: background-color var(--dur-instant) var(--ease);
 }
 
 .panel__row-title {
@@ -783,53 +1019,69 @@ button {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--text-primary);
-}
-
-/* A row that is a link says so on hover rather than by being blue while it sits
-   there. A panel of ten blue lines is harder to read than a panel of ten black
-   ones, and every row in these panels is clickable anyway. */
-.panel__row:hover .panel__row-title,
-.panel__row:focus-visible .panel__row-title {
-  color: var(--text-link);
+  font-weight: var(--weight-semibold);
 }
 
 .panel__row-meta {
   flex: none;
-  color: var(--text-muted);
-  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+}
+
+/*
+ * A row that is a link says so on hover rather than by being blue while it
+ * sits there. The tip rows on the home page are not links, so they carry
+ * .panel__row--static and their titles stay in the text colour in every
+ * state, which is a bug this file has already fixed once.
+ */
+button.panel__row:hover,
+a.panel__row:hover {
+  background: var(--bg-hover);
+}
+
+button.panel__row:hover .panel__row-title,
+a.panel__row:hover .panel__row-title {
+  color: var(--text-link);
+}
+
+.panel__row--static:hover .panel__row-title {
+  color: var(--text);
 }
 
 .stat {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+  padding: var(--space-2) 0;
 }
 
 .stat__value {
-  font-size: var(--text-2xl);
+  font-size: var(--text-display);
   font-weight: var(--weight-bold);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.01em;
+  line-height: var(--leading-display);
+  letter-spacing: var(--display-tracking);
 }
 
 .stat__label {
-  color: var(--text-muted);
-  font-size: var(--text-sm);
+  max-width: var(--measure);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
 }
 
 /* Drawer ----------------------------------------------------------------- */
 
+/* The other place a shadow is allowed, for the same reason. */
 .drawer {
   position: fixed;
   inset: 0 0 0 auto;
   z-index: var(--z-drawer);
-  width: min(560px, 100vw);
+  width: min(480px, 100vw);
   display: flex;
   flex-direction: column;
-  background: var(--bg-raised);
+  background: var(--bg);
   border-left: 1px solid var(--border);
-  box-shadow: var(--shadow-4);
+  box-shadow: var(--shadow-drawer);
   animation: slide-in var(--dur-base) var(--ease-out);
 }
 
@@ -848,8 +1100,7 @@ button {
   display: flex;
   align-items: flex-start;
   gap: var(--space-3);
-  padding: var(--space-5);
-  border-bottom: 1px solid var(--border);
+  padding: var(--space-6);
 }
 
 .drawer__heading {
@@ -857,20 +1108,30 @@ button {
   min-width: 0;
 }
 
+.drawer__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+}
+
 .drawer__title {
-  flex: 1;
-  font-size: var(--text-xl);
-  font-weight: var(--weight-semibold);
-  line-height: var(--leading-tight);
-  letter-spacing: -0.01em;
+  font-size: var(--text-heading);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-heading);
+  letter-spacing: var(--display-tracking);
 }
 
 .drawer__body {
   flex: 1;
+  max-width: var(--measure);
   overflow-y: auto;
-  padding: var(--space-5);
-  font-size: var(--text-md);
-  line-height: var(--leading-relaxed);
+  padding: 0 var(--space-6) var(--space-6);
+  font-size: var(--text-body);
+  line-height: var(--leading-prose);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
@@ -878,8 +1139,8 @@ button {
 .drawer__foot {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
-  padding: var(--space-4) var(--space-5);
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6);
   border-top: 1px solid var(--border);
 }
 
@@ -903,35 +1164,59 @@ button {
 
 /* Buttons ---------------------------------------------------------------- */
 
+/*
+ * The primary fill is near black rather than the accent. A page with one
+ * accent button and one accent focus ring has two things competing to be the
+ * accent. A page with a black button and an indigo ring has a clear button and
+ * an unmistakable focus state.
+ *
+ * No button has a shadow in any state and no button moves on hover, because a
+ * button that moves under the pointer is a button that is harder to hit.
+ */
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--space-2);
-  height: 32px;
-  padding: 0 var(--space-4);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--bg-raised);
+  height: 40px;
+  padding: 0 var(--space-5);
+  border: 1px solid var(--border-control);
+  border-radius: var(--radius-full);
+  background: none;
   color: var(--text);
-  font-size: var(--text-md);
-  font-weight: var(--weight-medium);
-  transition: background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease);
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
+  white-space: nowrap;
+  transition: background-color var(--dur-instant) var(--ease);
 }
 
 .button:hover {
   background: var(--bg-hover);
 }
 
-.button--primary {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
+.button:active {
+  background: var(--bg-active);
 }
 
-.button--primary:hover {
-  background: var(--accent-hover);
-  border-color: var(--accent-hover);
+.button--primary {
+  background: var(--bg-inverse);
+  border-color: var(--bg-inverse);
+  color: var(--text-inverse);
+}
+
+.button--primary:hover,
+.button--primary:active {
+  background: var(--bg-inverse-hover);
+  border-color: var(--bg-inverse-hover);
+}
+
+.button--ghost {
+  border-color: transparent;
+  color: var(--text-secondary);
+}
+
+.button--ghost:hover {
+  color: var(--text);
 }
 
 /* States ----------------------------------------------------------------- */
@@ -945,14 +1230,23 @@ button {
   text-align: center;
 }
 
+.state__icon {
+  color: var(--text-muted);
+}
+
 .state__title {
-  font-size: var(--text-xl);
+  font-size: var(--text-title);
   font-weight: var(--weight-semibold);
+  line-height: var(--leading-title);
 }
 
 .state__body {
   max-width: 46ch;
   color: var(--text-secondary);
+}
+
+.state--error .state__body {
+  color: var(--text);
 }
 
 .state__actions {
@@ -961,35 +1255,75 @@ button {
   margin-top: var(--space-2);
 }
 
-.state--error .state__title {
-  color: var(--danger-700);
+/* A line of secondary information that is not part of a named component. */
+.meta {
+  color: var(--text-secondary);
+  font-size: var(--text-small);
 }
 
 .banner {
   display: flex;
   align-items: center;
   gap: var(--space-3);
+  margin-bottom: var(--space-4);
   padding: var(--space-3) var(--space-4);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  background: var(--warning-50);
-  color: var(--warning-700);
-  font-size: var(--text-base);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
 }
 
-/* Skeletons. The layout is reserved before the data arrives, so nothing moves
-   when it does. That is the whole point: a list that reflows on load costs a
-   click on the wrong thing. */
+/*
+ * The revalidation bar. Two pixels under the filter bar, and it only appears
+ * once a revalidation has been running for 120ms, which on a warm server is
+ * almost never. Stale content underneath it is not dimmed: it is the previous
+ * answer and it is almost always still the right one.
+ */
+.progress {
+  position: sticky;
+  top: var(--filterbar-height);
+  z-index: var(--z-header);
+  height: 2px;
+  overflow: hidden;
+}
+
+.progress[hidden] {
+  display: none;
+}
+
+.progress::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 40%;
+  background: var(--accent);
+  animation: sweep 1.1s var(--ease) infinite;
+}
+
+@keyframes sweep {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(350%);
+  }
+}
+
+/* Skeletons -------------------------------------------------------------- */
+
+/* The layout is reserved before the data arrives, so nothing moves when it
+   does. A skeleton that does not match the shape it replaces causes a visible
+   reflow on load, which is worse than a spinner. */
 .skeleton {
   border-radius: var(--radius-sm);
   background: linear-gradient(
     90deg,
-    var(--bg-sunken) 25%,
-    var(--bg-hover) 37%,
-    var(--bg-sunken) 63%
+    var(--bg-subtle) 25%,
+    var(--bg-active) 37%,
+    var(--bg-subtle) 63%
   );
   background-size: 400% 100%;
-  animation: shimmer 1.4s ease infinite;
+  animation: shimmer 1.4s linear infinite;
 }
 
 @keyframes shimmer {
@@ -1001,14 +1335,12 @@ button {
   }
 }
 
-.skeleton-card {
+.skeleton-result {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  padding: var(--space-4);
-  border-radius: var(--radius-lg);
-  background: var(--bg-raised);
-  box-shadow: var(--shadow-1);
+  padding: var(--row-padding-block) var(--space-4);
+  border-bottom: 1px solid var(--border);
 }
 
 /* Shortcuts dialog ------------------------------------------------------- */
@@ -1027,27 +1359,30 @@ button {
   display: none;
 }
 
+/* The scrim already separates this from the page, so it takes a hairline
+   rather than the third shadow this stylesheet does not have. */
 .dialog__panel {
   width: min(520px, 100%);
   padding: var(--space-6);
+  border: 1px solid var(--border);
   border-radius: var(--radius-xl);
-  background: var(--bg-raised);
-  box-shadow: var(--shadow-4);
+  background: var(--bg);
 }
 
 .dialog__title {
   margin-bottom: var(--space-4);
-  font-size: var(--text-xl);
+  font-size: var(--text-title);
   font-weight: var(--weight-semibold);
+  line-height: var(--leading-title);
 }
 
 .shortcut {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-2) 0;
+  min-height: 40px;
   border-top: 1px solid var(--border);
-  font-size: var(--text-md);
+  font-size: var(--text-body);
 }
 
 .shortcut:first-of-type {
@@ -1062,22 +1397,122 @@ button {
 
 /* Responsive ------------------------------------------------------------- */
 
-@media (max-width: 1200px) {
+/*
+ * Four steps, named for what changes.
+ *
+ *   above 1600  content centres in --page-max, gutters take the rest
+ *   below 1280  the rail collapses to icons
+ *   below  960  the facets fold into a disclosure above the results
+ *   below  640  the rail goes off canvas behind the menu button
+ */
+
+@media (max-width: 1280px) {
+  :root {
+    --rail-width: 64px;
+  }
+
+  .rail {
+    align-items: center;
+    padding-inline: var(--space-2);
+  }
+
+  .rail__label,
+  .rail__title,
+  .rail__count,
+  .brand span:not(.brand__mark),
+  .rail__foot span:not(.avatar) {
+    display: none;
+  }
+
+  .rail__link,
+  .brand,
+  .rail__foot {
+    justify-content: center;
+    width: 44px;
+    padding: 0;
+  }
+
+  .rail__link {
+    border-left-width: 0;
+    border-bottom: 3px solid transparent;
+  }
+
+  /* A source row collapses to its colour dot, which on its own says nothing.
+     The same filter is one click away in the facet column, so the section
+     leaves rather than turning the rail into a column of dots. */
+  #rail-sources {
+    display: none;
+  }
+
+  .rail__link[aria-current="page"] {
+    border-bottom-color: var(--text-link);
+  }
+}
+
+@media (max-width: 960px) {
   .results {
     grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-6);
+  }
+
+  /* One column, so the explicit placement from the wide layout goes away. */
+  .facets,
+  .results__main {
+    grid-column: 1;
+  }
+
+  /*
+   * The tab strip is the part that scrolls, not the whole bar. When the bar
+   * scrolled, the Filters button rode off the right edge on a narrow screen,
+   * which is the one screen where the facet column is not on the page.
+   */
+  .filterbar {
+    overflow-x: visible;
+  }
+
+  .tabs {
+    flex: 1;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .filterbar__toggle {
+    display: inline-flex;
+    flex: none;
+    margin-left: auto;
+    align-self: center;
   }
 
   .facets {
     position: static;
+    max-height: none;
+    overflow: visible;
+    display: none;
+  }
+
+  .facets[data-open="true"] {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: var(--space-5);
-    padding-top: var(--space-5);
-    border-top: 1px solid var(--border);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--space-8);
+    padding-bottom: var(--space-6);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .facets__title {
+    grid-column: 1 / -1;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width: 640px) {
+  :root {
+    --rail-width: 256px;
+  }
+
   .app {
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
@@ -1089,7 +1524,9 @@ button {
     position: fixed;
     inset: 0 auto 0 0;
     z-index: var(--z-drawer);
+    align-items: stretch;
     width: var(--rail-width);
+    padding-inline: var(--space-3);
     transform: translateX(-100%);
     transition: transform var(--dur-base) var(--ease-out);
   }
@@ -1098,18 +1535,64 @@ button {
     transform: none;
   }
 
-  .header {
-    padding: 0 var(--space-4);
+  .rail__label,
+  .rail__title,
+  .rail__count,
+  .brand span:not(.brand__mark),
+  .rail__foot span:not(.avatar) {
+    display: revert;
   }
 
-  .results,
+  .rail__link,
+  .brand,
+  .rail__foot {
+    justify-content: flex-start;
+    width: auto;
+    padding: 0 var(--space-3);
+  }
+
+  .rail__link {
+    border-bottom: none;
+    border-left: 3px solid transparent;
+  }
+
+  .rail__link[aria-current="page"] {
+    border-left-color: var(--text-link);
+  }
+
+  .kbd {
+    display: none;
+  }
+
   .home {
-    padding: var(--space-4);
+    padding-top: var(--space-10);
+  }
+
+  .home__title {
+    font-size: var(--text-heading);
+    line-height: var(--leading-heading);
+  }
+
+  .drawer {
+    border-left: none;
   }
 }
 
-@media (min-width: 901px) {
+@media (min-width: 641px) {
   .rail__toggle {
     display: none;
+  }
+}
+
+/* A shimmer running at 0.01ms is a flash rather than an absence, so the
+   skeleton becomes a flat fill instead. */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    background: var(--bg-subtle);
+  }
+
+  .progress::after {
+    width: 100%;
+    opacity: 0.4;
   }
 }

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -3,7 +3,7 @@
 // It owns three things and nothing else: the URL, the keyboard, and which view
 // is on screen. Everything that draws is in its own module and takes a callback
 // rather than reaching back in here, which is what keeps a change to the result
-// card from being a change to routing.
+// row from being a change to routing.
 
 import { h, replace, svg } from "./dom.js";
 import { api, identity, setIdentity, ApiError } from "./api.js";
@@ -15,6 +15,16 @@ import { Drawer } from "./drawer.js";
 import { Home } from "./home.js";
 
 const THEME_KEY = "genba.theme";
+const DENSITY_KEY = "genba.density";
+
+// LOADING_DELAY is how long a search may run before the interface admits to it.
+//
+// Every API in this product is budgeted under ten milliseconds, and at that
+// latency a loading state appears and disappears inside one frame, which reads
+// as a flicker rather than as feedback. So the skeleton is a timer that the
+// response cancels: if the answer beats it, no loading state is ever mounted
+// and the transition is a single paint.
+const LOADING_DELAY = 120;
 
 class App {
   constructor(root) {
@@ -22,7 +32,7 @@ class App {
     this.session = null;
     this.query = urlState.read();
     this.pending = null;
-    this.lastRequest = null;
+    this.loadingTimer = null;
 
     this.omnibox = new Omnibox({
       onSearch: (text) => this.go({ ...this.query, q: text, offset: 0, open: "" }),
@@ -40,7 +50,18 @@ class App {
       onClose: () => this.go({ ...this.query, open: "" }, { replace: true }),
     });
 
-    this.main = h("main", { class: "main", id: "main" });
+    this.main = h("main", {
+      class: "main",
+      id: "main",
+      // The header carries a hairline only once there is something scrolled
+      // under it, so a page at rest has one less line on it.
+      onScroll: () => {
+        const scrolled = this.main.scrollTop > 0;
+        if ((this.header.dataset.scrolled === "true") !== scrolled) {
+          this.header.dataset.scrolled = String(scrolled);
+        }
+      },
+    });
     this.live = h("div", {
       class: "visually-hidden",
       role: "status",
@@ -49,6 +70,7 @@ class App {
     });
 
     this.rail = this.buildRail();
+    this.header = this.buildHeader();
     this.build();
     this.bindKeys();
 
@@ -66,55 +88,70 @@ class App {
         { class: "app" },
         h("a", { class: "visually-hidden", href: "#main" }, "Skip to results"),
         this.rail,
-        h(
-          "header",
-          { class: "header" },
-          h(
-            "button",
-            {
-              class: "icon-button rail__toggle",
-              type: "button",
-              "aria-label": "Menu",
-              onClick: () => {
-                const open = this.rail.dataset.open === "true";
-                this.rail.dataset.open = String(!open);
-              },
-            },
-            svg(icon("menu")),
-          ),
-          this.omnibox.el,
-          h(
-            "div",
-            { class: "header__actions" },
-            h(
-              "button",
-              {
-                class: "icon-button",
-                type: "button",
-                "aria-label": "Keyboard shortcuts",
-                title: "Keyboard shortcuts (?)",
-                onClick: () => this.shortcuts(),
-              },
-              svg(icon("keyboard")),
-            ),
-            h(
-              "button",
-              {
-                class: "icon-button",
-                type: "button",
-                "aria-label": "Switch theme",
-                title: "Switch theme",
-                onClick: () => this.theme(),
-              },
-              svg(icon(document.documentElement.dataset.theme === "dark" ? "sun" : "moon")),
-            ),
-          ),
-        ),
+        this.header,
         this.main,
       ),
       this.drawer.scrim,
       this.drawer.el,
       this.live,
+    );
+  }
+
+  buildHeader() {
+    return h(
+      "header",
+      { class: "header" },
+      h(
+        "button",
+        {
+          class: "icon-button rail__toggle",
+          type: "button",
+          "aria-label": "Menu",
+          onClick: () => {
+            const open = this.rail.dataset.open === "true";
+            this.rail.dataset.open = String(!open);
+          },
+        },
+        svg(icon("menu"), 20),
+      ),
+      this.omnibox.el,
+      h(
+        "div",
+        { class: "header__actions" },
+        h(
+          "button",
+          {
+            class: "icon-button",
+            type: "button",
+            "aria-label": "Switch density",
+            title: "Switch between comfortable and compact rows",
+            onClick: () => this.density(),
+          },
+          svg(icon("rows"), 20),
+        ),
+        h(
+          "button",
+          {
+            class: "icon-button",
+            type: "button",
+            "aria-label": "Keyboard shortcuts",
+            title: "Keyboard shortcuts (?)",
+            onClick: () => this.shortcuts(),
+          },
+          svg(icon("keyboard"), 20),
+        ),
+        h(
+          "button",
+          {
+            class: "icon-button",
+            type: "button",
+            "aria-label": "Switch theme",
+            title: "Switch theme",
+            onClick: () => this.theme(),
+          },
+          svg(icon(document.documentElement.dataset.theme === "dark" ? "sun" : "moon"), 20),
+        ),
+      ),
     );
   }
 
@@ -125,9 +162,9 @@ class App {
       { class: "rail", "aria-label": "Main" },
       h(
         "a",
-        { class: "brand", href: "/", onClick: (e) => this.link(e, {}) },
+        { class: "brand", href: "/", title: "genba", onClick: (e) => this.link(e, {}) },
         h("span", { class: "brand__mark" }, "G"),
-        "genba",
+        h("span", {}, "genba"),
       ),
       h(
         "div",
@@ -137,21 +174,23 @@ class App {
           {
             class: "rail__link",
             href: "/",
+            title: "Home",
             "aria-current": this.query.q || urlState.count(this.query) ? null : "page",
             onClick: (e) => this.link(e, {}),
           },
-          svg(icon("home"), 15),
-          "Home",
+          svg(icon("home"), 20),
+          h("span", { class: "rail__label" }, "Home"),
         ),
         h(
           "a",
           {
             class: "rail__link",
             href: "?sort=recent",
+            title: "Recent",
             onClick: (e) => this.link(e, { q: "", sort: "recent" }),
           },
-          svg(icon("clock"), 15),
-          "Recent",
+          svg(icon("clock"), 20),
+          h("span", { class: "rail__label" }, "Recent"),
         ),
       ),
       h(
@@ -164,10 +203,11 @@ class App {
             {
               class: "rail__link",
               href: `?tab=${v.id}`,
+              title: v.title,
               onClick: (e) => this.link(e, { ...this.query, tab: v.id, kind: [], offset: 0 }),
             },
-            svg(icon(v.id === "people" ? "people" : v.id === "code" ? "code" : v.id === "messages" ? "chat" : v.id === "tickets" ? "ticket" : "doc"), 15),
-            v.title,
+            svg(icon(v.id === "people" ? "people" : v.id === "code" ? "code" : v.id === "messages" ? "chat" : v.id === "tickets" ? "ticket" : "doc"), 20),
+            h("span", { class: "rail__label" }, v.title),
           ),
         ),
       ),
@@ -181,8 +221,7 @@ class App {
           onClick: () => this.switchIdentity(),
         },
         h("span", { class: "avatar" }, initials(who.subject)),
-        h("span", {}, who.subject),
-        svg(icon("slider"), 14),
+        h("span", { class: "rail__label" }, who.subject),
       ),
     );
   }
@@ -221,10 +260,11 @@ class App {
           {
             class: "rail__link",
             href: `?source=${encodeURIComponent(s.value)}`,
+            title: label(s.value),
             onClick: (e) => this.link(e, { source: [s.value] }),
           },
           h("span", { class: "source__dot", style: { background: sourceColor(s.value) } }),
-          label(s.value),
+          h("span", { class: "rail__label" }, label(s.value)),
           h("span", { class: "rail__count" }, s.count),
         ),
       ),
@@ -263,10 +303,20 @@ class App {
   }
 
   async search() {
-    if (this.main.firstChild !== this.results.el) replace(this.main, this.results.el);
+    const mounted = this.main.firstChild === this.results.el;
+    if (!mounted) replace(this.main, this.results.el);
 
     const request = urlState.params(this.query, VERTICALS);
-    this.results.loading(this.query);
+
+    // A first search has nothing on screen to keep, so it gets the skeleton
+    // after the delay. A subsequent one keeps the previous answer visible and
+    // shows a progress bar instead, because the previous answer is almost
+    // always still the right one and dimming it says otherwise.
+    clearTimeout(this.loadingTimer);
+    this.loadingTimer = setTimeout(() => {
+      if (mounted) this.results.revalidating(true);
+      else this.results.loading(this.query);
+    }, LOADING_DELAY);
 
     if (this.pending) this.pending.abort();
     const controller = new AbortController();
@@ -279,6 +329,9 @@ class App {
     } catch (err) {
       if (err.name === "AbortError") return;
       this.fail(err);
+    } finally {
+      clearTimeout(this.loadingTimer);
+      if (!controller.signal.aborted) this.results.revalidating(false);
     }
   }
 
@@ -298,6 +351,7 @@ class App {
       h(
         "div",
         { class: "state state--error" },
+        h("span", { class: "state__icon" }, svg(icon(unauthenticated ? "people" : "close"), 40)),
         h("p", { class: "state__title" }, unauthenticated ? "Not signed in" : "Something went wrong"),
         h(
           "p",
@@ -333,8 +387,24 @@ class App {
     const next = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
     document.documentElement.dataset.theme = next;
     localStorage.setItem(THEME_KEY, next);
+    this.header = this.buildHeader();
     this.build();
     this.sync();
+  }
+
+  /**
+   * density is the one escape hatch in the spacing system.
+   *
+   * The restyle costs vertical space deliberately, and somebody triaging four
+   * hundred results has a different job from somebody reading one. Compact
+   * reduces the row padding and drops the body size one step. It does not
+   * reintroduce borders, change the colour system or touch the type scale
+   * above body, so it is two token overrides rather than a second theme.
+   */
+  density() {
+    const next = document.documentElement.dataset.density === "compact" ? "comfortable" : "compact";
+    document.documentElement.dataset.density = next;
+    localStorage.setItem(DENSITY_KEY, next);
   }
 
   /**
@@ -496,12 +566,17 @@ class App {
 }
 
 // Theme before first paint, so a dark theme does not arrive as a white flash.
+// The same block runs inline in index.html, and this one is what keeps the two
+// in step when the module loads without a cached document.
 const saved = localStorage.getItem(THEME_KEY);
 if (saved) {
   document.documentElement.dataset.theme = saved;
 } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
   document.documentElement.dataset.theme = "dark";
 }
+
+const density = localStorage.getItem(DENSITY_KEY);
+if (density) document.documentElement.dataset.density = density;
 
 const app = new App(document.getElementById("app"));
 app.start();

--- a/web/dist/assets/drawer.js
+++ b/web/dist/assets/drawer.js
@@ -18,7 +18,7 @@ export class Drawer {
     this.pending = null;
 
     this.title = h("h2", { class: "drawer__title", id: "drawer-title" });
-    this.meta = h("div", { class: "card__head" });
+    this.meta = h("div", { class: "drawer__meta" });
     this.body = h("div", { class: "drawer__body" });
     this.foot = h("div", { class: "drawer__foot" });
 
@@ -40,7 +40,7 @@ export class Drawer {
         h(
           "button",
           { class: "icon-button", type: "button", "aria-label": "Close preview", onClick: () => this.close() },
-          svg(icon("close")),
+          svg(icon("close"), 20),
         ),
       ),
       this.body,
@@ -103,10 +103,10 @@ export class Drawer {
           "a",
           { class: "button button--primary", href: d.url, target: "_blank", rel: "noreferrer noopener" },
           "Open in source",
-          svg(icon("external"), 14),
+          svg(icon("external"), 16),
         ),
       d.modified_at &&
-        h("span", { class: "filterbar__meta", title: exact(d.modified_at) }, `Updated ${when(d.modified_at)}`),
+        h("span", { class: "meta", title: exact(d.modified_at) }, `Updated ${when(d.modified_at)}`),
     );
     // Focus lands on the first thing worth acting on once the content is in,
     // rather than on a spinner.

--- a/web/dist/assets/format.js
+++ b/web/dist/assets/format.js
@@ -18,6 +18,7 @@ const ICONS = {
   keyboard: "M4 7h16v10H4V7ZM7 11h.01M11 11h.01M15 11h.01M8 14h8",
   menu: "M4 7h16M4 12h16M4 17h16",
   check: "m5 12 5 5 9-10",
+  rows: "M4 6h16M4 10h16M4 14h16M4 18h16",
   preview: "M4 6h16v12H4zM4 10h16",
 };
 

--- a/web/dist/assets/home.js
+++ b/web/dist/assets/home.js
@@ -5,9 +5,9 @@
 // API the search page uses, so nothing here can show a document the person
 // could not have found by searching for it.
 
-import { h, replace, svg } from "./dom.js";
+import { h, replace } from "./dom.js";
 import { api } from "./api.js";
-import { icon, label, sourceColor, when, number, initials } from "./format.js";
+import { label, sourceColor, when, number, initials } from "./format.js";
 
 export class Home {
   constructor({ onQuery, onOpen }) {
@@ -57,9 +57,9 @@ export class Home {
       h(
         "div",
         { class: "panel" },
-        h("div", { class: "skeleton", style: { width: "40%", height: "14px", marginBottom: "16px" } }),
+        h("div", { class: "skeleton", style: { width: "40%", height: "24px", marginBottom: "24px" } }),
         ...Array.from({ length: 4 }, () =>
-          h("div", { class: "skeleton", style: { width: "100%", height: "12px", marginBottom: "10px" } }),
+          h("div", { class: "skeleton", style: { width: "100%", height: "16px", marginBottom: "24px" } }),
         ),
       ),
     );
@@ -73,7 +73,6 @@ export class Home {
       h(
         "div",
         { class: "panel__head" },
-        svg(icon("clock"), 15),
         h("h2", { class: "panel__title" }, "Recently updated"),
         h(
           "button",
@@ -91,7 +90,7 @@ export class Home {
               h("span", { class: "panel__row-meta" }, when(hit.modified_at)),
             ),
           )
-        : h("p", { class: "panel__row-meta" }, "Nothing has been indexed yet."),
+        : h("p", { class: "meta" }, "Nothing has been indexed yet."),
     );
   }
 
@@ -100,12 +99,7 @@ export class Home {
     return h(
       "section",
       { class: "panel" },
-      h(
-        "div",
-        { class: "panel__head" },
-        svg(icon("slider"), 15),
-        h("h2", { class: "panel__title" }, "Sources"),
-      ),
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Sources")),
       sources.length
         ? sources.map((s) =>
             h(
@@ -122,7 +116,7 @@ export class Home {
           )
         : h(
             "p",
-            { class: "panel__row-meta" },
+            { class: "meta" },
             "No source has documents you can read yet. Start genbad with -corpus to index a directory.",
           ),
     );
@@ -133,14 +127,13 @@ export class Home {
     return h(
       "section",
       { class: "panel" },
-      h("div", { class: "panel__head" }, svg(icon("doc"), 15), h("h2", { class: "panel__title" }, "Index")),
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Index")),
       h(
         "div",
         { class: "stat" },
         h("span", { class: "stat__value" }, number(stats.documents)),
         h("span", { class: "stat__label" }, "documents indexed"),
       ),
-      h("div", { class: "panel__row" }),
       h(
         "div",
         { class: "stat" },
@@ -151,9 +144,7 @@ export class Home {
           "held back because their permissions did not resolve, and never served to anyone",
         ),
       ),
-      session && session.tenant
-        ? h("div", { class: "panel__row" }, h("span", { class: "panel__row-meta" }, `Tenant ${session.tenant}`))
-        : null,
+      session && session.tenant ? h("p", { class: "meta" }, `Tenant ${session.tenant}`) : null,
     );
   }
 
@@ -168,16 +159,18 @@ export class Home {
     return h(
       "section",
       { class: "panel" },
-      h(
-        "div",
-        { class: "panel__head" },
-        svg(icon("keyboard"), 15),
-        h("h2", { class: "panel__title" }, "Narrow a search"),
-      ),
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Narrow a search")),
+      // These rows run a search rather than opening a document, so their title
+      // is prose rather than a link and stays in the text colour in every
+      // state. The operator itself is the thing being offered.
       tips.map(([op, what]) =>
         h(
           "button",
-          { class: "panel__row", type: "button", onClick: () => this.onQuery({ q: op }) },
+          {
+            class: "panel__row panel__row--static",
+            type: "button",
+            onClick: () => this.onQuery({ q: op }),
+          },
           h("code", { class: "suggestion__badge" }, op),
           h("span", { class: "panel__row-title" }, what),
         ),

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -1,4 +1,4 @@
-// The results view: verticals, filter bar, result cards and facets.
+// The results view: verticals, active filters, result rows and facets.
 
 import { h, replace, svg } from "./dom.js";
 import { kindIcon, sourceColor, label, when, exact, number, duration, icon } from "./format.js";
@@ -30,7 +30,7 @@ const FACETS = [
   { key: "author", field: "author", title: "Person" },
 ];
 
-const FACET_VISIBLE = 6;
+const FACET_VISIBLE = 8;
 
 export class Results {
   constructor({ onQuery, onOpen }) {
@@ -41,47 +41,93 @@ export class Results {
     this.hits = [];
 
     this.tabs = h("div", { class: "tabs", role: "tablist", "aria-label": "Result types" });
-    this.filterbar = h("div", { class: "filterbar" });
-    this.list = h("div", { class: "results__list", role: "list" });
     this.facets = h("aside", { class: "facets", "aria-label": "Filters" });
+
+    // The facet column becomes a disclosure below the medium breakpoint, where
+    // there is no room for a margin column. The button is hidden by CSS above
+    // it rather than by a resize listener, so nothing recomputes on drag.
+    this.toggle = h(
+      "button",
+      {
+        class: "button button--ghost filterbar__toggle",
+        type: "button",
+        "aria-expanded": "false",
+        onClick: () => {
+          const open = this.facets.dataset.open === "true";
+          this.facets.dataset.open = String(!open);
+          this.toggle.setAttribute("aria-expanded", String(!open));
+        },
+      },
+      svg(icon("slider"), 18),
+      "Filters",
+    );
+
+    this.filterbar = h("div", { class: "filterbar" }, this.tabs, this.toggle);
+    this.progress = h("div", { class: "progress", hidden: true });
+    this.chips = h("div", { class: "chips" });
+    this.head = h("div", { class: "results__head" });
+    this.list = h("div", { class: "results__list", role: "list" });
 
     this.el = h(
       "div",
       {},
-      this.tabs,
       this.filterbar,
-      h("div", { class: "results" }, this.list, this.facets),
+      this.progress,
+      this.chips,
+      h(
+        "div",
+        { class: "results" },
+        this.facets,
+        h("div", { class: "results__main" }, this.head, this.list),
+      ),
     );
   }
 
-  /** loading paints the shape of the answer before the answer arrives. */
+  /**
+   * loading paints the shape of the answer before the answer arrives.
+   *
+   * The shell decides when to call this. Under the 120ms threshold in the
+   * motion spec it never calls it at all, and the previous answer stays on
+   * screen until the new one replaces it in a single paint.
+   */
   loading(query) {
     this.renderTabs(query, null);
-    replace(
-      this.filterbar,
-      h("div", { class: "skeleton", style: { width: "220px", height: "20px" } }),
-    );
+    replace(this.chips);
+    replace(this.head, h("div", { class: "skeleton", style: { width: "180px", height: "16px" } }));
     replace(
       this.list,
-      Array.from({ length: 5 }, () =>
+      Array.from({ length: 6 }, () =>
         h(
           "div",
-          { class: "skeleton-card" },
-          h("div", { class: "skeleton", style: { width: "30%", height: "12px" } }),
-          h("div", { class: "skeleton", style: { width: "70%", height: "18px" } }),
-          h("div", { class: "skeleton", style: { width: "100%", height: "12px" } }),
-          h("div", { class: "skeleton", style: { width: "85%", height: "12px" } }),
+          { class: "skeleton-result" },
+          h("div", { class: "skeleton", style: { width: "60%", height: "20px" } }),
+          h("div", { class: "skeleton", style: { width: "40%", height: "14px" } }),
+          h("div", { class: "skeleton", style: { width: "100%", height: "14px" } }),
+          h("div", { class: "skeleton", style: { width: "82%", height: "14px" } }),
         ),
       ),
     );
     replace(this.facets);
   }
 
+  /**
+   * revalidating shows that a cached answer is being checked.
+   *
+   * The content underneath is not dimmed, blurred or overlaid. Dimming stale
+   * content tells the reader that what they are currently reading is wrong,
+   * which it almost never is.
+   */
+  revalidating(on) {
+    this.progress.hidden = !on;
+    this.list.setAttribute("aria-busy", String(Boolean(on)));
+  }
+
   render(query, res) {
     this.hits = res.hits || [];
     this.selected = -1;
     this.renderTabs(query, res);
-    this.renderFilterbar(query, res);
+    this.renderChips(query);
+    this.renderHead(query, res);
     this.renderList(query, res);
     this.renderFacets(query, res);
   }
@@ -108,7 +154,7 @@ export class Results {
     );
   }
 
-  renderFilterbar(query, res) {
+  renderChips(query) {
     const active = [];
     for (const { key, field } of FACETS) {
       for (const value of query[key] || []) {
@@ -125,7 +171,7 @@ export class Results {
                 "aria-label": `Remove the ${labelFor(field)} filter ${value}`,
                 onClick: () => this.onQuery(urlState.toggle(query, key, value)),
               },
-              svg(icon("close"), 12),
+              svg(icon("close"), 14),
             ),
           ),
         );
@@ -133,7 +179,7 @@ export class Results {
     }
 
     replace(
-      this.filterbar,
+      this.chips,
       active,
       active.length > 0 &&
         h(
@@ -141,22 +187,28 @@ export class Results {
           { class: "chip", type: "button", onClick: () => this.onQuery(urlState.clear(query)) },
           "Clear all",
         ),
-      h("span", { class: "filterbar__spacer" }),
+    );
+  }
+
+  renderHead(query, res) {
+    replace(
+      this.head,
       h(
         "span",
-        { class: "filterbar__meta" },
+        { class: "results__count" },
         res.partial
-          ? `${number(res.total)}+ results in ${duration(res.took_ms)}`
-          : `${number(res.total)} ${res.total === 1 ? "result" : "results"} in ${duration(res.took_ms)}`,
+          ? `${number(res.total)}+ results`
+          : `${number(res.total)} ${res.total === 1 ? "result" : "results"}`,
+        h("span", { class: "results__took" }, duration(res.took_ms)),
       ),
       h(
         "label",
-        { class: "filterbar__meta" },
+        {},
         h("span", { class: "visually-hidden" }, "Sort results"),
         h(
           "select",
           {
-            class: "select",
+            class: "sort",
             onChange: (e) => this.onQuery({ ...query, sort: e.target.value, offset: 0 }),
           },
           h("option", { value: "", selected: !query.sort }, "Most relevant"),
@@ -174,59 +226,68 @@ export class Results {
 
     replace(
       this.list,
-      this.hits.map((hit, i) => this.card(hit, i)),
+      this.hits.map((hit, i) => this.row(hit, i)),
       pager(query, res, this.onQuery),
     );
   }
 
-  card(hit, i) {
+  /**
+   * row is one result.
+   *
+   * Title first, then the line of provenance, then the snippet. The old order
+   * put provenance above the title, which meant the first thing on every row
+   * was the least distinguishing thing about it.
+   */
+  row(hit, i) {
     const open = () => this.onOpen(hit.id);
     return h(
       "article",
       {
-        class: "card",
+        class: "result",
         role: "listitem",
         dataset: { index: String(i) },
         onClick: (e) => {
           // A click on the title follows the source link. A click anywhere else
-          // on the card opens the preview, which is the cheaper of the two and
+          // on the row opens the preview, which is the cheaper of the two and
           // the one people want when they are still scanning.
           if (e.target.closest("a")) return;
           open();
         },
       },
+      hit.url
+        ? h(
+            "a",
+            { class: "result__title", href: hit.url, rel: "noreferrer noopener", target: "_blank" },
+            hit.title || hit.id,
+          )
+        : h("button", { class: "result__title", type: "button", onClick: open }, hit.title || hit.id),
       h(
         "div",
-        { class: "card__head" },
+        { class: "result__meta" },
         h(
           "span",
           { class: "source" },
           h("span", { class: "source__dot", style: { background: sourceColor(hit.source) } }),
           label(hit.source),
         ),
-        h("span", { class: "crumbs__sep" }, "/"),
-        h("span", { class: "crumbs" }, svg(kindIcon(hit.kind), 13), label(hit.kind)),
-        hit.container && h("span", { class: "crumbs__sep" }, "/"),
+        h("span", { class: "crumbs__sep" }, "·"),
+        h("span", { class: "crumbs" }, svg(kindIcon(hit.kind), 14), label(hit.kind)),
+        hit.container && h("span", { class: "crumbs__sep" }, "·"),
         hit.container && h("span", { class: "crumbs" }, hit.container),
-      ),
-      hit.url
-        ? h("a", { class: "card__title", href: hit.url, rel: "noreferrer noopener", target: "_blank" }, hit.title || hit.id)
-        : h("button", { class: "card__title", type: "button", onClick: open }, hit.title || hit.id),
-      h("p", { class: "card__snippet" }, passages(hit)),
-      h(
-        "div",
-        { class: "card__foot" },
-        hit.author && h("span", {}, hit.author),
+        hit.author && h("span", { class: "crumbs__sep" }, "·"),
+        hit.author && h("span", { class: "crumbs" }, hit.author),
+        hit.modified_at && h("span", { class: "crumbs__sep" }, "·"),
         hit.modified_at &&
-          h("span", { title: exact(hit.modified_at) }, `Updated ${when(hit.modified_at)}`),
+          h("time", { title: exact(hit.modified_at), datetime: hit.modified_at }, when(hit.modified_at)),
       ),
+      h("p", { class: "result__snippet" }, passages(hit)),
       h(
         "div",
-        { class: "card__actions" },
+        { class: "result__actions" },
         h(
           "button",
           { class: "icon-button", type: "button", title: "Preview (p)", "aria-label": "Preview", onClick: open },
-          svg(icon("preview"), 15),
+          svg(icon("preview"), 18),
         ),
         hit.url &&
           h(
@@ -239,7 +300,7 @@ export class Results {
               title: "Open in source",
               "aria-label": "Open in source",
             },
-            svg(icon("external"), 15),
+            svg(icon("external"), 18),
           ),
       ),
     );
@@ -271,7 +332,7 @@ export class Results {
                   "aria-pressed": String(on),
                   onClick: () => this.onQuery(urlState.toggle(query, key, v.value)),
                 },
-                h("span", { class: "facet__box" }, on ? svg(icon("check"), 10) : null),
+                h("span", { class: "facet__box" }, on ? svg(icon("check"), 12) : null),
                 h("span", { class: "facet__label", title: v.value }, titled ? label(v.value) : v.value),
                 h("span", { class: "facet__count" }, number(v.count)),
               ),
@@ -295,7 +356,11 @@ export class Results {
       );
     }).filter(Boolean);
 
-    replace(this.facets, groups.length ? groups : null);
+    replace(
+      this.facets,
+      groups.length ? h("h2", { class: "facets__title" }, "Filters") : null,
+      groups.length ? groups : null,
+    );
   }
 
   /** move walks the selection with j and k, and scrolls it into view. */
@@ -306,10 +371,10 @@ export class Results {
   }
 
   select(i) {
-    const cards = this.list.querySelectorAll(".card");
-    cards.forEach((card, n) => card.setAttribute("data-active", String(n === i)));
+    const rows = this.list.querySelectorAll(".result");
+    rows.forEach((row, n) => row.setAttribute("data-active", String(n === i)));
     this.selected = i;
-    if (cards[i]) cards[i].scrollIntoView({ block: "nearest" });
+    if (rows[i]) rows[i].scrollIntoView({ block: "nearest" });
   }
 
   current() {
@@ -354,7 +419,7 @@ function pager(query, res, onQuery) {
 
   return h(
     "nav",
-    { class: "filterbar", "aria-label": "Result pages" },
+    { class: "pager", "aria-label": "Result pages" },
     h(
       "button",
       {
@@ -367,7 +432,7 @@ function pager(query, res, onQuery) {
     ),
     h(
       "span",
-      { class: "filterbar__meta" },
+      { class: "pager__meta" },
       `${number(offset + 1)} to ${number(Math.min(offset + limit, res.total))} of ${number(res.total)}`,
     ),
     h(
@@ -396,6 +461,7 @@ function emptyState(query, res, onQuery) {
     return h(
       "div",
       { class: "state" },
+      h("span", { class: "state__icon" }, svg(icon("search"), 40)),
       h("p", { class: "state__title" }, "Search your company"),
       h("p", { class: "state__body" }, "Start typing above. Add app:, type:, in: or from: to narrow it down."),
     );
@@ -404,6 +470,7 @@ function emptyState(query, res, onQuery) {
     return h(
       "div",
       { class: "state" },
+      h("span", { class: "state__icon" }, svg(icon("slider"), 40)),
       h("p", { class: "state__title" }, "No results with these filters"),
       h("p", { class: "state__body" }, `Nothing matches ${query.q ? `"${query.q}"` : "this search"} in the selected filters.`),
       h(
@@ -420,6 +487,7 @@ function emptyState(query, res, onQuery) {
   return h(
     "div",
     { class: "state" },
+    h("span", { class: "state__icon" }, svg(icon("search"), 40)),
     h("p", { class: "state__title" }, `Nothing found for "${query.q}"`),
     h(
       "p",

--- a/web/dist/assets/tokens.css
+++ b/web/dist/assets/tokens.css
@@ -10,26 +10,44 @@
  * The layers are deliberate. The palette names raw colour. The semantic tokens
  * name what a colour is for. Components only ever use the semantic layer, so
  * re-theming means overriding a dozen values instead of auditing every rule.
+ *
+ * Three rules hold this together and every value below follows from them.
+ *
+ * The ground is white. There is one surface colour in the light theme, and
+ * there is no grey page with white cards floating on it.
+ *
+ * Elevation is a hairline. One pixel, one colour. Two things in the entire
+ * interface cast a shadow, and both of them genuinely float over content that
+ * is still visible behind them.
+ *
+ * Colour is reserved. Neutrals carry the interface. The accent appears on the
+ * focus ring, on links and on the selected state. The highlight appears under
+ * a matched query term. Everything else is grey.
  */
 
 :root {
-  /* Palette: warm neutrals. Cold greys read as unfinished next to document
-     content, which is mostly text on white. */
+  /* Palette: cold neutrals. The previous set was warm on the argument that
+     cold greys read as unfinished next to document content. That argument
+     applies to large grey fills, and the large grey fills are gone. On white,
+     with hairlines and text, a warm grey reads as a yellowed page and fights
+     the highlight. */
   --gray-0: #ffffff;
-  --gray-25: #fcfcfb;
-  --gray-50: #f7f7f5;
-  --gray-100: #efeeec;
-  --gray-200: #e4e2df;
-  --gray-300: #d3d0cc;
-  --gray-400: #a8a49f;
-  --gray-500: #7c7873;
-  --gray-600: #5c5854;
-  --gray-700: #423f3c;
-  --gray-800: #2b2927;
-  --gray-900: #1a1918;
-  --gray-950: #111010;
+  --gray-25: #fafafa;
+  --gray-50: #f5f5f5;
+  --gray-100: #ebebeb;
+  --gray-200: #e0e0e0;
+  --gray-300: #c6c6c6;
+  --gray-400: #9e9e9e;
+  --gray-500: #757575;
+  --gray-600: #5c5c5c;
+  --gray-700: #3d3d3d;
+  --gray-800: #262626;
+  --gray-900: #1a1a1a;
+  --gray-950: #0f0f0f;
 
-  /* Brand indigo. */
+  /* Brand indigo. Unchanged. What changed is how much of it appears: it is
+     the focus ring, the link colour and the selected state, and it is not the
+     fill of anything. */
   --brand-50: #eef2ff;
   --brand-100: #e0e7ff;
   --brand-200: #c7d2fe;
@@ -41,28 +59,25 @@
   --brand-800: #3730a3;
 
   /* Violet is reserved for generated content. Nothing else may use it, so that
-     a person can tell at a glance which parts of a page a model wrote. */
-  --ai-50: #f5f3ff;
-  --ai-100: #ede9fe;
+     a person can tell at a glance which parts of a page a model wrote. It is
+     applied as a rule and a label rather than as a background wash, so it does
+     not tint the text it marks. */
   --ai-300: #c4b5fd;
   --ai-600: #7c3aed;
   --ai-700: #6d28d9;
 
-  /* Functional hues. */
-  --success-50: #ecfdf5;
+  /* Functional hues, for text and rules only. */
   --success-600: #059669;
   --success-700: #047857;
-  --warning-50: #fffbeb;
   --warning-600: #d97706;
   --warning-700: #b45309;
-  --danger-50: #fef2f2;
   --danger-600: #dc2626;
   --danger-700: #b91c1c;
-  --info-50: #eff6ff;
   --info-600: #2563eb;
 
   /* Source accents. A connector gets a colour so that a result list scans by
-     shape and colour before it is read. */
+     shape and colour before it is read. It appears as an eight pixel dot and
+     never as a fill or as text. */
   --source-drive: #0f9d58;
   --source-slack: #611f69;
   --source-github: #24292f;
@@ -70,35 +85,41 @@
   --source-notion: #37352f;
   --source-files: #6b7280;
 
+  /* Highlight. A matched term is set in semibold with this drawn as a two
+     pixel rule behind it, near the baseline. Not a filled background: on a
+     page with eight results and three terms each, filled highlighting turns
+     the page into a rash, and a rule marks the same words and leaves the page
+     calm. */
+  --mark: #fae041;
+
   /* Semantic layer. This is what components use. */
-  --bg: var(--gray-50);
-  --bg-raised: var(--gray-0);
-  --bg-sunken: var(--gray-100);
-  --bg-hover: var(--gray-100);
-  --bg-active: var(--gray-200);
-  --bg-brand-subtle: var(--brand-50);
-  --bg-ai-subtle: var(--ai-50);
-  --bg-overlay: rgb(17 16 16 / 0.45);
+  --bg: var(--gray-0);
+  --bg-subtle: var(--gray-50);
+  --bg-hover: var(--gray-50);
+  --bg-active: var(--gray-100);
+  --bg-inverse: var(--gray-900);
+  --bg-inverse-hover: var(--gray-800);
+  --bg-overlay: rgb(0 0 0 / 0.32);
 
   --text: var(--gray-900);
   --text-secondary: var(--gray-600);
   --text-muted: var(--gray-500);
   --text-inverse: var(--gray-0);
-  --text-brand: var(--brand-700);
   --text-link: var(--brand-700);
 
+  /* Two hairlines. One for structure, one for anything that takes a pointer,
+     and a third for a control that is selected. There is no other border
+     width anywhere except the focus ring. */
   --border: var(--gray-200);
-  --border-strong: var(--gray-300);
-  --border-brand: var(--brand-600);
+  --border-control: var(--gray-300);
+  --border-strong: var(--gray-900);
 
   --accent: var(--brand-600);
-  --accent-hover: var(--brand-700);
-  --accent-subtle: var(--brand-100);
   --focus-ring: var(--brand-500);
-  --mark-bg: #fef3c7;
-  --mark-text: var(--gray-900);
 
-  /* Space, on a 4px grid. */
+  /* Space, on a four pixel grid. The scale was never the problem: nothing
+     above --space-6 was ever used. */
+  --space-0: 0;
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
@@ -109,8 +130,11 @@
   --space-10: 40px;
   --space-12: 48px;
   --space-16: 64px;
+  --space-20: 80px;
+  --space-24: 96px;
 
-  /* Radius. */
+  /* Radius. Controls are pills, containers are twelve, nothing is square
+     except type. */
   --radius-xs: 4px;
   --radius-sm: 6px;
   --radius-md: 8px;
@@ -118,38 +142,68 @@
   --radius-xl: 16px;
   --radius-full: 9999px;
 
-  /* Elevation. Shadows are soft and low contrast: a search result is not a
-     dialog and should not look like one. */
-  --shadow-1: 0 1px 2px rgb(17 16 16 / 0.05);
-  --shadow-2: 0 1px 3px rgb(17 16 16 / 0.08), 0 1px 2px rgb(17 16 16 / 0.04);
-  --shadow-3: 0 4px 12px rgb(17 16 16 / 0.08), 0 2px 4px rgb(17 16 16 / 0.04);
-  --shadow-4: 0 12px 32px rgb(17 16 16 / 0.12), 0 4px 8px rgb(17 16 16 / 0.06);
+  /* Elevation. Two tokens, for the two things that float over content that is
+     still visible behind them. Nothing else in the interface casts a shadow,
+     and a card does not, because there are no cards. */
+  --shadow-popover: 0 4px 16px rgb(0 0 0 / 0.08), 0 1px 3px rgb(0 0 0 / 0.06);
+  --shadow-drawer: 0 16px 48px rgb(0 0 0 / 0.14);
 
   /* Type. The stack is the platform's own UI font. Self hosting a variable
-     font would mean shipping a binary asset and a build step to subset it, and
-     the system stack renders text that already looks native on every desktop
-     this runs on. */
+     font would mean shipping a binary asset and a build step to subset it, the
+     system stack already renders text that looks native on every desktop this
+     runs on, and a web font is a render blocking request the latency budget
+     does not have room for. */
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
     "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji";
   --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
     "Liberation Mono", monospace;
 
-  --text-xs: 11px;
-  --text-sm: 12px;
-  --text-base: 13px;
-  --text-md: 14px;
-  --text-lg: 16px;
-  --text-xl: 20px;
-  --text-2xl: 24px;
-  --text-3xl: 32px;
+  /*
+   * The scale is named by role rather than by size, so a component asks for
+   * what it is rather than for how big it is. Sixteen is the interface. The
+   * old scale started at eleven and based the interface on thirteen, which is
+   * the single number that explains why the old interface read as a dense
+   * admin console.
+   *
+   * The steps are wide on purpose. Sizes that sit close together force the
+   * reader to compare rather than glance.
+   *
+   * Line heights are absolute rather than unitless. A unitless line height
+   * inherited into a nested element with a different font size produces a
+   * different absolute leading, which is how a list inside a panel ends up
+   * with different rhythm from the same list outside it.
+   */
+  --text-caption: 12px;
+  --text-small: 14px;
+  --text-body: 16px;
+  --text-lead: 18px;
+  --text-title: 20px;
+  --text-heading: 24px;
+  --text-display: 32px;
+  --text-hero: 44px;
 
-  --leading-tight: 1.25;
-  --leading-normal: 1.5;
-  --leading-relaxed: 1.65;
+  --leading-caption: 16px;
+  --leading-small: 20px;
+  --leading-body: 24px;
+  --leading-lead: 28px;
+  --leading-title: 28px;
+  --leading-heading: 32px;
+  --leading-display: 40px;
+  --leading-hero: 52px;
 
+  --leading-prose: 1.65;
+
+  /* We have no licence for a display face, so the display role is the same
+     face at a tighter setting. Negative tracking at thirty two and above is
+     what makes a system sans read as set rather than as large body text. It is
+     never applied below twenty four, where it costs legibility and buys
+     nothing. */
+  --display-tracking: -0.02em;
+
+  /* Three weights. --weight-medium is gone: it was used in eleven places and
+     in none of them was it distinguishable from normal. */
   --weight-normal: 400;
-  --weight-medium: 500;
   --weight-semibold: 600;
   --weight-bold: 700;
 
@@ -162,11 +216,21 @@
   --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
 
   /* Layout. */
-  --rail-width: 260px;
-  --facets-width: 300px;
-  --header-height: 64px;
-  --filterbar-height: 44px;
-  --content-max: 760px;
+  --rail-width: 256px;
+  --facets-width: 280px;
+  --header-height: 72px;
+  --filterbar-height: 56px;
+  --page-max: 1440px;
+  --measure: 68ch;
+
+  /* The gutter grows with the viewport rather than sitting at a fixed value.
+     Forty eight either side on a wide window is what makes the page feel
+     unhurried, and sixteen on a phone is what stops it feeling wasteful. */
+  --gutter: clamp(16px, 4vw, 48px);
+
+  /* Row padding is a variable because the density toggle is the one escape
+     hatch in the system. Comfortable is the default. */
+  --row-padding-block: var(--space-4);
 
   /*
    * Stacking order, lowest first. The header is sticky and has to sit over the
@@ -181,44 +245,65 @@
 }
 
 /*
+ * Density. The restyle costs vertical space on purpose: a viewport that showed
+ * fourteen results shows six. Somebody triaging four hundred results has a
+ * different job from somebody reading one, so there is a toggle.
+ *
+ * It reduces row padding and drops the body size one step. It does not touch
+ * the scale above body, does not reintroduce borders and does not change the
+ * colour system. This is the only density variable allowed to exist.
+ */
+[data-density="compact"] {
+  --row-padding-block: var(--space-2);
+  --text-body: 14px;
+  --leading-body: 20px;
+}
+
+/*
  * Dark theme. Only the semantic layer moves, and the palette is untouched, so
  * a component written against the semantic tokens is already dark ready.
+ *
+ * The ground is a very slightly blue near black rather than pure black. Pure
+ * black next to a white document body in the drawer produces a contrast step
+ * large enough to be uncomfortable at night, which is the only time anybody
+ * uses this theme.
  */
 [data-theme="dark"] {
-  --bg: var(--gray-950);
-  --bg-raised: var(--gray-900);
-  --bg-sunken: #0b0b0a;
-  --bg-hover: var(--gray-800);
-  --bg-active: var(--gray-700);
-  --bg-brand-subtle: #1e1b4b;
-  --bg-ai-subtle: #2e1065;
+  --bg: #0f1011;
+  --bg-subtle: #17191b;
+  --bg-hover: #1c1e21;
+  --bg-active: #24272b;
+
+  /* The primary button inverts rather than staying dark, because the highest
+     contrast fill available against this ground is a light one. */
+  --bg-inverse: #e8eaed;
+  --bg-inverse-hover: #ffffff;
   --bg-overlay: rgb(0 0 0 / 0.6);
 
-  --text: var(--gray-100);
-  --text-secondary: var(--gray-400);
-  --text-muted: var(--gray-500);
-  --text-inverse: var(--gray-950);
-  --text-brand: var(--brand-300);
+  --text: #e8eaed;
+  --text-secondary: #b0b4b9;
+  --text-muted: #8b9096;
+  --text-inverse: #0f1011;
   --text-link: var(--brand-300);
 
-  --border: #322f2c;
-  --border-strong: #46423e;
-  --border-brand: var(--brand-500);
+  --border: #2a2d31;
+  --border-control: #3c4045;
+  --border-strong: #e8eaed;
 
-  --accent: var(--brand-500);
-  --accent-hover: var(--brand-400);
-  --accent-subtle: #312e81;
+  --accent: var(--brand-400);
   --focus-ring: var(--brand-400);
-  --mark-bg: #78350f;
-  --mark-text: #fef3c7;
+
+  /* Higher chroma, to hold against a near black ground. The mark keeps
+     colour: inherit on the text, so no second foreground token is needed. */
+  --mark: #f5c518;
 
   --source-github: #c9d1d9;
   --source-notion: #d4d0c8;
 
-  --shadow-1: 0 1px 2px rgb(0 0 0 / 0.4);
-  --shadow-2: 0 1px 3px rgb(0 0 0 / 0.5), 0 1px 2px rgb(0 0 0 / 0.3);
-  --shadow-3: 0 4px 12px rgb(0 0 0 / 0.5), 0 2px 4px rgb(0 0 0 / 0.3);
-  --shadow-4: 0 12px 32px rgb(0 0 0 / 0.6), 0 4px 8px rgb(0 0 0 / 0.4);
+  /* A shadow on a dark ground carries almost no information, so the drawer
+     additionally takes a hairline to define its edge. */
+  --shadow-popover: 0 4px 16px rgb(0 0 0 / 0.5), 0 1px 3px rgb(0 0 0 / 0.4);
+  --shadow-drawer: 0 16px 48px rgb(0 0 0 / 0.6);
 }
 
 /* Somebody who has asked their system not to animate things means it. */

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -12,12 +12,15 @@
     <link rel="modulepreload" href="/assets/api.js" />
     <link rel="modulepreload" href="/assets/dom.js" />
     <script>
-      // The theme is read before the first paint. Doing it in the module would
-      // put a white frame in front of somebody who chose a dark theme.
+      // The theme and the density are read before the first paint. Doing it in
+      // the module would put a white frame in front of somebody who chose a
+      // dark theme, and would reflow every row for somebody on compact.
       try {
         var saved = localStorage.getItem("genba.theme");
         if (saved) document.documentElement.dataset.theme = saved;
         else if (matchMedia("(prefers-color-scheme: dark)").matches) document.documentElement.dataset.theme = "dark";
+        var density = localStorage.getItem("genba.density");
+        if (density) document.documentElement.dataset.density = density;
       } catch (e) {}
     </script>
   </head>
@@ -30,7 +33,7 @@
     <div id="app">
       <div class="app">
         <nav class="rail" aria-label="Main">
-          <span class="brand"><span class="brand__mark">G</span>genba</span>
+          <span class="brand"><span class="brand__mark">G</span><span>genba</span></span>
         </nav>
         <header class="header">
           <div class="omnibox" role="search">
@@ -41,18 +44,22 @@
         </header>
         <main class="main">
           <div class="home">
+            <div class="home__greeting">
+              <div class="skeleton" style="width: 340px; max-width: 80%; height: 40px"></div>
+              <div class="skeleton" style="width: 480px; max-width: 90%; height: 28px; margin-top: 8px"></div>
+            </div>
             <div class="home__grid">
               <div class="panel">
-                <div class="skeleton" style="width: 40%; height: 14px; margin-bottom: 16px"></div>
-                <div class="skeleton" style="width: 100%; height: 12px; margin-bottom: 10px"></div>
-                <div class="skeleton" style="width: 88%; height: 12px; margin-bottom: 10px"></div>
-                <div class="skeleton" style="width: 72%; height: 12px"></div>
+                <div class="skeleton" style="width: 40%; height: 24px; margin-bottom: 24px"></div>
+                <div class="skeleton" style="width: 100%; height: 16px; margin-bottom: 24px"></div>
+                <div class="skeleton" style="width: 88%; height: 16px; margin-bottom: 24px"></div>
+                <div class="skeleton" style="width: 72%; height: 16px"></div>
               </div>
               <div class="panel">
-                <div class="skeleton" style="width: 40%; height: 14px; margin-bottom: 16px"></div>
-                <div class="skeleton" style="width: 100%; height: 12px; margin-bottom: 10px"></div>
-                <div class="skeleton" style="width: 88%; height: 12px; margin-bottom: 10px"></div>
-                <div class="skeleton" style="width: 72%; height: 12px"></div>
+                <div class="skeleton" style="width: 40%; height: 24px; margin-bottom: 24px"></div>
+                <div class="skeleton" style="width: 100%; height: 16px; margin-bottom: 24px"></div>
+                <div class="skeleton" style="width: 88%; height: 16px; margin-bottom: 24px"></div>
+                <div class="skeleton" style="width: 72%; height: 16px"></div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Stacked on #59.

The interface shipped in #59 is built on a grey ground with cards, four shadows and a thirteen pixel base.
It works, and it reads as dense rather than as calm.
This rebuilds the visual layer against the specs in `ui/01` through `ui/08`, which were written after measuring a real Kaggle page in a browser rather than after reading about it.

## What changes

**Tokens.**
`tokens.css` becomes a palette layer and a semantic layer, so no component names a colour or a size.
The base font is 16px with an eight step role named scale and absolute line heights, three weights, and cold neutrals.
There are exactly two shadows in the product, one for a popover and one for the drawer.

**Surfaces.**
The ground is white end to end in the light theme, with no grey panel anywhere.
Separation is a one pixel hairline, so a results page with eight rows shows seven row rules, the filter bar rule and the rail rule, and nothing else.

**The result row.**
No card, no radius, no fill, no shadow.
Title, then the meta line, then a two line snippet.
A matched term is set in semibold with a two pixel rule drawn behind the word near the baseline, so a descender is never crossed and the page never gets a stripe of highlighter through it.

**Facets.**
Out of the panel and into a 280 pixel margin column on the left, sticky, borderless.
Below 960 they collapse behind a Filters button in the tab strip.

**The count row.**
The count is now a 20px bold headline and the timing sits behind it, muted.
The count answers the question that was just asked and the timing is instrumentation, so they no longer share one sentence.

**Density and motion.**
A density toggle in the header switches the row padding and the body size, and the choice is read before the first paint.
Loading is delayed by 120ms.
A query that replaces an answer already on screen gets a two pixel progress bar and the stale content is never dimmed or blurred.

## Verified in a browser

Checked at 1440, 1180, 900 and 600 against a live index of 53 documents across four sources.

- White ground with no grey panel, in both themes.
- Semibold plus a yellow rule on a match, no filled highlight, checked on a word with a descender.
- Two shadows in the stylesheet, both of them tokens.
- No literal colour and no literal font size in `app.css`.
- CSS ships at 11KB gzip against a 40KB budget.

Three defects turned up in that pass and are fixed here.
A query with no results dropped the results column into the facet column, because `.facets:empty` is `display: none` and the column was auto placed.
The collapsed rail rendered the source list as four coloured dots with no words.
The Filters button scrolled off the right edge below 640, on the one screen where the facet column is not on the page.

## Not in this pull request

The result row has no leading thumbnail.
Kaggle's does, and it is the single thing that makes their list scannable at a glance.
It is worth having once there is something real to put in it, which is the content rendering work.

Closes #49
Closes #50
Closes #51
Closes #52
Closes #53
