### PR TITLE
feat: render documents as what they are, not as one wall of text

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -13,6 +13,9 @@
 package api
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -113,6 +116,7 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("GET /api/v1/search", s.authenticated(s.handleSearch))
 	mux.Handle("GET /api/v1/suggest", s.authenticated(s.handleSuggest))
 	mux.Handle("GET /api/v1/documents/{id}", s.authenticated(s.handleDocument))
+	mux.Handle("GET /api/v1/documents/{id}/content", s.authenticated(s.handleContent))
 	mux.Handle("GET /api/v1/stats", s.authenticated(s.handleStats))
 	if s.assets != nil {
 		mux.Handle("GET /", s.assets)
@@ -219,6 +223,7 @@ type searchHit struct {
 	Kind       string    `json:"kind"`
 	Container  string    `json:"container,omitempty"`
 	Author     string    `json:"author,omitempty"`
+	MediaType  string    `json:"media_type,omitempty"`
 	ModifiedAt time.Time `json:"modified_at,omitzero"`
 	Snippet    string    `json:"snippet,omitempty"`
 
@@ -267,6 +272,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 			Kind:       string(h.Document.Kind),
 			Container:  h.Document.Container,
 			Author:     personName(h.Document.Author),
+			MediaType:  h.Document.Properties[doc.MediaType],
 			ModifiedAt: h.Document.ModifiedAt,
 			Snippet:    h.Snippet,
 			Passages:   passages(h.Passages),
@@ -507,9 +513,15 @@ func (s *Server) handleDocument(w http.ResponseWriter, r *http.Request, p *acl.P
 }
 
 type documentBody struct {
-	ID         string            `json:"id"`
-	Title      string            `json:"title"`
-	Body       string            `json:"body"`
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+
+	// MediaType is what the body is, so the interface can decide how to render
+	// it instead of guessing from the file name a second time. It is lifted out
+	// of the properties because every document has one and a client should not
+	// have to reach into a bag of source specific strings for it.
+	MediaType  string            `json:"media_type,omitempty"`
 	URL        string            `json:"url,omitempty"`
 	Source     string            `json:"source"`
 	Kind       string            `json:"kind"`
@@ -527,6 +539,7 @@ func documentResponse(d doc.Document) documentBody {
 		ID:         d.ID,
 		Title:      d.Title,
 		Body:       d.Body,
+		MediaType:  d.Properties[doc.MediaType],
 		URL:        d.URL,
 		Source:     d.Source,
 		Kind:       string(d.Kind),
@@ -534,6 +547,79 @@ func documentResponse(d doc.Document) documentBody {
 		ModifiedAt: d.ModifiedAt,
 		Properties: d.Properties,
 	}
+}
+
+// inlineTypes are the media types served with Content-Disposition: inline.
+//
+// The list is short and it is an allow list rather than a deny list. Everything
+// on it is something a browser renders in an img element, where it cannot run
+// script, and everything else is a download. An SVG is on the list for exactly
+// that reason: as an image it is inert, and it is only dangerous when a
+// document embeds it as markup, which this interface never does.
+var inlineTypes = map[string]bool{
+	"image/png":     true,
+	"image/jpeg":    true,
+	"image/gif":     true,
+	"image/webp":    true,
+	"image/svg+xml": true,
+}
+
+func (s *Server) handleContent(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	cs, ok := s.store.(store.ContentStore)
+	if !ok {
+		// A deployment on a driver that holds no bytes has no content to serve,
+		// and says so the same way it would for a document that is not there.
+		writeError(w, http.StatusNotFound, "not_found", "no such document")
+		return
+	}
+
+	id := r.PathValue("id")
+	// The document is read first because it is where the permission decision and
+	// the media type both come from. The driver applies the principal again on
+	// the content read, so this is a lookup rather than the check itself.
+	d, err := s.store.Get(r.Context(), p, id)
+	if err == nil {
+		var c doc.Content
+		c, err = cs.Content(r.Context(), p, id)
+		if err == nil {
+			s.writeContent(w, r, d, c)
+			return
+		}
+	}
+	switch {
+	case errors.Is(err, genba.ErrNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "no such document")
+	default:
+		s.log.Error("content lookup failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal", "the document could not be read")
+	}
+}
+
+// writeContent sends the bytes with the caching and the sniffing rules that
+// make an image safe to put in a page.
+func (s *Server) writeContent(w http.ResponseWriter, r *http.Request, d doc.Document, c doc.Content) {
+	media := d.Properties[doc.MediaType]
+	disposition := "inline"
+	if !inlineTypes[media] {
+		// A type nobody vetted is not rendered in the page and is not described
+		// to the browser as anything it might act on.
+		media, disposition = "application/octet-stream", "attachment"
+	}
+
+	sum := sha256.Sum256(c.Bytes)
+	w.Header().Set("Content-Type", media)
+	w.Header().Set("Content-Disposition", disposition)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("ETag", `"`+hex.EncodeToString(sum[:8])+`"`)
+	// Private, because the response depends on who asked. A shared cache that
+	// kept this would be handing one tenant's screenshot to another.
+	w.Header().Set("Cache-Control", "private, max-age=600")
+	if c.Width > 0 && c.Height > 0 {
+		w.Header().Set("X-Content-Dimensions", strconv.Itoa(c.Width)+"x"+strconv.Itoa(c.Height))
+	}
+	// ServeContent handles the conditional request, the range request and the
+	// length, which are three things worth not writing again.
+	http.ServeContent(w, r, "", d.ModifiedAt, bytes.NewReader(c.Bytes))
 }
 
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request, _ *acl.Principal) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -317,3 +317,136 @@ func engineerWithBothGroups() map[string]string {
 		api.HeaderGroups:  "gdrive:eng@acme.com,gdrive:sales@acme.com",
 	}
 }
+
+// contentServer holds an image, a page with no bytes, and an image of a type
+// the interface will not render inline.
+func contentServer(t *testing.T) http.Handler {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	perm := acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "gdrive",
+		AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}},
+		Version:     1,
+	}
+	docs := []doc.Document{
+		{
+			ID: "img", Tenant: "acme", Source: "gdrive", Kind: doc.KindImage,
+			Title: "architecture.png", Permissions: perm,
+			Properties: map[string]string{doc.MediaType: "image/png"},
+			Content:    &doc.Content{Bytes: []byte("\x89PNG\r\n\x1a\nbytes"), Width: 24, Height: 16},
+		},
+		{
+			ID: "page", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "A page", Body: "text", Permissions: perm,
+			Properties: map[string]string{doc.MediaType: "text/markdown"},
+		},
+		{
+			ID: "odd", Tenant: "acme", Source: "gdrive", Kind: doc.KindFile,
+			Title: "report.pdf", Permissions: perm,
+			Properties: map[string]string{doc.MediaType: "application/pdf"},
+			Content:    &doc.Content{Bytes: []byte("%PDF-1.7")},
+		},
+	}
+	if err := st.Put(t.Context(), docs...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"})
+	return s.Handler()
+}
+
+func TestContentServesTheBytesToAReaderWhoMaySeeTheDocument(t *testing.T) {
+	h := contentServer(t)
+	w := request(t, h, http.MethodGet, "/api/v1/documents/img/content", engineer())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", w.Code)
+	}
+	if got := w.Body.String(); got != "\x89PNG\r\n\x1a\nbytes" {
+		t.Errorf("body is %q", got)
+	}
+	for header, want := range map[string]string{
+		"Content-Type":           "image/png",
+		"Content-Disposition":    "inline",
+		"X-Content-Type-Options": "nosniff",
+		"Cache-Control":          "private, max-age=600",
+		"X-Content-Dimensions":   "24x16",
+	} {
+		if got := w.Header().Get(header); got != want {
+			t.Errorf("%s is %q, want %q", header, got, want)
+		}
+	}
+	if w.Header().Get("ETag") == "" {
+		t.Error("no ETag, so every open pays for the bytes again")
+	}
+}
+
+func TestContentAnswersAConditionalRequestWithoutTheBytes(t *testing.T) {
+	h := contentServer(t)
+	first := request(t, h, http.MethodGet, "/api/v1/documents/img/content", engineer())
+	headers := engineer()
+	headers["If-None-Match"] = first.Header().Get("ETag")
+
+	w := request(t, h, http.MethodGet, "/api/v1/documents/img/content", headers)
+	if w.Code != http.StatusNotModified {
+		t.Fatalf("status %d, want 304", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("a 304 carried %d bytes", w.Body.Len())
+	}
+}
+
+// The endpoint may not become a way to ask whether a document exists, so a
+// document somebody may not read, one that is not there and one that holds no
+// bytes all answer the same way the document endpoint does.
+func TestContentIsNotFoundForEverythingTheCallerMayNotSee(t *testing.T) {
+	h := contentServer(t)
+	stranger := map[string]string{
+		api.HeaderSubject: "u_kenji",
+		api.HeaderGroups:  "gdrive:sales@acme.com",
+	}
+	cases := []struct {
+		name    string
+		target  string
+		headers map[string]string
+	}{
+		{"a document the caller may not read", "/api/v1/documents/img/content", stranger},
+		{"a document that is not there", "/api/v1/documents/nope/content", engineer()},
+		{"a document that holds no bytes", "/api/v1/documents/page/content", engineer()},
+	}
+	var bodies []string
+	for _, c := range cases {
+		w := request(t, h, http.MethodGet, c.target, c.headers)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("%s: status %d, want 404", c.name, w.Code)
+		}
+		bodies = append(bodies, w.Body.String())
+	}
+	for _, b := range bodies[1:] {
+		if b != bodies[0] {
+			t.Errorf("the responses differ, which tells a caller which case they hit:\n%s\n%s", bodies[0], b)
+		}
+	}
+}
+
+func TestContentOffTheAllowListIsADownloadRatherThanAPage(t *testing.T) {
+	w := request(t, contentServer(t), http.MethodGet, "/api/v1/documents/odd/content", engineer())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/octet-stream" {
+		t.Errorf("Content-Type is %q, want application/octet-stream", got)
+	}
+	if got := w.Header().Get("Content-Disposition"); got != "attachment" {
+		t.Errorf("Content-Disposition is %q, want attachment", got)
+	}
+}
+
+func TestDocumentReportsItsMediaType(t *testing.T) {
+	w := request(t, contentServer(t), http.MethodGet, "/api/v1/documents/page", engineer())
+	got := decode[map[string]any](t, w)
+	if got["media_type"] != "text/markdown" {
+		t.Errorf("media_type is %v, want text/markdown", got["media_type"])
+	}
+}

--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -29,13 +29,19 @@
 package fssource
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"image"
+	_ "image/gif"  // registers the GIF config decoder
+	_ "image/jpeg" // registers the JPEG config decoder
+	_ "image/png"  // registers the PNG config decoder
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -50,6 +56,13 @@ import (
 // Past this the file is almost never prose somebody wants to search, and it is
 // often a checked in binary that would cost far more to index than it is worth.
 const DefaultMaxFileSize = 1 << 20
+
+// DefaultMaxImageSize is the largest image read into a document's content.
+//
+// It is separate from the body limit and larger, because the two limits are
+// about different things. A one megabyte text file is almost certainly not
+// prose. A one megabyte screenshot is a screenshot.
+const DefaultMaxImageSize = 4 << 20
 
 // Policy decides who may read a file.
 //
@@ -89,6 +102,7 @@ type Source struct {
 	policy Policy
 
 	maxSize   int64
+	maxImage  int64
 	skipDir   func(name string) bool
 	includeIf func(name string) bool
 	skipped   func(path string, reason error)
@@ -123,6 +137,16 @@ func WithSkipped(f func(path string, reason error)) Option {
 	return func(s *Source) {
 		if f != nil {
 			s.skipped = f
+		}
+	}
+}
+
+// WithMaxImageSize sets the largest image that will be read into a document's
+// content. A value below one selects [DefaultMaxImageSize].
+func WithMaxImageSize(n int64) Option {
+	return func(s *Source) {
+		if n > 0 {
+			s.maxImage = n
 		}
 	}
 }
@@ -177,6 +201,7 @@ func New(root, name string, policy Policy, opts ...Option) (*Source, error) {
 		name:      name,
 		policy:    policy,
 		maxSize:   DefaultMaxFileSize,
+		maxImage:  DefaultMaxImageSize,
 		skipDir:   defaultSkipDir,
 		includeIf: defaultInclude,
 		skipped:   func(string, error) {},
@@ -236,8 +261,8 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 			s.skipped(p, err)
 			return nil
 		}
-		if info.Size() > s.maxSize {
-			s.skipped(p, fmt.Errorf("%d bytes is over the limit of %d", info.Size(), s.maxSize))
+		if limit := s.limitFor(d.Name()); info.Size() > limit {
+			s.skipped(p, fmt.Errorf("%d bytes is over the limit of %d", info.Size(), limit))
 			return nil
 		}
 		mod := info.ModTime()
@@ -277,16 +302,27 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 	return connector.Cursor{Value: highest.UTC().Format(time.RFC3339Nano), Time: highest}, nil
 }
 
+// limitFor is the size limit that applies to one file name. An image gets the
+// image limit and everything else gets the body limit.
+func (s *Source) limitFor(name string) int64 {
+	if isImage(name) {
+		return s.maxImage
+	}
+	return s.maxSize
+}
+
 // read turns one file into a document.
 func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (doc.Document, error) {
-	body, err := os.ReadFile(full)
+	raw, err := os.ReadFile(full)
 	if err != nil {
 		return doc.Document{}, err
 	}
-	// A file that is not valid UTF-8 is a binary this connector has no business
-	// pretending to have read. Extraction of real binary formats is a separate
-	// job with separate failure modes.
-	if !utf8.Valid(body) {
+
+	image := isImage(rel)
+	// A file that is not valid UTF-8 and is not an image we recognise is a
+	// binary this connector has no business pretending to have read. Extraction
+	// of real binary formats is a separate job with separate failure modes.
+	if !image && !utf8.Valid(raw) {
 		return doc.Document{}, errors.New("not text")
 	}
 
@@ -301,7 +337,20 @@ func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (
 		// publish.
 	}
 
-	text := string(body)
+	var (
+		text    string
+		content *doc.Content
+	)
+	// An image has no body. Its file name is what a query can match, which is
+	// how somebody finds architecture.png by typing architecture, and the bytes
+	// are what the preview shows.
+	if image {
+		content = &doc.Content{Bytes: raw}
+		content.Width, content.Height = pixels(raw)
+	} else {
+		text = string(raw)
+	}
+
 	kind := kindOf(rel)
 	return doc.Document{
 		ID:           s.name + ":" + rel,
@@ -315,10 +364,26 @@ func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (
 		SourceUpdate: info.ModTime().UTC().Format(time.RFC3339Nano),
 		Permissions:  perms,
 		Properties: map[string]string{
-			"path":      rel,
-			"extension": strings.TrimPrefix(path.Ext(rel), "."),
+			"path":        rel,
+			"extension":   strings.TrimPrefix(path.Ext(rel), "."),
+			doc.MediaType: mediaTypeOf(rel),
+			"size_bytes":  strconv.FormatInt(info.Size(), 10),
 		},
+		Content: content,
 	}, nil
+}
+
+// pixels reads the dimensions out of an encoded image without decoding it.
+//
+// The standard library answers for png, jpeg and gif. It does not answer for
+// webp or svg, and rather than pull in a decoder for each, those record a zero,
+// which the interface reads as no box to reserve.
+func pixels(raw []byte) (int, int) {
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
+	if err != nil {
+		return 0, 0
+	}
+	return cfg.Width, cfg.Height
 }
 
 // parseCursor reads the modification time out of a cursor.
@@ -388,6 +453,9 @@ func containerOf(rel string) string {
 // kindOf maps an extension onto a document kind. Anything unrecognised is a
 // file, which is the kind that promises the least.
 func kindOf(rel string) doc.Kind {
+	if isImage(rel) {
+		return doc.KindImage
+	}
 	switch strings.ToLower(path.Ext(rel)) {
 	case ".md", ".markdown", ".rst", ".adoc", ".txt", ".html":
 		return doc.KindPage
@@ -397,6 +465,64 @@ func kindOf(rel string) doc.Kind {
 	default:
 		return doc.KindFile
 	}
+}
+
+// mediaTypes is the extension to media type table.
+//
+// It is a table rather than a call to mime.TypeByExtension because that
+// function reads the operating system's mime database, which means the same
+// corpus crawled on two machines can produce two different answers, and because
+// the code types below are ours rather than registered ones.
+var mediaTypes = map[string]string{
+	".md":       "text/markdown",
+	".markdown": "text/markdown",
+	".txt":      "text/plain",
+	".rst":      "text/plain",
+	".adoc":     "text/plain",
+	".html":     "text/html",
+	".css":      "text/css",
+	".go":       "text/x-go",
+	".rs":       "text/x-rust",
+	".py":       "text/x-python",
+	".js":       "text/javascript",
+	".jsx":      "text/javascript",
+	".ts":       "text/x-typescript",
+	".tsx":      "text/x-typescript",
+	".c":        "text/x-c",
+	".h":        "text/x-c",
+	".cc":       "text/x-c++",
+	".cpp":      "text/x-c++",
+	".java":     "text/x-java",
+	".rb":       "text/x-ruby",
+	".sh":       "text/x-shellscript",
+	".sql":      "text/x-sql",
+	".yaml":     "text/x-yaml",
+	".yml":      "text/x-yaml",
+	".toml":     "text/x-toml",
+	".json":     "application/json",
+	".proto":    "text/x-protobuf",
+	".png":      "image/png",
+	".jpg":      "image/jpeg",
+	".jpeg":     "image/jpeg",
+	".gif":      "image/gif",
+	".webp":     "image/webp",
+	".svg":      "image/svg+xml",
+}
+
+// mediaTypeOf is what a document says it is. An extension nobody recognises is
+// text/plain, because that is what the connector actually read and it is the
+// type a preview can render without guessing.
+func mediaTypeOf(rel string) string {
+	if t, ok := mediaTypes[strings.ToLower(path.Ext(rel))]; ok {
+		return t
+	}
+	return "text/plain"
+}
+
+// isImage reports whether a file name is one of the image types this connector
+// stores bytes for.
+func isImage(name string) bool {
+	return strings.HasPrefix(mediaTypeOf(name), "image/")
 }
 
 // defaultSkipDir skips version control, dependency and build directories, which
@@ -410,7 +536,7 @@ func defaultSkipDir(name string) bool {
 	return strings.HasPrefix(name, ".")
 }
 
-// defaultInclude reads text formats and nothing else.
+// defaultInclude reads text formats and the image formats a preview can show.
 func defaultInclude(name string) bool {
 	if strings.HasPrefix(name, ".") {
 		return false
@@ -419,9 +545,10 @@ func defaultInclude(name string) bool {
 		return true
 	}
 	switch strings.ToLower(path.Ext(name)) {
-	case ".md", ".markdown", ".rst", ".adoc", ".txt", ".html",
+	case ".md", ".markdown", ".rst", ".adoc", ".txt", ".html", ".css",
 		".go", ".rs", ".py", ".js", ".ts", ".tsx", ".jsx", ".c", ".h", ".cc", ".cpp",
-		".java", ".rb", ".sh", ".sql", ".yaml", ".yml", ".toml", ".json", ".proto":
+		".java", ".rb", ".sh", ".sql", ".yaml", ".yml", ".toml", ".json", ".proto",
+		".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg":
 		return true
 	}
 	return false

--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -318,11 +318,11 @@ func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (
 		return doc.Document{}, err
 	}
 
-	image := isImage(rel)
+	picture := isImage(rel)
 	// A file that is not valid UTF-8 and is not an image we recognise is a
 	// binary this connector has no business pretending to have read. Extraction
 	// of real binary formats is a separate job with separate failure modes.
-	if !image && !utf8.Valid(raw) {
+	if !picture && !utf8.Valid(raw) {
 		return doc.Document{}, errors.New("not text")
 	}
 
@@ -344,7 +344,7 @@ func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (
 	// An image has no body. Its file name is what a query can match, which is
 	// how somebody finds architecture.png by typing architecture, and the bytes
 	// are what the preview shows.
-	if image {
+	if picture {
 		content = &doc.Content{Bytes: raw}
 		content.Width, content.Height = pixels(raw)
 	} else {
@@ -378,7 +378,7 @@ func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (
 // The standard library answers for png, jpeg and gif. It does not answer for
 // webp or svg, and rather than pull in a decoder for each, those record a zero,
 // which the interface reads as no box to reserve.
-func pixels(raw []byte) (int, int) {
+func pixels(raw []byte) (width, height int) {
 	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
 	if err != nil {
 		return 0, 0

--- a/connector/fssource/fssource_test.go
+++ b/connector/fssource/fssource_test.go
@@ -1,8 +1,11 @@
 package fssource_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"image"
+	pngenc "image/png"
 	"os"
 	"path/filepath"
 	"slices"
@@ -75,7 +78,7 @@ func TestItReadsATreeIntoDocuments(t *testing.T) {
 
 	got, cursor := collect(t, s, connector.Cursor{})
 
-	want := []string{"repo:README.md", "repo:cmd/main.go", "repo:docs/deep/nested.md", "repo:docs/install.md"}
+	want := []string{"repo:README.md", "repo:assets/logo.png", "repo:cmd/main.go", "repo:docs/deep/nested.md", "repo:docs/install.md"}
 	if !slices.Equal(ids(got), want) {
 		t.Errorf("read %v\nwant %v", ids(got), want)
 	}
@@ -112,8 +115,80 @@ func TestItReadsATreeIntoDocuments(t *testing.T) {
 	if p := byID["repo:cmd/main.go"].Properties["extension"]; p != "go" {
 		t.Errorf("extension property is %q", p)
 	}
+	for id, want := range map[string]string{
+		"repo:README.md":       "text/markdown",
+		"repo:cmd/main.go":     "text/x-go",
+		"repo:assets/logo.png": "image/png",
+	} {
+		if got := byID[id].Properties[doc.MediaType]; got != want {
+			t.Errorf("%s has media type %q, want %q", id, got, want)
+		}
+	}
 	if byID["repo:README.md"].ModifiedAt.IsZero() {
 		t.Error("ModifiedAt was not set from the file")
+	}
+}
+
+// An image is the one binary this connector reads. It has no body, because
+// there is no text in it to search, and it carries its bytes and its pixel size
+// so the preview can show it without guessing either.
+func TestAnImageBecomesADocumentWithItsBytes(t *testing.T) {
+	root := t.TempDir()
+	var png bytes.Buffer
+	if err := pngenc.Encode(&png, image.NewRGBA(image.Rect(0, 0, 24, 16))); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "diagram.png"), png.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A webp is stored without dimensions, because the standard library cannot
+	// read them and a decoder for one format is not worth a dependency.
+	if err := os.WriteFile(filepath.Join(root, "shot.webp"), []byte("RIFF....WEBPVP8 "), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	got, _ := collect(t, s, connector.Cursor{})
+	byID := map[string]doc.Document{}
+	for _, d := range got {
+		byID[d.ID] = d
+	}
+
+	d := byID["repo:diagram.png"]
+	switch {
+	case d.Kind != doc.KindImage:
+		t.Errorf("kind is %q, want image", d.Kind)
+	case d.Body != "":
+		t.Errorf("an image has a body of %q, want none", d.Body)
+	case d.Content == nil:
+		t.Fatal("an image document carries no bytes")
+	case !bytes.Equal(d.Content.Bytes, png.Bytes()):
+		t.Error("the bytes are not the ones on disk")
+	case d.Content.Width != 24 || d.Content.Height != 16:
+		t.Errorf("size is %dx%d, want 24x16", d.Content.Width, d.Content.Height)
+	}
+	if w := byID["repo:shot.webp"]; w.Content == nil || w.Content.Width != 0 {
+		t.Errorf("a webp should be stored with no dimensions, got %+v", w.Content)
+	}
+}
+
+func TestAnOversizeImageIsSkipped(t *testing.T) {
+	root := tree(t, map[string]string{
+		"small.png": "\x89PNG\r\n\x1a\n",
+		"huge.png":  string(make([]byte, 4096)),
+	})
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"), fssource.WithMaxImageSize(1024))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := collect(t, s, connector.Cursor{})
+	if !slices.Equal(ids(got), []string{"repo:small.png"}) {
+		t.Errorf("read %v, want only the small image", ids(got))
 	}
 }
 

--- a/doc/doc.go
+++ b/doc/doc.go
@@ -28,7 +28,34 @@ const (
 	KindEmail    Kind = "email"
 	KindCalendar Kind = "calendar"
 	KindPerson   Kind = "person"
+	KindImage    Kind = "image"
 )
+
+// MediaType is the property every connector sets to say what a document
+// actually is. The kind is coarse on purpose and drives the layout of a result
+// row; the media type is what a preview needs before it can decide whether it
+// is looking at a wiki page, a Go file or a screenshot.
+//
+// A connector that knows nothing better sets text/plain. An empty media type is
+// treated the same way downstream, but writing the honest default is cheaper
+// than making every reader handle the missing case.
+const MediaType = "media_type"
+
+// Content is the raw bytes of a document whose meaning is not its text.
+//
+// It is nil for everything that is prose, which is almost everything. A store
+// keeps it beside the document rather than inside it, so that the megabyte of
+// PNG behind a screenshot never rides along on the scan that ranking does.
+type Content struct {
+	Bytes []byte
+
+	// Width and Height are pixels, and zero when nobody could tell. They are
+	// recorded at crawl time so a preview can reserve the box before the image
+	// arrives, rather than shoving the paragraph under it down the page when it
+	// does.
+	Width  int
+	Height int
+}
 
 // Person is a name attached to a document, resolved to a subject where we could
 // and left as a raw source identity where we could not.
@@ -65,6 +92,11 @@ type Document struct {
 	// Properties carries source specific fields that are worth faceting or
 	// filtering on, such as a ticket status or a file's mime type.
 	Properties map[string]string
+
+	// Content is the bytes of a document that is not text, and nil for one that
+	// is. It is not indexed and it is not returned by a query path: a store
+	// takes it on Put and hands it back only through [store.ContentStore].
+	Content *Content
 }
 
 // Queryable reports whether the document may be served to a query at all. It is

--- a/index/index.go
+++ b/index/index.go
@@ -265,7 +265,7 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 			continue
 		}
 		res.Hits[i].Document = full
-		res.Hits[i].Snippet, res.Hits[i].Passages = snippet(full.Body, req.Terms)
+		res.Hits[i].Snippet, res.Hits[i].Passages = snippet(readable(full), req.Terms)
 	}
 	res.Took = s.now().Sub(start)
 	return res, nil

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -40,6 +40,7 @@ type fixture struct {
 	body     string
 	source   string
 	kind     doc.Kind
+	media    string
 	modified time.Time
 	perm     acl.Permissions
 }
@@ -57,6 +58,10 @@ func newSearcher(t *testing.T, fixtures []fixture, opts ...index.Option) *index.
 		if f.kind == "" {
 			f.kind = doc.KindPage
 		}
+		var props map[string]string
+		if f.media != "" {
+			props = map[string]string{doc.MediaType: f.media}
+		}
 		docs = append(docs, doc.Document{
 			ID:          f.id,
 			Tenant:      "acme",
@@ -66,6 +71,7 @@ func newSearcher(t *testing.T, fixtures []fixture, opts ...index.Option) *index.
 			Body:        f.body,
 			ModifiedAt:  f.modified,
 			Permissions: f.perm,
+			Properties:  props,
 		})
 	}
 	if err := st.Put(t.Context(), docs...); err != nil {
@@ -301,5 +307,67 @@ func TestPassagesAreEmptyWithoutAMatchInTheBody(t *testing.T) {
 		if p.Match {
 			t.Fatalf("marked %q, which is not in the body", p.Text)
 		}
+	}
+}
+
+// Two lines of a result row is a small budget, and a snippet full of hashes,
+// asterisks and table pipes has spent it on nothing.
+func TestSnippetsFromMarkdownReadAsProse(t *testing.T) {
+	s := newSearcher(t, []fixture{{
+		id:    "spec",
+		title: "Permissions",
+		media: "text/markdown",
+		body: "# Permissions\n\n" +
+			"The rule is that a **principal** is applied by the `driver`, not by the caller.\n" +
+			"\n| Mode | Meaning |\n| --- | --- |\n| acl | a list |\n",
+		perm: openTo("eng@acme.com"),
+	}})
+	res, err := s.Search(t.Context(), principal("gdrive:eng@acme.com"), index.Query{Text: "principal"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res.Hits) != 1 {
+		t.Fatalf("got %d hits, want 1", len(res.Hits))
+	}
+	snippet := res.Hits[0].Snippet
+	for _, syntax := range []string{"#", "**", "`", "|"} {
+		if strings.Contains(snippet, syntax) {
+			t.Errorf("the snippet still carries %q:\n%s", syntax, snippet)
+		}
+	}
+	if !strings.Contains(snippet, "principal") {
+		t.Errorf("the matched term is gone from the snippet:\n%s", snippet)
+	}
+	var marked []string
+	for _, p := range res.Hits[0].Passages {
+		if p.Match {
+			marked = append(marked, p.Text)
+		}
+	}
+	if !slices.Equal(marked, []string{"principal"}) {
+		t.Errorf("marked %v, want the term marked at its offset in the stripped text", marked)
+	}
+}
+
+// A source file is not markdown, and stripping what looks like syntax out of
+// code would be lying about the file.
+func TestSnippetsFromCodeAreLeftAlone(t *testing.T) {
+	s := newSearcher(t, []fixture{{
+		id:    "src",
+		title: "store/store.go",
+		kind:  doc.KindCode,
+		media: "text/x-go",
+		body:  "// principal is applied by the driver\nfunc visible(p *acl.Principal) bool { return *p.ok }\n",
+		perm:  openTo("eng@acme.com"),
+	}})
+	res, err := s.Search(t.Context(), principal("gdrive:eng@acme.com"), index.Query{Text: "principal"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res.Hits) != 1 {
+		t.Fatalf("got %d hits, want 1", len(res.Hits))
+	}
+	if !strings.Contains(res.Hits[0].Snippet, "*p.ok") {
+		t.Errorf("the code was rewritten:\n%s", res.Hits[0].Snippet)
 	}
 }

--- a/index/plain.go
+++ b/index/plain.go
@@ -1,0 +1,252 @@
+package index
+
+import (
+	"strings"
+
+	"github.com/tamnd/genba/doc"
+)
+
+// readable is the text a snippet is cut out of.
+//
+// For most documents that is the body as it was indexed. For a markdown
+// document it is the body with the syntax taken out, because two lines of a
+// result row is a small budget and a snippet that spends it on hashes, asterisks
+// and table pipes has spent it on nothing. The person reading wants the sentence
+// somebody wrote.
+//
+// Only markdown is treated this way. A source file is not markdown, and stripping
+// what looks like syntax out of code would be lying about the file.
+func readable(d doc.Document) string {
+	if d.Properties[doc.MediaType] != "text/markdown" {
+		return d.Body
+	}
+	return plainText(d.Body)
+}
+
+// plainText removes markdown syntax and keeps the words.
+//
+// It is a line pass and then an inline pass, which is enough for a snippet and
+// deliberately less than a renderer. It never reorders text: a term at the start
+// of the body is still near the start afterwards, so the passage this produces is
+// the passage a reader would have picked.
+func plainText(md string) string {
+	if md == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(md))
+
+	fence := ""
+	for line := range strings.SplitSeq(md, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		// Inside a fence the text is code and it is kept exactly, because that
+		// is the one place where an asterisk means an asterisk.
+		if fence != "" {
+			if strings.HasPrefix(trimmed, fence) {
+				fence = ""
+				continue
+			}
+			b.WriteString(line)
+			b.WriteByte('\n')
+			continue
+		}
+		if marker := fenceOf(trimmed); marker != "" {
+			fence = marker
+			continue
+		}
+		if isRule(trimmed) || isTableDivider(trimmed) {
+			continue
+		}
+
+		trimmed = trimMarkers(trimmed)
+		if strings.HasPrefix(trimmed, "|") {
+			trimmed = tableRow(trimmed)
+		}
+		b.WriteString(inlineText(trimmed))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// fenceOf returns the fence marker a line opens, or an empty string.
+func fenceOf(line string) string {
+	for _, marker := range []string{"```", "~~~"} {
+		if strings.HasPrefix(line, marker) {
+			return marker
+		}
+	}
+	return ""
+}
+
+// isRule reports whether a line is a horizontal rule, which carries no words.
+func isRule(line string) bool {
+	if len(line) < 3 {
+		return false
+	}
+	c := line[0]
+	if c != '-' && c != '*' && c != '_' {
+		return false
+	}
+	return strings.Trim(line, string(c)) == ""
+}
+
+// isTableDivider reports whether a line is the alignment row under a table
+// head. It is the one table line that is pure syntax.
+func isTableDivider(line string) bool {
+	if !strings.HasPrefix(line, "|") {
+		return false
+	}
+	return strings.Trim(line, "|-: \t") == "" && strings.ContainsRune(line, '-')
+}
+
+// trimMarkers removes the block level markers from the front of a line: the
+// hashes of a heading, the arrows of a quote, a list bullet or number, and a
+// task box.
+func trimMarkers(line string) string {
+	for {
+		before := line
+		switch {
+		case strings.HasPrefix(line, "#"):
+			line = strings.TrimLeft(line, "#")
+		case strings.HasPrefix(line, ">"):
+			line = strings.TrimLeft(line, ">")
+		case len(line) > 1 && (line[0] == '-' || line[0] == '*' || line[0] == '+') && line[1] == ' ':
+			line = line[1:]
+		default:
+			line = trimOrderedMarker(line)
+		}
+		line = strings.TrimLeft(line, " \t")
+		if line == before {
+			break
+		}
+	}
+	// A task box is a marker too, and an empty one in a snippet reads as a typo.
+	for _, box := range []string{"[ ] ", "[x] ", "[X] "} {
+		if rest, ok := strings.CutPrefix(line, box); ok {
+			return rest
+		}
+	}
+	return line
+}
+
+// trimOrderedMarker removes a leading "12. " or "12) ".
+func trimOrderedMarker(line string) string {
+	i := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	if i == 0 || i+1 >= len(line) {
+		return line
+	}
+	if (line[i] == '.' || line[i] == ')') && line[i+1] == ' ' {
+		return line[i+1:]
+	}
+	return line
+}
+
+// tableRow turns a row of cells into the words in it, in order.
+func tableRow(line string) string {
+	cells := strings.Split(strings.Trim(line, "|"), "|")
+	for i, c := range cells {
+		cells[i] = strings.TrimSpace(c)
+	}
+	return strings.Join(cells, " ")
+}
+
+// inlineText removes the inline syntax from one line.
+//
+// Emphasis markers are only dropped at a word boundary, so snake_case survives
+// and a multiplication sign in prose is not mistaken for the start of an
+// emphasis run. A link keeps its text and loses its target, because the target
+// is not something anybody reads in a result row.
+func inlineText(line string) string {
+	var b strings.Builder
+	b.Grow(len(line))
+
+	for i := 0; i < len(line); {
+		switch c := line[i]; {
+		case c == '`':
+			i++
+		case c == '\\' && i+1 < len(line) && isPunct(line[i+1]):
+			// An escaped marker is the character itself.
+			b.WriteByte(line[i+1])
+			i += 2
+		case (c == '*' || c == '_') && boundary(line, i):
+			for i < len(line) && line[i] == c {
+				i++
+			}
+		case c == '!' && i+1 < len(line) && line[i+1] == '[':
+			text, next, ok := linkAt(line, i+1)
+			if !ok {
+				b.WriteByte(c)
+				i++
+				continue
+			}
+			b.WriteString(text)
+			i = next
+		case c == '[':
+			text, next, ok := linkAt(line, i)
+			if !ok {
+				b.WriteByte(c)
+				i++
+				continue
+			}
+			b.WriteString(text)
+			i = next
+		case c == '<':
+			if end := strings.IndexByte(line[i:], '>'); end > 0 && isAutolink(line[i+1:i+end]) {
+				b.WriteString(line[i+1 : i+end])
+				i += end + 1
+				continue
+			}
+			b.WriteByte(c)
+			i++
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
+}
+
+// linkAt reads a [text](target) starting at an open bracket, returning the text
+// and the offset just past the target.
+func linkAt(line string, i int) (string, int, bool) {
+	bracket := strings.IndexByte(line[i:], ']')
+	if bracket < 0 || i+bracket+1 >= len(line) || line[i+bracket+1] != '(' {
+		return "", 0, false
+	}
+	paren := strings.IndexByte(line[i+bracket+1:], ')')
+	if paren < 0 {
+		return "", 0, false
+	}
+	return line[i+1 : i+bracket], i + bracket + paren + 2, true
+}
+
+// boundary reports whether the marker at i starts or ends a run of emphasis
+// rather than sitting inside a word.
+func boundary(line string, i int) bool {
+	c := line[i]
+	before := byte(' ')
+	if i > 0 {
+		before = line[i-1]
+	}
+	j := i
+	for j < len(line) && line[j] == c {
+		j++
+	}
+	after := byte(' ')
+	if j < len(line) {
+		after = line[j]
+	}
+	return before == ' ' || before == '\t' || after == ' ' || after == '\t' || j == len(line)
+}
+
+func isAutolink(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "mailto:")
+}
+
+func isPunct(c byte) bool {
+	return strings.IndexByte("\\`*_{}[]()#+-.!|>~", c) >= 0
+}

--- a/index/plain.go
+++ b/index/plain.go
@@ -212,7 +212,7 @@ func inlineText(line string) string {
 
 // linkAt reads a [text](target) starting at an open bracket, returning the text
 // and the offset just past the target.
-func linkAt(line string, i int) (string, int, bool) {
+func linkAt(line string, i int) (text string, past int, ok bool) {
 	bracket := strings.IndexByte(line[i:], ']')
 	if bracket < 0 || i+bracket+1 >= len(line) || line[i+bracket+1] != '(' {
 		return "", 0, false

--- a/index/plain_test.go
+++ b/index/plain_test.go
@@ -1,0 +1,64 @@
+package index
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPlainTextKeepsTheWordsAndDropsTheSyntax(t *testing.T) {
+	cases := []struct {
+		name string
+		md   string
+		want string
+	}{
+		{"heading", "# Permissions and governance", "Permissions and governance"},
+		{"setext style hashes", "### 3.1 The count row", "3.1 The count row"},
+		{"emphasis", "the rule is **never** shown to a *user*", "the rule is never shown to a user"},
+		{"inline code", "call `store.Get` first", "call store.Get first"},
+		{"link", "see [the spec](https://example.com/spec) for the rest", "see the spec for the rest"},
+		{"image", "![architecture](diagram.png)", "architecture"},
+		{"autolink", "written at <https://example.com/x>", "written at https://example.com/x"},
+		{"bullet", "- a permission that failed to resolve", "a permission that failed to resolve"},
+		{"numbered", "3. tokens are rewritten first", "tokens are rewritten first"},
+		{"task", "- [x] every focus selector is focus-visible", "every focus selector is focus-visible"},
+		{"quote", "> the principal is applied by the driver", "the principal is applied by the driver"},
+		{"table row", "| Media type | Renderer |", "Media type Renderer"},
+		{"snake case survives", "the store_id column is folded", "the store_id column is folded"},
+		{"escaped marker", `a literal \* stays`, "a literal * stays"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := strings.TrimSpace(plainText(c.md)); got != c.want {
+				t.Errorf("plainText(%q)\n got %q\nwant %q", c.md, got, c.want)
+			}
+		})
+	}
+}
+
+func TestPlainTextDropsWholeLinesThatAreOnlySyntax(t *testing.T) {
+	md := "# Head\n\n---\n\n| a | b |\n| --- | :-- |\n| one | two |\n"
+	got := strings.Join(strings.Fields(plainText(md)), " ")
+	if got != "Head a b one two" {
+		t.Errorf("got %q, want the rule and the alignment row gone", got)
+	}
+}
+
+// Code inside a fence is the one place a marker means itself, so it survives.
+func TestPlainTextLeavesFencedCodeAlone(t *testing.T) {
+	md := "before\n\n```go\nx := *p // **not** emphasis\n```\n\nafter\n"
+	got := plainText(md)
+	if !strings.Contains(got, "x := *p // **not** emphasis") {
+		t.Errorf("fenced code was rewritten:\n%s", got)
+	}
+	if strings.Contains(got, "```") {
+		t.Errorf("the fence itself survived:\n%s", got)
+	}
+}
+
+func TestPlainTextIsUnchangedForTextThatIsNotMarkdown(t *testing.T) {
+	// Nothing here is markdown syntax, so nothing should move.
+	const prose = "Fail the payments queue over to the replica, then page the on call."
+	if got := strings.TrimSpace(plainText(prose)); got != prose {
+		t.Errorf("got %q, want it unchanged", got)
+	}
+}

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -22,17 +22,25 @@ import (
 
 // Store keeps documents in a map guarded by a read write mutex.
 type Store struct {
-	mu     sync.RWMutex
-	docs   map[string]doc.Document
-	closed bool
+	mu   sync.RWMutex
+	docs map[string]doc.Document
+
+	// content is kept out of the document for the same reason the SQLite driver
+	// keeps it in its own table: a scan that carried image bytes would make
+	// every query pay for them.
+	content map[string]doc.Content
+	closed  bool
 }
 
 // New returns an empty store.
 func New() *Store {
-	return &Store{docs: make(map[string]doc.Document)}
+	return &Store{
+		docs:    make(map[string]doc.Document),
+		content: make(map[string]doc.Content),
+	}
 }
 
-var _ store.Store = (*Store)(nil)
+var _ store.ContentStore = (*Store)(nil)
 
 // Put inserts or replaces documents.
 func (s *Store) Put(ctx context.Context, docs ...doc.Document) error {
@@ -48,6 +56,12 @@ func (s *Store) Put(ctx context.Context, docs ...doc.Document) error {
 		if d.ID == "" {
 			return fmt.Errorf("memstore: put: %w", errNoID)
 		}
+		if d.Content != nil {
+			s.content[d.ID] = *d.Content
+		} else {
+			delete(s.content, d.ID)
+		}
+		d.Content = nil
 		s.docs[d.ID] = d
 	}
 	return nil
@@ -65,6 +79,7 @@ func (s *Store) Delete(ctx context.Context, ids ...string) error {
 	}
 	for _, id := range ids {
 		delete(s.docs, id)
+		delete(s.content, id)
 	}
 	return nil
 }
@@ -120,6 +135,33 @@ func (s *Store) Scan(ctx context.Context, p *acl.Principal, fn func(doc.Document
 	return nil
 }
 
+// Content returns the bytes of one document if the principal may read it.
+func (s *Store) Content(ctx context.Context, p *acl.Principal, id string) (doc.Content, error) {
+	if err := ctx.Err(); err != nil {
+		return doc.Content{}, err
+	}
+	if p == nil {
+		return doc.Content{}, genba.ErrNoPrincipal
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return doc.Content{}, genba.ErrClosed
+	}
+	d, ok := s.docs[id]
+	if !ok || !visible(p, d) {
+		return doc.Content{}, genba.ErrNotFound
+	}
+	c, ok := s.content[id]
+	if !ok {
+		// A document with no content is not distinguishable from one that is not
+		// there, because telling the two apart is a way of asking whether a
+		// document exists.
+		return doc.Content{}, genba.ErrNotFound
+	}
+	return c, nil
+}
+
 // Stats reports what the store holds.
 func (s *Store) Stats(ctx context.Context) (store.Stats, error) {
 	if err := ctx.Err(); err != nil {
@@ -147,6 +189,7 @@ func (s *Store) Close() error {
 	defer s.mu.Unlock()
 	s.closed = true
 	s.docs = nil
+	s.content = nil
 	return nil
 }
 

--- a/store/sqlitestore/schema.go
+++ b/store/sqlitestore/schema.go
@@ -74,6 +74,18 @@ var migrations = []string{
 		contentless_delete=1,
 		tokenize='unicode61 remove_diacritics 0'
 	)`,
+
+	// document_content is the bytes of a document that is not text, in its own
+	// table rather than in the data column. The reason is the shape of the
+	// reads: data is selected by every query path, and a megabyte of PNG in it
+	// would be a megabyte read per hit whether or not anybody ever looks at the
+	// image. Here it is only read by the one endpoint that serves it.
+	`CREATE TABLE document_content (
+		doc_id     TEXT PRIMARY KEY REFERENCES document(id) ON DELETE CASCADE,
+		width      INTEGER NOT NULL,
+		height     INTEGER NOT NULL,
+		bytes      BLOB NOT NULL
+	)`,
 }
 
 // migrate brings an open database up to the current schema.

--- a/store/sqlitestore/sqlitestore.go
+++ b/store/sqlitestore/sqlitestore.go
@@ -60,8 +60,9 @@ type Store struct {
 }
 
 var (
-	_ store.Store     = (*Store)(nil)
-	_ store.Retriever = (*Store)(nil)
+	_ store.Store        = (*Store)(nil)
+	_ store.Retriever    = (*Store)(nil)
+	_ store.ContentStore = (*Store)(nil)
 )
 
 // Open opens or creates a database at path and brings its schema up to date.
@@ -154,6 +155,12 @@ func (s *Store) Put(ctx context.Context, docs ...doc.Document) error {
 // joined on it. A delete and insert would give the row a new identity and leave
 // the old terms behind under the old one.
 func putOne(ctx context.Context, tx *sql.Tx, d doc.Document) error {
+	// The content comes off the document before it is encoded, so the data
+	// column stays the size of the text and Get cannot hand image bytes back to
+	// a query path that has no use for them.
+	content := d.Content
+	d.Content = nil
+
 	data, err := json.Marshal(d)
 	if err != nil {
 		return fmt.Errorf("encode: %w", err)
@@ -198,6 +205,20 @@ func putOne(ctx context.Context, tx *sql.Tx, d doc.Document) error {
 		if _, err := tx.ExecContext(ctx,
 			`INSERT INTO document_ref (doc_id, effect, scope, key) VALUES (?, ?, ?, ?)`,
 			d.ID, r.effect, r.scope, r.key,
+		); err != nil {
+			return err
+		}
+	}
+
+	// A put that carries no content clears whatever was there, because a source
+	// replacing a screenshot with a text file has to leave nothing behind.
+	if _, err := tx.ExecContext(ctx, `DELETE FROM document_content WHERE doc_id = ?`, d.ID); err != nil {
+		return err
+	}
+	if content != nil {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO document_content (doc_id, width, height, bytes) VALUES (?, ?, ?, ?)`,
+			d.ID, content.Width, content.Height, content.Bytes,
 		); err != nil {
 			return err
 		}
@@ -307,6 +328,40 @@ func (s *Store) Get(ctx context.Context, p *acl.Principal, id string) (doc.Docum
 	}
 	s.rows.Add(1)
 	return decode(data)
+}
+
+// Content returns the bytes of one document if the principal may read it.
+//
+// The join is the point. The permission predicate is applied in the same
+// statement that reads the blob, so a caller who may not see the document never
+// causes the bytes to be read at all, let alone returned.
+func (s *Store) Content(ctx context.Context, p *acl.Principal, id string) (doc.Content, error) {
+	if err := s.ready(ctx); err != nil {
+		return doc.Content{}, err
+	}
+	if p == nil {
+		return doc.Content{}, genba.ErrNoPrincipal
+	}
+
+	c := visible(p)
+	args := append([]any{id}, c.args...)
+	row := s.db.QueryRowContext(ctx, `
+		SELECT c.width, c.height, c.bytes
+		FROM document_content c
+		JOIN document d ON d.id = c.doc_id
+		WHERE c.doc_id = ? AND `+c.where(), args...)
+
+	var out doc.Content
+	switch err := row.Scan(&out.Width, &out.Height, &out.Bytes); {
+	case errors.Is(err, sql.ErrNoRows):
+		// Missing, invisible and text only are one answer here, for the reason
+		// they are one answer in Get.
+		return doc.Content{}, genba.ErrNotFound
+	case err != nil:
+		return doc.Content{}, fmt.Errorf("sqlitestore: content: %w", err)
+	}
+	s.rows.Add(1)
+	return out, nil
 }
 
 // Scan calls fn for every document the principal may read, in id order.

--- a/store/store.go
+++ b/store/store.go
@@ -51,6 +51,33 @@ type Store interface {
 	Close() error
 }
 
+// ContentStore is a store that can also hold the bytes of a document.
+//
+// It is an optional capability rather than part of [Store], because a driver
+// over a search service that only keeps an inverted index has nowhere to put a
+// megabyte of PNG, and refusing to implement it is a better answer than
+// implementing it badly. A caller checks for it with a type assertion and
+// serves nothing where it is absent.
+//
+// The rule the rest of the interface follows is not relaxed here. The principal
+// is applied while the driver walks its own data, and a caller who may not read
+// the document gets the same not found the document itself would produce.
+//
+// A driver that implements this takes [doc.Content] on Put and stores it beside
+// the document. Get and Scan must not return it: a scan that carried image
+// bytes would make every query pay for them.
+type ContentStore interface {
+	Store
+
+	// Content returns the bytes of one document if the principal may read it.
+	//
+	// It returns an error matching genba.ErrNotFound when the document does not
+	// exist, when the principal may not see it, and when it exists but holds no
+	// content. All three are the same answer for the same reason: a caller who
+	// can tell them apart can use the difference to prove a document exists.
+	Content(ctx context.Context, p *acl.Principal, id string) (doc.Content, error)
+}
+
 // Stats is a snapshot of a store's contents.
 type Stats struct {
 	// Documents is the number of documents that can be served to a query.

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -56,6 +56,31 @@ var cases = []testCase{
 	{"put replaces an existing document", testReplace},
 	{"a revoked document disappears", testRevocation},
 	{"stats count served and quarantined documents", testStats},
+	{"content is served only to a reader who may see the document", testContent},
+	{"content never rides along on a query path", testContentIsNotInTheDocument},
+	{"deleting a document deletes its content", testContentDelete},
+}
+
+// contentStore skips a case for a driver that does not hold bytes.
+//
+// The capability is optional, so a driver without it is not failing the suite,
+// and a driver with it does not get to opt out of the permission rule.
+func contentStore(t *testing.T, s store.Store) store.ContentStore {
+	t.Helper()
+	cs, ok := s.(store.ContentStore)
+	if !ok {
+		t.Skip("driver does not implement store.ContentStore")
+	}
+	return cs
+}
+
+func withContent(id string, perm acl.Permissions) doc.Document {
+	d := document(id, perm)
+	d.Kind = doc.KindImage
+	d.Body = ""
+	d.Properties = map[string]string{doc.MediaType: "image/png"}
+	d.Content = &doc.Content{Bytes: []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a}, Width: 12, Height: 8}
+	return d
 }
 
 func reader() *acl.Principal {
@@ -290,5 +315,74 @@ func testStats(t *testing.T, s store.Store) {
 	}
 	if st.Documents != 2 || st.Quarantined != 1 {
 		t.Fatalf("Stats = %+v, want 2 served and 1 quarantined", st)
+	}
+}
+
+func testContent(t *testing.T, s store.Store) {
+	cs := contentStore(t, s)
+	mustPut(t, s, withContent("d1", readable()))
+
+	got, err := cs.Content(t.Context(), reader(), "d1")
+	if err != nil {
+		t.Fatalf("Content: %v", err)
+	}
+	if len(got.Bytes) != 6 || got.Width != 12 || got.Height != 8 {
+		t.Fatalf("Content returned %d bytes at %dx%d, want 6 bytes at 12x8", len(got.Bytes), got.Width, got.Height)
+	}
+
+	if _, err := cs.Content(t.Context(), stranger(), "d1"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("Content for a reader without access returned %v, want ErrNotFound", err)
+	}
+	// A document that exists and holds no bytes answers the same way a missing
+	// one does, so the response cannot be used to ask whether a document is
+	// there.
+	mustPut(t, s, document("d2", readable()))
+	if _, err := cs.Content(t.Context(), reader(), "d2"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("Content for a document with no bytes returned %v, want ErrNotFound", err)
+	}
+	if _, err := cs.Content(t.Context(), reader(), "missing"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("Content for a missing document returned %v, want ErrNotFound", err)
+	}
+	if _, err := cs.Content(t.Context(), nil, "d1"); err == nil {
+		t.Fatal("Content with a nil principal returned bytes")
+	}
+}
+
+func testContentIsNotInTheDocument(t *testing.T, s store.Store) {
+	contentStore(t, s)
+	mustPut(t, s, withContent("d1", readable()))
+
+	got, err := s.Get(t.Context(), reader(), "d1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Content != nil {
+		t.Fatal("Get returned a document carrying content bytes")
+	}
+	if err := s.Scan(t.Context(), reader(), func(d doc.Document) bool {
+		if d.Content != nil {
+			t.Error("Scan yielded a document carrying content bytes")
+		}
+		return true
+	}); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+}
+
+func testContentDelete(t *testing.T, s store.Store) {
+	cs := contentStore(t, s)
+	mustPut(t, s, withContent("d1", readable()))
+	if err := s.Delete(t.Context(), "d1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := cs.Content(t.Context(), reader(), "d1"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("Content after Delete returned %v, want ErrNotFound", err)
+	}
+
+	// Replacing an image with a text document has to leave nothing behind.
+	mustPut(t, s, withContent("d2", readable()))
+	mustPut(t, s, document("d2", readable()))
+	if _, err := cs.Content(t.Context(), reader(), "d2"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("Content after a put with no bytes returned %v, want ErrNotFound", err)
 	}
 }

--- a/web/dist/assets/api.js
+++ b/web/dist/assets/api.js
@@ -84,11 +84,32 @@ async function get(path, params, signal) {
   return res.json();
 }
 
+/**
+ * bytes fetches a document's raw content.
+ *
+ * An img tag cannot carry the identity headers, so the bytes come through fetch
+ * and become an object URL. That keeps one rule for who may read what: the
+ * server decides, from the same headers as every other request, and a document
+ * somebody may not read is a 404 here exactly as it is everywhere else.
+ */
+async function bytes(path, signal) {
+  const res = await fetch(BASE + path, { headers: headers(), signal });
+  if (!res.ok) throw new ApiError(res.status, "error", `the server returned ${res.status}`);
+  const dims = (res.headers.get("X-Content-Dimensions") || "").split("x");
+  return {
+    blob: await res.blob(),
+    type: res.headers.get("Content-Type") || "",
+    width: Number(dims[0]) || 0,
+    height: Number(dims[1]) || 0,
+  };
+}
+
 export const api = {
   me: (signal) => get("/me", {}, signal),
   stats: (signal) => get("/stats", {}, signal),
   search: (query, signal) => get("/search", query, signal),
   suggest: (q, signal) => get("/suggest", { q }, signal),
   document: (id, signal) => get(`/documents/${encodeURIComponent(id)}`, {}, signal),
+  content: (id, signal) => bytes(`/documents/${encodeURIComponent(id)}/content`, signal),
   health: (signal) => fetch("/healthz", { signal }).then((r) => r.json()),
 };

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -679,7 +679,10 @@ time {
  */
 .result {
   position: relative;
-  display: block;
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  column-gap: var(--space-4);
+  align-items: start;
   padding: var(--row-padding-block) var(--space-4);
   border-bottom: 1px solid var(--border);
   border-left: 3px solid transparent;
@@ -707,7 +710,58 @@ time {
   border-left-color: var(--focus-ring);
 }
 
+/*
+ * The tile is the only part of a row that is not words.
+ *
+ * It sits in its own column and spans the three rows of text beside it, so the
+ * row keeps the height its content asks for rather than the height of a square.
+ * For an image it is the image, which is how somebody recognises the one they
+ * meant without opening anything.
+ */
+.tile {
+  grid-row: 1 / 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-bottom: 2px solid transparent;
+  border-radius: var(--radius-md);
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  overflow: hidden;
+}
+
+.tile--image {
+  border-bottom: none;
+}
+
+.tile .image,
+.tile .image__img {
+  width: 100%;
+  height: 100%;
+}
+
+.tile .image__img {
+  object-fit: cover;
+}
+
+[data-density="compact"] .result {
+  grid-template-columns: 32px minmax(0, 1fr);
+}
+
+[data-density="compact"] .tile {
+  width: 32px;
+  height: 32px;
+}
+
+[data-density="compact"] .tile svg {
+  width: 16px;
+  height: 16px;
+}
+
 .result__title {
+  grid-column: 2;
   display: -webkit-box;
   margin-bottom: var(--space-1);
   padding: 0;
@@ -729,6 +783,7 @@ time {
 }
 
 .result__meta {
+  grid-column: 2;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -740,6 +795,7 @@ time {
 }
 
 .result__snippet {
+  grid-column: 2;
   display: -webkit-box;
   color: var(--text-secondary);
   font-size: var(--text-small);
@@ -1076,7 +1132,10 @@ a.panel__row:hover .panel__row-title {
   position: fixed;
   inset: 0 0 0 auto;
   z-index: var(--z-drawer);
-  width: min(480px, 100vw);
+  /* Wide enough that an eighty column code block does not wrap and an image
+     is shown at a size worth looking at, and narrow enough that the results
+     behind it are still there to go back to. */
+  width: min(720px, 100vw);
   display: flex;
   flex-direction: column;
   background: var(--bg);
@@ -1125,15 +1184,28 @@ a.panel__row:hover .panel__row-title {
   letter-spacing: var(--display-tracking);
 }
 
+/*
+ * The body holds whatever the document turned out to be.
+ *
+ * Prose is held to the measure because a line of a hundred and twenty
+ * characters is a line people lose their place in. Code and images are not:
+ * wrapping code to a measure is how a diff becomes unreadable, and an image
+ * shown at two thirds of the space available is an image shown smaller than it
+ * needed to be.
+ */
 .drawer__body {
   flex: 1;
-  max-width: var(--measure);
+  min-height: 0;
   overflow-y: auto;
   padding: 0 var(--space-6) var(--space-6);
   font-size: var(--text-body);
   line-height: var(--leading-prose);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+}
+
+.drawer__body[data-shape="prose"],
+.drawer__body[data-shape="text"] {
+  max-width: var(--measure);
 }
 
 .drawer__foot {
@@ -1160,6 +1232,339 @@ a.panel__row:hover .panel__row-title {
   from {
     opacity: 0;
   }
+}
+
+/* Content ---------------------------------------------------------------- */
+
+/*
+ * A document body, in whichever of its four shapes it turned out to be.
+ *
+ * The rules here are the same type scale, the same spacing grid and the same
+ * two hairlines as the rest of the interface. A preview that introduces its own
+ * type scale is a second design system living inside the first one, and the
+ * document is the thing people came to read, so it gets the plainest treatment
+ * in the product rather than the most decorated.
+ */
+
+.preview__empty {
+  color: var(--text-muted);
+}
+
+/* Text that is not markdown and not code keeps the line breaks somebody typed
+   and nothing else. */
+.plain {
+  margin: 0;
+  font-family: inherit;
+  font-size: var(--text-body);
+  line-height: var(--leading-prose);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+/* Prose ------------------------------------------------------------------- */
+
+.prose {
+  font-size: var(--text-body);
+  line-height: var(--leading-prose);
+}
+
+.prose > :first-child {
+  margin-top: 0;
+}
+
+.prose__p {
+  margin: 0 0 var(--space-4);
+}
+
+/* Headings take their space from above, so a section is attached to its own
+   content rather than floating between two of them. */
+.prose__h {
+  margin: var(--space-8) 0 var(--space-3);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-title);
+  scroll-margin-top: var(--space-6);
+}
+
+h1.prose__h {
+  font-size: var(--text-heading);
+  line-height: var(--leading-heading);
+  letter-spacing: var(--display-tracking);
+}
+
+h2.prose__h {
+  font-size: var(--text-title);
+}
+
+h3.prose__h {
+  font-size: var(--text-lead);
+  font-weight: var(--weight-semibold);
+}
+
+h4.prose__h,
+h5.prose__h,
+h6.prose__h {
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
+}
+
+.prose__link {
+  color: var(--text-link);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.prose__strong {
+  font-weight: var(--weight-semibold);
+}
+
+.prose__del {
+  color: var(--text-muted);
+}
+
+.prose__list {
+  margin: 0 0 var(--space-4);
+  padding-left: var(--space-6);
+}
+
+.prose__list .prose__list {
+  margin: var(--space-2) 0 0;
+}
+
+.prose__item {
+  margin-bottom: var(--space-2);
+}
+
+.prose__item--task {
+  list-style: none;
+  margin-left: calc(var(--space-6) * -1);
+  padding-left: var(--space-6);
+  position: relative;
+}
+
+.prose__item--task input {
+  position: absolute;
+  left: 0;
+  top: 5px;
+  accent-color: var(--accent);
+}
+
+/* A quote is a rule and an indent. A tinted panel would be a card, and there
+   are no cards. */
+.prose__quote {
+  margin: 0 0 var(--space-4);
+  padding-left: var(--space-4);
+  border-left: 2px solid var(--border);
+  color: var(--text-secondary);
+}
+
+.prose__quote > :last-child {
+  margin-bottom: 0;
+}
+
+.prose__rule {
+  margin: var(--space-8) 0;
+  border: none;
+  border-top: 1px solid var(--border);
+}
+
+.prose__code {
+  padding: 1px 5px;
+  border-radius: var(--radius-xs);
+  background: var(--bg-subtle);
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+}
+
+.prose__figure {
+  margin: var(--space-6) 0;
+}
+
+.prose__figure figcaption {
+  margin-top: var(--space-2);
+  color: var(--text-muted);
+  font-size: var(--text-small);
+}
+
+.prose__img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.prose__img-missing {
+  color: var(--text-muted);
+  font-size: var(--text-small);
+}
+
+/* A table scrolls sideways inside its own box rather than widening the
+   drawer, because a document with one wide table should not change the width
+   of every other document. */
+.prose__scroll {
+  margin: 0 0 var(--space-4);
+  overflow-x: auto;
+}
+
+.prose__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.prose__table th,
+.prose__table td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.prose__table th {
+  font-weight: var(--weight-semibold);
+  white-space: nowrap;
+}
+
+/* Code -------------------------------------------------------------------- */
+
+.code {
+  margin: 0 0 var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-subtle);
+  overflow: hidden;
+}
+
+.prose .code {
+  margin: var(--space-4) 0;
+}
+
+.code__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-1) var(--space-1) var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.code__lang {
+  color: var(--text-muted);
+  font-size: var(--text-caption);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.code__copy {
+  height: 28px;
+  padding: 0 var(--space-3);
+  font-size: var(--text-caption);
+}
+
+.code__pre {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  overflow-x: auto;
+}
+
+.code__text {
+  font-family: var(--font-mono);
+  font-size: var(--text-small);
+  line-height: 22px;
+  white-space: pre;
+  tab-size: 4;
+}
+
+.tok--keyword {
+  color: var(--code-keyword);
+}
+
+.tok--string {
+  color: var(--code-string);
+}
+
+.tok--number {
+  color: var(--code-number);
+}
+
+.tok--func {
+  color: var(--code-func);
+}
+
+.tok--comment {
+  color: var(--code-comment);
+  font-style: italic;
+}
+
+/* Images ------------------------------------------------------------------ */
+
+/*
+ * The box exists before the bytes do.
+ *
+ * It fills with the source colour of nothing in particular while it waits, and
+ * takes the aspect ratio the server recorded as soon as the response arrives,
+ * so an image landing never pushes the paragraph under it down the page.
+ */
+.image {
+  display: block;
+  background: var(--bg-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.image[data-state="loading"] {
+  background: linear-gradient(
+    90deg,
+    var(--bg-subtle) 25%,
+    var(--bg-active) 37%,
+    var(--bg-subtle) 63%
+  );
+  background-size: 400% 100%;
+  animation: shimmer 1.4s linear infinite;
+}
+
+.image[data-state="failed"] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: var(--space-3);
+  color: var(--text-muted);
+  font-size: var(--text-small);
+  text-align: center;
+}
+
+.image__img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.figure {
+  margin: 0;
+}
+
+.figure .image {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+}
+
+.figure .image__img {
+  width: auto;
+  max-width: 100%;
+  max-height: 70vh;
+  border-radius: var(--radius-sm);
+}
+
+.figure__caption {
+  margin-top: var(--space-3);
+  color: var(--text-muted);
+  font-size: var(--text-small);
 }
 
 /* Buttons ---------------------------------------------------------------- */
@@ -1335,12 +1740,37 @@ a.panel__row:hover .panel__row-title {
   }
 }
 
+/* The same grid as a real row, so the tile column does not appear from
+   nowhere when the answer arrives. */
 .skeleton-result {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  column-gap: var(--space-4);
+  row-gap: var(--space-2);
+  align-items: start;
   padding: var(--row-padding-block) var(--space-4);
   border-bottom: 1px solid var(--border);
+}
+
+.skeleton-result > * {
+  grid-column: 2;
+}
+
+.skeleton-result__tile {
+  grid-column: 1;
+  grid-row: 1 / 5;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-md);
+}
+
+[data-density="compact"] .skeleton-result {
+  grid-template-columns: 32px minmax(0, 1fr);
+}
+
+[data-density="compact"] .skeleton-result__tile {
+  width: 32px;
+  height: 32px;
 }
 
 /* Shortcuts dialog ------------------------------------------------------- */

--- a/web/dist/assets/content.js
+++ b/web/dist/assets/content.js
@@ -1,0 +1,309 @@
+// Content rendering.
+//
+// One place decides what a document is and how to draw it. The drawer asks for
+// a body and gets prose, code, an image or plain text, and a result row asks for
+// a tile and gets a thumbnail or an icon. Everything downstream of that decision
+// is presentation, so adding a media type is a line in a table here rather than
+// a branch in three views.
+
+import { h, svg } from "./dom.js";
+import { api } from "./api.js";
+import { render as markdown, codeBlock } from "./markdown.js";
+import { kindIcon, sourceColor, bytes as formatBytes } from "./format.js";
+
+// Media types the interface knows how to draw as code, and the language each
+// one is highlighted as. A type that is not here and is not an image is drawn
+// as the text it is.
+const CODE = {
+  "text/x-go": "go",
+  "text/javascript": "javascript",
+  "text/x-typescript": "typescript",
+  "text/x-python": "python",
+  "text/x-rust": "rust",
+  "text/x-c": "c",
+  "text/x-c++": "cpp",
+  "text/x-java": "java",
+  "text/x-ruby": "ruby",
+  "text/x-shellscript": "shell",
+  "text/x-sql": "sql",
+  "text/x-yaml": "yaml",
+  "text/x-toml": "toml",
+  "text/x-protobuf": "proto",
+  "application/json": "json",
+  "text/css": "css",
+  "text/html": "html",
+};
+
+const BY_EXTENSION = {
+  go: "go",
+  js: "javascript",
+  mjs: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  sh: "shell",
+  sql: "sql",
+  yaml: "yaml",
+  yml: "yaml",
+  json: "json",
+  css: "css",
+  html: "html",
+  md: "markdown",
+};
+
+/**
+ * shapeOf says which renderer a document belongs to.
+ *
+ * It returns one of image, prose, code or text. The media type is the answer
+ * when there is one, because the connector decided it while it had the file in
+ * its hands, and the file name is only a fallback for a document that arrived
+ * without one.
+ */
+export function shapeOf(d) {
+  const media = (d.media_type || "").toLowerCase();
+  if (media.startsWith("image/")) return "image";
+  if (media === "text/markdown") return "prose";
+  if (CODE[media]) return "code";
+  if (!media && languageOf(d)) return "code";
+  return "text";
+}
+
+/** languageOf is the language a code document is highlighted as. */
+export function languageOf(d) {
+  const media = (d.media_type || "").toLowerCase();
+  if (CODE[media]) return CODE[media];
+  const ext = String(d.id || "").split(".").pop().toLowerCase();
+  return BY_EXTENSION[ext] || "";
+}
+
+/**
+ * body renders a document into the preview.
+ *
+ * Every branch produces the same reading experience at a different density:
+ * one measure, one type scale, and no case where the reader has to work out
+ * what they are looking at.
+ */
+export function body(d) {
+  const shape = shapeOf(d);
+
+  if (shape === "image") {
+    return h("div", { class: "preview preview--image" }, figure(d));
+  }
+  if (!d.body) {
+    return h("p", { class: "preview__empty" }, "This document has no text body.");
+  }
+  if (shape === "prose") {
+    const nodes = markdown(d.body, { imageNode: (src, alt) => inlineImage(d, src, alt) });
+    // A document whose first line is its own title would otherwise show that
+    // title twice, once in the head of the drawer and once at the top of the
+    // body, which reads as a rendering bug rather than as a document.
+    const first = nodes.firstElementChild;
+    if (first && first.tagName === "H1" && same(first.textContent, d.title)) first.remove();
+    return h("div", { class: "prose" }, nodes);
+  }
+  if (shape === "code") {
+    return h("div", { class: "preview preview--code" }, codeBlock(d.body, languageOf(d)));
+  }
+  return h("div", { class: "preview" }, h("pre", { class: "plain" }, d.body));
+}
+
+/** same compares two headings the way a reader would, ignoring spacing and case. */
+function same(a, b) {
+  const flat = (v) => String(v || "").trim().replace(/\s+/g, " ").toLowerCase();
+  return Boolean(flat(a)) && flat(a) === flat(b);
+}
+
+/**
+ * figure is a whole document that is an image.
+ *
+ * The caption carries what the file is rather than a description of it, because
+ * a description is the alt text and the alt text belongs to whoever wrote the
+ * document.
+ */
+function figure(d) {
+  const caption = h("figcaption", { class: "figure__caption" });
+  const img = image(d.id, d.title || "", {
+    // The preview fits the image to the space rather than to its own shape, so
+    // the box is not held to the aspect ratio the way an inline image is.
+    reserve: false,
+    onLoad: ({ width, height, blob }) => {
+      const parts = [];
+      if (width && height) parts.push(`${width} by ${height} pixels`);
+      const type = (d.media_type || "").split("/")[1];
+      if (type) parts.push(type.replace("+xml", "").toUpperCase());
+      const size = Number((d.properties && d.properties.size_bytes) || (blob && blob.size) || 0);
+      if (size) parts.push(formatBytes(size));
+      caption.textContent = parts.join(" · ");
+    },
+  });
+  return h("figure", { class: "figure" }, img, caption);
+}
+
+/**
+ * inlineImage draws an image written inside a markdown document.
+ *
+ * The renderer already decided whether this sits in a figure or in the middle
+ * of a sentence, so all this returns is the image itself.
+ */
+function inlineImage(d, src, alt) {
+  const id = resolve(d.id, src);
+  if (!id) return null;
+  return image(id, alt, { class: "prose__img" });
+}
+
+/**
+ * resolve turns a path written inside a document into the id of the document
+ * holding it.
+ *
+ * A document id is a source name and a path, and an image beside a page is a
+ * path relative to that page, so this is the same join a reader does in their
+ * head when they see the markdown.
+ */
+export function resolve(from, src) {
+  const value = String(src || "").trim();
+  if (!value || /^[a-z][\w+.-]*:/i.test(value) || value.startsWith("//") || value.startsWith("#")) return "";
+
+  const cut = String(from || "").indexOf(":");
+  if (cut < 0) return "";
+  const prefix = from.slice(0, cut + 1);
+  const base = from.slice(cut + 1).split("/").slice(0, -1);
+
+  const parts = value.startsWith("/") ? [] : base;
+  const out = [...parts];
+  for (const part of value.replace(/^\//, "").split("/")) {
+    if (part === "." || part === "") continue;
+    if (part === "..") out.pop();
+    else out.push(part);
+  }
+  return out.length ? prefix + out.join("/") : "";
+}
+
+// Images -------------------------------------------------------------------
+
+// Bytes arrive through fetch, so they arrive as a blob and are shown through an
+// object URL. The cache keeps the last handful alive: scrolling a result list
+// back and forth should not refetch, and holding every image a session ever
+// touched should not be how the tab runs out of memory.
+const LIVE = new Map();
+const LIVE_MAX = 64;
+
+function load(id) {
+  const held = LIVE.get(id);
+  if (held) {
+    LIVE.delete(id);
+    LIVE.set(id, held);
+    return held;
+  }
+
+  const pending = api.content(id).then((res) => ({ ...res, url: URL.createObjectURL(res.blob) }));
+  pending.catch(() => LIVE.delete(id));
+  LIVE.set(id, pending);
+
+  while (LIVE.size > LIVE_MAX) {
+    const [oldest] = LIVE.keys();
+    const dropped = LIVE.get(oldest);
+    LIVE.delete(oldest);
+    dropped.then((v) => URL.revokeObjectURL(v.url)).catch(() => {});
+  }
+  return pending;
+}
+
+let watcher = null;
+const jobs = new WeakMap();
+
+/** near runs the job when the element is close to the viewport. */
+function near(el, job) {
+  if (!("IntersectionObserver" in window)) {
+    job();
+    return;
+  }
+  if (!watcher) {
+    watcher = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          watcher.unobserve(entry.target);
+          const run = jobs.get(entry.target);
+          jobs.delete(entry.target);
+          if (run) run();
+        }
+      },
+      { rootMargin: "400px" },
+    );
+  }
+  jobs.set(el, job);
+  watcher.observe(el);
+}
+
+/**
+ * image is a box that fills itself in when it scrolls into view.
+ *
+ * The box exists before the bytes do and keeps its place afterwards, so nothing
+ * below it moves when the image lands. An image that fails to load leaves its
+ * alt text, which is the sentence somebody wrote about it and is more use than
+ * a broken glyph.
+ */
+export function image(id, alt, options = {}) {
+  const box = h("span", { class: `image ${options.class || ""}`.trim(), "data-state": "idle" });
+
+  near(box, async () => {
+    box.dataset.state = "loading";
+    try {
+      const res = await load(id);
+      const img = h("img", {
+        class: "image__img",
+        src: res.url,
+        alt: alt || "",
+        decoding: "async",
+        width: res.width || null,
+        height: res.height || null,
+      });
+      img.addEventListener("load", () => {
+        box.dataset.state = "ready";
+      });
+      img.addEventListener("error", () => fail(box, alt));
+      if (res.width && res.height && options.reserve !== false) {
+        box.style.aspectRatio = `${res.width} / ${res.height}`;
+      }
+      box.appendChild(img);
+      if (options.onLoad) options.onLoad(res);
+    } catch {
+      fail(box, alt);
+    }
+  });
+
+  return box;
+}
+
+function fail(box, alt) {
+  box.dataset.state = "failed";
+  box.textContent = alt || "Image not available";
+}
+
+/**
+ * tile is the small square at the head of a result row.
+ *
+ * For an image it is the image, which is the fastest way to recognise one. For
+ * everything else it is the icon for the kind on a tint of the source colour,
+ * which turns the left edge of the list into something the eye can group by
+ * without reading a word.
+ */
+export function tile(hit) {
+  if (shapeOf(hit) === "image") {
+    return h("span", { class: "tile tile--image" }, image(hit.id, hit.title || ""));
+  }
+  return h(
+    "span",
+    {
+      class: "tile",
+      // The source colour is a two pixel rule under the glyph rather than a
+      // fill. A list of twenty tinted squares is a list nobody can scan, and
+      // the rule groups by source just as well at a tenth of the ink.
+      style: { borderBottomColor: sourceColor(hit.source) },
+      "aria-hidden": "true",
+    },
+    svg(kindIcon(hit.kind), 24),
+  );
+}

--- a/web/dist/assets/drawer.js
+++ b/web/dist/assets/drawer.js
@@ -10,6 +10,7 @@
 import { h, replace, svg } from "./dom.js";
 import { api } from "./api.js";
 import { icon, label, sourceColor, when, exact } from "./format.js";
+import { body as renderBody, shapeOf } from "./content.js";
 
 export class Drawer {
   constructor({ onClose }) {
@@ -90,12 +91,15 @@ export class Drawer {
         h("span", { class: "source__dot", style: { background: sourceColor(d.source) } }),
         label(d.source),
       ),
-      h("span", { class: "crumbs__sep" }, "/"),
+      h("span", { class: "crumbs__sep" }, "·"),
       h("span", {}, label(d.kind)),
-      d.container && h("span", { class: "crumbs__sep" }, "/"),
+      d.container && h("span", { class: "crumbs__sep" }, "·"),
       d.container && h("span", {}, d.container),
     );
-    replace(this.body, d.body || "This document has no text body.");
+    // The body decides its own shape from the media type, so the drawer only
+    // has to say where it goes and how wide it is.
+    this.body.dataset.shape = shapeOf(d);
+    replace(this.body, renderBody(d));
     replace(
       this.foot,
       d.url &&
@@ -118,6 +122,7 @@ export class Drawer {
     const missing = err.status === 404;
     replace(this.title, missing ? "Not available" : "Could not load this document");
     replace(this.meta);
+    this.body.dataset.shape = "text";
     replace(
       this.body,
       missing

--- a/web/dist/assets/format.js
+++ b/web/dist/assets/format.js
@@ -113,6 +113,26 @@ export function duration(ms) {
   return `${(ms / 1000).toFixed(2)} s`;
 }
 
+/**
+ * bytes renders a file size the way a file manager does.
+ *
+ * Two significant figures is all anybody reads off a caption, and the unit is
+ * the decimal one because that is what the operating system showing the same
+ * file will say.
+ */
+export function bytes(n) {
+  const size = Number(n) || 0;
+  if (size < 1000) return `${size} B`;
+  const units = ["KB", "MB", "GB"];
+  let value = size / 1000;
+  let unit = 0;
+  while (value >= 1000 && unit < units.length - 1) {
+    value /= 1000;
+    unit++;
+  }
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
 export function initials(name) {
   const parts = String(name || "?").trim().split(/[\s@._-]+/).filter(Boolean);
   if (!parts.length) return "?";

--- a/web/dist/assets/highlight.js
+++ b/web/dist/assets/highlight.js
@@ -1,0 +1,369 @@
+// Syntax highlighting.
+//
+// This is a lexer, not a parser. It finds comments, strings, numbers, keywords
+// and the name in front of an open paren, and it leaves everything else as
+// plain text. That is five colours, which is all the palette has room for and
+// more than enough to read code by: the eye is looking for where a string ends
+// and where a block starts, not for a semantic model of the file.
+//
+// A language it does not know renders as an unhighlighted block, which is a
+// correct answer rather than a failure. Highlighting the wrong thing is worse
+// than highlighting nothing.
+
+import { h } from "./dom.js";
+
+// Blocks under this many characters are highlighted as they are built. Anything
+// longer waits until it is near the viewport, so a document holding a thousand
+// line file costs nothing until somebody scrolls to it.
+const EAGER = 4000;
+
+/**
+ * highlight returns an element holding the highlighted source.
+ *
+ * It is an element rather than a fragment because a long block is highlighted
+ * lazily, and lazily means there has to be something left in the tree to watch.
+ */
+export function highlight(source, lang) {
+  const spec = LANGS[alias(lang)];
+  const root = h("span", { class: "code__body" });
+
+  if (!spec) {
+    root.textContent = source;
+    return root;
+  }
+  if (source.length <= EAGER) {
+    fill(root, source, spec);
+    return root;
+  }
+
+  root.textContent = source;
+  watch(root, () => fill(root, source, spec));
+  return root;
+}
+
+/** languages returns the names highlighting is available for. */
+export function languages() {
+  return Object.keys(LANGS).sort();
+}
+
+function fill(root, source, spec) {
+  const frag = document.createDocumentFragment();
+  for (const token of scan(source, spec)) {
+    frag.appendChild(token.cls ? h("span", { class: `tok tok--${token.cls}` }, token.text) : document.createTextNode(token.text));
+  }
+  root.textContent = "";
+  root.appendChild(frag);
+}
+
+let observer = null;
+const pending = new WeakMap();
+
+function watch(el, run) {
+  if (!("IntersectionObserver" in window)) {
+    run();
+    return;
+  }
+  if (!observer) {
+    observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          observer.unobserve(entry.target);
+          const job = pending.get(entry.target);
+          pending.delete(entry.target);
+          if (job) job();
+        }
+      },
+      { rootMargin: "300px" },
+    );
+  }
+  pending.set(el, run);
+  observer.observe(el);
+}
+
+// The lexer ----------------------------------------------------------------
+
+function scan(src, spec) {
+  const out = [];
+  let i = 0;
+  let run = 0;
+
+  const flush = (to) => {
+    if (to > run) out.push({ text: src.slice(run, to) });
+  };
+  const emit = (end, cls) => {
+    flush(i);
+    out.push({ text: src.slice(i, end), cls });
+    i = end;
+    run = end;
+  };
+
+  while (i < src.length) {
+    let end = commentEnd(src, i, spec);
+    if (end > i) {
+      emit(end, "comment");
+      continue;
+    }
+
+    end = stringEnd(src, i, spec);
+    if (end > i) {
+      emit(end, spec.keyStrings && follows(src, end) === ":" ? "keyword" : "string");
+      continue;
+    }
+
+    if (spec.rule) {
+      const hit = spec.rule(src, i);
+      if (hit) {
+        emit(hit.end, hit.cls);
+        continue;
+      }
+    }
+
+    if (isDigit(src[i]) && !isWord(src[i - 1])) {
+      end = i + 1;
+      while (end < src.length && /[\w.]/.test(src[end])) end++;
+      emit(end, "number");
+      continue;
+    }
+
+    if (isWordStart(src[i])) {
+      end = i + 1;
+      while (end < src.length && isWord(src[end])) end++;
+      const cls = classify(src.slice(i, end), src, end, spec);
+      if (cls) emit(end, cls);
+      else i = end;
+      continue;
+    }
+
+    i++;
+  }
+
+  flush(src.length);
+  return out;
+}
+
+function classify(word, src, end, spec) {
+  const key = spec.fold ? word.toLowerCase() : word;
+  if (spec.literals && spec.literals.has(key)) return "number";
+  if (spec.keywords.has(key)) return "keyword";
+  if (spec.types && spec.types.has(key)) return "func";
+  if (spec.keyWords && follows(src, end) === ":" && startsLine(src, end - word.length)) return "keyword";
+  if (follows(src, end) === "(") return "func";
+  return null;
+}
+
+function commentEnd(src, i, spec) {
+  for (const marker of spec.line || []) {
+    if (src.startsWith(marker, i)) {
+      const nl = src.indexOf("\n", i);
+      return nl < 0 ? src.length : nl;
+    }
+  }
+  for (const [open, close] of spec.block || []) {
+    if (src.startsWith(open, i)) {
+      const end = src.indexOf(close, i + open.length);
+      return end < 0 ? src.length : end + close.length;
+    }
+  }
+  return i;
+}
+
+function stringEnd(src, i, spec) {
+  for (const quote of spec.quotes || []) {
+    if (!src.startsWith(quote, i)) continue;
+    let j = i + quote.length;
+    while (j < src.length) {
+      if (src[j] === "\\" && quote !== "`" && spec.escapes !== false) {
+        j += 2;
+        continue;
+      }
+      if (src.startsWith(quote, j)) return j + quote.length;
+      // A single quoted string that runs past the end of its line is almost
+      // always an apostrophe in a comment or a word, so it stops there.
+      if (src[j] === "\n" && quote.length === 1 && !spec.multiline) return j;
+      j++;
+    }
+    return src.length;
+  }
+  return i;
+}
+
+function follows(src, i) {
+  while (i < src.length && (src[i] === " " || src[i] === "\t")) i++;
+  return src[i] || "";
+}
+
+function startsLine(src, i) {
+  for (let j = i - 1; j >= 0; j--) {
+    if (src[j] === "\n") return true;
+    if (src[j] !== " " && src[j] !== "\t" && src[j] !== "-") return false;
+  }
+  return true;
+}
+
+const isDigit = (c) => c >= "0" && c <= "9";
+const isWordStart = (c) => Boolean(c) && /[A-Za-z_$@]/.test(c);
+const isWord = (c) => Boolean(c) && /[\w$]/.test(c);
+
+const set = (words) => new Set(words.split(/\s+/));
+
+// The languages ------------------------------------------------------------
+
+const ALIASES = {
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  py: "python",
+  golang: "go",
+  yml: "yaml",
+  sh: "shell",
+  bash: "shell",
+  zsh: "shell",
+  console: "shell",
+  md: "markdown",
+  htm: "html",
+  postgres: "sql",
+  sqlite: "sql",
+};
+
+function alias(lang) {
+  const name = String(lang || "").toLowerCase();
+  return ALIASES[name] || name;
+}
+
+const LANGS = {
+  go: {
+    line: ["//"],
+    block: [["/*", "*/"]],
+    quotes: ['"', "`", "'"],
+    multiline: true,
+    keywords: set(`break case chan const continue default defer else fallthrough for func go goto if
+      import interface map package range return select struct switch type var`),
+    types: set(`string bool byte rune error any int int8 int16 int32 int64 uint uint8 uint16 uint32
+      uint64 uintptr float32 float64 complex64 complex128 append cap close copy delete len make new
+      panic print println recover`),
+    literals: set("true false nil iota"),
+  },
+
+  javascript: {
+    line: ["//"],
+    block: [["/*", "*/"]],
+    quotes: ['"', "'", "`"],
+    keywords: set(`async await break case catch class const continue debugger default delete do else
+      export extends finally for from function get if import in instanceof let new of return set
+      static super switch this throw try typeof var void while with yield`),
+    literals: set("true false null undefined NaN Infinity"),
+  },
+
+  typescript: {
+    line: ["//"],
+    block: [["/*", "*/"]],
+    quotes: ['"', "'", "`"],
+    keywords: set(`abstract any as asserts async await break case catch class const continue declare
+      default delete do else enum export extends finally for from function get if implements import
+      in infer instanceof interface is keyof let namespace new of private protected public readonly
+      return satisfies set static super switch this throw try type typeof var void while yield`),
+    types: set("string number boolean object symbol bigint unknown never void Array Promise Record Partial"),
+    literals: set("true false null undefined"),
+  },
+
+  python: {
+    line: ["#"],
+    quotes: ['"""', "'''", '"', "'"],
+    keywords: set(`and as assert async await break class continue def del elif else except finally
+      for from global if import in is lambda match nonlocal not or pass raise return try while with
+      yield`),
+    types: set(`int float str bool bytes list dict set tuple len range print open enumerate zip type
+      isinstance super self`),
+    literals: set("True False None"),
+  },
+
+  json: {
+    quotes: ['"'],
+    keyStrings: true,
+    keywords: new Set(),
+    literals: set("true false null"),
+  },
+
+  yaml: {
+    line: ["#"],
+    quotes: ['"', "'"],
+    keyStrings: true,
+    keyWords: true,
+    keywords: new Set(),
+    literals: set("true false null yes no on off ~"),
+  },
+
+  sql: {
+    line: ["--"],
+    block: [["/*", "*/"]],
+    quotes: ["'", '"'],
+    fold: true,
+    keywords: set(`select from where group by order having limit offset join left right full inner
+      outer cross on using union all except intersect insert into values update set delete create
+      table view index unique drop alter add column primary foreign key references constraint
+      cascade default as distinct with returning case when then else end asc desc between in like
+      is not and or exists begin commit rollback pragma explain analyze`),
+    types: set(`count sum avg min max coalesce cast text integer real blob boolean timestamp date
+      varchar numeric json jsonb uuid serial now length substr lower upper`),
+    literals: set("null true false"),
+  },
+
+  shell: {
+    line: ["#"],
+    quotes: ['"', "'"],
+    multiline: true,
+    keywords: set(`if then else elif fi for in do done while until case esac function return local
+      export declare readonly source shift trap set unset exit break continue`),
+    types: set(`echo cd ls cat grep sed awk find make go git curl docker kubectl mkdir rm cp mv chmod
+      test printf read sleep sudo env`),
+  },
+
+  css: {
+    block: [["/*", "*/"]],
+    quotes: ['"', "'"],
+    keywords: set(`important inherit initial unset auto none var calc clamp min max url rgb rgba hsl
+      hsla`),
+    rule(src, i) {
+      if (src[i] === "#" && /[\da-f]{3}/i.test(src.slice(i + 1, i + 4))) {
+        let end = i + 1;
+        while (end < src.length && /[\da-fA-F]/.test(src[end])) end++;
+        return { end, cls: "number" };
+      }
+      if (src[i] === "@" || src[i] === "." || src[i] === "#" || src[i] === ":") {
+        const m = /^[.#:@][\w-]+/.exec(src.slice(i));
+        if (m) return { end: i + m[0].length, cls: src[i] === "@" ? "keyword" : "func" };
+      }
+      if (isWordStart(src[i]) && startsLine(src, i)) {
+        const m = /^[-\w]+(?=\s*:)/.exec(src.slice(i));
+        if (m) return { end: i + m[0].length, cls: "keyword" };
+      }
+      return null;
+    },
+  },
+
+  html: {
+    block: [["<!--", "-->"]],
+    quotes: ['"', "'"],
+    multiline: true,
+    keywords: new Set(),
+    rule(src, i) {
+      if (src[i] !== "<") return null;
+      const m = /^<\/?[A-Za-z][\w:-]*/.exec(src.slice(i));
+      return m ? { end: i + m[0].length, cls: "func" } : null;
+    },
+  },
+
+  markdown: {
+    quotes: ["`"],
+    multiline: true,
+    keywords: new Set(),
+    rule(src, i) {
+      if (!startsLine(src, i)) return null;
+      const m = /^(#{1,6}\s|>\s|[-*+]\s|\d+[.)]\s)/.exec(src.slice(i));
+      return m ? { end: i + m[0].length, cls: "keyword" } : null;
+    },
+  },
+};

--- a/web/dist/assets/markdown.js
+++ b/web/dist/assets/markdown.js
@@ -1,0 +1,497 @@
+// A markdown renderer for the preview.
+//
+// It covers the subset people actually write in a wiki: headings, paragraphs,
+// emphasis, links, images, lists, quotes, fenced code, pipe tables and rules.
+// Anything outside that is printed as the characters that were typed, and raw
+// HTML in a document is printed rather than parsed.
+//
+// Nothing here builds a node from a string of markup. Every element comes from
+// createElement and every piece of text goes in through a text node, so there is
+// no sanitiser to get wrong and a body containing a script tag is a body
+// containing the text of a script tag. That is the whole security argument for
+// this file and it is the reason it is hand written rather than pulled in.
+
+import { h } from "./dom.js";
+import { highlight } from "./highlight.js";
+
+/**
+ * render turns markdown into nodes.
+ *
+ * options.imageNode is given the source of an image the renderer cannot resolve
+ * on its own, which is every image written as a path relative to the document.
+ * It returns a node to put there, or nothing to fall back to the alt text.
+ * Without it, only absolute http and https images are drawn.
+ */
+export function render(src, options = {}) {
+  const frag = document.createDocumentFragment();
+  for (const node of blocks(String(src || "").replace(/\r\n?/g, "\n").split("\n"), options)) {
+    frag.appendChild(node);
+  }
+  return frag;
+}
+
+/** blocks parses a run of lines into block level nodes. */
+function blocks(lines, options) {
+  const out = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      i++;
+      continue;
+    }
+
+    const fence = fenceOf(trimmed);
+    if (fence) {
+      const lang = trimmed.slice(fence.length).trim().split(/\s+/)[0];
+      const body = [];
+      i++;
+      while (i < lines.length && !lines[i].trim().startsWith(fence)) {
+        body.push(lines[i]);
+        i++;
+      }
+      i++; // the closing fence, or the end of the document
+      out.push(codeBlock(body.join("\n"), lang));
+      continue;
+    }
+
+    if (isRule(trimmed)) {
+      out.push(h("hr", { class: "prose__rule" }));
+      i++;
+      continue;
+    }
+
+    const heading = /^(#{1,6})\s+(.*)$/.exec(trimmed);
+    if (heading) {
+      const level = heading[1].length;
+      out.push(h(`h${level}`, { class: "prose__h" }, inline(heading[2].replace(/\s+#+$/, ""), options)));
+      i++;
+      continue;
+    }
+
+    if (trimmed.startsWith(">")) {
+      const quoted = [];
+      while (i < lines.length && lines[i].trim().startsWith(">")) {
+        quoted.push(lines[i].trim().replace(/^>\s?/, ""));
+        i++;
+      }
+      // A quote can hold anything a document can hold, including another quote,
+      // so its contents go back through the same parser.
+      out.push(h("blockquote", { class: "prose__quote" }, ...blocks(quoted, options)));
+      continue;
+    }
+
+    if (isTableAt(lines, i)) {
+      const rows = [];
+      while (i < lines.length && lines[i].trim().startsWith("|")) {
+        rows.push(lines[i].trim());
+        i++;
+      }
+      out.push(table(rows, options));
+      continue;
+    }
+
+    if (itemOf(line)) {
+      const collected = [];
+      while (i < lines.length && (itemOf(lines[i]) || continuation(lines[i], collected.length))) {
+        collected.push(lines[i]);
+        i++;
+      }
+      out.push(list(collected, options));
+      continue;
+    }
+
+    // A paragraph runs until a blank line or the start of another block. The
+    // lines are joined with a space rather than kept, because a hard wrapped
+    // paragraph is one sentence that somebody's editor broke, and showing the
+    // break is showing their editor's settings.
+    const para = [];
+    while (i < lines.length && lines[i].trim() && !startsBlock(lines, i)) {
+      para.push(lines[i].trim());
+      i++;
+    }
+    if (!para.length) continue;
+    const text = para.join(" ");
+
+    // An image on a line of its own is a figure rather than a paragraph with a
+    // picture in it, which is what lets it take the space it deserves and take
+    // its title as a caption.
+    if (text.startsWith("![")) {
+      const link = linkAt(text.slice(1));
+      if (link && link.length === text.length - 1) {
+        out.push(
+          h(
+            "figure",
+            { class: "prose__figure" },
+            image(link, options),
+            link.title && h("figcaption", {}, link.title),
+          ),
+        );
+        continue;
+      }
+    }
+    out.push(h("p", { class: "prose__p" }, inline(text, options)));
+  }
+
+  return out;
+}
+
+function startsBlock(lines, i) {
+  const t = lines[i].trim();
+  return (
+    Boolean(fenceOf(t)) ||
+    isRule(t) ||
+    /^#{1,6}\s/.test(t) ||
+    t.startsWith(">") ||
+    Boolean(itemOf(lines[i])) ||
+    isTableAt(lines, i)
+  );
+}
+
+function fenceOf(line) {
+  if (line.startsWith("```")) return "```";
+  if (line.startsWith("~~~")) return "~~~";
+  return "";
+}
+
+function isRule(line) {
+  return /^(-{3,}|\*{3,}|_{3,})$/.test(line.replace(/\s/g, ""));
+}
+
+/** itemOf splits a list line into its indent, its marker and its text. */
+function itemOf(line) {
+  const m = /^(\s*)([-*+]|\d+[.)])\s+(.*)$/.exec(line);
+  if (!m) return null;
+  return { indent: m[1].length, ordered: /\d/.test(m[2]), text: m[3] };
+}
+
+/** continuation reports whether a line belongs to the item above it. */
+function continuation(line, started) {
+  return started > 0 && Boolean(line.trim()) && /^\s{2,}/.test(line) && !isRule(line.trim());
+}
+
+/**
+ * list builds a nested list from the flat lines that make it up.
+ *
+ * Nesting is by indentation, which is what people type, rather than by any of
+ * the several other things markdown will accept.
+ */
+function list(lines, options) {
+  const items = [];
+  for (const line of lines) {
+    const item = itemOf(line);
+    if (item) {
+      items.push({ ...item, lines: [item.text] });
+    } else if (items.length) {
+      items[items.length - 1].lines.push(line.trim());
+    }
+  }
+
+  const build = (start, indent) => {
+    const ordered = items[start].ordered;
+    const el = h(ordered ? "ol" : "ul", { class: "prose__list" });
+    let i = start;
+    while (i < items.length && items[i].indent >= indent) {
+      if (items[i].indent > indent) {
+        const [child, next] = build(i, items[i].indent);
+        const last = el.lastElementChild;
+        if (last) last.appendChild(child);
+        i = next;
+        continue;
+      }
+      const item = items[i];
+      const li = h("li", { class: "prose__item" });
+      const task = /^\[([ xX])\]\s+(.*)$/.exec(item.lines.join(" "));
+      if (task) {
+        li.className = "prose__item prose__item--task";
+        li.appendChild(
+          h("input", { type: "checkbox", disabled: true, checked: task[1] !== " " }),
+        );
+        li.appendChild(inline(task[2], options));
+      } else {
+        li.appendChild(inline(item.lines.join(" "), options));
+      }
+      el.appendChild(li);
+      i++;
+    }
+    return [el, i];
+  };
+
+  return items.length ? build(0, items[0].indent)[0] : h("ul", { class: "prose__list" });
+}
+
+function isTableAt(lines, i) {
+  const row = lines[i].trim();
+  const next = (lines[i + 1] || "").trim();
+  return row.startsWith("|") && /^\|[\s:|-]+\|?$/.test(next) && next.includes("-");
+}
+
+function table(rows, options) {
+  const cells = (row) =>
+    row
+      .replace(/^\||\|$/g, "")
+      .split("|")
+      .map((c) => c.trim());
+
+  const align = cells(rows[1]).map((c) => {
+    if (c.startsWith(":") && c.endsWith(":")) return "center";
+    if (c.endsWith(":")) return "right";
+    return null;
+  });
+  const cell = (tag, text, i) =>
+    h(tag, align[i] ? { style: { textAlign: align[i] } } : {}, inline(text, options));
+
+  return h(
+    "div",
+    { class: "prose__scroll" },
+    h(
+      "table",
+      { class: "prose__table" },
+      h("thead", {}, h("tr", {}, cells(rows[0]).map((c, i) => cell("th", c, i)))),
+      h(
+        "tbody",
+        {},
+        rows.slice(2).map((row) => h("tr", {}, cells(row).map((c, i) => cell("td", c, i)))),
+      ),
+    ),
+  );
+}
+
+/**
+ * codeBlock renders a fenced block, with its language named and a copy button.
+ *
+ * The head is only drawn when there is something to put in it, so a two line
+ * snippet does not grow a bar of chrome taller than the code inside it.
+ */
+export function codeBlock(source, lang) {
+  const code = h("code", { class: "code__text" }, highlight(source, lang));
+  const pre = h("pre", { class: "code__pre" }, code);
+  const long = source.split("\n").length > 6;
+  if (!lang && !long) return h("div", { class: "code" }, pre);
+
+  const copy = h(
+    "button",
+    {
+      class: "button button--ghost code__copy",
+      type: "button",
+      onClick: async (e) => {
+        const button = e.currentTarget;
+        try {
+          await navigator.clipboard.writeText(source);
+          button.textContent = "Copied";
+        } catch {
+          button.textContent = "Press ctrl C";
+        }
+        setTimeout(() => {
+          button.textContent = "Copy";
+        }, 1600);
+      },
+    },
+    "Copy",
+  );
+  return h(
+    "div",
+    { class: "code" },
+    h("div", { class: "code__head" }, h("span", { class: "code__lang" }, lang || "text"), copy),
+    pre,
+  );
+}
+
+// Inline ------------------------------------------------------------------
+
+const SPECIAL = /[\\`*_~[!<]|https?:\/\//;
+
+/** inline renders one run of text into a fragment. */
+function inline(text, options) {
+  const frag = document.createDocumentFragment();
+  let rest = String(text);
+
+  while (rest) {
+    const at = rest.search(SPECIAL);
+    if (at < 0) {
+      frag.appendChild(document.createTextNode(rest));
+      break;
+    }
+    if (at > 0) {
+      frag.appendChild(document.createTextNode(rest.slice(0, at)));
+      rest = rest.slice(at);
+    }
+
+    const taken = take(rest, options);
+    if (!taken) {
+      // Nothing matched, so the character is a character. Consuming one keeps
+      // the loop finite, which matters more here than anywhere else in the file.
+      frag.appendChild(document.createTextNode(rest[0]));
+      rest = rest.slice(1);
+      continue;
+    }
+    frag.appendChild(taken.node);
+    rest = rest.slice(taken.length);
+  }
+  return frag;
+}
+
+/** take matches one inline construct at the start of the string. */
+function take(rest, options) {
+  const c = rest[0];
+
+  if (c === "\\" && rest.length > 1) {
+    return { node: document.createTextNode(rest[1]), length: 2 };
+  }
+
+  if (c === "`") {
+    const ticks = /^`+/.exec(rest)[0];
+    const end = rest.indexOf(ticks, ticks.length);
+    if (end > 0) {
+      return {
+        node: h("code", { class: "prose__code" }, rest.slice(ticks.length, end)),
+        length: end + ticks.length,
+      };
+    }
+    return null;
+  }
+
+  if (c === "!" && rest[1] === "[") {
+    const link = linkAt(rest.slice(1));
+    if (link) return { node: image(link, options), length: link.length + 1 };
+    return null;
+  }
+
+  if (c === "[") {
+    const link = linkAt(rest);
+    if (!link) return null;
+    const href = safeURL(link.href);
+    if (!href) {
+      // A scheme nobody vetted is not a link. The text survives, because the
+      // words are what somebody wrote and only the target is suspect.
+      return { node: inline(link.text, options), length: link.length };
+    }
+    return {
+      node: h(
+        "a",
+        { class: "prose__link", href, target: "_blank", rel: "noreferrer noopener" },
+        inline(link.text, options),
+      ),
+      length: link.length,
+    };
+  }
+
+  if (c === "<") {
+    const end = rest.indexOf(">");
+    const inner = end > 0 ? rest.slice(1, end) : "";
+    const href = inner && safeURL(inner);
+    if (href) {
+      return {
+        node: h("a", { class: "prose__link", href, target: "_blank", rel: "noreferrer noopener" }, inner),
+        length: end + 1,
+      };
+    }
+    return null;
+  }
+
+  for (const [marker, tag, cls] of [
+    ["**", "strong", "prose__strong"],
+    ["__", "strong", "prose__strong"],
+    ["~~", "del", "prose__del"],
+    ["*", "em", "prose__em"],
+    ["_", "em", "prose__em"],
+  ]) {
+    if (!rest.startsWith(marker)) continue;
+    // An underscore inside a word is part of the word. store_id is a column
+    // name, not the start of an emphasis run.
+    if (marker === "_" && /\w/.test(rest[marker.length] || "")) {
+      const closer = rest.indexOf(marker, marker.length);
+      if (closer > 0 && /\w/.test(rest[closer - 1]) && /\w/.test(rest[closer + 1] || "")) continue;
+    }
+    const end = rest.indexOf(marker, marker.length);
+    if (end < 0 || end === marker.length) continue;
+    return {
+      node: h(tag, { class: cls }, inline(rest.slice(marker.length, end), options)),
+      length: end + marker.length,
+    };
+  }
+
+  const bare = /^https?:\/\/[^\s<>()]+/.exec(rest);
+  if (bare) {
+    return {
+      node: h(
+        "a",
+        { class: "prose__link", href: bare[0], target: "_blank", rel: "noreferrer noopener" },
+        bare[0],
+      ),
+      length: bare[0].length,
+    };
+  }
+
+  return null;
+}
+
+/** linkAt reads a [text](target) at the start of the string. */
+function linkAt(rest) {
+  if (rest[0] !== "[") return null;
+  let depth = 0;
+  let close = -1;
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i] === "[") depth++;
+    else if (rest[i] === "]") {
+      depth--;
+      if (!depth) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close < 0 || rest[close + 1] !== "(") return null;
+  const end = rest.indexOf(")", close + 2);
+  if (end < 0) return null;
+
+  const target = rest.slice(close + 2, end).trim();
+  const space = target.search(/\s/);
+  return {
+    text: rest.slice(1, close),
+    href: space < 0 ? target : target.slice(0, space),
+    title: space < 0 ? "" : target.slice(space).trim().replace(/^["']|["']$/g, ""),
+    length: end + 1,
+  };
+}
+
+function image(link, options) {
+  const alt = link.text || link.title;
+  const src = safeURL(link.href);
+  if (!src) {
+    const node = options.imageNode && options.imageNode(link.href, alt, link.title);
+    return node || document.createTextNode(alt);
+  }
+
+  const img = h("img", {
+    class: "prose__img",
+    src,
+    alt,
+    title: link.title || null,
+    loading: "lazy",
+    decoding: "async",
+  });
+  // An image that will not load collapses to the words that describe it, which
+  // is more use than a broken glyph and is what somebody wrote the alt text for.
+  img.addEventListener("error", () => {
+    const fallback = h("span", { class: "prose__img-missing" }, alt || "image");
+    if (img.parentNode) img.parentNode.replaceChild(fallback, img);
+  });
+  return img;
+}
+
+/**
+ * safeURL returns a target worth turning into a link, or an empty string.
+ *
+ * The list is short on purpose. A javascript: target in a document body is
+ * either a mistake or an attack, and in both cases the right answer is to show
+ * the words and drop the target.
+ */
+export function safeURL(href) {
+  const value = String(href || "").trim();
+  if (/^(https?:|mailto:)/i.test(value)) return value;
+  return "";
+}

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -2,6 +2,7 @@
 
 import { h, replace, svg } from "./dom.js";
 import { kindIcon, sourceColor, label, when, exact, number, duration, icon } from "./format.js";
+import { tile } from "./content.js";
 import * as urlState from "./state.js";
 
 /**
@@ -100,6 +101,7 @@ export class Results {
         h(
           "div",
           { class: "skeleton-result" },
+          h("div", { class: "skeleton skeleton-result__tile" }),
           h("div", { class: "skeleton", style: { width: "60%", height: "20px" } }),
           h("div", { class: "skeleton", style: { width: "40%", height: "14px" } }),
           h("div", { class: "skeleton", style: { width: "100%", height: "14px" } }),
@@ -234,9 +236,10 @@ export class Results {
   /**
    * row is one result.
    *
-   * Title first, then the line of provenance, then the snippet. The old order
-   * put provenance above the title, which meant the first thing on every row
-   * was the least distinguishing thing about it.
+   * A tile, then the title, then the line of provenance, then the snippet. The
+   * old order put provenance above the title, which meant the first thing on
+   * every row was the least distinguishing thing about it. The tile is the only
+   * part of a row that is not words, and for an image it is the whole answer.
    */
   row(hit, i) {
     const open = () => this.onOpen(hit.id);
@@ -254,6 +257,7 @@ export class Results {
           open();
         },
       },
+      tile(hit),
       hit.url
         ? h(
             "a",

--- a/web/dist/assets/tokens.css
+++ b/web/dist/assets/tokens.css
@@ -92,6 +92,17 @@
      calm. */
   --mark: #fae041;
 
+  /* Code. Five colours, because the highlighter finds five things: a comment,
+     a string, a number, a keyword and the name of a function or a type. A
+     twenty colour theme is a theme for somebody editing the file, and nobody
+     edits a file in a search preview. Violet is not in this set, because violet
+     means a model wrote it and a keyword is not written by a model. */
+  --code-keyword: #cf222e;
+  --code-string: #0a3069;
+  --code-number: #0550ae;
+  --code-func: #953800;
+  --code-comment: var(--text-muted);
+
   /* Semantic layer. This is what components use. */
   --bg: var(--gray-0);
   --bg-subtle: var(--gray-50);
@@ -299,6 +310,14 @@
 
   --source-github: #c9d1d9;
   --source-notion: #d4d0c8;
+
+  /* The same five roles, lifted until they hold against a near black ground.
+     The light set would read as mud here, which is the whole reason the theme
+     remaps the semantic layer instead of dimming it. */
+  --code-keyword: #ff7b72;
+  --code-string: #a5d6ff;
+  --code-number: #79c0ff;
+  --code-func: #ffa657;
 
   /* A shadow on a dark ground carries almost no information, so the drawer
      additionally takes a hairline to define its edge. */

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1,8 +1,11 @@
 package web_test
 
 import (
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
 	"strings"
 	"testing"
 
@@ -38,6 +41,34 @@ func TestUnknownPathsFallBackToTheDocument(t *testing.T) {
 	}
 	if w.Header().Get("Cache-Control") != "no-cache" {
 		t.Errorf("Cache-Control = %q, the document must not be cached", w.Header().Get("Cache-Control"))
+	}
+}
+
+// The interface builds every node it shows, and never hands the browser a
+// string to parse as markup. That is what makes a document title containing a
+// script tag a document title, and it is the only defence there is, because
+// there is no sanitiser in the stack to fall back on. It is a test rather than a
+// convention because a single innerHTML added later would undo it silently.
+func TestAssetsBuildNodesRatherThanMarkup(t *testing.T) {
+	banned := []string{"innerHTML", "outerHTML", "insertAdjacentHTML", "document.write", "eval("}
+
+	err := fs.WalkDir(os.DirFS("dist"), ".", func(name string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || path.Ext(name) != ".js" {
+			return err
+		}
+		body, err := os.ReadFile(path.Join("dist", name))
+		if err != nil {
+			return err
+		}
+		for _, bad := range banned {
+			if strings.Contains(string(body), bad) {
+				t.Errorf("%s uses %s, which turns a string into markup", name, bad)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the assets: %v", err)
 	}
 }
 


### PR DESCRIPTION
Stacked on #60.

Every preview in the product was the body of the document printed into a div with `white-space: pre-wrap`.
A markdown page showed its hashes and its table pipes, a Go file showed as grey prose, and an image showed as nothing at all, because an image has no text body to print.
The result row had the same problem one line at a time: the snippet came out of a markdown body, so it spent its two lines on asterisks and backticks instead of on the sentence somebody wrote.

This teaches the product what a document is and draws each one as itself.

## The model and the store

`doc.Document` carries a media type on every document, and `doc.Content` carries bytes for the ones whose meaning is not text.
Bytes stay out of the query path.
A store takes them on `Put`, strips them off the document it indexes, and hands them back only through the new `store.ContentStore` capability.
Both drivers implement it, the SQLite driver keeps them in a `document_content` table that cascades on delete, and the conformance suite in `store/storetest` covers round trip, replace and delete.

The file connector reads images, records the pixel size while it has the file open, and stamps a media type on everything it walks.
Files over 4MB are indexed as documents without bytes rather than pulled into memory.

## The endpoint

`GET /api/v1/documents/{id}/content` serves those bytes behind the same permission check as the document itself.
Not permitted, not there and no bytes are one 404 with one body, so the endpoint cannot be used to find out whether a document exists.

It sets `nosniff`, a strong ETag and a private cache, serves inline only for an allow list of image types and everything else as an attachment, and goes through `http.ServeContent` so conditional and range requests work without any code here.
`X-Content-Dimensions` carries the pixel size so the client can reserve the box before the bytes land.

## The client

Three new modules under `web/dist/assets`.

`markdown.js` renders headings, lists, task lists, quotes, tables, fences, links and images.
`highlight.js` colours eleven languages into five token classes, and defers anything over 4000 characters until it is near the viewport.
`content.js` picks the renderer from the media type and is the only file that has to change when a media type is added.

Neither builds a node from a string of markup.
A document whose title contains a script tag is a document whose title contains the text of a script tag, and `TestAssetsBuildNodesRatherThanMarkup` fails the build if `innerHTML` ever appears under `web/dist/assets`, because a convention would not survive the next contributor.

An image is fetched with the caller's identity headers rather than through a bare `img src`, which is what keeps one rule for who may read what and keeps identity out of URLs.
It loads when it comes near the viewport, reserves its box from the size the store recorded so nothing below it jumps, holds the last 64 object URLs and revokes on eviction, and falls back to its alt text rather than to a broken glyph.

The result row grows a 56 pixel tile at the head.
For an image document the tile is the image.
For everything else it is the icon for the kind with a two pixel source coloured rule under it, so the left edge of the list groups by source without a wall of tinted squares.

## Snippets

Passages are cut from a markdown body with the syntax taken out, in the passage builder on the server, so the offsets that mark a matched term are offsets into the text the reader will actually see.
A fenced block is kept verbatim, because a code sample is what it looks like.

## Verified in a browser

Checked at 1440 and 600 against a live index over a corpus holding markdown with relative images, a 2880x1800 screenshot, and Go and JavaScript sources.

- Prose renders with headings, tables, task lists and inline code at the reading measure.
- A code document highlights with the copy button in the head, in both themes.
- An image document shows the image with `2880 by 1800 pixels · PNG · 597 KB` under it.
- A relative image inside a markdown page resolves to the document beside it and renders in place.
- Result rows show tiles, and image rows show the thumbnail.
- No console errors or warnings.

## Not in this pull request

Video and audio, PDF, and thumbnail generation on the server.
The tile for an image document is the full image scaled down by the browser, which is fine for a corpus of this size and is not fine for a corpus of photographs.
That wants a resize step in the ingestion path, which belongs with the performance work rather than here.

Closes #61
Closes #62
Closes #63
Closes #64
Closes #65
Closes #66
