### PR TITLE
feat: rank in the database instead of reading the corpus into memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bin/
 /dist/
 *.out
+*.test
 coverage.out
 .DS_Store
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,13 @@ LDFLAGS := -s -w \
 
 export CGO_ENABLED := 0
 
-.PHONY: build cli install test race cover bench vet fmt lint tidy vuln headless clean run
+.PHONY: build cli install test race cover bench bench-corpus bench-search bench-counters vet fmt lint tidy vuln headless clean run
+
+# How large the benchmark corpus is. The budgets are stated against a hundred
+# thousand documents, which takes a couple of minutes to generate, so the
+# default here is the smaller corpus people actually run while they work.
+BENCH_DOCS ?= 20000
+BENCH_SEED ?= 2121
 
 build:
 	go build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN) $(PKG)
@@ -33,6 +39,29 @@ cover:
 
 bench:
 	go test -run '^$$' -bench . -benchmem ./...
+
+# The benchmark corpus, which is generated rather than checked in. It is a few
+# hundred megabytes and it is derived entirely from the seed, so anybody who
+# runs this gets the same documents and the numbers stay comparable. The
+# benchmarks build it on demand too, and this target is for building it once up
+# front rather than inside a timed run.
+bench-corpus:
+	go run ./benchcorpus/gen -seed $(BENCH_SEED) -n $(BENCH_DOCS) -out testdata/bench-$(BENCH_SEED)-$(BENCH_DOCS).db
+
+# The endpoint, search and driver benchmarks, against that corpus. Three levels
+# of the same corpus, so the difference between two of the numbers is the cost of
+# the layer between them.
+bench-search:
+	GENBA_BENCH_DOCS=$(BENCH_DOCS) go test -run '^$$' -bench . -benchmem ./api/ ./index/ ./store/sqlitestore/
+
+# The performance gate, which is what runs on every pull request.
+#
+# It asserts work rather than time: how many rows a query reads, how many
+# statements it runs, how many documents it decodes. A shared CI runner cannot
+# measure a millisecond and it can count rows exactly, so this fails on a change
+# that makes a query read the corpus and stays quiet when the runner is busy.
+bench-counters:
+	go test -count=1 -run 'Counters' ./index/
 
 vet:
 	go vet ./...

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -23,7 +23,7 @@ import (
 // and a number there are comparable and the difference between them is the cost
 // of the HTTP layer.
 
-func handler(b *testing.B) (http.Handler, map[string]string) {
+func handler(b *testing.B) (h http.Handler, ids map[string]string) {
 	b.Helper()
 	st, spec := benchcorpus.Fixture(b)
 	s := api.New(st, index.New(st, index.WithClock(func() time.Time { return benchcorpus.Epoch })),

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -1,0 +1,156 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/benchcorpus"
+	"github.com/tamnd/genba/index"
+)
+
+// These measure the endpoint rather than the searcher, because the budget is
+// stated against what a browser waits for. Between the two there is header
+// parsing, query parsing, snippet building and JSON encoding, and every one of
+// them has been the surprise in somebody's latency budget at some point.
+//
+// The corpus is the same fixed one the search benchmarks use, so a number here
+// and a number there are comparable and the difference between them is the cost
+// of the HTTP layer.
+
+func handler(b *testing.B) (http.Handler, map[string]string) {
+	b.Helper()
+	st, spec := benchcorpus.Fixture(b)
+	s := api.New(st, index.New(st, index.WithClock(func() time.Time { return benchcorpus.Epoch })),
+		api.HeaderAuth{Tenant: benchcorpus.Tenant})
+	return s.Handler(), headers(spec.Principal())
+}
+
+// headers is the principal as a trusted proxy would pass it down.
+func headers(p *acl.Principal) map[string]string {
+	identities := make([]string, 0, len(p.Identities))
+	for _, id := range p.Identities {
+		identities = append(identities, id.Source+":"+id.Value)
+	}
+	return map[string]string{
+		api.HeaderSubject:      p.Subject,
+		api.HeaderTenant:       p.Tenant,
+		api.HeaderGroups:       strings.Join(p.Groups.Members, ","),
+		api.HeaderIdentities:   strings.Join(identities, ","),
+		api.HeaderGroupVersion: "1",
+	}
+}
+
+// get issues one request and fails the benchmark on anything that is not a
+// success, because a benchmark of an error path measures nothing.
+func get(b *testing.B, h http.Handler, target string, hdr map[string]string) *httptest.ResponseRecorder {
+	r := httptest.NewRequestWithContext(b.Context(), http.MethodGet, target, nil)
+	for k, v := range hdr {
+		r.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		b.Fatalf("GET %s = %d, %s", target, w.Code, w.Body)
+	}
+	return w
+}
+
+// endpoint measures one path, cycling through the checked in queries of a class
+// so the measurement is over a distribution rather than over one lucky term.
+func endpoint(b *testing.B, path string, class benchcorpus.Class) {
+	h, hdr := handler(b)
+	queries := benchcorpus.ByClass(benchcorpus.Queries())[class]
+	if len(queries) == 0 {
+		b.Fatalf("the query set has no %s queries", class)
+	}
+
+	targets := make([]string, len(queries))
+	for i, q := range queries {
+		targets[i] = path + "?q=" + urlQuery(q.Text)
+	}
+	for _, t := range targets[:min(len(targets), 20)] {
+		get(b, h, t, hdr)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		get(b, h, targets[i%len(targets)], hdr)
+	}
+}
+
+func BenchmarkAPISearch(b *testing.B) { endpoint(b, "/api/v1/search", benchcorpus.ClassCommon) }
+
+// BenchmarkAPISearchFilter is the endpoint with the facets doing the work and
+// no terms at all, which is what the interface asks for when somebody clicks a
+// source in the sidebar with an empty box.
+func BenchmarkAPISearchFilter(b *testing.B) {
+	endpoint(b, "/api/v1/search", benchcorpus.ClassFilter)
+}
+
+// BenchmarkAPISuggest is the typeahead, and it has the tightest budget of
+// anything here: it runs on a keystroke, so a person will issue several of them
+// in the time it takes to read one result page.
+func BenchmarkAPISuggest(b *testing.B) { endpoint(b, "/api/v1/suggest", benchcorpus.ClassCommon) }
+
+// BenchmarkAPIDocument is opening a result, over ids taken from a real search so
+// that every one of them is a document this reader may actually read.
+func BenchmarkAPIDocument(b *testing.B) {
+	h, hdr := handler(b)
+	queries := benchcorpus.ByClass(benchcorpus.Queries())[benchcorpus.ClassCommon]
+
+	var page struct {
+		Hits []struct {
+			ID string `json:"id"`
+		} `json:"hits"`
+	}
+	w := get(b, h, "/api/v1/search?q="+urlQuery(queries[0].Text), hdr)
+	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil {
+		b.Fatalf("decoding the search page: %v", err)
+	}
+	if len(page.Hits) == 0 {
+		b.Fatal("the first benchmark query returned nothing to open")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		get(b, h, "/api/v1/documents/"+page.Hits[i%len(page.Hits)].ID, hdr)
+	}
+}
+
+// BenchmarkAPIMe and BenchmarkAPIStats are the two calls the interface makes
+// before it can draw anything, so they are on the path to first paint even
+// though neither of them searches for anything.
+func BenchmarkAPIMe(b *testing.B) {
+	h, hdr := handler(b)
+	get(b, h, "/api/v1/me", hdr)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		get(b, h, "/api/v1/me", hdr)
+	}
+}
+
+func BenchmarkAPIStats(b *testing.B) {
+	h, hdr := handler(b)
+	get(b, h, "/api/v1/stats", hdr)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		get(b, h, "/api/v1/stats", hdr)
+	}
+}
+
+// urlQuery escapes a query for the q parameter. The benchmark queries are
+// generated words, spaces and colons, so this is all the escaping they need and
+// url.QueryEscape would turn the spaces into plus signs for no reason.
+func urlQuery(s string) string {
+	return strings.ReplaceAll(s, " ", "%20")
+}

--- a/arch_test.go
+++ b/arch_test.go
@@ -44,6 +44,14 @@ var allowed = map[string][]string{
 	"connector/fssource": {"acl", "connector", "doc"},
 	"ingest":             {"", "connector", "doc", "store"},
 
+	// The benchmark corpus sits above everything, like storetest does, because
+	// it exists to be measured against rather than to be built on. It is the one
+	// package that names a driver: the fixture it hands a benchmark is a SQLite
+	// file on disk, cached between runs, and generating it is far too slow to do
+	// through an interface for the sake of symmetry.
+	"benchcorpus":     {"acl", "doc", "store", "store/sqlitestore"},
+	"benchcorpus/gen": {"benchcorpus", "store/sqlitestore"},
+
 	"cmd/genba":  {""},
 	"cmd/genbad": {"", "api", "config", "connector", "connector/fssource", "index", "ingest", "store", "store/memstore", "store/sqlitestore", "web"},
 }

--- a/benchcorpus/BASELINE.md
+++ b/benchcorpus/BASELINE.md
@@ -1,0 +1,88 @@
+# Baseline
+
+Where the query path stands after the two phase retrieval work, measured against the corpus this package generates.
+
+The point of writing it down is that the next person who changes any of this has something to compare against, and that the numbers we are not happy with are on the record rather than in somebody's memory.
+
+## What was measured
+
+| | |
+| --- | --- |
+| Corpus | seed 2121, 20,000 documents |
+| Queries | `benchcorpus/queries.txt`, cycled per class |
+| Machine | Apple M4, 10 cores, macOS 15, `CGO_ENABLED=0` |
+| Driver | `modernc.org/sqlite`, which is SQLite transpiled to Go |
+| Command | `make bench-search` |
+| Recorded | 19 August 2026 |
+
+Read these as orientation, not as a gate.
+They were taken on a laptop that was doing other things, and the same commit measured 43ms and 50ms for the same benchmark twenty minutes apart.
+That is exactly why the thing CI enforces is `make bench-counters`, which counts rows and statements and cannot flake, and why the latency gate that will sit beside it compares against a baseline recorded on the runner it runs on.
+
+## The endpoints
+
+| Benchmark | Time | Allocations |
+| --- | --- | --- |
+| `BenchmarkAPIDocument` | 113µs | 122 |
+| `BenchmarkAPIStats` | 1.9ms | 63 |
+| `BenchmarkAPISearchFilter` | 16.2ms | 21,066 |
+| `BenchmarkAPISuggest` | 42.7ms | 16,844 |
+| `BenchmarkAPISearch` | 55.4ms | 22,558 |
+| `BenchmarkAPIMe` | 86.8ms | 9,996 |
+
+## The searcher
+
+| Benchmark | Time | Allocations |
+| --- | --- | --- |
+| `BenchmarkSearchRare` | 3.8ms | 14,930 |
+| `BenchmarkSearchTermFilter` | 10.5ms | 18,984 |
+| `BenchmarkSearchFilterOnly` | 18.5ms | 20,925 |
+| `BenchmarkSearchMultiTerm` | 26.6ms | 25,437 |
+| `BenchmarkSearchStranger` | 37.6ms | 23,318 |
+| `BenchmarkSearchByRecency` | 43.3ms | 50,844 |
+| `BenchmarkSearchCommonTerm` | 50.4ms | 22,425 |
+| `BenchmarkSearchDeepPage` | 57.0ms | 71,934 |
+| `BenchmarkSearchPathological` | 128.9ms | 65,853 |
+
+## The driver
+
+| Benchmark | Time | Allocations |
+| --- | --- | --- |
+| `BenchmarkStatistics` | 31µs | 84 |
+| `BenchmarkGetByIDs` | 910µs | 674 |
+| `BenchmarkRankFilterOnly` | 12.5ms | 5,097 |
+| `BenchmarkRankMultiTerm` | 20.8ms | 14,137 |
+| `BenchmarkRank` | 45.0ms | 13,723 |
+| `BenchmarkPutBatch` | 510 documents/s | 2,670 per document |
+
+## Where the time goes
+
+Every number above is explained by one sentence: the cost of a query is proportional to the number of documents the asker may read that match it, and to nothing else.
+
+A rare term matches a handful of documents and costs 3.8ms whether the corpus holds five thousand documents or twenty thousand.
+A common term in this corpus matches four thousand and is visible in three thousand, and costs 50ms.
+The pathological class is the term most of the corpus carries, and it costs 129ms.
+Fetching a page of twenty documents by id costs 910µs and does not move at all, because it is twenty primary key lookups.
+
+Two of the three statements a search runs walk the visible match set.
+The candidate cut walks it to find the best five hundred, and the counts statement walks it again to produce the total and the four facet lists.
+Timed separately on this corpus, with the C build of SQLite so the driver is out of the picture, the candidate cut is 6ms and the counts statement is 7ms for a match set of three thousand.
+Through the Go driver each is roughly one and a half times that, and the rest of the difference between 13ms and 50ms is the classes with larger match sets that the benchmark averages over.
+
+`BenchmarkAPIMe` is the worst number here and it is the first request the interface makes.
+It runs a search with no terms and no filters, so the match set is every document the reader may see, which is fifteen thousand of the twenty thousand.
+It then throws away everything except the source and kind facet lists, which are the same on every page load and change only when somebody indexes a document.
+That is a cache, and it is the next piece of work.
+
+## What is not met yet
+
+The budgets are in the measurement spec and three of them are missed.
+
+**Search under ten milliseconds.** Met for a rare term and for a term with a filter, missed for a common term by a factor of five. Closing it needs the counts statement to stop being a second walk of the match set, and needs the repeated queries that a real workload is mostly made of to be served from a cache.
+
+**Two thousand documents indexed per second.** Measured at 510. A document averages three hundred and thirty distinct terms, and each one costs a posting insert and a term statistic upsert, so a document is about six hundred and sixty statements. Batching those is the obvious fix and it has not been done.
+
+**Index overhead under sixty percent of the corpus.** Measured at a hundred and forty three percent. The raw document JSON is 119MB, and on top of it sit 131MB of postings, 35MB of full text index and 4MB of everything else. The posting table stores the term as text on every row, so a term appearing in eight thousand documents is stored eight thousand times. A term dictionary with integer ids would take most of that back.
+
+None of these are surprises and none of them are hidden.
+They are written here so that the next change to this code starts from a number rather than from a guess.

--- a/benchcorpus/benchcorpus.go
+++ b/benchcorpus/benchcorpus.go
@@ -1,0 +1,407 @@
+// Package benchcorpus generates the fixed corpus the performance work is
+// measured against.
+//
+// A benchmark is only worth the corpus it runs on. Ten documents in a map
+// answer every query in microseconds and prove nothing, and a corpus of
+// "lorem ipsum" repeated is uniform in a way real text never is, so it hides
+// exactly the behaviour that makes search slow: a handful of terms appearing in
+// most documents, a long tail appearing in one, documents that differ in length
+// by two orders of magnitude, and a permission structure where the asker can
+// read some of it rather than all or none.
+//
+// So the corpus here is generated from distributions rather than from a loop.
+// Term frequencies are Zipf, body lengths are log normal, sources and group
+// sizes are uneven, and the benchmark principal can read roughly sixty percent
+// of it. Everything is derived from a seed, so the same seed produces the same
+// database on any machine, which is what lets a number recorded last month be
+// compared to one measured today.
+//
+// BASELINE.md in this directory is where the query path stood the last time
+// somebody wrote it down, including the budgets it does not meet.
+package benchcorpus
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// Spec is a corpus to generate.
+//
+// The defaults come from the measurement plan, which took them from surveys of
+// real document corpora rather than from what felt about right. They are fields
+// rather than constants so a benchmark can generate a tenth of the corpus while
+// somebody is iterating, and the recorded baseline can state the size it was
+// measured at.
+type Spec struct {
+	Seed      uint64
+	Documents int
+
+	// Vocabulary is how many distinct terms the generator draws from. Sixty
+	// thousand is about what a hundred thousand real documents carry once
+	// names, identifiers and misspellings are counted.
+	Vocabulary int
+
+	// Zipf is the exponent of the term distribution. Just above one is what
+	// natural language produces, and it is the reason a search for a common word
+	// touches a quarter of the corpus while the median word touches four
+	// documents.
+	Zipf float64
+
+	// MedianBody and P99Body pin the log normal body length, in words.
+	MedianBody int
+	P99Body    int
+
+	Containers int
+	People     int
+	Groups     int
+
+	// Readable is the share of the corpus the benchmark principal can read. It
+	// is not one, because a permission predicate that never excludes anything is
+	// not being measured, and it is not a tenth, because then the ranking is
+	// measured over a corpus nobody has.
+	Readable float64
+}
+
+// Default is the corpus the budgets are stated against.
+func Default(seed uint64, documents int) Spec {
+	return Spec{
+		Seed:       seed,
+		Documents:  documents,
+		Vocabulary: 60_000,
+		Zipf:       1.07,
+		MedianBody: 380,
+		P99Body:    4_200,
+		Containers: 2_400,
+		People:     1_200,
+		Groups:     180,
+		Readable:   0.60,
+	}
+}
+
+// Tenant is the tenant every generated document belongs to.
+const Tenant = "acme"
+
+// Epoch is the date the generated modification times are measured back from.
+//
+// It is a constant rather than time.Now, because a corpus whose dates move with
+// the calendar makes the recency prior part of the ranking move too, and then a
+// benchmark recorded in March cannot be compared with one recorded in June.
+var Epoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// share is one source and how much of the corpus comes from it.
+type share struct {
+	name   string
+	weight int
+}
+
+// sources are uneven, because every real deployment is: one system holds most
+// of the documents and the rest hold the interesting ones.
+var sources = []share{
+	{"gdrive", 30}, {"slack", 25}, {"github", 18},
+	{"jira", 12}, {"confluence", 9}, {"notion", 6},
+}
+
+var kinds = []doc.Kind{
+	doc.KindPage, doc.KindMessage, doc.KindTicket, doc.KindFile,
+	doc.KindCode, doc.KindEmail, doc.KindCalendar, doc.KindPerson,
+}
+
+// Each calls fn with every document in the corpus, in order, and stops early if
+// it returns false.
+//
+// It is deliberately serial. Generating in parallel would be faster and the
+// resulting corpus would depend on scheduling, which is the one property this
+// package exists to avoid.
+func (s Spec) Each(fn func(doc.Document) bool) {
+	g := s.generator()
+	for i := range s.Documents {
+		if !fn(g.document(i)) {
+			return
+		}
+	}
+}
+
+// Generate writes the corpus into st in batches.
+//
+// Five hundred at a time, which is the batch size the ingestion budget is
+// stated against, so building the fixture is also a rough measurement of the
+// write path.
+func (s Spec) Generate(ctx context.Context, st store.Store, progress func(done int)) error {
+	const batch = 500
+
+	var (
+		docs = make([]doc.Document, 0, batch)
+		done int
+		err  error
+	)
+	flush := func() bool {
+		if err = st.Put(ctx, docs...); err != nil {
+			err = fmt.Errorf("benchcorpus: %w", err)
+			return false
+		}
+		done += len(docs)
+		docs = docs[:0]
+		if progress != nil {
+			progress(done)
+		}
+		return true
+	}
+
+	s.Each(func(d doc.Document) bool {
+		docs = append(docs, d)
+		return len(docs) < batch || flush()
+	})
+	if err != nil {
+		return err
+	}
+	if len(docs) > 0 && !flush() {
+		return err
+	}
+	return nil
+}
+
+// generator is the whole of one corpus's random state, in one place, so that
+// the document builder is a method rather than a function taking nine
+// arguments.
+type generator struct {
+	spec   Spec
+	r      *rand.Rand
+	terms  *rand.Zipf
+	mu     float64
+	sigma  float64
+	people []doc.Person
+	groups []float64
+}
+
+func (s Spec) generator() *generator {
+	r := rand.New(rand.NewPCG(s.Seed, s.Seed^0x9e3779b97f4a7c15))
+	return &generator{
+		spec:  s,
+		r:     r,
+		terms: rand.NewZipf(r, s.Zipf, 1, uint64(s.Vocabulary-1)),
+		mu:    math.Log(float64(s.MedianBody)),
+		// The p99 of a log normal is exp(mu + 2.326 sigma), which is where the
+		// sigma that reproduces the stated pair comes from.
+		sigma:  math.Log(float64(s.P99Body)/float64(s.MedianBody)) / 2.326,
+		people: s.people(),
+		groups: s.groupSizes(),
+	}
+}
+
+func (g *generator) document(i int) doc.Document {
+	body := int(math.Exp(g.mu + g.sigma*g.r.NormFloat64()))
+	body = min(max(body, 8), 20_000)
+
+	author := g.people[g.r.IntN(len(g.people))]
+	owner := g.people[g.r.IntN(len(g.people))]
+
+	d := doc.Document{
+		ID:        "b" + strconv.Itoa(i),
+		Tenant:    Tenant,
+		Source:    sources[weighted(g.r, sources)].name,
+		Kind:      kinds[g.r.IntN(len(kinds))],
+		Title:     g.text(3 + g.r.IntN(10)),
+		Body:      g.text(body),
+		Container: "c" + strconv.Itoa(g.r.IntN(g.spec.Containers)),
+		Author:    author,
+		Owner:     owner,
+		// Skewed towards the recent, because a document store is: most of what
+		// exists was touched in the last year and the rest is archive. An even
+		// spread would make the recency prior look weaker than it is.
+		ModifiedAt: Epoch.Add(-time.Duration(g.r.Float64()*g.r.Float64()*1095*24) * time.Hour),
+	}
+	d.Permissions = g.permissions(i, owner)
+	return d
+}
+
+// permissions gives the document either a tenant wide mode or a single allow
+// group drawn from the same skewed distribution the membership was computed
+// against.
+func (g *generator) permissions(i int, owner doc.Person) acl.Permissions {
+	p := acl.Permissions{
+		Source:  "gdrive",
+		Version: 1,
+		Owner:   acl.Ref{Source: "gdrive", Value: owner.Email},
+	}
+	// A quarter of the corpus is readable by everybody in the tenant, which is
+	// what a wiki looks like, and it is also the cheap branch of the predicate,
+	// so a corpus without it measures only the expensive one.
+	if i%4 == 0 {
+		p.Mode = acl.ModePublicToTenant
+		return p
+	}
+	p.Mode = acl.ModeACL
+	p.AllowGroups = []acl.Ref{{Source: "gdrive", Value: groupName(pick(g.r, g.groups))}}
+	return p
+}
+
+// people are the authors and owners. A thousand or so, so that an author facet
+// has a long tail rather than six values.
+func (s Spec) people() []doc.Person {
+	out := make([]doc.Person, s.People)
+	for i := range out {
+		name := word(i*7919%s.Vocabulary) + " " + word((i*104729+13)%s.Vocabulary)
+		out[i] = doc.Person{
+			Subject: "u" + strconv.Itoa(i),
+			Name:    strings.ToUpper(name[:1]) + name[1:],
+			Email:   "u" + strconv.Itoa(i) + "@acme.com",
+		}
+	}
+	return out
+}
+
+// groupSizes is the share of documents each group guards, Zipf again: a few
+// company wide groups hold most of the corpus and most groups hold a project.
+func (s Spec) groupSizes() []float64 {
+	out := make([]float64, s.Groups)
+	var total float64
+	for i := range out {
+		out[i] = 1 / math.Pow(float64(i+1), 1.2)
+		total += out[i]
+	}
+	for i := range out {
+		out[i] /= total
+	}
+	return out
+}
+
+// membership picks the groups the benchmark principal belongs to.
+//
+// It walks the groups in a fixed shuffled order and takes them until the share
+// of the corpus it can read reaches [Spec.Readable], counting the quarter that
+// is public to the tenant. Taking the largest groups first would give the
+// principal three groups and a very cheap predicate, which is not what a real
+// membership looks like.
+func (s Spec) membership(groups []float64) []bool {
+	const public = 0.25
+	order := make([]int, len(groups))
+	for i := range order {
+		order[i] = i
+	}
+	r := rand.New(rand.NewPCG(s.Seed^0xdeadbeef, s.Seed))
+	r.Shuffle(len(order), func(i, j int) { order[i], order[j] = order[j], order[i] })
+
+	member := make([]bool, len(groups))
+	share := public
+	for _, g := range order {
+		if share >= s.Readable {
+			break
+		}
+		member[g] = true
+		share += (1 - public) * groups[g]
+	}
+	return member
+}
+
+// Principal is the reader every benchmark runs as.
+func (s Spec) Principal() *acl.Principal {
+	groups := s.groupSizes()
+	member := s.membership(groups)
+	p := &acl.Principal{
+		Tenant:     Tenant,
+		Subject:    "u_bench",
+		Identities: []acl.Identity{{Source: "gdrive", Value: "bench@acme.com"}},
+		Groups:     acl.GroupSet{Version: 1},
+	}
+	for g, in := range member {
+		if in {
+			p.Groups.Members = append(p.Groups.Members, "gdrive:"+groupName(g))
+		}
+	}
+	return p
+}
+
+// Stranger is a reader in the same tenant who is in no group at all, which is
+// the case that proves the predicate is doing work rather than being skipped.
+func (s Spec) Stranger() *acl.Principal {
+	return &acl.Principal{
+		Tenant:     Tenant,
+		Subject:    "u_stranger",
+		Identities: []acl.Identity{{Source: "gdrive", Value: "stranger@acme.com"}},
+		Groups:     acl.GroupSet{Version: 1},
+	}
+}
+
+func groupName(i int) string { return "g" + strconv.Itoa(i) + "@acme.com" }
+
+// text draws n words from the Zipf distribution.
+func (g *generator) text(n int) string {
+	var b strings.Builder
+	b.Grow(n * 7)
+	for i := range n {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(word(int(g.terms.Uint64())))
+		// A sentence break every dozen words or so, which is what gives the
+		// snippet code something to cut at.
+		if i%13 == 12 {
+			b.WriteByte('.')
+		}
+	}
+	return b.String()
+}
+
+// syllables build the vocabulary. Synthetic, but with the shape of words: two
+// or three syllables, a suffix, and a length distribution close enough that the
+// analyzer, the full text index and the snippet code all do the work they would
+// do on real text.
+var syllables = []string{
+	"ba", "ka", "ro", "mi", "ten", "dor", "fal", "que", "nix", "sar",
+	"vel", "tri", "gon", "lum", "per", "cas", "mor", "ith", "ral", "sen",
+	"tor", "vex", "wyn", "zal",
+}
+
+var suffixes = []string{"", "s", "ing", "ed", "er", "ion"}
+
+// Word maps a term rank to its spelling, and does it the same way every time,
+// so a query recorded against one corpus means the same thing in the next one.
+// Rank zero is the most common term in the corpus.
+func Word(rank int) string { return word(rank) }
+
+func word(i int) string {
+	n := len(syllables)
+	var b strings.Builder
+	b.WriteString(syllables[i%n])
+	b.WriteString(syllables[(i/n)%n])
+	b.WriteString(syllables[(i/(n*n))%n])
+	b.WriteString(suffixes[(i/(n*n*n))%len(suffixes)])
+	return b.String()
+}
+
+// weighted picks an index in proportion to the weights.
+func weighted(r *rand.Rand, items []share) int {
+	var total int
+	for _, it := range items {
+		total += it.weight
+	}
+	n := r.IntN(total)
+	for i, it := range items {
+		if n < it.weight {
+			return i
+		}
+		n -= it.weight
+	}
+	return len(items) - 1
+}
+
+// pick chooses an index in proportion to a normalised distribution.
+func pick(r *rand.Rand, weights []float64) int {
+	n := r.Float64()
+	for i, w := range weights {
+		if n < w {
+			return i
+		}
+		n -= w
+	}
+	return len(weights) - 1
+}

--- a/benchcorpus/benchcorpus_test.go
+++ b/benchcorpus/benchcorpus_test.go
@@ -1,0 +1,151 @@
+package benchcorpus_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/tamnd/genba/benchcorpus"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store/memstore"
+	"github.com/tamnd/genba/store/sqlitestore"
+)
+
+// The corpus is the thing every performance number is measured against, so the
+// properties asserted here are the ones that would silently invalidate a
+// comparison: that the same seed produces the same documents, and that the
+// benchmark principal can read roughly the share the budgets assume. A corpus
+// that quietly became readable in full would make every measurement look good.
+
+const sample = 2_000
+
+func TestSameSeedSameCorpus(t *testing.T) {
+	first := collect(t, benchcorpus.Default(2121, sample))
+	second := collect(t, benchcorpus.Default(2121, sample))
+
+	if len(first) != sample {
+		t.Fatalf("generated %d documents, asked for %d", len(first), sample)
+	}
+	for i := range first {
+		if first[i].ID != second[i].ID || first[i].Title != second[i].Title || first[i].Body != second[i].Body {
+			t.Fatalf("document %d differs between two runs of the same seed", i)
+		}
+	}
+
+	// And a different seed has to produce a different corpus, or the seed is
+	// not doing anything and the reproducibility above is trivially true.
+	other := collect(t, benchcorpus.Default(7, sample))
+	if other[0].Body == first[0].Body {
+		t.Fatal("two seeds produced the same first document")
+	}
+}
+
+func TestPrincipalReadsTheStatedShare(t *testing.T) {
+	spec := benchcorpus.Default(2121, sample)
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	if err := spec.Generate(t.Context(), st, nil); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var readable int
+	if err := st.Scan(t.Context(), spec.Principal(), func(doc.Document) bool {
+		readable++
+		return true
+	}); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	share := float64(readable) / float64(spec.Documents)
+	if share < spec.Readable-0.10 || share > spec.Readable+0.10 {
+		t.Fatalf("the principal reads %.0f%% of the corpus and the spec says %.0f%%", share*100, spec.Readable*100)
+	}
+
+	// The stranger is in no group, so the only thing they can read is the
+	// quarter that is public to the tenant. If this ever returns everything, the
+	// permission predicate has stopped being part of what the benchmark
+	// measures.
+	var strangerReads int
+	if err := st.Scan(t.Context(), spec.Stranger(), func(doc.Document) bool {
+		strangerReads++
+		return true
+	}); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if got := float64(strangerReads) / float64(spec.Documents); got < 0.20 || got > 0.30 {
+		t.Fatalf("a stranger reads %.0f%% of the corpus, expected the quarter that is public to the tenant", got*100)
+	}
+}
+
+// TestTermsAreZipf checks the shape of the vocabulary rather than its values. A
+// uniform corpus is the failure mode that makes a search benchmark meaningless:
+// every query costs the same and none of them cost what a real one does.
+func TestTermsAreZipf(t *testing.T) {
+	spec := benchcorpus.Default(2121, sample)
+	docs := collect(t, spec)
+
+	counts := map[string]int{}
+	for _, d := range docs {
+		for term := range d.Analyze().Terms {
+			counts[term]++
+		}
+	}
+
+	// The most common term is in most documents and the thousandth is in a few
+	// percent of them, which is the spread the query classes are drawn against.
+	if got := float64(counts[benchcorpus.Word(0)]) / float64(len(docs)); got < 0.80 {
+		t.Fatalf("the most common term is in %.0f%% of documents, expected most of them", got*100)
+	}
+	if got := float64(counts[benchcorpus.Word(1_000)]) / float64(len(docs)); got > 0.25 {
+		t.Fatalf("the thousandth term is in %.0f%% of documents, which is too flat a distribution", got*100)
+	}
+	if len(counts) < 5_000 {
+		t.Fatalf("the corpus carries %d distinct terms, which is too uniform to measure anything", len(counts))
+	}
+}
+
+func TestQueriesCoverEveryClass(t *testing.T) {
+	byClass := benchcorpus.ByClass(benchcorpus.Queries())
+	if len(byClass) == 0 {
+		t.Fatal("the checked in query set is empty")
+	}
+	for class := range benchcorpus.Budget {
+		if len(byClass[class]) == 0 {
+			t.Fatalf("the query set has no %s queries, so that budget is never measured", class)
+		}
+	}
+}
+
+// TestGeneratesIntoSQLite is the smoke test for the driver the fixture actually
+// uses, since memstore accepts documents a schema might not.
+func TestGeneratesIntoSQLite(t *testing.T) {
+	spec := benchcorpus.Default(2121, 500)
+	st, err := sqlitestore.Open(t.Context(), filepath.Join(t.TempDir(), "bench.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	if err := spec.Generate(t.Context(), st, nil); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	stats, err := st.Stats(t.Context())
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if stats.Documents != spec.Documents {
+		t.Fatalf("stored %d documents, generated %d", stats.Documents, spec.Documents)
+	}
+	if stats.Quarantined != 0 {
+		t.Fatalf("%d generated documents have permissions that did not resolve", stats.Quarantined)
+	}
+}
+
+func collect(t *testing.T, spec benchcorpus.Spec) []doc.Document {
+	t.Helper()
+	docs := make([]doc.Document, 0, spec.Documents)
+	spec.Each(func(d doc.Document) bool {
+		docs = append(docs, d)
+		return true
+	})
+	return docs
+}

--- a/benchcorpus/fixture.go
+++ b/benchcorpus/fixture.go
@@ -1,0 +1,147 @@
+package benchcorpus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/tamnd/genba/store/sqlitestore"
+)
+
+// DefaultSeed is the seed every recorded number was measured at.
+const DefaultSeed = 2121
+
+// DefaultDocuments is how large the corpus is when nothing says otherwise.
+//
+// The budgets are stated against a hundred thousand documents and the gate
+// measures that, which takes a minute or two to build. Twenty thousand is the
+// default here because the common case is somebody running a benchmark while
+// they change something, and a fixture that takes two minutes to appear is a
+// fixture people stop using. Set GENBA_BENCH_DOCS to measure the real thing.
+const DefaultDocuments = 20_000
+
+// Fixture opens the benchmark corpus, building it first if it is not there.
+//
+// The database is cached under testdata and reused across runs, because
+// generating it is the slowest thing in this repository by a wide margin and it
+// is derived entirely from the seed, so the same seed and the same size is
+// always the same corpus. Deleting the file is how it is rebuilt.
+func Fixture(tb testing.TB) (*sqlitestore.Store, Spec) {
+	tb.Helper()
+
+	spec := Default(DefaultSeed, envInt("GENBA_BENCH_DOCS", DefaultDocuments))
+	return FixtureOf(tb, spec), spec
+}
+
+// FixtureOf is [Fixture] for a corpus of a stated shape, which is what a test
+// that needs a corpus rather than a measurement wants: the counter assertions
+// need a few thousand documents and would rather not wait for a hundred
+// thousand. Each shape is cached under its own name.
+func FixtureOf(tb testing.TB, spec Spec) *sqlitestore.Store {
+	tb.Helper()
+
+	path, err := FixturePath(spec)
+	if err != nil {
+		tb.Fatalf("benchcorpus: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := os.Stat(path); err != nil {
+		tb.Logf("generating %d documents into %s, this happens once", spec.Documents, path)
+		if err := build(ctx, spec, path); err != nil {
+			tb.Fatalf("benchcorpus: %v", err)
+		}
+	}
+
+	st, err := sqlitestore.Open(ctx, path)
+	if err != nil {
+		tb.Fatalf("benchcorpus: %v", err)
+	}
+	tb.Cleanup(func() { _ = st.Close() })
+
+	// A fixture that is there but half written measures nothing and says
+	// nothing, so the count is checked rather than assumed.
+	stats, err := st.Stats(ctx)
+	if err != nil {
+		tb.Fatalf("benchcorpus: %v", err)
+	}
+	if got := stats.Documents + stats.Quarantined; got != spec.Documents {
+		tb.Fatalf("benchcorpus: %s holds %d documents and the spec says %d, delete it and rerun", path, got, spec.Documents)
+	}
+	return st
+}
+
+// FixturePath is where a corpus of this shape is cached.
+func FixturePath(spec Spec) (string, error) {
+	if p := os.Getenv("GENBA_BENCH_DB"); p != "" {
+		return p, nil
+	}
+	root, err := moduleRoot()
+	if err != nil {
+		return "", err
+	}
+	name := "bench-" + strconv.FormatUint(spec.Seed, 10) + "-" + strconv.Itoa(spec.Documents) + ".db"
+	return filepath.Join(root, "testdata", name), nil
+}
+
+func build(ctx context.Context, spec Spec, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	// The same temporary name and rename the generator command uses, for the
+	// same reason: an interrupted build must not leave something that looks
+	// like a corpus.
+	tmp := path + ".partial"
+	_ = os.Remove(tmp)
+
+	st, err := sqlitestore.Open(ctx, tmp)
+	if err != nil {
+		return err
+	}
+	if err := spec.Generate(ctx, st, nil); err != nil {
+		_ = st.Close()
+		return err
+	}
+	if err := st.Close(); err != nil {
+		return err
+	}
+	for _, ext := range []string{"", "-wal", "-shm"} {
+		if _, err := os.Stat(tmp + ext); err != nil {
+			continue
+		}
+		if err := os.Rename(tmp+ext, path+ext); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// moduleRoot walks up for the go.mod, so the fixture lands in one place
+// whichever package's benchmarks asked for it.
+func moduleRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}
+
+func envInt(name string, fallback int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return fallback
+}

--- a/benchcorpus/gen/main.go
+++ b/benchcorpus/gen/main.go
@@ -1,0 +1,123 @@
+// Command gen writes the benchmark corpus and the benchmark query set.
+//
+//	go run ./benchcorpus/gen -seed 2121 -n 100000 -out testdata/bench.db
+//	go run ./benchcorpus/gen -queries benchcorpus/queries.txt
+//
+// The database is not checked in. It is a few hundred megabytes, it is derived
+// entirely from the seed, and CI restores it from a cache keyed on the hash of
+// the generator rather than from the repository. The query set is checked in,
+// because it is a thousand short lines and because a baseline is only
+// comparable against the queries it was recorded with.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/benchcorpus"
+	"github.com/tamnd/genba/store/sqlitestore"
+)
+
+func main() {
+	var (
+		seed    = flag.Uint64("seed", 2121, "the seed the corpus is derived from")
+		n       = flag.Int("n", 100_000, "how many documents to generate")
+		out     = flag.String("out", "", "where to write the database")
+		queries = flag.String("queries", "", "write the query set to this file instead of generating a corpus")
+		count   = flag.Int("query-count", 1_000, "how many queries to write")
+	)
+	flag.Parse()
+
+	spec := benchcorpus.Default(*seed, *n)
+	if *queries != "" {
+		if err := writeQueries(spec, *queries, *count); err != nil {
+			fail(err)
+		}
+		return
+	}
+	if *out == "" {
+		fail(fmt.Errorf("no -out and no -queries, so there is nothing to write"))
+	}
+	if err := writeCorpus(spec, *out); err != nil {
+		fail(err)
+	}
+}
+
+func writeCorpus(spec benchcorpus.Spec, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	// A partial corpus is worse than none: it looks like a corpus and every
+	// number measured against it is wrong. Writing to a temporary name and
+	// renaming at the end means an interrupted run leaves nothing behind.
+	tmp := path + ".partial"
+	_ = os.Remove(tmp)
+
+	ctx := context.Background()
+	st, err := sqlitestore.Open(ctx, tmp)
+	if err != nil {
+		return err
+	}
+
+	start := time.Now()
+	err = spec.Generate(ctx, st, func(done int) {
+		if done%10_000 != 0 && done != spec.Documents {
+			return
+		}
+		elapsed := time.Since(start)
+		fmt.Fprintf(os.Stderr, "\r%d/%d documents, %.0f/s", done, spec.Documents, float64(done)/elapsed.Seconds())
+	})
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		_ = st.Close()
+		return err
+	}
+	if err := st.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	// The write ahead log and its index belong to the database, so a corpus
+	// moved without them is a corpus missing whatever had not been checkpointed.
+	for _, ext := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(tmp + ext); err == nil {
+			if err := os.Rename(tmp+ext, path+ext); err != nil {
+				return err
+			}
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("wrote %s, %d documents, %.1f MB, seed %d\n",
+		path, spec.Documents, float64(info.Size())/(1<<20), spec.Seed)
+	return nil
+}
+
+func writeQueries(spec benchcorpus.Spec, path string, count int) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %d benchmark queries, seed %d, class distribution from the budgets.\n", count, spec.Seed)
+	fmt.Fprintf(&b, "# Regenerated with: go run ./benchcorpus/gen -queries %s\n", path)
+	fmt.Fprintf(&b, "# Regenerating this file invalidates every recorded baseline.\n")
+	for _, q := range spec.BuildQueries(count) {
+		fmt.Fprintf(&b, "%s\t%s\n", q.Class, q.Text)
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %s, %d queries, seed %d\n", path, count, spec.Seed)
+	return nil
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, "benchcorpus:", err)
+	os.Exit(1)
+}

--- a/benchcorpus/gen/main.go
+++ b/benchcorpus/gen/main.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -41,7 +42,7 @@ func main() {
 		return
 	}
 	if *out == "" {
-		fail(fmt.Errorf("no -out and no -queries, so there is nothing to write"))
+		fail(errors.New("no -out and no -queries, so there is nothing to write"))
 	}
 	if err := writeCorpus(spec, *out); err != nil {
 		fail(err)

--- a/benchcorpus/queries.go
+++ b/benchcorpus/queries.go
@@ -1,0 +1,190 @@
+package benchcorpus
+
+import (
+	"bufio"
+	_ "embed"
+	"math/rand/v2"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Class is a kind of query, because one number for "search" hides the fact that
+// queries differ in cost by two orders of magnitude.
+//
+// A single average over a mixed workload can be met by being fast at the cheap
+// queries and hopeless at the expensive ones, which is the shape of every
+// search system that feels slow while its dashboard looks fine. Each class gets
+// its own budget and is measured separately.
+type Class string
+
+// The classes, with the share of traffic each one stands for.
+const (
+	// ClassCommon is one term that a good fraction of the corpus carries. The
+	// most common real query and the one where the candidate cut earns its keep.
+	ClassCommon Class = "common"
+
+	// ClassMulti is the two to four term query somebody types when they know
+	// roughly what they are looking for.
+	ClassMulti Class = "multi"
+
+	// ClassFilter is browsing: no text at all, just facets. It has no full text
+	// index to narrow with, so it is the class that exposes a permission
+	// predicate that cannot use an index.
+	ClassFilter Class = "filter"
+
+	// ClassTermFilter is a term plus a facet, which is what somebody does
+	// straight after a search returns too much.
+	ClassTermFilter Class = "term-filter"
+
+	// ClassRare is a term almost nothing carries, including terms nothing
+	// carries at all. Cheap, and the class that catches work being done before
+	// the match set is known to be empty.
+	ClassRare Class = "rare"
+
+	// ClassPathological is one character, or a term in most of the corpus. One
+	// query in a hundred, its own relaxed budget, and measured rather than
+	// ignored, because "we do not care about that query" is how a denial of
+	// service works.
+	ClassPathological Class = "pathological"
+)
+
+// Budget is the p95 each class is allowed.
+var Budget = map[Class]time.Duration{
+	ClassCommon:       10 * time.Millisecond,
+	ClassMulti:        10 * time.Millisecond,
+	ClassFilter:       8 * time.Millisecond,
+	ClassTermFilter:   10 * time.Millisecond,
+	ClassRare:         3 * time.Millisecond,
+	ClassPathological: 25 * time.Millisecond,
+}
+
+// shares is the traffic mix, in parts per thousand.
+var shares = []struct {
+	class Class
+	parts int
+}{
+	{ClassCommon, 300},
+	{ClassMulti, 350},
+	{ClassFilter, 150},
+	{ClassTermFilter, 150},
+	{ClassRare, 40},
+	{ClassPathological, 10},
+}
+
+// Query is one benchmark query, in the syntax a person would type.
+type Query struct {
+	Class Class
+	Text  string
+}
+
+// queryFile is the checked in query set.
+//
+// It is a file rather than a generator call, because a benchmark comparing this
+// month's number against last month's has to be running the same queries, and a
+// generator is one refactor away from quietly producing a different set. The
+// corpus is too large to check in and is rebuilt from its seed. A thousand
+// lines of text is not.
+//
+//go:embed queries.txt
+var queryFile string
+
+// Queries returns the checked in query set.
+func Queries() []Query {
+	var out []Query
+	s := bufio.NewScanner(strings.NewReader(queryFile))
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		class, text, ok := strings.Cut(line, "\t")
+		if !ok {
+			continue
+		}
+		out = append(out, Query{Class: Class(class), Text: text})
+	}
+	return out
+}
+
+// ByClass groups a query set, which is how every assertion in the gate is made:
+// per class, against that class's budget.
+func ByClass(queries []Query) map[Class][]Query {
+	out := map[Class][]Query{}
+	for _, q := range queries {
+		out[q.Class] = append(out[q.Class], q)
+	}
+	return out
+}
+
+// BuildQueries regenerates the query set from the seed.
+//
+// It is used to write queries.txt and by nothing else. Regenerating the file is
+// a deliberate act that invalidates every recorded baseline, so it lives behind
+// the generator command rather than being called at test time.
+func (s Spec) BuildQueries(n int) []Query {
+	r := rand.New(rand.NewPCG(s.Seed^0x51ed270b, s.Seed))
+
+	// The mix is dealt out and then shuffled, rather than sampled, so the set
+	// has exactly the stated proportions instead of approximately them. Four
+	// pathological queries where there should be ten is a twenty five percent
+	// error in the class that dominates the tail.
+	classes := make([]Class, 0, n)
+	for _, sh := range shares {
+		for range sh.parts * n / 1_000 {
+			classes = append(classes, sh.class)
+		}
+	}
+	for len(classes) < n {
+		classes = append(classes, ClassCommon)
+	}
+	r.Shuffle(len(classes), func(i, j int) { classes[i], classes[j] = classes[j], classes[i] })
+
+	out := make([]Query, 0, n)
+	for _, class := range classes {
+		out = append(out, s.query(r, class))
+	}
+	return out
+}
+
+func (s Spec) query(r *rand.Rand, class Class) Query {
+	switch class {
+	case ClassCommon:
+		// Term ranks 20 to 200. Rank one is in almost every document and is the
+		// pathological class, and rank ten thousand is in four, so the band in
+		// between is where the ordinary query lives.
+		return Query{class, word(20 + r.IntN(180))}
+
+	case ClassMulti:
+		terms := make([]string, 2+r.IntN(3))
+		for j := range terms {
+			terms[j] = word(30 + r.IntN(4_000))
+		}
+		return Query{class, strings.Join(terms, " ")}
+
+	case ClassFilter:
+		return Query{class, "source:" + sources[r.IntN(len(sources))].name +
+			" kind:" + string(kinds[r.IntN(len(kinds))])}
+
+	case ClassTermFilter:
+		return Query{class, word(20+r.IntN(2_000)) +
+			" source:" + sources[r.IntN(len(sources))].name}
+
+	case ClassRare:
+		if r.IntN(4) == 0 {
+			// A term the vocabulary does not contain at all, which is the empty
+			// match set and the cheapest query there is.
+			return Query{class, "zzqx" + strconv.Itoa(r.IntN(1_000))}
+		}
+		return Query{class, word(s.Vocabulary - 1 - r.IntN(20_000))}
+
+	default:
+		if r.IntN(2) == 0 {
+			// The most common term in the corpus, which most documents carry.
+			return Query{class, word(0)}
+		}
+		// One character, which matches by prefix in the suggest path and is the
+		// query a person generates by accident on their way to a real one.
+		return Query{class, string(rune('a' + r.IntN(26)))}
+	}
+}

--- a/benchcorpus/queries.txt
+++ b/benchcorpus/queries.txt
@@ -1,0 +1,1003 @@
+# 1000 benchmark queries, seed 2121, class distribution from the budgets.
+# Regenerated with: go run ./internal/benchcorpus/gen -queries internal/benchcorpus/queries.txt
+# Regenerating this file invalidates every recorded baseline.
+term-filter	pervelro source:notion
+common	ronixba
+term-filter	sarfalro source:notion
+rare	casmisared
+multi	lummika dorralro raltorten raltenten
+filter	source:github kind:email
+pathological	bababa
+multi	sarqueka tordorten lumgonro ralrodor
+term-filter	tritenka source:github
+multi	gondorro lumroten dorvexro
+common	nixtenba
+term-filter	casroka source:gdrive
+common	falfalba
+pathological	bababa
+common	baroba
+filter	source:confluence kind:code
+filter	source:jira kind:person
+common	vexkaba
+multi	falithba bamidor lumlumfal
+multi	zalbaten ithvexba
+multi	kafalten bamifal zalgonba
+common	ralkaba
+term-filter	sennixka source:github
+term-filter	dornixro source:jira
+common	minixba
+multi	roveldor faltenka
+common	quetenba
+multi	triralmi miithmi trikaten velperro
+multi	velroba sarvelten zalkafal
+filter	source:confluence kind:email
+filter	source:confluence kind:person
+multi	pervelba sartriro
+common	dorroba
+common	badorba
+common	tormiba
+filter	source:confluence kind:file
+term-filter	zalfalro source:jira
+multi	dorroro gonvexro
+multi	lumraldor faltendor
+term-filter	nixkaba source:gdrive
+multi	sarralro wyndordor kaperten bawynro
+common	dorfalba
+term-filter	rotriba source:notion
+term-filter	torvelka source:notion
+filter	source:confluence kind:page
+filter	source:slack kind:page
+term-filter	tenroba source:slack
+common	quefalba
+common	wyntenba
+rare	zzqx632
+common	vextenba
+term-filter	quesenba source:github
+term-filter	sarnixro source:notion
+common	vexfalba
+pathological	bababa
+common	lumroba
+common	torkaba
+filter	source:slack kind:calendar
+term-filter	rolumka source:notion
+multi	senithka morgonten velperfal
+filter	source:confluence kind:ticket
+common	badorba
+common	nixkaba
+common	sarfalba
+term-filter	romika source:jira
+common	falfalba
+common	velqueba
+term-filter	kamorka source:confluence
+multi	sartenfal vexzaldor ithroro perbaten
+common	vexfalba
+common	tortenba
+multi	senvelka nixroka zalralfal zalsarba
+filter	source:slack kind:page
+common	senqueba
+filter	source:confluence kind:email
+filter	source:jira kind:file
+common	morroba
+multi	ralcasten rogonmi mornixfal tenquero
+common	caskaba
+multi	migonro gonfaldor tenfalten wyndorfal
+filter	source:github kind:calendar
+multi	lumtenka mitorfal
+common	dordorba
+multi	roralro dorwynten quesendor morsarba
+common	falroba
+multi	ralsarmi tenvelka karomi
+rare	zzqx103
+multi	gonquefal katorro
+common	miroba
+multi	gonzalro senrodor gonbafal falralten
+term-filter	dorfalka source:jira
+common	vextenba
+multi	wynzalro zaltordor romorka
+common	bafalba
+multi	lumromi ralquero nixlumdor
+common	vexroba
+multi	senwynmi wynsenmi wyntriba
+term-filter	rovelba source:gdrive
+multi	tentenmi kagonten senpermi dorithdor
+common	senmiba
+term-filter	casnixka source:jira
+common	morroba
+multi	tenmiro bafalfal
+term-filter	roralka source:confluence
+term-filter	dorlumba source:slack
+multi	morperten ithbaka nixnixka
+multi	roraldor falcasdor tenmordor
+filter	source:github kind:calendar
+common	banixba
+common	lumqueba
+multi	vexvexfal morvelba gongonten kaithfal
+term-filter	falgonba source:jira
+common	minixba
+common	ithroba
+common	gontenba
+common	tenkaba
+filter	source:notion kind:person
+multi	perwynmi sarroro sartriro wyntorten
+multi	gontenten sargonba lumperten
+term-filter	ralsenba source:github
+multi	velquemi queralro sententen
+multi	kadorten nixperten goncasba
+multi	falralro migondor lumsarro
+common	gonkaba
+multi	ralgonka basardor vexdordor
+common	lumqueba
+common	mikaba
+term-filter	ralroro source:notion
+multi	rotenba tormorba
+filter	source:jira kind:person
+common	baroba
+common	senfalba
+multi	senqueka morzalba
+pathological	bababa
+multi	mitordor ithkami trivexfal percasba
+multi	perfalten gonithfal velbaro
+common	kamiba
+multi	nixvelten zaltriten dorbaka caszaldor
+multi	caslumka mivelka
+common	casroba
+multi	perkaka lumvexmi zalrodor
+multi	zalsenten wynwynba
+multi	vexmika vexvexmi
+common	lumfalba
+common	triroba
+multi	raltorfal morperten nixralba
+filter	source:slack kind:calendar
+term-filter	torwynka source:notion
+multi	misarka senithdor batorro katorka
+term-filter	tensarmi source:gdrive
+filter	source:slack kind:file
+common	casqueba
+filter	source:slack kind:message
+term-filter	torzalba source:notion
+common	falnixba
+common	sarqueba
+multi	velquero lumithka velfalka sarzalba
+term-filter	casfalka source:notion
+common	roqueba
+common	casroba
+common	mordorba
+multi	rallumfal caslumten
+term-filter	vexsarka source:notion
+multi	casvexmi basarmi
+common	morkaba
+common	zalmiba
+filter	source:gdrive kind:code
+multi	ralnixro faltenfal
+multi	ralzalten nixquedor
+rare	lumsarpered
+multi	lumqueka bavexdor
+multi	sarzalmi ithmidor
+multi	senlumten dorsardor torralmi
+common	minixba
+common	torroba
+multi	nixvelro ronixmi
+multi	rotenten dormimi ralvexba
+term-filter	dorlumro source:slack
+term-filter	nixcasro source:jira
+filter	source:gdrive kind:email
+filter	source:confluence kind:calendar
+filter	source:gdrive kind:person
+multi	persenten lumfalfal
+multi	perqueba pernixdor nixdorba lumbaten
+term-filter	veltrika source:gdrive
+multi	tridordor kacasfal percasdor
+multi	velfalmi ralveldor tenkaro
+term-filter	vexralba source:notion
+multi	lumwynten sartriten tordorro
+common	perroba
+multi	lummimi lummorba
+filter	source:confluence kind:ticket
+term-filter	morroka source:notion
+multi	torroten morgonro
+multi	robami ithsarfal vexmorro sartenmi
+filter	source:notion kind:page
+term-filter	quevexro source:slack
+multi	nixlumro tortorka rotenfal
+multi	midordor migonfal gonperten
+filter	source:github kind:ticket
+filter	source:jira kind:file
+common	morfalba
+multi	vexvexmi falmormi dordordor
+term-filter	falfalba source:jira
+multi	senmiba trisenmi
+multi	quewynka tentorka
+common	ralfalba
+common	senroba
+multi	rotormi casraldor
+common	gonmiba
+common	ralmiba
+multi	kaveldor tencasmi queroka rosarmi
+multi	lumvelba mortrifal katenmi casmiro
+multi	tennixro quenixdor
+term-filter	nixroro source:slack
+common	perroba
+multi	ralralba sensenten kaquemi
+multi	miralro veltorten
+rare	zalsarnixed
+multi	gonwynro katorka mitorba
+common	roroba
+term-filter	senbaka source:confluence
+term-filter	caswynka source:notion
+common	quequeba
+filter	source:confluence kind:file
+term-filter	lumfalmi source:gdrive
+common	nixdorba
+multi	casquedor veltrimi vexnixka velzalten
+multi	tridorfal nixtridor perralfal ralithdor
+multi	cascasmi sarmiro
+term-filter	nixtenka source:notion
+multi	zalithba tenralro
+multi	gonrofal quezalfal
+term-filter	micaska source:notion
+common	zalkaba
+rare	sarquemied
+multi	sarzalba ithsarro
+common	zalqueba
+multi	gonbami dorgonba rotrifal
+term-filter	trivelba source:github
+multi	zalmiro minixdor morsenro gonwynfal
+multi	percasten nixlumka zaldorten
+filter	source:confluence kind:email
+term-filter	vexnixba source:github
+common	morqueba
+common	vextenba
+rare	ithcasdorer
+common	wynbaba
+term-filter	mitenmi source:notion
+multi	mormorten tricasmi ithralka velwyndor
+term-filter	zalqueba source:confluence
+common	quedorba
+common	triroba
+term-filter	sardorba source:jira
+common	mormiba
+filter	source:jira kind:code
+common	batenba
+term-filter	faltenmi source:gdrive
+rare	bamilumed
+term-filter	bacasba source:confluence
+common	zalfalba
+term-filter	zalralba source:confluence
+multi	casnixfal rotorka midorba
+filter	source:jira kind:person
+filter	source:jira kind:page
+multi	ithsenfal quetriba kaithfal torlumba
+term-filter	baqueka source:github
+multi	rosarten ithmika vexwynmi
+pathological	bababa
+common	zalbaba
+common	quemiba
+filter	source:notion kind:message
+filter	source:jira kind:email
+filter	source:github kind:file
+common	morroba
+common	sartenba
+multi	ithgonro tendorro
+term-filter	tenroba source:notion
+multi	gonfalka velmiro wynmika
+common	dornixba
+common	dormiba
+term-filter	roperba source:notion
+common	falfalba
+term-filter	dormorba source:gdrive
+rare	sarraldorer
+common	trifalba
+term-filter	sartorro source:confluence
+multi	ralkador lumtridor migonmi
+multi	rocasten raltrimi falsenfal baroka
+multi	falmorka falromi
+term-filter	quegonro source:jira
+multi	perzalmi nixralmi tenlumba
+common	wyntenba
+common	miqueba
+multi	tritorka velnixro
+multi	perqueka mitenfal
+term-filter	sentorba source:github
+common	ithkaba
+multi	vexrofal ithvelfal bacasten triithfal
+multi	zalkaka casgonro
+common	sarkaba
+common	permiba
+common	karoba
+term-filter	nixwynba source:github
+common	bakaba
+common	gonqueba
+multi	lumnixro kabaro wyntrika tribami
+term-filter	wyntenba source:jira
+filter	source:gdrive kind:calendar
+common	dormiba
+multi	sarmiro trisenro karalro
+common	vexdorba
+term-filter	bagonmi source:jira
+multi	morveldor bamiba ronixka raltorfal
+multi	tritriten nixbaka
+common	triqueba
+multi	tricaska nixgonka tenralten gonfalmi
+term-filter	castorro source:slack
+filter	source:jira kind:calendar
+common	mimiba
+common	bafalba
+filter	source:notion kind:ticket
+filter	source:jira kind:message
+common	zalroba
+common	casdorba
+multi	morzaldor miroka ralralka bacasmi
+common	dorkaba
+filter	source:notion kind:code
+common	gonkaba
+common	ithdorba
+multi	ralfaldor tenzalba pervelba wynbaka
+multi	rovelfal casmorfal
+common	dorkaba
+multi	ralkador raldordor
+rare	caszalmier
+multi	wynwynro trimiba veltenten
+common	senroba
+multi	tendorka morzalten tortenfal mivexten
+term-filter	zalbami source:slack
+common	casfalba
+common	nixkaba
+multi	sarmiro wyntendor
+common	wynkaba
+filter	source:slack kind:person
+multi	casgonten nixtriba
+common	vexqueba
+filter	source:slack kind:message
+filter	source:gdrive kind:code
+common	sarfalba
+multi	quesenba trigonka lumraldor
+multi	torgonba tenwynro ithquemi
+multi	nixmidor tribaten tortenten mitormi
+multi	gonsarfal nixtenmi sentriba dorbador
+multi	queromi casdorfal morzalmi
+common	tendorba
+term-filter	ralfalmi source:confluence
+rare	zzqx311
+multi	velvexten rogondor
+common	baqueba
+multi	tritenmi sarmiro zaltrifal kazalfal
+filter	source:jira kind:person
+common	perqueba
+term-filter	gonithro source:github
+term-filter	falbaka source:github
+multi	queperdor fallumba zallumdor
+common	vexbaba
+filter	source:notion kind:code
+multi	karomi caswynba
+common	gonqueba
+multi	perbador wynnixdor micasten wynroba
+multi	vexgonba zaldorfal
+multi	rodordor nixmorba nixfalba
+common	dornixba
+common	badorba
+multi	dorwynmi perlumten
+common	permiba
+term-filter	nixgonba source:github
+multi	ithralka rallumba
+term-filter	lumvelro source:notion
+filter	source:notion kind:calendar
+term-filter	trinixka source:jira
+multi	morperten vexpermi
+multi	vexgonten zalmidor senzalmi
+multi	sensarmi torgonro
+multi	perrofal velbami mortorten miralba
+common	triqueba
+multi	sartenka falralka
+term-filter	ralsarka source:jira
+common	ithroba
+rare	mirosened
+common	mimiba
+common	badorba
+filter	source:gdrive kind:file
+common	dorqueba
+multi	senvexfal lummiten falralfal
+multi	nixwynmi mimifal rogonfal casqueka
+common	quedorba
+common	dorroba
+multi	gonperro perkaka wyndorfal
+term-filter	torgonro source:notion
+common	rodorba
+multi	zalnixten nixsenten quegonba vexmorfal
+filter	source:slack kind:email
+common	dormiba
+multi	nixvelka falveldor nixralro tenmiro
+common	wynroba
+common	velfalba
+multi	sendorten nixralfal katorka
+multi	pernixdor dorcasdor wynvexba
+term-filter	lumralka source:github
+filter	source:confluence kind:message
+common	falkaba
+term-filter	velnixka source:jira
+filter	source:notion kind:calendar
+common	zalroba
+multi	miralro nixithten
+term-filter	veltenka source:notion
+common	casdorba
+filter	source:gdrive kind:person
+term-filter	kadorka source:gdrive
+multi	wynqueka baquemi
+common	ithqueba
+multi	ralithdor lumkaka falwynba
+term-filter	nixtrimi source:github
+multi	triithten nixkaba perralba kasarfal
+filter	source:notion kind:email
+term-filter	morroba source:confluence
+term-filter	rosarba source:notion
+common	mimiba
+multi	quefalba morsenten ralzalka
+multi	ralperfal dorwynten falgonka
+term-filter	falralro source:github
+common	gonmiba
+multi	tritenten quenixka wyntorba
+common	vexkaba
+multi	casvexmi mibami
+common	ithfalba
+filter	source:notion kind:calendar
+common	kakaba
+term-filter	senzalba source:notion
+filter	source:jira kind:ticket
+multi	mirodor casbami nixsarka
+common	nixkaba
+multi	ithmorka sarroro tenvelba
+common	sarmiba
+multi	mormimi sarsardor morsenfal
+filter	source:notion kind:page
+filter	source:github kind:ticket
+filter	source:jira kind:code
+multi	velgonmi morsardor wyntenfal
+multi	faldorfal ralquedor wynsarmi
+common	nixqueba
+common	banixba
+filter	source:jira kind:code
+multi	senfalfal velkaka ralzalro mitenro
+multi	tortorfal mivelten quetenro dorvelro
+multi	triquefal lumvexfal gonzalten quenixro
+common	banixba
+common	vexkaba
+term-filter	veltriro source:notion
+multi	raltorba sentenka casgonmi gontrika
+common	nixkaba
+common	tordorba
+multi	veltrika trikaba wynroka
+rare	zalzalzaling
+multi	tormifal ithsenka balumfal
+multi	tormorba ithcasdor morcasdor
+filter	source:notion kind:ticket
+common	bamiba
+filter	source:notion kind:person
+common	nixfalba
+multi	wynithka quefalfal
+filter	source:slack kind:code
+common	baroba
+multi	casvelka velcasro
+filter	source:confluence kind:ticket
+multi	ithgondor percasten zalralba sensardor
+term-filter	tenithka source:notion
+term-filter	pernixmi source:jira
+pathological	bababa
+filter	source:notion kind:code
+common	ithqueba
+filter	source:jira kind:file
+filter	source:github kind:page
+common	dorfalba
+multi	lumralba tensardor
+common	perfalba
+rare	pertorkaer
+term-filter	mormiba source:gdrive
+multi	wynfaldor sarlumfal
+filter	source:github kind:email
+multi	ithmidor senithten morlumba casmidor
+common	rodorba
+filter	source:slack kind:page
+common	velroba
+filter	source:confluence kind:calendar
+multi	morbador kafalten gonpermi
+filter	source:confluence kind:calendar
+multi	caswynmi wynmordor
+term-filter	senithka source:slack
+multi	quequero wynmifal
+multi	casdormi ithdorka
+rare	zzqx643
+common	lumroba
+multi	bagonmi torwynten lummordor quemiba
+multi	zalbafal bavelro casbami ithmika
+pathological	x
+common	ralkaba
+common	miroba
+multi	quetenka lumithba tenlumdor
+common	kanixba
+multi	baithmi ralqueba bamorfal
+common	nixtenba
+term-filter	senvexro source:gdrive
+term-filter	katenba source:jira
+common	vexfalba
+term-filter	pertenka source:slack
+filter	source:gdrive kind:calendar
+multi	wynnixfal wyngonmi basenba
+multi	tensenba dorvexba
+multi	goncasdor mornixba gonsenba trisarten
+multi	torrodor lumtorten
+common	vexfalba
+filter	source:notion kind:code
+common	dornixba
+multi	senmiten sarralba
+common	dorfalba
+filter	source:notion kind:email
+multi	baralba mirodor velnixfal perralfal
+multi	quezaldor gonfaldor
+common	baroba
+multi	quebami nixithfal
+common	trifalba
+filter	source:github kind:person
+multi	vexperdor kakaro
+multi	kasarka kazalka gonzalro
+common	ithdorba
+multi	morgonten senperka torqueba
+common	triqueba
+filter	source:gdrive kind:page
+term-filter	mibaka source:notion
+multi	wynqueba morquemi mordormi
+term-filter	lumzalro source:github
+rare	mivellumed
+rare	perpertener
+multi	perfalba banixro
+term-filter	sarithka source:slack
+multi	lumnixba quetenten tenperdor
+multi	velromi tribaro
+term-filter	falwynro source:jira
+multi	dorquemi vextenro
+common	banixba
+rare	karoroed
+common	tennixba
+term-filter	vexvelka source:gdrive
+common	tormiba
+common	bamiba
+multi	nixlumka vexbaten zalbafal lumtenten
+filter	source:confluence kind:person
+common	faldorba
+filter	source:github kind:message
+filter	source:confluence kind:code
+term-filter	castenro source:jira
+multi	wynwyndor vexzalfal
+common	casroba
+multi	mimifal morcasmi rovexka gontordor
+term-filter	senmorba source:gdrive
+multi	sarmorba lumroro mifalba
+common	baqueba
+multi	kavelba velithfal
+filter	source:notion kind:message
+term-filter	vextenmi source:github
+multi	triithten roveldor castordor lumnixba
+multi	bavexfal misarka romidor
+term-filter	nixroka source:jira
+filter	source:gdrive kind:file
+multi	sargonmi wynwynmi
+common	senmiba
+filter	source:confluence kind:ticket
+filter	source:gdrive kind:file
+filter	source:gdrive kind:person
+common	vexkaba
+multi	dorgonmi mimiro
+multi	ithtenten misenmi falithro
+common	dormiba
+common	tenkaba
+multi	tortenro kazalba sentorfal quenixfal
+multi	tenbaka casnixfal
+common	zaldorba
+filter	source:jira kind:code
+filter	source:jira kind:file
+multi	zalsarten torvexfal milumba mortenmi
+multi	tenbaro rocasdor ithsarro
+common	veltenba
+common	falroba
+common	morfalba
+multi	velbami nixcasro wynkaka
+common	ithkaba
+common	sarroba
+multi	tennixmi ithbafal
+common	trikaba
+common	roqueba
+multi	mormimi nixsardor
+term-filter	caslumro source:github
+filter	source:gdrive kind:code
+rare	pergonsared
+common	ithqueba
+rare	sarsenithed
+common	rokaba
+multi	pervelro quesarfal pertorro
+filter	source:gdrive kind:page
+common	rotenba
+rare	nixtribaer
+term-filter	bamorro source:slack
+filter	source:confluence kind:page
+multi	falithka falgonro ithkafal queralfal
+multi	torkami ralperten
+multi	mitriro casvexka
+term-filter	velsarmi source:gdrive
+common	tenroba
+multi	sargonro misardor falvelmi
+common	senmiba
+common	senfalba
+term-filter	torvexba source:confluence
+multi	kanixmi castorten
+filter	source:notion kind:email
+common	wynmiba
+filter	source:jira kind:page
+term-filter	gondorka source:notion
+common	nixdorba
+filter	source:gdrive kind:message
+multi	dorsarka falgonka gonithten
+term-filter	kamika source:notion
+multi	mormiba quebador dorcasro
+multi	tendorka zalfalro barofal rogonro
+rare	vexmormier
+multi	misendor kafalro senralfal
+multi	tormordor trikaba mortormi
+multi	miralfal nixveldor gonzalfal nixithro
+multi	torvexro rolummi
+filter	source:slack kind:calendar
+term-filter	misenro source:confluence
+multi	ralnixba raldordor gontorten
+filter	source:confluence kind:code
+filter	source:github kind:ticket
+filter	source:jira kind:code
+rare	velgonlumed
+multi	tencasdor velfalmi
+multi	perwynka triperka castriten cascasfal
+common	lumkaba
+multi	wynbami mitenba
+common	falroba
+multi	mortrika dormiba casithba morveldor
+multi	ralmormi vexgonka
+multi	babador morgonka sartormi sengonmi
+common	falroba
+multi	gonithmi tenlumdor gontenmi ithvelka
+filter	source:jira kind:calendar
+multi	ralsarka dortenten nixkaba
+filter	source:notion kind:code
+term-filter	ralperka source:slack
+common	veldorba
+rare	vexithvexed
+common	vexdorba
+filter	source:gdrive kind:ticket
+common	romiba
+multi	falgonba veltorka rosarro
+filter	source:jira kind:ticket
+common	perdorba
+rare	nixvelcased
+multi	tortenba velmormi sensarfal rozalfal
+common	sarkaba
+multi	wyngonro perdorten miithka
+multi	tenlumro kakaten lumgondor gonbaten
+common	wynkaba
+multi	tribami nixralro lumpermi
+multi	gontorba velqueka ralmorfal
+common	romiba
+multi	casvexka rotorten pertorba
+multi	torroka sarithro falbafal queithten
+common	velqueba
+common	veldorba
+common	perqueba
+multi	gonperten velbaro kagonro tentrika
+rare	kamormied
+common	tritenba
+filter	source:jira kind:person
+common	senkaba
+multi	sarvexba baraldor
+common	dorqueba
+multi	bazalka mormormi
+common	dornixba
+multi	quequefal torgonba sentorba pernixba
+term-filter	zalperba source:gdrive
+multi	tengondor mornixten sencasdor morfalka
+multi	torithka mikaro velgonka
+common	morkaba
+pathological	bababa
+common	rofalba
+rare	zzqx986
+multi	mormimi nixmifal
+multi	morsarmi morzalten ralnixba
+common	mikaba
+common	nixfalba
+common	banixba
+term-filter	tensenro source:gdrive
+multi	trivelfal lumvexmi quesarmi mortenka
+multi	mordordor vexmifal trinixten
+filter	source:confluence kind:page
+term-filter	zalmiro source:slack
+multi	percasmi perfalba wynralba quesenba
+term-filter	morlumba source:slack
+multi	morsenro baveldor morithmi tenzalfal
+common	nixqueba
+multi	castorfal faltenten rowynka
+multi	midorro rotrifal sarvexro castorka
+term-filter	torquemi source:gdrive
+rare	velvelwyning
+common	vextenba
+multi	nixperfal tennixmi sennixdor tenrofal
+common	casroba
+filter	source:gdrive kind:person
+multi	queithdor bawynro dordordor quezalfal
+filter	source:jira kind:calendar
+multi	micasba senzalka
+filter	source:jira kind:file
+multi	lumwynmi goncasro dormidor zaldorba
+multi	trilumten trisarmi ralmormi
+term-filter	roquemi source:jira
+term-filter	wynsarka source:slack
+term-filter	lumithba source:jira
+filter	source:confluence kind:code
+term-filter	wynnixmi source:confluence
+multi	ithlumka tenralka sardorro torzalba
+common	vexmiba
+common	falfalba
+common	nixkaba
+common	morqueba
+common	perfalba
+multi	falperka senroten zalithfal perperro
+multi	mimorfal rosarka
+term-filter	wynqueka source:gdrive
+multi	nixvelro trivelten ithmiro sartrifal
+common	zaldorba
+multi	pervexten rosenfal
+common	gondorba
+filter	source:gdrive kind:person
+common	banixba
+common	quedorba
+term-filter	tenkaka source:confluence
+filter	source:slack kind:message
+common	triqueba
+multi	kasarfal kamimi sartrika
+common	ronixba
+multi	triithro tritrifal quesarka trizalfal
+common	minixba
+common	lumroba
+multi	faltenro gonmorfal
+filter	source:notion kind:message
+term-filter	falnixka source:jira
+common	nixmiba
+common	wyndorba
+common	tendorba
+common	faltenba
+multi	zalnixdor karoro kavexdor
+common	zalfalba
+filter	source:jira kind:file
+multi	gonlummi rorodor
+multi	quecasba ithveldor torsenka nixvexka
+multi	zalsarmi permordor bamiro zalgonba
+multi	rovexmi dortriba bavexfal cassarka
+term-filter	minixmi source:confluence
+common	vexmiba
+common	lumdorba
+multi	rofalka morcasten lumvexro
+multi	nixsarten falmorro kadorten tormiten
+multi	bafalro midordor
+filter	source:jira kind:page
+common	dorroba
+rare	falfaldored
+multi	kavexro trisarba ithroba senzalten
+common	badorba
+filter	source:slack kind:code
+filter	source:slack kind:code
+term-filter	veltrimi source:notion
+multi	miithdor quemorten
+common	zalfalba
+rare	dorithdored
+multi	bazalba perbaten
+filter	source:gdrive kind:message
+common	zaldorba
+multi	rolumro ralquefal
+filter	source:slack kind:message
+common	nixfalba
+multi	casmiro pertridor zalmiba
+common	morqueba
+multi	kafalmi sarroro
+term-filter	quesenro source:slack
+multi	kawynmi pervelka
+multi	wynlumten mortordor nixzalba
+multi	kaquedor trinixmi lumdorba
+term-filter	dortenka source:github
+multi	trivexdor senvelten gontenka tentridor
+filter	source:notion kind:page
+multi	trimormi babador
+multi	faltenro ralzalba morithro ithbador
+common	faltenba
+common	ralmiba
+common	casroba
+term-filter	batorba source:gdrive
+common	miroba
+filter	source:slack kind:person
+term-filter	kavexro source:gdrive
+term-filter	mikaro source:slack
+common	gonqueba
+common	lumqueba
+filter	source:jira kind:email
+filter	source:jira kind:message
+term-filter	raltenba source:gdrive
+common	bamiba
+multi	tenlummi gondorba bagonmi dorfalfal
+pathological	bababa
+multi	torralten mitorba velzalfal
+multi	ithithten falquero mimidor
+multi	bamimi tenmiro sengonro
+filter	source:jira kind:person
+common	dordorba
+multi	mitenka lumtenten vextorba
+filter	source:slack kind:email
+filter	source:confluence kind:code
+common	sarqueba
+term-filter	senlumka source:confluence
+common	wynqueba
+common	faltenba
+term-filter	torralro source:github
+common	karoba
+rare	zzqx697
+filter	source:github kind:page
+filter	source:gdrive kind:calendar
+common	midorba
+multi	romorfal quecasfal katrika
+common	wyntenba
+multi	senroro kaithdor
+multi	perbafal gonsarro wynlumten
+multi	ithnixro sartorfal zaldorba balumten
+common	rokaba
+term-filter	senbami source:confluence
+term-filter	casralba source:confluence
+term-filter	gonkaro source:confluence
+filter	source:jira kind:email
+common	gonroba
+multi	rodorba vexlumka cascasfal gonithro
+multi	ithsenka ralsarfal
+term-filter	baralro source:confluence
+filter	source:notion kind:code
+common	nixroba
+term-filter	trizalro source:slack
+multi	dorroka tenrodor
+pathological	bababa
+multi	dorithmi rosenmi falmiro nixfalro
+common	vextenba
+rare	tenfalqueer
+common	perqueba
+filter	source:gdrive kind:person
+common	banixba
+multi	zalbafal tenithfal mitordor
+multi	vextenba wynmorten raltenmi lumtorten
+multi	perralro dorkafal
+common	wynroba
+rare	zzqx797
+filter	source:confluence kind:email
+term-filter	mitorba source:gdrive
+term-filter	casroro source:notion
+term-filter	velbami source:confluence
+common	senmiba
+filter	source:confluence kind:email
+common	kaqueba
+common	kakaba
+common	casfalba
+filter	source:gdrive kind:code
+multi	vexmiro velzalba torperro caslumka
+common	zaltenba
+multi	morzalka dorroba sendorba dortridor
+rare	zzqx326
+filter	source:confluence kind:ticket
+filter	source:notion kind:message
+common	nixqueba
+filter	source:confluence kind:page
+filter	source:github kind:person
+multi	lumfalmi ithtenten
+rare	falperdored
+common	karoba
+filter	source:notion kind:file
+multi	ithqueten ralfaldor
+rare	zzqx897
+multi	ithwynba vexmimi vexperfal
+common	dortenba
+multi	katrifal faltriten basenmi
+multi	gonvelba ithtriro morsenro
+term-filter	tribaro source:slack
+filter	source:slack kind:email
+filter	source:notion kind:file
+multi	lumbaten dorlumba zalkador
+common	quemiba
+multi	quebafal vexquefal
+multi	nixkafal falbador dorithdor tentridor
+common	sartenba
+common	nixqueba
+filter	source:notion kind:email
+multi	ralzalfal misenro ithdormi ithralka
+common	tenqueba
+multi	ithfalmi wynzalba morqueka sarvexro
+term-filter	velralro source:github
+multi	tenralmi mitriba mortriro
+multi	tricasmi bamiten rokaka raltenba
+filter	source:confluence kind:person
+filter	source:confluence kind:file
+filter	source:gdrive kind:message
+filter	source:slack kind:person
+multi	wynzalmi rodordor
+common	sendorba
+rare	morquemied
+multi	bamordor milumba dorfalmi quequeka
+multi	velroba gonkafal kamidor
+term-filter	falithro source:confluence
+multi	tentenmi vexdorka sarromi kafaldor
+multi	rallumka nixroka
+filter	source:jira kind:ticket
+term-filter	gonroro source:confluence
+rare	triithbaer
+multi	mormordor falralro ithkafal quetrifal
+common	velroba
+term-filter	wyntenro source:slack
+filter	source:notion kind:person
+filter	source:confluence kind:email
+term-filter	vexperka source:notion
+multi	senvelba bagondor wynsardor
+filter	source:github kind:ticket
+multi	tentrifal mivexro morzalka vexromi
+common	tritenba
+common	tormiba
+filter	source:github kind:message
+multi	perperba mitenka ithroka ralroba
+multi	castrika trimidor
+rare	morrowyned
+term-filter	nixmorro source:jira
+common	badorba
+common	dorqueba
+multi	lumbami baithba kaperba
+common	ralqueba
+common	morqueba
+multi	triithmi tordordor trifalfal perzalmi
+multi	zalfalro zalvelba trivexka
+common	sarfalba
+filter	source:gdrive kind:email
+multi	ithzalro bagonmi lumkami fallumfal
+multi	ralsenba castriro casralmi gonquefal
+multi	zalfaldor ralwynmi wyngonba senzaldor
+multi	mormormi lumroba falperdor rocasmi
+filter	source:jira kind:message
+rare	morsenvexed
+term-filter	dorzalka source:gdrive
+multi	senperba ralvelka
+multi	ithmorfal torsenka
+term-filter	torroro source:jira
+term-filter	zalzalba source:gdrive
+multi	batenro baqueba
+common	dornixba
+multi	zaltrimi dorgonka sarmika
+common	ralfalba
+common	dornixba
+multi	nixtriro trimorfal dorzalba
+term-filter	morgonka source:confluence
+multi	lumsarten gonwynfal quevelka wynvexten
+term-filter	mifalro source:gdrive
+multi	wynlumba velkaba permiba
+common	lumkaba
+filter	source:jira kind:file
+multi	raldorro sencasro torlummi
+multi	gonfaldor velbaro ithtriba
+common	lumqueba
+common	velmiba
+multi	nixlummi rovelfal dorgonro quetrifal
+multi	quebafal morralmi sarperka
+common	falqueba
+common	mitenba
+multi	dorbaro nixquero perithba nixzalten
+multi	velvelro gontorka trisarmi
+filter	source:confluence kind:code
+multi	ralvexba senfalmi ithsarten trikafal
+term-filter	senlumba source:confluence
+multi	gongondor torlumfal
+multi	velnixro vexgonfal torzaldor bavelka
+term-filter	ithmorka source:notion
+term-filter	nixroro source:notion
+term-filter	falroka source:jira
+multi	sarroka kacasfal rolummi
+common	roroba
+multi	dortriro senkaba perithdor
+multi	senlumro tennixdor

--- a/doc/analyze.go
+++ b/doc/analyze.go
@@ -98,3 +98,64 @@ func (d Document) Terms() []string {
 	terms = append(terms, body...)
 	return terms
 }
+
+// TermCount is how often one term occurs in a document, by field.
+type TermCount struct{ Title, Body int }
+
+// Analysis is everything a ranker needs to know about one document, computed
+// once from its text.
+//
+// It exists because the alternative is computing it at query time, which means
+// running the analyzer over every document in the match set on every search.
+// That is the single thing that made search cost a second on a five thousand
+// document corpus: the numbers here are small, they never change unless the
+// document does, and a store that keeps them turns a scan of the corpus into a
+// lookup of a few hundred rows.
+type Analysis struct {
+	// TitleTokens and BodyTokens are token counts, not distinct terms. BM25
+	// normalises by document length and length is a count of tokens.
+	TitleTokens int
+	BodyTokens  int
+
+	// Terms is the per term occurrence count, by field.
+	Terms map[string]TermCount
+}
+
+// Analyze returns the document's statistics in one pass over its text.
+func (d Document) Analyze() Analysis {
+	title, body := Tokenize(d.Title), Tokenize(d.Body)
+	a := Analysis{
+		TitleTokens: len(title),
+		BodyTokens:  len(body),
+		Terms:       make(map[string]TermCount, len(title)+len(body)),
+	}
+	for _, t := range title {
+		c := a.Terms[t]
+		c.Title++
+		a.Terms[t] = c
+	}
+	for _, t := range body {
+		c := a.Terms[t]
+		c.Body++
+		a.Terms[t] = c
+	}
+	return a
+}
+
+// Display is what a person is labelled with in a facet or a result row, which
+// is the most specific thing the connector managed to resolve.
+//
+// It is here rather than in whichever package happened to need it first because
+// a storage driver stores this string in a column and the ranking counts facets
+// over it. Two definitions of a person's display name is two facet lists that
+// disagree about who wrote what.
+func (p Person) Display() string {
+	switch {
+	case p.Name != "":
+		return p.Name
+	case p.Email != "":
+		return p.Email
+	default:
+		return p.Identity.Value
+	}
+}

--- a/index/bench_test.go
+++ b/index/bench_test.go
@@ -1,0 +1,113 @@
+package index_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/benchcorpus"
+	"github.com/tamnd/genba/index"
+)
+
+// These run against the fixed corpus, which is generated once and cached under
+// testdata. See benchcorpus for what is in it and why. The first run
+// builds it and is slow; every run after that is not.
+//
+// The point of measuring per query class rather than over a mixed workload is
+// that the classes differ in cost by two orders of magnitude, and an average
+// over the mix can be met by being fast at the cheap ones. A regression in the
+// expensive class is exactly the regression somebody notices.
+
+func searcher(b *testing.B) (*index.Searcher, *acl.Principal) {
+	b.Helper()
+	st, spec := benchcorpus.Fixture(b)
+	// A fixed clock, because the recency prior is part of the score and a clock
+	// that moves makes today's number incomparable with last month's.
+	s := index.New(st, index.WithClock(func() time.Time { return benchcorpus.Epoch }))
+	return s, spec.Principal()
+}
+
+// run measures one query class, cycling through the checked in queries of that
+// class so the measurement is over a distribution rather than over one lucky
+// term that happens to be in the page cache.
+func run(b *testing.B, class benchcorpus.Class, shape func(index.Query) index.Query) {
+	s, p := searcher(b)
+	queries := benchcorpus.ByClass(benchcorpus.Queries())[class]
+	if len(queries) == 0 {
+		b.Fatalf("the query set has no %s queries", class)
+	}
+
+	parsed := make([]index.Query, len(queries))
+	for i, q := range queries {
+		parsed[i] = index.Parse(q.Text)
+		if shape != nil {
+			parsed[i] = shape(parsed[i])
+		}
+	}
+
+	// Warm, because the budget is stated warm: the process has been running and
+	// the page cache holds the working set. A cold measurement is a measurement
+	// of the disk.
+	for _, q := range parsed[:min(len(parsed), 20)] {
+		if _, err := s.Search(b.Context(), p, q); err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		if _, err := s.Search(b.Context(), p, parsed[i%len(parsed)]); err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+	}
+}
+
+func BenchmarkSearchCommonTerm(b *testing.B) { run(b, benchcorpus.ClassCommon, nil) }
+func BenchmarkSearchMultiTerm(b *testing.B)  { run(b, benchcorpus.ClassMulti, nil) }
+func BenchmarkSearchFilterOnly(b *testing.B) { run(b, benchcorpus.ClassFilter, nil) }
+func BenchmarkSearchTermFilter(b *testing.B) { run(b, benchcorpus.ClassTermFilter, nil) }
+func BenchmarkSearchRare(b *testing.B)       { run(b, benchcorpus.ClassRare, nil) }
+
+// BenchmarkSearchPathological is the one character query and the term most of
+// the corpus carries. It has its own relaxed budget and it is measured rather
+// than ignored, because a query class nobody measures is a denial of service
+// waiting to be found.
+func BenchmarkSearchPathological(b *testing.B) { run(b, benchcorpus.ClassPathological, nil) }
+
+// BenchmarkSearchDeepPage pages far enough in that the candidate pool has to
+// grow, which is where a naive top K falls over: the tenth page cannot be
+// served from a pool of twenty.
+func BenchmarkSearchDeepPage(b *testing.B) {
+	run(b, benchcorpus.ClassCommon, func(q index.Query) index.Query {
+		q.Offset = 200
+		return q
+	})
+}
+
+// BenchmarkSearchByRecency ranks on the date instead of the score, which takes
+// a different path through the driver: the cut is on modified_at rather than on
+// the full text rank.
+func BenchmarkSearchByRecency(b *testing.B) {
+	run(b, benchcorpus.ClassCommon, func(q index.Query) index.Query {
+		q.Sort = index.ByRecent
+		return q
+	})
+}
+
+// BenchmarkSearchStranger is the reader who is in no group. The match set is
+// small and the predicate is doing all the work, so this is the measurement
+// that would notice the permission filter moving out of the query and into Go.
+func BenchmarkSearchStranger(b *testing.B) {
+	st, spec := benchcorpus.Fixture(b)
+	s := index.New(st, index.WithClock(func() time.Time { return benchcorpus.Epoch }))
+	queries := benchcorpus.ByClass(benchcorpus.Queries())[benchcorpus.ClassCommon]
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		if _, err := s.Search(b.Context(), spec.Stranger(), index.Parse(queries[i%len(queries)].Text)); err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+	}
+}

--- a/index/counters_test.go
+++ b/index/counters_test.go
@@ -1,0 +1,209 @@
+package index_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/benchcorpus"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store"
+	"github.com/tamnd/genba/store/sqlitestore"
+)
+
+// A latency number is a property of the machine that produced it. A CI runner
+// shares its cores with whatever else is on the box, so a gate written in
+// milliseconds fails on a bad afternoon and passes on a good one, and after the
+// third false alarm somebody raises the threshold until it never fails at all.
+//
+// These assert on work instead: rows read, statements executed, documents
+// decoded, candidates ranked. Those numbers are the same on a laptop and on a
+// loaded runner, they are what latency is made of, and the regressions worth
+// catching are all visible in them. A search that starts decoding the whole
+// match set to return twenty results shows up here as a decode count in the
+// thousands long before anybody notices the page got slower.
+//
+// The wall clock budgets live in the benchmarks and in the CI gate. This is the
+// part that runs on every pull request.
+
+// counterCorpus is smaller than the benchmark fixture on purpose. It only has
+// to be large enough that the match set of a common term is several times the
+// candidate pool, which is what makes the bounds below mean anything, and small
+// enough that generating it the first time is a few seconds rather than a
+// minute.
+const counterCorpus = 4_000
+
+const (
+	// maxStatements is the statement budget for one search. Four queries do the
+	// work: the candidate cut, the counts and facets, the corpus statistics and
+	// the fetch of the page. The budget is a little above that so an extra
+	// lookup is allowed, and far below one statement per result, which is the
+	// shape of every N plus one regression.
+	maxStatements = 8
+
+	// facetRows is the rows the facet counts return: four fields, each capped
+	// at the number of values a facet reports, and the total.
+	facetRows = 4*store.MaxFacetValues + 1
+)
+
+// rowBudget is every row one search is allowed to read, by where it is read.
+//
+// Writing it out rather than picking a round number is the point. Each term is
+// a bound somebody chose, and a search that goes over one of them has broken
+// the thing that bound was protecting, which is a more useful failure than
+// "slower than it was".
+func rowBudget(pool, terms, hits int) int64 {
+	// Phase one hands back at most the pool.
+	rows := pool
+	// The term frequencies for those candidates, which is the one part that
+	// grows with the query: one row per candidate per term it carries.
+	rows += pool * terms
+	// The total and the facet counts, which are aggregates, so the rows are the
+	// values reported and not the documents behind them.
+	rows += facetRows
+	// The corpus row and one row per term of statistics.
+	rows += 1 + terms
+	// And the page that is actually returned.
+	return int64(rows + hits)
+}
+
+func counters(t *testing.T) (*index.Searcher, *acl.Principal, *sqlitestore.Store) {
+	t.Helper()
+	spec := benchcorpus.Default(benchcorpus.DefaultSeed, counterCorpus)
+	st := benchcorpus.FixtureOf(t, spec)
+	// A fixed clock, so the recency prior is the same on every run and the
+	// counts are not a function of what day it is.
+	s := index.New(st, index.WithClock(func() time.Time { return benchcorpus.Epoch }))
+	return s, spec.Principal(), st
+}
+
+func TestSearchCounters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("generating the corpus takes a few seconds the first time")
+	}
+	s, p, st := counters(t)
+
+	for _, tc := range []struct {
+		name  string
+		class benchcorpus.Class
+	}{
+		{"a common term", benchcorpus.ClassCommon},
+		{"several terms", benchcorpus.ClassMulti},
+		{"filters and no terms", benchcorpus.ClassFilter},
+		{"a term and a filter", benchcorpus.ClassTermFilter},
+		{"a term almost nothing carries", benchcorpus.ClassRare},
+		{"the worst query somebody can type", benchcorpus.ClassPathological},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			queries := benchcorpus.ByClass(benchcorpus.Queries())[tc.class]
+			if len(queries) == 0 {
+				t.Fatalf("the query set has no %s queries", tc.class)
+			}
+
+			// Several queries of the class rather than one, because a single
+			// query that happened to match nothing would pass every bound here
+			// without proving anything.
+			for _, q := range queries[:min(len(queries), 12)] {
+				query := index.Parse(q.Text)
+				st.ResetCounters()
+
+				res, err := s.Search(t.Context(), p, query)
+				if err != nil {
+					t.Fatalf("Search(%q): %v", q.Text, err)
+				}
+				c := st.Counters()
+				pool := int64(index.CandidatePool(query.Offset, index.DefaultLimit))
+
+				// Decoding is the expensive part of returning a result, because
+				// it is JSON, so a search decodes the page it is about to
+				// return and nothing else. This is the counter that catches two
+				// phase retrieval quietly turning back into one phase.
+				if want := int64(len(res.Hits)); c.Decodes > want {
+					t.Errorf("Search(%q) decoded %d documents to return %d", q.Text, c.Decodes, want)
+				}
+				if c.Statements > maxStatements {
+					t.Errorf("Search(%q) ran %d statements, at most %d", q.Text, c.Statements, maxStatements)
+				}
+
+				// The ranker sees the pool, never the match set, so a query
+				// that matches every document in the tenant costs what a query
+				// matching a thousand costs.
+				if c.Candidates > pool {
+					t.Errorf("Search(%q) ranked %d candidates, the pool is %d", q.Text, c.Candidates, pool)
+				}
+
+				// And the rows, which is the counter that catches a count being
+				// done by reading the rows and adding them up in Go.
+				if most := rowBudget(int(pool), len(query.Request().Terms), len(res.Hits)); c.Rows > most {
+					t.Errorf("Search(%q) read %d rows, at most %d", q.Text, c.Rows, most)
+				}
+			}
+		})
+	}
+
+	// A reader in another tenant may see nothing at all, and that has to cost
+	// nothing at all. If this ever reads rows, the permission predicate has
+	// moved out of the SQL and into Go, where it filters after the database has
+	// already done the work.
+	t.Run("a principal who may read nothing costs nothing", func(t *testing.T) {
+		outsider := &acl.Principal{Tenant: "other", Subject: "u_outsider", Groups: acl.GroupSet{Version: 1}}
+		for _, q := range benchcorpus.ByClass(benchcorpus.Queries())[benchcorpus.ClassCommon][:12] {
+			st.ResetCounters()
+			res, err := s.Search(t.Context(), outsider, index.Parse(q.Text))
+			if err != nil {
+				t.Fatalf("Search(%q): %v", q.Text, err)
+			}
+			if len(res.Hits) != 0 {
+				t.Fatalf("Search(%q) returned %d hits to a reader in another tenant", q.Text, len(res.Hits))
+			}
+			// Not zero rows, because a count returns a row to say the answer is
+			// zero, but a handful and never a walk. Nothing is ranked and
+			// nothing is decoded.
+			c := st.Counters()
+			if c.Candidates != 0 || c.Decodes != 0 {
+				t.Errorf("Search(%q) ranked %d candidates and decoded %d documents for a reader who may see nothing", q.Text, c.Candidates, c.Decodes)
+			}
+			if c.Rows > facetRows {
+				t.Errorf("Search(%q) read %d rows for a reader who may see nothing", q.Text, c.Rows)
+			}
+		}
+	})
+}
+
+// TestDeepPageCounters holds the tenth page to the same bounds as the first.
+// Paging is where a searcher that keeps the whole match set in memory stops
+// being a rounding error, because the pool has to grow with the offset and the
+// naive implementation grows the decode count along with it.
+func TestDeepPageCounters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("generating the corpus takes a few seconds the first time")
+	}
+	s, p, st := counters(t)
+
+	text := benchcorpus.ByClass(benchcorpus.Queries())[benchcorpus.ClassCommon][0].Text
+	for _, offset := range []int{0, 20, 100, 200, 500} {
+		query := index.Parse(text)
+		query.Offset = offset
+
+		st.ResetCounters()
+		res, err := s.Search(t.Context(), p, query)
+		if err != nil {
+			t.Fatalf("Search at offset %d: %v", offset, err)
+		}
+		c := st.Counters()
+		pool := int64(index.CandidatePool(offset, index.DefaultLimit))
+
+		if want := int64(len(res.Hits)); c.Decodes > want {
+			t.Errorf("offset %d decoded %d documents to return %d", offset, c.Decodes, want)
+		}
+		if c.Statements > maxStatements {
+			t.Errorf("offset %d ran %d statements, at most %d", offset, c.Statements, maxStatements)
+		}
+		// The pool grows with the offset, because the two hundredth result
+		// cannot be picked out of a pool of twenty, and it grows by a factor so
+		// that the growth stays bounded and stated in one place.
+		if c.Candidates > pool {
+			t.Errorf("offset %d ranked %d candidates, the pool is %d", offset, c.Candidates, pool)
+		}
+	}
+}

--- a/index/driver_test.go
+++ b/index/driver_test.go
@@ -13,16 +13,19 @@ import (
 	"github.com/tamnd/genba/store/sqlitestore"
 )
 
-// The searcher has two ways to collect candidates. A driver that implements
-// store.Retriever is asked for the match set and does the filtering in its own
-// query, and a driver that does not is scanned with the same rules applied in
-// Go. There is one definition of the match set and both paths are held to it,
-// so the only honest test is to run the same searches through both drivers and
-// require the same answer.
+// The searcher has more than one way to collect candidates. A driver that
+// implements store.Ranker cuts to a candidate pool inside its own query, counts
+// the match set there, and reads the token counts out of columns. A driver that
+// implements neither that nor store.Retriever is scanned and the same rules are
+// applied in Go, over text analysed on the spot. There is one definition of the
+// match set and one ranking function, and both paths are held to them, so the
+// only honest test is to run the same searches through both drivers and require
+// the same answer.
 //
-// This is also the test that would catch a driver drifting from the analyzer:
-// the ranking is computed from what the driver returned, so a candidate set
-// that differs by one document changes the order of everything after it.
+// This is also the test that would catch a driver drifting from the analyzer.
+// The ranking is computed from what the driver reported, so a title token count
+// written at index time that disagrees with what the tokenizer produces now
+// moves every score that document is compared against.
 
 func TestDriversAgree(t *testing.T) {
 	mem := memstore.New()
@@ -37,8 +40,11 @@ func TestDriversAgree(t *testing.T) {
 	if _, ok := any(mem).(store.Retriever); ok {
 		t.Fatal("memstore now implements store.Retriever, so this test no longer covers the scan path")
 	}
-	if _, ok := any(sq).(store.Retriever); !ok {
-		t.Fatal("sqlitestore does not implement store.Retriever, so this test no longer covers the retrieve path")
+	if _, ok := any(mem).(store.Ranker); ok {
+		t.Fatal("memstore now implements store.Ranker, so this test no longer covers the scan path")
+	}
+	if _, ok := any(sq).(store.Ranker); !ok {
+		t.Fatal("sqlitestore does not implement store.Ranker, so this test no longer covers the rank path")
 	}
 
 	docs := driverCorpus()
@@ -50,10 +56,10 @@ func TestDriversAgree(t *testing.T) {
 
 	scanning := index.New(mem, index.WithClock(clock))
 	retrieving := index.New(sq, index.WithClock(clock))
-	if scanning.Retrieving() {
-		t.Fatal("the memstore searcher reports that it retrieves")
+	if scanning.Ranking() {
+		t.Fatal("the memstore searcher reports that it ranks in the driver")
 	}
-	if !retrieving.Retrieving() {
+	if !retrieving.Ranking() {
 		t.Fatal("the sqlite searcher reports that it scans")
 	}
 

--- a/index/index.go
+++ b/index/index.go
@@ -14,10 +14,20 @@
 //
 // # Where the work happens
 //
-// A driver that implements [store.Retriever] is asked for the match set and
-// returns it out of an index of its own. A driver that does not is walked with
-// [store.Store.Scan] and filtered here. The ranking is the same either way, and
-// the match set is the same set, which store/storetest checks. The difference
+// A search runs in two phases. Phase one asks the driver which documents are
+// worth ranking, and gets back candidates rather than documents: an id, the
+// four strings a result row and a facet are drawn from, a date, and the token
+// counts for the query terms. Phase two ranks those in Go and then reads the
+// bodies for the page, in one statement, which is the only point at which any
+// document text is touched. A query matching a hundred thousand documents
+// therefore decodes twenty of them.
+//
+// A driver that implements [store.Ranker] makes the cut inside the same
+// statement that applies the permission rule, so the cost follows the page. One
+// that implements [store.Retriever] answers the match set out of an index of
+// its own and the cut happens here. One that implements neither is walked with
+// [store.Store.Scan] and filtered here. The ranking is the same in all three
+// cases, over the same match set, which store/storetest checks. The difference
 // is only how much of the corpus had to be touched to produce it.
 package index
 
@@ -190,7 +200,18 @@ func New(st store.Store, opts ...Option) *Searcher {
 // document. It is here so that an operator can be told which one they are
 // running on instead of having to infer it from a latency graph.
 func (s *Searcher) Retrieving() bool {
+	if _, ok := s.store.(store.Ranker); ok {
+		return true
+	}
 	_, ok := s.store.(store.Retriever)
+	return ok
+}
+
+// Ranking reports whether the store can cut to a candidate pool for itself,
+// which is the difference between a search whose cost follows the page and one
+// whose cost follows the match set.
+func (s *Searcher) Ranking() bool {
+	_, ok := s.store.(store.Ranker)
 	return ok
 }
 
@@ -208,27 +229,37 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 	limit = min(limit, MaxLimit)
 
 	req := q.Request()
-	cands, err := s.collect(ctx, p, req)
+	sel := store.Selection{Limit: CandidatePool(q.Offset, limit), Recent: q.Sort == ByRecent}
+
+	// Phase one. Which documents are worth ranking, how many matched, and what
+	// the facet counts are, all under the permission rule and none of it
+	// carrying a body.
+	found, err := s.collect(ctx, p, req, sel)
 	if err != nil {
+		return Results{}, err
+	}
+	if found.corpus, err = s.statistics(ctx, p, req.Terms, found); err != nil {
 		return Results{}, err
 	}
 
 	res := Results{
-		Total:     len(cands.docs),
-		Truncated: cands.truncated,
-		Facets:    facetsOf(cands.docs),
+		Total:     found.total,
+		Truncated: found.truncated,
+		Facets:    found.facets,
 	}
-	if len(cands.docs) == 0 {
+	if len(found.cands) == 0 {
 		res.Took = s.now().Sub(start)
 		return res, nil
 	}
 
+	// Phase two. Ranking, in Go, over the candidates and nothing else.
 	now := s.now()
-	scored := make([]Result, 0, len(cands.docs))
-	for i, d := range cands.docs {
-		score := cands.bm25(i, req.Terms)
-		score *= s.recency(d, now)
-		scored = append(scored, Result{Document: d, Score: score})
+	scored := make([]ranked, 0, len(found.cands))
+	for _, c := range found.cands {
+		scored = append(scored, ranked{
+			cand:  c,
+			score: score(c, req.Terms, found.corpus) * s.recency(c.ModifiedAt, now),
+		})
 	}
 
 	// Sort by score, then by id, so equal scores do not shuffle between runs and
@@ -236,43 +267,100 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 	switch q.Sort {
 	case ByRecent:
 		sort.SliceStable(scored, func(i, j int) bool {
-			if !scored[i].Document.ModifiedAt.Equal(scored[j].Document.ModifiedAt) {
-				return scored[i].Document.ModifiedAt.After(scored[j].Document.ModifiedAt)
+			if !scored[i].cand.ModifiedAt.Equal(scored[j].cand.ModifiedAt) {
+				return scored[i].cand.ModifiedAt.After(scored[j].cand.ModifiedAt)
 			}
-			return scored[i].Document.ID < scored[j].Document.ID
+			return scored[i].cand.ID < scored[j].cand.ID
 		})
 	default:
 		sort.SliceStable(scored, func(i, j int) bool {
-			if scored[i].Score != scored[j].Score {
-				return scored[i].Score > scored[j].Score
+			if scored[i].score != scored[j].score {
+				return scored[i].score > scored[j].score
 			}
-			return scored[i].Document.ID < scored[j].Document.ID
+			return scored[i].cand.ID < scored[j].cand.ID
 		})
 	}
 
-	res.Hits = page(scored, q.Offset, limit)
-
 	// Bodies and snippets are for the page and not for the match set. On a broad
 	// query that is the difference between reading twenty documents and reading
-	// a hundred thousand, and it is why collect drops the bodies it walked past.
-	for i := range res.Hits {
-		full, err := s.store.Get(ctx, p, res.Hits[i].Document.ID)
-		if err != nil {
-			// The document went away or stopped being readable between the walk
-			// and now. Serving the metadata we already ranked without a snippet
-			// is better than failing a whole page over one stale row, and the
-			// permission check has not been skipped: Get applied it too.
-			continue
+	// a hundred thousand, and it is why phase one never asks for a body.
+	window := page(scored, q.Offset, limit)
+	bodies, err := s.fetch(ctx, p, window)
+	if err != nil {
+		return Results{}, err
+	}
+	res.Hits = make([]Result, 0, len(window))
+	for _, r := range window {
+		hit := Result{Document: outline(r.cand), Score: r.score}
+		if full, ok := bodies[r.cand.ID]; ok {
+			hit.Document = full
+			hit.Snippet, hit.Passages = snippet(readable(full), req.Terms)
 		}
-		res.Hits[i].Document = full
-		res.Hits[i].Snippet, res.Hits[i].Passages = snippet(readable(full), req.Terms)
+		res.Hits = append(res.Hits, hit)
 	}
 	res.Took = s.now().Sub(start)
 	return res, nil
 }
 
+// ranked is a candidate and what it scored.
+type ranked struct {
+	cand  store.Candidate
+	score float64
+}
+
+// fetch reads the documents behind one page.
+//
+// A driver that can do it in one statement is asked to. One that cannot is
+// asked document by document, which is the old behaviour and is correct, just
+// twenty round trips instead of one. Either way an id that has stopped being
+// readable between the ranking and now is simply missing from the result, and
+// the caller falls back to the metadata it already ranked rather than failing
+// the page.
+func (s *Searcher) fetch(ctx context.Context, p *acl.Principal, window []ranked) (map[string]doc.Document, error) {
+	out := make(map[string]doc.Document, len(window))
+	if len(window) == 0 {
+		return out, nil
+	}
+	ids := make([]string, 0, len(window))
+	for _, r := range window {
+		ids = append(ids, r.cand.ID)
+	}
+
+	if f, ok := s.store.(store.Fetcher); ok {
+		docs, err := f.Fetch(ctx, p, ids)
+		if err != nil {
+			return nil, err
+		}
+		for _, d := range docs {
+			out[d.ID] = d
+		}
+		return out, nil
+	}
+	for _, id := range ids {
+		d, err := s.store.Get(ctx, p, id)
+		if err != nil {
+			continue
+		}
+		out[id] = d
+	}
+	return out, nil
+}
+
+// outline is the document a result falls back to when the fetch could not read
+// it: everything the ranking already knew, and no body.
+func outline(c store.Candidate) doc.Document {
+	return doc.Document{
+		ID:         c.ID,
+		Source:     c.Source,
+		Kind:       c.Kind,
+		Container:  c.Container,
+		Author:     doc.Person{Name: c.Author},
+		ModifiedAt: c.ModifiedAt,
+	}
+}
+
 // page slices a sorted result set, tolerating an offset past the end.
-func page(all []Result, offset, limit int) []Result {
+func page(all []ranked, offset, limit int) []ranked {
 	if offset < 0 || offset >= len(all) {
 		return nil
 	}
@@ -282,74 +370,17 @@ func page(all []Result, offset, limit int) []Result {
 // recency is a multiplier in (0, 1]. A document modified now scores at full
 // weight and one older than several half lives keeps a floor, because an old
 // document that is a perfect lexical match is still the right answer.
-func (s *Searcher) recency(d doc.Document, now time.Time) float64 {
-	if s.halfLife <= 0 || d.ModifiedAt.IsZero() {
+func (s *Searcher) recency(modified, now time.Time) float64 {
+	if s.halfLife <= 0 || modified.IsZero() {
 		return 1
 	}
-	age := now.Sub(d.ModifiedAt)
+	age := now.Sub(modified)
 	if age <= 0 {
 		return 1
 	}
 	const floor = 0.5
 	decay := math.Exp2(-age.Hours() / s.halfLife.Hours())
 	return floor + (1-floor)*decay
-}
-
-func facetsOf(docs []doc.Document) map[string][]Facet {
-	bySource := map[string]int{}
-	byKind := map[string]int{}
-	byContainer := map[string]int{}
-	byAuthor := map[string]int{}
-	for _, d := range docs {
-		bySource[d.Source]++
-		byKind[string(d.Kind)]++
-		byContainer[d.Container]++
-		byAuthor[displayName(d.Author)]++
-	}
-	return map[string][]Facet{
-		"source":    sortedFacets(bySource),
-		"kind":      sortedFacets(byKind),
-		"container": sortedFacets(byContainer),
-		"author":    sortedFacets(byAuthor),
-	}
-}
-
-// displayName is what a person facet is labelled with, which is the most
-// specific thing the connector managed to resolve.
-func displayName(p doc.Person) string {
-	switch {
-	case p.Name != "":
-		return p.Name
-	case p.Email != "":
-		return p.Email
-	default:
-		return p.Identity.Value
-	}
-}
-
-// MaxFacetValues caps how many values one facet reports. A facet with ten
-// thousand values is not a filter, it is a scroll bar, and counting them all
-// into a response costs more than the sidebar it feeds is worth.
-const MaxFacetValues = 50
-
-func sortedFacets(counts map[string]int) []Facet {
-	out := make([]Facet, 0, len(counts))
-	for v, n := range counts {
-		if v == "" {
-			continue
-		}
-		out = append(out, Facet{Value: v, Count: n})
-	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Count != out[j].Count {
-			return out[i].Count > out[j].Count
-		}
-		return out[i].Value < out[j].Value
-	})
-	if len(out) > MaxFacetValues {
-		out = out[:MaxFacetValues]
-	}
-	return out
 }
 
 // SnippetWidth is roughly how many characters of body a snippet shows.

--- a/index/score.go
+++ b/index/score.go
@@ -3,6 +3,7 @@ package index
 import (
 	"context"
 	"math"
+	"sort"
 
 	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/doc"
@@ -20,143 +21,269 @@ const (
 	// titleWeight is how many body occurrences one title occurrence is worth. A
 	// document titled "payments runbook" should beat one that mentions payments
 	// forty times in a changelog.
+	//
+	// It lives here and only here. A storage driver stores token counts by
+	// field and never a weighted length, so that changing this number is a
+	// change to the ranking rather than a reindex of the corpus.
 	titleWeight = 3.0
 )
 
-// MaxMatches caps how many documents one query scores.
+// MaxMatches caps how many documents one query scores on the fallback path.
 //
-// A query for a common word against a large corpus otherwise pulls the whole
-// corpus into memory to rank it, and the twenty results anyone reads would have
-// been the same without the last ninety nine percent of that work. When the cap
-// bites, [Results.Truncated] says so, because a total that quietly stops
-// counting is worse than one that admits it is a lower bound.
+// A driver that can select candidates for itself is asked for a pool instead,
+// which is what [CandidateFloor] sizes. This is the cap for a driver that
+// cannot: a query for a common word otherwise pulls the whole corpus into
+// memory to rank it, and the twenty results anyone reads would have been the
+// same without the last ninety nine percent of that work. When the cap bites,
+// [Results.Truncated] says so, because a total that quietly stops counting is
+// worse than one that admits it is a lower bound.
 const MaxMatches = 100_000
 
-// candidates is the match set of one query along with the statistics needed to
-// score it.
-//
-// The documents held here have had their bodies dropped. Everything the ranking
-// and the facets need is either a small metadata field or already folded into
-// the term frequencies, and a match set of a hundred thousand bodies is hundreds
-// of megabytes of text that only twenty documents' worth ever gets read. The
-// page's bodies are fetched back afterwards, which is twenty point reads instead
-// of one very large allocation.
-type candidates struct {
-	docs   []doc.Document
-	tf     []map[string]float64
-	length []float64
-	df     map[string]int
-	avgLen float64
+const (
+	// CandidateFloor is the smallest candidate pool a driver is asked for.
+	//
+	// It is not twenty, because the recency prior reorders. A document ranked a
+	// hundred and eightieth on lexical match alone can reach the first page
+	// once the prior has been applied to everything above it, and cutting at
+	// the page size would make the prior invisible. That is the kind of change
+	// that gets discovered as "search got worse" six months later. Five hundred
+	// candidates cost about a tenth of a millisecond to score, so the floor is
+	// very nearly free.
+	CandidateFloor = 500
 
-	// truncated records that [MaxMatches] stopped the walk, so the count above
-	// can be reported as the lower bound it is.
-	truncated bool
+	// CandidateFactor multiplies the requested window, so that deep paging
+	// still ranks over more than it returns.
+	CandidateFactor = 10
+)
+
+// CandidatePool is how many candidates a query asks its driver for.
+//
+// It is exported because it is the bound the performance assertions are stated
+// against: a search may rank this many candidates and not one more, whatever
+// the match set turns out to be.
+func CandidatePool(offset, limit int) int {
+	return min(max(CandidateFloor, (offset+limit)*CandidateFactor), MaxMatches)
 }
 
-// collect builds the match set.
+// pool is one query's retrieval: the candidates worth scoring, the counts over
+// the whole match set, and the corpus statistics the scorer needs.
 //
-// A driver that implements [store.Retriever] is asked for the set directly and
-// answers it out of an index of its own, with the principal, the terms and the
-// filters all applied inside its own query. A driver that does not is walked in
-// full and filtered here. Both paths produce the same documents, which is what
-// store/storetest holds a driver to, so the only thing the capability changes is
-// how much data had to be touched to get them.
-func (s *Searcher) collect(ctx context.Context, p *acl.Principal, r store.Request) (*candidates, error) {
-	c := &candidates{df: make(map[string]int, len(r.Terms))}
-	want := make(map[string]bool, len(r.Terms))
-	for _, t := range r.Terms {
-		want[t] = true
+// A candidate is not a document. It is the twenty or so bytes of an id, four
+// display strings, a date and the per term counts, which is everything the
+// ranking reads and nothing else. The bodies of the twenty documents on the
+// page are fetched afterwards, in one statement, because a match set of a
+// hundred thousand bodies is hundreds of megabytes of text that only the page's
+// worth is ever read from.
+type pool struct {
+	cands     []store.Candidate
+	total     int
+	truncated bool
+	facets    map[string][]Facet
+	corpus    store.Corpus
+}
+
+// collect asks the driver for the candidates, using the best capability it has.
+//
+// A driver implementing [store.Ranker] makes the cut inside the statement that
+// applies the permission rule, so the work is proportional to the pool. One
+// implementing [store.Retriever] answers the match set out of its own index and
+// the cut happens here. One implementing neither is walked in full and filtered
+// here. All three produce the same ranking over the same documents, which is
+// what store/storetest holds a driver to, and the only thing the capability
+// changes is how much data had to be touched to get there.
+func (s *Searcher) collect(ctx context.Context, p *acl.Principal, r store.Request, sel store.Selection) (pool, error) {
+	if rk, ok := s.store.(store.Ranker); ok {
+		ranked, err := rk.Rank(ctx, p, r, sel)
+		if err != nil {
+			return pool{}, err
+		}
+		return pool{
+			cands:     ranked.Candidates,
+			total:     ranked.Total,
+			truncated: ranked.Truncated,
+			facets:    facetsFrom(ranked.Facets),
+		}, nil
 	}
 
-	var totalLen float64
-	take := func(d doc.Document, terms []string) bool {
-		if len(c.docs) >= MaxMatches {
-			c.truncated = true
+	var (
+		out  pool
+		seen []store.Candidate
+	)
+	take := func(d doc.Document) bool {
+		if len(seen) >= MaxMatches {
+			out.truncated = true
 			return false
 		}
-		title := doc.Tokenize(d.Title)
-		length := titleWeight*float64(len(title)) + float64(len(terms)-len(title))
-
-		tf := make(map[string]float64)
-		for i, t := range terms {
-			if !want[t] {
-				continue
-			}
-			if i < len(title) {
-				tf[t] += titleWeight
-			} else {
-				tf[t]++
-			}
-		}
-		for t := range tf {
-			c.df[t]++
-		}
-
-		d.Body = "" // fetched back for the page only, see [Searcher.Search]
-		c.docs = append(c.docs, d)
-		c.tf = append(c.tf, tf)
-		c.length = append(c.length, length)
-		totalLen += length
+		seen = append(seen, candidateOf(d, r.Terms))
 		return true
 	}
 
 	var err error
 	if rt, ok := s.store.(store.Retriever); ok {
-		// The driver has already applied the terms, so every document it yields
-		// is in the match set and only its statistics are still needed.
-		err = rt.Retrieve(ctx, p, r, func(d doc.Document) bool {
-			return take(d, d.Terms())
-		})
+		// The driver has already applied the terms and the filters, so every
+		// document it yields is in the match set.
+		err = rt.Retrieve(ctx, p, r, take)
 	} else {
 		err = s.store.Scan(ctx, p, func(d doc.Document) bool {
-			if !r.Filters(d) {
+			if !r.Matches(d) {
 				return true
 			}
-			// Analyse once and use the result for both the term test and the
-			// statistics, rather than tokenizing every document in the corpus
-			// twice to answer one query.
-			terms := d.Terms()
-			if len(r.Terms) > 0 && !anyWanted(terms, want) {
-				return true
-			}
-			return take(d, terms)
+			return take(d)
 		})
 	}
 	if err != nil {
-		return nil, err
+		return pool{}, err
 	}
-	if n := len(c.docs); n > 0 {
-		c.avgLen = totalLen / float64(n)
+
+	// The whole match set is in hand, so the counts are exact and the cut is
+	// this side of the driver. Sorting before the cut would be sorting by a
+	// score that has not been computed yet, so the pool is trimmed after
+	// scoring instead: see [Searcher.Search].
+	out.cands = seen
+	out.total = len(seen)
+	out.facets = facetsOf(seen)
+	return out, nil
+}
+
+// candidateOf is a document reduced to what the ranking reads.
+func candidateOf(d doc.Document, terms []string) store.Candidate {
+	a := d.Analyze()
+	c := store.Candidate{
+		ID:          d.ID,
+		Source:      d.Source,
+		Kind:        d.Kind,
+		Container:   d.Container,
+		Author:      d.Author.Display(),
+		ModifiedAt:  d.ModifiedAt,
+		TitleTokens: a.TitleTokens,
+		BodyTokens:  a.BodyTokens,
+	}
+	// Only the query terms, for the same reason a driver returns only those: a
+	// four hundred word document has three hundred terms the scorer will never
+	// look at.
+	for _, t := range terms {
+		if n, ok := a.Terms[t]; ok {
+			if c.Terms == nil {
+				c.Terms = make(map[string]doc.TermCount, len(terms))
+			}
+			c.Terms[t] = n
+		}
+	}
+	return c
+}
+
+// statistics reads the corpus numbers the scorer needs.
+//
+// A driver that maintains them answers in a couple of key lookups. One that
+// does not gets them derived from the candidates in hand, which is the old
+// behaviour and is an approximation: the document frequency of a term among the
+// documents that matched is not its frequency in the corpus. It is kept as a
+// fallback so that a driver is not required to implement anything to work at
+// all, and both drivers in the tree implement the capability.
+func (s *Searcher) statistics(ctx context.Context, p *acl.Principal, terms []string, from pool) (store.Corpus, error) {
+	if st, ok := s.store.(store.Statistician); ok {
+		return st.Statistics(ctx, p, terms)
+	}
+	c := store.Corpus{Documents: len(from.cands), DocFreq: make(map[string]int, len(terms))}
+	for _, cand := range from.cands {
+		c.TitleTokens += int64(cand.TitleTokens)
+		c.BodyTokens += int64(cand.BodyTokens)
+		for t := range cand.Terms {
+			c.DocFreq[t]++
+		}
 	}
 	return c, nil
 }
 
-func anyWanted(terms []string, want map[string]bool) bool {
-	for _, t := range terms {
-		if want[t] {
-			return true
-		}
-	}
-	return false
-}
-
-// bm25 scores document i against the query terms.
-func (c *candidates) bm25(i int, terms []string) float64 {
-	if c.avgLen == 0 {
+// score is BM25F over one candidate.
+//
+// It is the only place the ranking function exists. A driver could compute this
+// in SQL and it would be faster still, and then the function would exist twice,
+// once per driver, and the cross driver test that proves nineteen queries
+// produce the same answer on both would have to be weakened to "similar". A
+// ranking that depends on which deployment you asked is not something anybody
+// finds until it is in production.
+func score(c store.Candidate, terms []string, corpus store.Corpus) float64 {
+	avg := corpus.AvgLength(titleWeight)
+	if avg == 0 || corpus.Documents == 0 {
 		return 0
 	}
-	n := float64(len(c.docs))
-	norm := bm25K1 * (1 - bm25B + bm25B*c.length[i]/c.avgLen)
+	length := titleWeight*float64(c.TitleTokens) + float64(c.BodyTokens)
+	norm := bm25K1 * (1 - bm25B + bm25B*length/avg)
+	n := float64(corpus.Documents)
 
-	var score float64
+	var total float64
 	for _, t := range terms {
-		tf := c.tf[i][t]
+		count, ok := c.Terms[t]
+		if !ok {
+			continue
+		}
+		tf := titleWeight*float64(count.Title) + float64(count.Body)
 		if tf == 0 {
 			continue
 		}
-		df := float64(c.df[t])
+		df := float64(corpus.DocFreq[t])
 		idf := math.Log(1 + (n-df+0.5)/(df+0.5))
-		score += idf * tf * (bm25K1 + 1) / (tf + norm)
+		total += idf * tf * (bm25K1 + 1) / (tf + norm)
 	}
-	return score
+	return total
+}
+
+// facetsOf counts the facets over a match set the caller holds in full.
+func facetsOf(cands []store.Candidate) map[string][]Facet {
+	bySource := map[string]int{}
+	byKind := map[string]int{}
+	byContainer := map[string]int{}
+	byAuthor := map[string]int{}
+	for _, c := range cands {
+		bySource[c.Source]++
+		byKind[string(c.Kind)]++
+		byContainer[c.Container]++
+		byAuthor[c.Author]++
+	}
+	return map[string][]Facet{
+		"source":    sortedFacets(bySource),
+		"kind":      sortedFacets(byKind),
+		"container": sortedFacets(byContainer),
+		"author":    sortedFacets(byAuthor),
+	}
+}
+
+// facetsFrom carries a driver's counts across, in the same order the Go side
+// produces so that the two are comparable value for value.
+func facetsFrom(in map[string][]store.Facet) map[string][]Facet {
+	out := make(map[string][]Facet, len(in))
+	for field, values := range in {
+		counts := make(map[string]int, len(values))
+		for _, v := range values {
+			counts[v.Value] = v.Count
+		}
+		out[field] = sortedFacets(counts)
+	}
+	for _, field := range []string{"source", "kind", "container", "author"} {
+		if out[field] == nil {
+			out[field] = []Facet{}
+		}
+	}
+	return out
+}
+
+func sortedFacets(counts map[string]int) []Facet {
+	out := make([]Facet, 0, len(counts))
+	for v, n := range counts {
+		if v == "" {
+			continue
+		}
+		out = append(out, Facet{Value: v, Count: n})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Value < out[j].Value
+	})
+	if len(out) > store.MaxFacetValues {
+		out = out[:store.MaxFacetValues]
+	}
+	return out
 }

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -40,7 +40,10 @@ func New() *Store {
 	}
 }
 
-var _ store.ContentStore = (*Store)(nil)
+var (
+	_ store.ContentStore = (*Store)(nil)
+	_ store.Statistician = (*Store)(nil)
+)
 
 // Put inserts or replaces documents.
 func (s *Store) Put(ctx context.Context, docs ...doc.Document) error {
@@ -158,6 +161,51 @@ func (s *Store) Content(ctx context.Context, p *acl.Principal, id string) (doc.C
 		// there, because telling the two apart is a way of asking whether a
 		// document exists.
 		return doc.Content{}, genba.ErrNotFound
+	}
+	return c, nil
+}
+
+// Statistics counts the corpus by walking it.
+//
+// This driver keeps no derived numbers, so it recomputes them, which is O(n) on
+// every call and is the correct thing for a reference implementation to do. It
+// is what the driver that maintains them incrementally is checked against, and
+// the whole value of a reference is that it is obviously right rather than
+// fast.
+func (s *Store) Statistics(ctx context.Context, p *acl.Principal, terms []string) (store.Corpus, error) {
+	if err := ctx.Err(); err != nil {
+		return store.Corpus{}, err
+	}
+	if p == nil {
+		return store.Corpus{}, genba.ErrNoPrincipal
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return store.Corpus{}, genba.ErrClosed
+	}
+
+	want := make(map[string]bool, len(terms))
+	for _, t := range terms {
+		want[t] = true
+	}
+
+	c := store.Corpus{DocFreq: make(map[string]int, len(terms))}
+	for _, d := range s.docs {
+		// The tenant, and not the principal's visibility. See [store.Corpus] for
+		// why the counts are over what the tenant holds.
+		if !d.Queryable() || d.Tenant != p.Tenant {
+			continue
+		}
+		a := d.Analyze()
+		c.Documents++
+		c.TitleTokens += int64(a.TitleTokens)
+		c.BodyTokens += int64(a.BodyTokens)
+		for t := range a.Terms {
+			if want[t] {
+				c.DocFreq[t]++
+			}
+		}
 	}
 	return c, nil
 }

--- a/store/memstore/memstore_test.go
+++ b/store/memstore/memstore_test.go
@@ -8,8 +8,20 @@ import (
 	"github.com/tamnd/genba/store/storetest"
 )
 
+func newStore(t *testing.T) store.Store { return memstore.New() }
+
 func TestConformance(t *testing.T) {
-	storetest.Run(t, func(t *testing.T) store.Store { return memstore.New() })
+	storetest.Run(t, newStore)
+}
+
+// memstore implements store.Statistician and neither of the other two, so most
+// of this suite skips. The cases that do run are the ones that matter here: the
+// corpus statistics are what the ranking is normalised against, and they have
+// to mean the same thing on the driver that is walked as on the driver that is
+// queried, or the same corpus ranks differently depending on where it is
+// stored.
+func TestRanking(t *testing.T) {
+	storetest.RunRanker(t, newStore)
 }
 
 func TestClosedStoreRefusesWork(t *testing.T) {

--- a/store/rank.go
+++ b/store/rank.go
@@ -1,0 +1,167 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+)
+
+// Ranker is the optional capability of a driver that can select the candidates
+// worth ranking without materialising the documents behind them.
+//
+// The distinction from [Retriever] is where the cut happens. Retrieve hands the
+// caller the whole match set and the caller throws most of it away after
+// scoring. Rank makes the cut inside the same statement that applies the
+// permission rule, so the work is proportional to what comes back rather than
+// to what matched.
+//
+// The permission rule does not move, for the same reason it did not move for
+// Retrieve: the predicate is in the statement, so no count, facet or candidate
+// derived from it can name a document the asker may not read.
+type Ranker interface {
+	Rank(ctx context.Context, p *acl.Principal, r Request, sel Selection) (Ranked, error)
+}
+
+// Selection is how many candidates to cut to, and in what order.
+type Selection struct {
+	// Limit is the size of the candidate pool. A driver returns at most this
+	// many candidates and still counts the whole match set.
+	Limit int
+
+	// Recent asks for the most recently modified rather than the best matching.
+	//
+	// It is here rather than being left to the caller because a caller sorting
+	// by date over a pool that was selected by relevance would be showing the
+	// most recent of the most relevant, which is neither of the two things
+	// anybody asked for.
+	Recent bool
+}
+
+// Ranked is one query's retrieval: the candidates worth scoring and the counts
+// over the whole match set.
+type Ranked struct {
+	Candidates []Candidate
+
+	// Total is the size of the match set, not of the candidate pool.
+	Total int
+
+	// Truncated reports that the match set was larger than the pool, so the
+	// ranking is over candidates rather than over everything. A caller is
+	// entitled to know which of the two it got.
+	Truncated bool
+
+	// Facets are counted over the whole match set, which is what makes them
+	// usable as filters rather than as a description of the current page.
+	Facets map[string][]Facet
+}
+
+// Candidate is what a ranker needs to score a document without reading it.
+//
+// The four strings are the display forms a facet is counted over and a result
+// row is drawn from. They are here rather than decoded out of the document
+// because decoding the document is the cost being removed.
+type Candidate struct {
+	ID        string
+	Source    string
+	Kind      doc.Kind
+	Container string
+	Author    string
+
+	ModifiedAt time.Time
+
+	// TitleTokens and BodyTokens are the token counts recorded when the
+	// document was written.
+	TitleTokens int
+	BodyTokens  int
+
+	// Terms holds the occurrence counts for the query terms only. A driver does
+	// not return the whole term vector: the scorer looks up the query terms and
+	// nothing else, and a four hundred word document has three hundred terms it
+	// would never read.
+	Terms map[string]doc.TermCount
+}
+
+// Facet is one value of a facet and how many documents in the match set carry
+// it.
+type Facet struct {
+	Value string
+	Count int
+}
+
+// MaxFacetValues caps how many values one facet reports.
+//
+// A facet with ten thousand values is not a filter, it is a scroll bar, and
+// counting them all into a response costs more than the sidebar it feeds is
+// worth. It lives here rather than next to the ranking because a driver
+// counting facets in SQL and a caller counting them in Go have to cut at the
+// same place, or the two produce different sidebars for the same query.
+const MaxFacetValues = 50
+
+// Statistician is the optional capability of a driver that maintains the corpus
+// statistics a scorer needs, instead of leaving them to be derived from
+// whatever one query happened to walk past.
+//
+// BM25 needs three numbers that are properties of the corpus rather than of a
+// document: how many documents there are, how long they are on average, and how
+// many of them carry each query term. Deriving those from the match set makes
+// them depend on the query, which is wrong, and deriving them from a scan makes
+// every search read the corpus, which is slow. A driver that keeps them updated
+// as it writes answers all three with a handful of key lookups.
+type Statistician interface {
+	// Statistics returns the corpus numbers for the terms, in the principal's
+	// tenant.
+	Statistics(ctx context.Context, p *acl.Principal, terms []string) (Corpus, error)
+}
+
+// Corpus is what a scorer needs to know about the corpus rather than about one
+// document.
+//
+// The counts are over the tenant, not over what the asker may read. That is a
+// deliberate trade and it is worth being explicit about it. A per asker
+// document frequency is the more principled definition, and it costs a
+// permission filtered aggregate over every document carrying the term on every
+// query, which is the entire latency budget spent on a number that moves the
+// ranking by a fraction of a percent. What is exposed by the tenant wide form
+// is the shape of the ranking, not a document, a title or an id, and the
+// document count it derives from is already reported by the stats endpoint.
+type Corpus struct {
+	// Documents is how many documents in the tenant a query could match.
+	Documents int
+
+	// TitleTokens and BodyTokens are the sums over those documents, kept apart
+	// so that the average length is a division rather than a scan and so that
+	// the weight a ranker puts on a title stays in the ranker. A storage driver
+	// that knew the title weight would be a second place the ranking function
+	// lives, which is exactly what this milestone is trying not to create.
+	TitleTokens int64
+	BodyTokens  int64
+
+	// DocFreq is how many of those documents carry each requested term. A term
+	// nobody has is absent rather than zero.
+	DocFreq map[string]int
+}
+
+// AvgLength is the mean document length under the given title weight, and zero
+// for an empty corpus.
+func (c Corpus) AvgLength(titleWeight float64) float64 {
+	if c.Documents == 0 {
+		return 0
+	}
+	return (titleWeight*float64(c.TitleTokens) + float64(c.BodyTokens)) / float64(c.Documents)
+}
+
+// Fetcher is the optional capability of a driver that can return a page of
+// documents in one round trip.
+//
+// It exists because the alternative is a call to [Store.Get] per result, which
+// is twenty statements, twenty round trips and twenty decodes for a page a
+// single statement can answer. The permission rule is unchanged: a driver
+// applies the principal inside the same statement, and an id the principal may
+// not read is simply absent from the answer rather than being an error, because
+// a page that fails because one document was revoked mid query is worse than a
+// page with nineteen results on it.
+type Fetcher interface {
+	Fetch(ctx context.Context, p *acl.Principal, ids []string) ([]doc.Document, error)
+}

--- a/store/sqlitestore/bench_test.go
+++ b/store/sqlitestore/bench_test.go
@@ -1,0 +1,186 @@
+package sqlitestore_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tamnd/genba/benchcorpus"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store"
+	"github.com/tamnd/genba/store/sqlitestore"
+)
+
+// This file is an external test package because package benchcorpus imports
+// sqlitestore to build the fixture, and a benchmark in package sqlitestore
+// would close that loop into an import cycle.
+//
+// These measure the driver rather than the search, so what they tell you is
+// where a search regression lives: if index gets slower and Rank did not, the
+// cost moved into Go.
+
+const pool = 500
+
+func BenchmarkRank(b *testing.B) {
+	st, spec := benchcorpus.Fixture(b)
+	p := spec.Principal()
+	requests := requestsOf(benchcorpus.ClassCommon)
+	sel := store.Selection{Limit: pool}
+
+	b.ReportAllocs()
+	for i := 0; b.Loop(); i++ {
+		if _, err := st.Rank(b.Context(), p, requests[i%len(requests)], sel); err != nil {
+			b.Fatalf("Rank: %v", err)
+		}
+	}
+}
+
+// BenchmarkRankMultiTerm is the class that costs the most in the driver,
+// because every extra term is another set of postings to join against.
+func BenchmarkRankMultiTerm(b *testing.B) {
+	st, spec := benchcorpus.Fixture(b)
+	p := spec.Principal()
+	requests := requestsOf(benchcorpus.ClassMulti)
+	sel := store.Selection{Limit: pool}
+
+	b.ReportAllocs()
+	for i := 0; b.Loop(); i++ {
+		if _, err := st.Rank(b.Context(), p, requests[i%len(requests)], sel); err != nil {
+			b.Fatalf("Rank: %v", err)
+		}
+	}
+}
+
+// BenchmarkRankFilterOnly has no terms at all, so there is no full text index
+// to cut the match set down and the filter columns are carrying it alone.
+func BenchmarkRankFilterOnly(b *testing.B) {
+	st, spec := benchcorpus.Fixture(b)
+	p := spec.Principal()
+	requests := requestsOf(benchcorpus.ClassFilter)
+	sel := store.Selection{Limit: pool}
+
+	b.ReportAllocs()
+	for i := 0; b.Loop(); i++ {
+		if _, err := st.Rank(b.Context(), p, requests[i%len(requests)], sel); err != nil {
+			b.Fatalf("Rank: %v", err)
+		}
+	}
+}
+
+// BenchmarkStatistics is the second query of every search. It is separate
+// because it is the one that would quietly become a scan over every document
+// carrying a common term.
+func BenchmarkStatistics(b *testing.B) {
+	st, spec := benchcorpus.Fixture(b)
+	p := spec.Principal()
+	requests := requestsOf(benchcorpus.ClassMulti)
+
+	b.ReportAllocs()
+	for i := 0; b.Loop(); i++ {
+		if _, err := st.Statistics(b.Context(), p, requests[i%len(requests)].Terms); err != nil {
+			b.Fatalf("Statistics: %v", err)
+		}
+	}
+}
+
+// BenchmarkGetByIDs fetches one page worth of documents, which is the third and
+// last query of a search and the only one that decodes any JSON.
+func BenchmarkGetByIDs(b *testing.B) {
+	st, spec := benchcorpus.Fixture(b)
+	p := spec.Principal()
+
+	ranked, err := st.Rank(context.Background(), p, requestsOf(benchcorpus.ClassCommon)[0], store.Selection{Limit: pool})
+	if err != nil {
+		b.Fatalf("Rank: %v", err)
+	}
+	if len(ranked.Candidates) < 20 {
+		b.Fatalf("the corpus returned %d candidates, too few to fetch a page from", len(ranked.Candidates))
+	}
+	ids := make([]string, 0, 20)
+	for _, c := range ranked.Candidates[:20] {
+		ids = append(ids, c.ID)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		got, err := st.Fetch(b.Context(), p, ids)
+		if err != nil {
+			b.Fatalf("Fetch: %v", err)
+		}
+		if len(got) != len(ids) {
+			b.Fatalf("fetched %d of %d documents", len(got), len(ids))
+		}
+	}
+}
+
+// BenchmarkPutBatch is ingestion, in the batch size a connector actually uses.
+//
+// Every iteration writes the same documents into a database that has just been
+// created. Writing them into the same store twice would be measuring a replace,
+// which retires the old postings before writing the new ones and is not the
+// path a first crawl takes. Creating the database is outside the timer.
+func BenchmarkPutBatch(b *testing.B) {
+	const batch = 500
+
+	docs := make([]doc.Document, 0, batch)
+	benchcorpus.Default(benchcorpus.DefaultSeed, batch).Each(func(d doc.Document) bool {
+		docs = append(docs, d)
+		return true
+	})
+
+	dir := b.TempDir()
+	var n int
+
+	b.ReportAllocs()
+	b.SetBytes(int64(bodyBytes(docs)))
+	for b.Loop() {
+		b.StopTimer()
+		path := filepath.Join(dir, fmt.Sprintf("put-%d.db", n))
+		st, err := sqlitestore.Open(b.Context(), path)
+		if err != nil {
+			b.Fatalf("Open: %v", err)
+		}
+		n++
+		b.StartTimer()
+
+		if err := st.Put(b.Context(), docs...); err != nil {
+			b.Fatalf("Put: %v", err)
+		}
+
+		b.StopTimer()
+		if err := st.Close(); err != nil {
+			b.Fatalf("Close: %v", err)
+		}
+		// Each iteration leaves behind a database holding five hundred
+		// documents, and a long run leaves hundreds of them. That filled a disk
+		// while this benchmark was being written, which is a silly way to lose
+		// a measurement, so the file goes as soon as it has been measured.
+		for _, ext := range []string{"", "-wal", "-shm"} {
+			_ = os.Remove(path + ext)
+		}
+		b.StartTimer()
+	}
+	b.ReportMetric(float64(batch*n)/b.Elapsed().Seconds(), "docs/s")
+}
+
+// requestsOf turns the checked in queries of one class into store requests, so
+// the driver benchmarks measure the same text the search benchmarks do.
+func requestsOf(class benchcorpus.Class) []store.Request {
+	queries := benchcorpus.ByClass(benchcorpus.Queries())[class]
+	out := make([]store.Request, 0, len(queries))
+	for _, q := range queries {
+		out = append(out, index.Parse(q.Text).Request())
+	}
+	return out
+}
+
+func bodyBytes(docs []doc.Document) int {
+	var n int
+	for _, d := range docs {
+		n += len(d.Body) + len(d.Title)
+	}
+	return n
+}

--- a/store/sqlitestore/query.go
+++ b/store/sqlitestore/query.go
@@ -145,6 +145,14 @@ func jsonList(values []string) string {
 	return string(b)
 }
 
+func jsonInts(values []int64) string {
+	if values == nil {
+		values = []int64{}
+	}
+	b, _ := json.Marshal(values)
+	return string(b)
+}
+
 func jsonFolded(values []string) string {
 	folded := make([]string, 0, len(values))
 	for _, v := range values {

--- a/store/sqlitestore/rank.go
+++ b/store/sqlitestore/rank.go
@@ -1,0 +1,349 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// Rank answers one query out of the database's own indexes, and returns the
+// candidates worth scoring rather than everything that matched.
+//
+// This is the whole difference between a search that costs a second and one
+// that costs a few milliseconds. Retrieve hands back the match set, which on a
+// common term is most of the corpus, and the caller then throws all but twenty
+// of them away after re-analysing every one. Here the cut happens inside the
+// statement that applies the permission rule, the numbers the scorer needs are
+// read out of columns rather than derived from text, and nothing on the path is
+// proportional to the corpus outside the index walk SQLite does for itself.
+//
+// Three statements: the candidates, their term frequencies, and one that
+// carries the total and every facet count over the same predicate.
+func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel store.Selection) (store.Ranked, error) {
+	if err := s.ready(ctx); err != nil {
+		return store.Ranked{}, err
+	}
+	if p == nil {
+		return store.Ranked{}, genba.ErrNoPrincipal
+	}
+	if sel.Limit <= 0 {
+		return store.Ranked{}, errors.New("sqlitestore: rank: no candidate limit")
+	}
+
+	c := visible(p)
+	filters(r, c)
+
+	// The full text table leads the join for the same reason it does in
+	// Retrieve: it is the most selective thing in the statement on any real
+	// query, so the permission predicate is evaluated for the documents that
+	// matched rather than for the corpus.
+	//
+	// CROSS JOIN is how that is said out loud, and it has to be said. Written as
+	// an ordinary join the planner is free to reorder, and for the counts it
+	// does: it leads with the tenant index over document and runs the MATCH once
+	// per row, which measured at a second on twenty thousand documents against
+	// a hundred and forty milliseconds for the same statement with the order
+	// fixed. The candidate cut got away with it only because its ORDER BY
+	// bm25(document_fts) pinned the order by accident. Two statements share this
+	// string, so it is stated here once and neither of them relies on luck.
+	from := `document d`
+	order := `d.id`
+	if sel.Recent {
+		// NULLs last, because a document whose date the source never gave us is
+		// not the most recent thing in the corpus.
+		order = `d.modified_at IS NULL, d.modified_at DESC, d.id`
+	}
+	if q, ok := match(r.Terms); ok {
+		from = `document_fts CROSS JOIN document d ON d.rowid = document_fts.rowid`
+		c.add(`document_fts MATCH ?`, q)
+		if !sel.Recent {
+			// bm25 returns a smaller number for a better match, so ascending is
+			// best first. It is only the cut, not the ranking: the score that
+			// orders the results is computed in Go over what comes back, which
+			// is what keeps one ranking function for every driver.
+			order = `bm25(document_fts)`
+		}
+	}
+
+	cands, rowids, err := s.candidates(ctx, from, c, order, sel.Limit)
+	if err != nil {
+		return store.Ranked{}, err
+	}
+	s.counters.candidates.Add(int64(len(cands)))
+
+	out := store.Ranked{Candidates: cands}
+	if len(cands) > 0 && len(r.Terms) > 0 {
+		if err := s.frequencies(ctx, cands, rowids, r.Terms); err != nil {
+			return store.Ranked{}, err
+		}
+	}
+	if out.Total, out.Facets, err = s.counts(ctx, from, c); err != nil {
+		return store.Ranked{}, err
+	}
+	out.Truncated = out.Total > len(cands)
+	return out, nil
+}
+
+// candidates runs phase one: the cut, in one statement, with the permission
+// rule inside it.
+func (s *Store) candidates(ctx context.Context, from string, c *clause, order string, limit int) ([]store.Candidate, []int64, error) {
+	args := append(append([]any{}, c.args...), limit)
+	rows, err := s.query(ctx, `
+		SELECT d.id, d.source, d.kind, d.container, d.author_name, d.modified_at,
+		       d.title_tokens, d.body_tokens, d.rowid
+		FROM `+from+`
+		WHERE `+c.where()+`
+		ORDER BY `+order+`
+		LIMIT ?`, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("sqlitestore: rank: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var (
+		out    []store.Candidate
+		rowids []int64
+	)
+	for rows.Next() {
+		var (
+			cand     store.Candidate
+			kind     string
+			modified sql.NullInt64
+			rowid    int64
+		)
+		if err := rows.Scan(&cand.ID, &cand.Source, &kind, &cand.Container, &cand.Author,
+			&modified, &cand.TitleTokens, &cand.BodyTokens, &rowid); err != nil {
+			return nil, nil, fmt.Errorf("sqlitestore: rank: %w", err)
+		}
+		s.counters.rows.Add(1)
+		cand.Kind = doc.Kind(kind)
+		if modified.Valid {
+			cand.ModifiedAt = unixNano(modified.Int64)
+		}
+		out = append(out, cand)
+		rowids = append(rowids, rowid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("sqlitestore: rank: %w", err)
+	}
+	return out, rowids, nil
+}
+
+// frequencies fills in the per term counts for the candidates, in one
+// statement.
+//
+// It reads the query terms for the chosen documents and nothing else. The
+// posting table is keyed by document first for exactly this: a few hundred
+// candidates is a few hundred primary key ranges, and the terms nobody asked
+// about are never touched.
+func (s *Store) frequencies(ctx context.Context, cands []store.Candidate, rowids []int64, terms []string) error {
+	at := make(map[int64]int, len(rowids))
+	for i, id := range rowids {
+		at[id] = i
+	}
+
+	rows, err := s.query(ctx, `
+		SELECT doc_rowid, term, title_tf, body_tf FROM posting
+		WHERE doc_rowid IN (SELECT value FROM json_each(?))
+		  AND term IN (SELECT value FROM json_each(?))`,
+		jsonInts(rowids), jsonList(terms))
+	if err != nil {
+		return fmt.Errorf("sqlitestore: rank: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var (
+			rowid       int64
+			term        string
+			title, body int
+		)
+		if err := rows.Scan(&rowid, &term, &title, &body); err != nil {
+			return fmt.Errorf("sqlitestore: rank: %w", err)
+		}
+		s.counters.rows.Add(1)
+		i, ok := at[rowid]
+		if !ok {
+			continue
+		}
+		if cands[i].Terms == nil {
+			cands[i].Terms = make(map[string]doc.TermCount, len(terms))
+		}
+		cands[i].Terms[term] = doc.TermCount{Title: title, Body: body}
+	}
+	return rows.Err()
+}
+
+// counts is the total and every facet, over the same predicate, in one
+// statement.
+//
+// One rather than five, because the predicate is the expensive part and the
+// common table expression is materialised so it is evaluated once. Five
+// statements would apply the permission rule to the match set five times over
+// to answer five questions about the same rows.
+func (s *Store) counts(ctx context.Context, from string, c *clause) (int, map[string][]store.Facet, error) {
+	const fields = `
+		SELECT 'total' AS field, '' AS value, count(*) AS n FROM m
+		UNION ALL SELECT * FROM (SELECT 'source', source, count(*) FROM m WHERE source <> '' GROUP BY source ORDER BY 3 DESC, 2 LIMIT ?)
+		UNION ALL SELECT * FROM (SELECT 'kind', kind, count(*) FROM m WHERE kind <> '' GROUP BY kind ORDER BY 3 DESC, 2 LIMIT ?)
+		UNION ALL SELECT * FROM (SELECT 'container', container, count(*) FROM m WHERE container <> '' GROUP BY container ORDER BY 3 DESC, 2 LIMIT ?)
+		UNION ALL SELECT * FROM (SELECT 'author', author, count(*) FROM m WHERE author <> '' GROUP BY author ORDER BY 3 DESC, 2 LIMIT ?)`
+
+	args := append([]any{}, c.args...)
+	for range 4 {
+		args = append(args, store.MaxFacetValues)
+	}
+
+	rows, err := s.query(ctx, `
+		WITH m AS MATERIALIZED (
+			SELECT d.source AS source, d.kind AS kind, d.container AS container, d.author_name AS author
+			FROM `+from+` WHERE `+c.where()+`
+		)`+fields, args...)
+	if err != nil {
+		return 0, nil, fmt.Errorf("sqlitestore: rank: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var (
+		total  int
+		facets = map[string][]store.Facet{}
+	)
+	for rows.Next() {
+		var (
+			field, value string
+			n            int
+		)
+		if err := rows.Scan(&field, &value, &n); err != nil {
+			return 0, nil, fmt.Errorf("sqlitestore: rank: %w", err)
+		}
+		s.counters.rows.Add(1)
+		if field == "total" {
+			total = n
+			continue
+		}
+		facets[field] = append(facets[field], store.Facet{Value: value, Count: n})
+	}
+	if err := rows.Err(); err != nil {
+		return 0, nil, fmt.Errorf("sqlitestore: rank: %w", err)
+	}
+	return total, facets, nil
+}
+
+// Statistics reads the corpus numbers the scorer needs, in two key lookups.
+//
+// They are maintained on every write, which is what turns "how many documents
+// carry this term" from a count over the term's whole posting list into a
+// primary key hit. See [store.Corpus] for why they are counted over the tenant
+// rather than over what the asker may read.
+func (s *Store) Statistics(ctx context.Context, p *acl.Principal, terms []string) (store.Corpus, error) {
+	if err := s.ready(ctx); err != nil {
+		return store.Corpus{}, err
+	}
+	if p == nil {
+		return store.Corpus{}, genba.ErrNoPrincipal
+	}
+
+	out := store.Corpus{DocFreq: make(map[string]int, len(terms))}
+	switch err := s.queryRow(ctx,
+		`SELECT documents, title_tokens, body_tokens FROM corpus WHERE tenant = ?`, p.Tenant,
+	).Scan(&out.Documents, &out.TitleTokens, &out.BodyTokens); {
+	case errors.Is(err, sql.ErrNoRows):
+		// A tenant nobody has written to yet. Zero is the honest answer and the
+		// scorer treats it as an empty corpus rather than as an error.
+		return out, nil
+	case err != nil:
+		return store.Corpus{}, fmt.Errorf("sqlitestore: statistics: %w", err)
+	}
+	s.counters.rows.Add(1)
+
+	if len(terms) == 0 {
+		return out, nil
+	}
+	rows, err := s.query(ctx, `
+		SELECT term, documents FROM term_stat
+		WHERE tenant = ? AND term IN (SELECT value FROM json_each(?)) AND documents > 0`,
+		p.Tenant, jsonList(terms))
+	if err != nil {
+		return store.Corpus{}, fmt.Errorf("sqlitestore: statistics: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var (
+			term string
+			n    int
+		)
+		if err := rows.Scan(&term, &n); err != nil {
+			return store.Corpus{}, fmt.Errorf("sqlitestore: statistics: %w", err)
+		}
+		s.counters.rows.Add(1)
+		out.DocFreq[term] = n
+	}
+	if err := rows.Err(); err != nil {
+		return store.Corpus{}, fmt.Errorf("sqlitestore: statistics: %w", err)
+	}
+	return out, nil
+}
+
+// Fetch returns a page of documents in one statement.
+//
+// An id the principal may not read is absent from the answer rather than an
+// error, because the alternative is a whole page failing because one document
+// was revoked between the ranking and the fetch.
+func (s *Store) Fetch(ctx context.Context, p *acl.Principal, ids []string) ([]doc.Document, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	// The id list leads the join, and CROSS JOIN is how that is said out loud.
+	//
+	// This is twenty primary key lookups and the planner has to be told so.
+	// Given the ids in an IN clause it preferred the tenant index and walked
+	// every document in the tenant, which measured at eight milliseconds a page
+	// on twenty thousand documents. Given them as an ordinary join it did the
+	// same thing, because it has no idea how many rows a json_each will produce
+	// and guesses high. CROSS JOIN is SQLite's documented way of fixing the join
+	// order, and it is the difference between twenty key lookups and a scan.
+	c := visible(p)
+	args := append([]any{jsonList(ids)}, c.args...)
+	rows, err := s.query(ctx, `
+		SELECT x.data
+		FROM json_each(?) j
+		CROSS JOIN document d ON d.id = j.value
+		CROSS JOIN document_data x ON x.doc_id = d.id
+		WHERE `+c.where(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlitestore: fetch: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]doc.Document, 0, len(ids))
+	for rows.Next() {
+		var data string
+		if err := rows.Scan(&data); err != nil {
+			return nil, fmt.Errorf("sqlitestore: fetch: %w", err)
+		}
+		s.counters.rows.Add(1)
+		d, err := s.decoded(data)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlitestore: fetch: %w", err)
+	}
+	return out, nil
+}

--- a/store/sqlitestore/rank.go
+++ b/store/sqlitestore/rank.go
@@ -187,7 +187,7 @@ func (s *Store) frequencies(ctx context.Context, cands []store.Candidate, rowids
 // common table expression is materialised so it is evaluated once. Five
 // statements would apply the permission rule to the match set five times over
 // to answer five questions about the same rows.
-func (s *Store) counts(ctx context.Context, from string, c *clause) (int, map[string][]store.Facet, error) {
+func (s *Store) counts(ctx context.Context, from string, c *clause) (total int, facets map[string][]store.Facet, err error) {
 	const fields = `
 		SELECT 'total' AS field, '' AS value, count(*) AS n FROM m
 		UNION ALL SELECT * FROM (SELECT 'source', source, count(*) FROM m WHERE source <> '' GROUP BY source ORDER BY 3 DESC, 2 LIMIT ?)
@@ -210,10 +210,7 @@ func (s *Store) counts(ctx context.Context, from string, c *clause) (int, map[st
 	}
 	defer func() { _ = rows.Close() }()
 
-	var (
-		total  int
-		facets = map[string][]store.Facet{}
-	)
+	facets = map[string][]store.Facet{}
 	for rows.Next() {
 		var (
 			field, value string

--- a/store/sqlitestore/schema.go
+++ b/store/sqlitestore/schema.go
@@ -3,8 +3,18 @@ package sqlitestore
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 )
+
+// step is one migration: a statement, or a piece of Go for the ones that need
+// to read a document to decide what to write.
+type step struct {
+	sql string
+	run func(ctx context.Context, tx *sql.Tx) error
+}
+
+func ddl(s string) step { return step{sql: s} }
 
 // migrations are applied in order and recorded by index in user_version.
 //
@@ -12,8 +22,8 @@ import (
 // whole schema fits on a screen and a migration tool would be more machinery
 // than the thing it manages. The rules are the usual ones: a migration is never
 // edited once it has shipped, and a new one is appended.
-var migrations = []string{
-	`CREATE TABLE document (
+var migrations = []step{
+	ddl(`CREATE TABLE document (
 		id            TEXT PRIMARY KEY,
 		tenant        TEXT NOT NULL,
 		source        TEXT NOT NULL,
@@ -45,47 +55,177 @@ var migrations = []string{
 		-- returns exactly what Put was given, and the columns above are only
 		-- ever an index over it.
 		data          TEXT NOT NULL
-	)`,
-	`CREATE INDEX document_tenant ON document (tenant, queryable)`,
-	`CREATE INDEX document_source ON document (source)`,
-	`CREATE INDEX document_modified ON document (modified_at)`,
+	)`),
+	ddl(`CREATE INDEX document_tenant ON document (tenant, queryable)`),
+	ddl(`CREATE INDEX document_source ON document (source)`),
+	ddl(`CREATE INDEX document_modified ON document (modified_at)`),
 
 	// document_ref is the allow and deny lists, one row per reference, in the
 	// key form acl.Ref produces. The permission predicate is set membership
 	// against this table, which is the same set membership acl.Permissions
 	// performs in Go.
-	`CREATE TABLE document_ref (
+	ddl(`CREATE TABLE document_ref (
 		doc_id TEXT NOT NULL REFERENCES document(id) ON DELETE CASCADE,
 		effect INTEGER NOT NULL, -- 0 allow, 1 deny
 		scope  INTEGER NOT NULL, -- 0 user,  1 group
 		key    TEXT NOT NULL
-	)`,
-	`CREATE INDEX document_ref_doc ON document_ref (doc_id, effect, scope)`,
-	`CREATE INDEX document_ref_key ON document_ref (key, effect, scope)`,
+	)`),
+	ddl(`CREATE INDEX document_ref_doc ON document_ref (doc_id, effect, scope)`),
+	ddl(`CREATE INDEX document_ref_key ON document_ref (key, effect, scope)`),
 
 	// The full text index holds doc.Document.Analyzed, which is already the
 	// terms the ranking tokenizes to. unicode61 then has nothing left to do but
 	// split on the spaces we put there, so the driver's match set and the Go
 	// rule cannot drift over what counts as a word. Diacritic folding is turned
 	// off for the same reason: the Go analyzer does not do it.
-	`CREATE VIRTUAL TABLE document_fts USING fts5(
+	ddl(`CREATE VIRTUAL TABLE document_fts USING fts5(
 		terms,
 		content='',
 		contentless_delete=1,
 		tokenize='unicode61 remove_diacritics 0'
-	)`,
+	)`),
 
 	// document_content is the bytes of a document that is not text, in its own
 	// table rather than in the data column. The reason is the shape of the
 	// reads: data is selected by every query path, and a megabyte of PNG in it
 	// would be a megabyte read per hit whether or not anybody ever looks at the
 	// image. Here it is only read by the one endpoint that serves it.
-	`CREATE TABLE document_content (
+	ddl(`CREATE TABLE document_content (
 		doc_id     TEXT PRIMARY KEY REFERENCES document(id) ON DELETE CASCADE,
 		width      INTEGER NOT NULL,
 		height     INTEGER NOT NULL,
 		bytes      BLOB NOT NULL
-	)`,
+	)`),
+
+	// Everything below is the ranking data model. It exists so that no part of
+	// answering a query is proportional to the corpus outside an index walk
+	// SQLite does for itself.
+	//
+	// Token counts, not a weighted length. The weight a ranker puts on a title
+	// is part of the ranking function, and a column that had it baked in would
+	// be a second place that function lives.
+	ddl(`ALTER TABLE document ADD COLUMN title_tokens INTEGER NOT NULL DEFAULT 0`),
+	ddl(`ALTER TABLE document ADD COLUMN body_tokens INTEGER NOT NULL DEFAULT 0`),
+
+	// The display forms of the two fields that are faceted on. container_fold
+	// and author_keys are already here for filtering, and a facet needs the
+	// string a person reads. Deriving it by decoding a document per row is
+	// precisely the cost this is removing.
+	ddl(`ALTER TABLE document ADD COLUMN container TEXT NOT NULL DEFAULT ''`),
+	ddl(`ALTER TABLE document ADD COLUMN author_name TEXT NOT NULL DEFAULT ''`),
+
+	// posting is the term frequency store, not a second matcher. FTS5 stays the
+	// thing that decides which documents are candidates, because it is good at
+	// it and it handles the phrase queries the operator grammar will grow.
+	//
+	// The key is (doc_rowid, term) rather than (term, doc_rowid), which is the
+	// other way round from a classic inverted index. Nothing here ever asks
+	// which documents carry a term: that question is answered by FTS5 for
+	// matching and by term_stat for document frequency. What it does ask is
+	// which terms a handful of already chosen candidates carry, and this order
+	// answers that from the primary key, which also means the delete on rewrite
+	// is one range rather than a scan and there is no second index to keep.
+	ddl(`CREATE TABLE posting (
+		doc_rowid INTEGER NOT NULL,
+		term      TEXT    NOT NULL,
+		title_tf  INTEGER NOT NULL,
+		body_tf   INTEGER NOT NULL,
+		PRIMARY KEY (doc_rowid, term)
+	) WITHOUT ROWID`),
+
+	// corpus and term_stat are the numbers BM25 needs about the corpus rather
+	// than about a document. They are maintained on every write so that a query
+	// reads a row instead of running an aggregate over everything.
+	ddl(`CREATE TABLE corpus (
+		tenant       TEXT PRIMARY KEY,
+		documents    INTEGER NOT NULL,
+		title_tokens INTEGER NOT NULL,
+		body_tokens  INTEGER NOT NULL
+	) WITHOUT ROWID`),
+	ddl(`CREATE TABLE term_stat (
+		tenant    TEXT    NOT NULL,
+		term      TEXT    NOT NULL,
+		documents INTEGER NOT NULL,
+		PRIMARY KEY (tenant, term)
+	) WITHOUT ROWID`),
+
+	// A database written before the statistics existed has none of them, and
+	// every document in it would score zero. Rebuilding them is a read and a
+	// rewrite of every row, which is slow and is also exactly right: it happens
+	// once, at open, and the alternative is a corpus that silently ranks badly
+	// until somebody notices.
+	{run: backfill},
+
+	// The document body moves out of the document row.
+	//
+	// This one is worth explaining, because it looks like tidiness and it is
+	// worth ten milliseconds a query. A row in SQLite is stored whole, and a
+	// row longer than a page spills onto overflow pages. The document JSON
+	// averages four kilobytes here, so every document row is a page of its own
+	// plus a chain of overflow pages, and reading any column of it reads the
+	// start of that chain.
+	//
+	// Phase one of a search does exactly that, for every document that matched
+	// the terms, because the permission predicate is columns on this row. On
+	// twenty thousand documents that measured at seventy five milliseconds for
+	// the candidate cut alone, against a budget of ten for the whole query, and
+	// the same statement against a table without the body in it measured at
+	// three. The bodies were never read. They were in the way.
+	//
+	// So the columns a query filters, counts and ranks on stay in a narrow row
+	// that a page holds hundreds of, and the document itself lives in a table
+	// that only the twenty results on the page ever touch. It is the same
+	// argument document_content was split out on, one level further in.
+	ddl(`CREATE TABLE document_data (
+		doc_id TEXT PRIMARY KEY REFERENCES document(id) ON DELETE CASCADE,
+		data   TEXT NOT NULL
+	) WITHOUT ROWID`),
+	ddl(`INSERT INTO document_data (doc_id, data) SELECT id, data FROM document`),
+	ddl(`ALTER TABLE document DROP COLUMN data`),
+}
+
+// backfill recomputes the ranking statistics for every document already stored.
+func backfill(ctx context.Context, tx *sql.Tx) error {
+	rows, err := tx.QueryContext(ctx, `SELECT rowid, data FROM document ORDER BY rowid`)
+	if err != nil {
+		return err
+	}
+	type row struct {
+		rowid int64
+		data  string
+	}
+	var all []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.rowid, &r.data); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		all = append(all, r)
+	}
+	if err := errors.Join(rows.Err(), rows.Close()); err != nil {
+		return err
+	}
+	if len(all) == 0 {
+		return nil
+	}
+
+	w, err := newWriter(ctx, tx)
+	if err != nil {
+		return err
+	}
+	defer w.close()
+
+	for _, r := range all {
+		d, err := decode(r.data)
+		if err != nil {
+			return err
+		}
+		if err := w.statistics(ctx, r.rowid, d); err != nil {
+			return fmt.Errorf("rebuild %s: %w", d.ID, err)
+		}
+	}
+	return nil
 }
 
 // migrate brings an open database up to the current schema.
@@ -94,7 +234,11 @@ var migrations = []string{
 // makes opening an existing file the same code path as creating a new one.
 // user_version is SQLite's own four byte header field, so the version is read
 // without a table having to exist first.
-func migrate(ctx context.Context, db *sql.DB) error {
+//
+// The steps are a parameter rather than the package variable so that a test can
+// build a database at an older version and then upgrade it, which is the only
+// way to exercise a migration against data that was written before it existed.
+func migrate(ctx context.Context, db *sql.DB, migrations []step) error {
 	var version int
 	if err := db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&version); err != nil {
 		return fmt.Errorf("read schema version: %w", err)
@@ -112,9 +256,16 @@ func migrate(ctx context.Context, db *sql.DB) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	for _, stmt := range migrations[version:] {
-		if _, err := tx.ExecContext(ctx, stmt); err != nil {
-			return fmt.Errorf("apply migration %d: %w", version, err)
+	for _, m := range migrations[version:] {
+		switch {
+		case m.sql != "":
+			if _, err := tx.ExecContext(ctx, m.sql); err != nil {
+				return fmt.Errorf("apply migration %d: %w", version, err)
+			}
+		case m.run != nil:
+			if err := m.run(ctx, tx); err != nil {
+				return fmt.Errorf("apply migration %d: %w", version, err)
+			}
 		}
 		version++
 	}

--- a/store/sqlitestore/sqlitestore.go
+++ b/store/sqlitestore/sqlitestore.go
@@ -123,14 +123,14 @@ func (s *Store) ResetCounters() {
 
 // query and queryRow are the only two ways this driver reads, so that the
 // statement counter cannot be forgotten at a new call site.
-func (s *Store) query(ctx context.Context, sql string, args ...any) (*sql.Rows, error) {
+func (s *Store) query(ctx context.Context, stmt string, args ...any) (*sql.Rows, error) {
 	s.counters.statements.Add(1)
-	return s.db.QueryContext(ctx, sql, args...)
+	return s.db.QueryContext(ctx, stmt, args...)
 }
 
-func (s *Store) queryRow(ctx context.Context, sql string, args ...any) *sql.Row {
+func (s *Store) queryRow(ctx context.Context, stmt string, args ...any) *sql.Row {
 	s.counters.statements.Add(1)
-	return s.db.QueryRowContext(ctx, sql, args...)
+	return s.db.QueryRowContext(ctx, stmt, args...)
 }
 
 // Open opens or creates a database at path and brings its schema up to date.

--- a/store/sqlitestore/sqlitestore.go
+++ b/store/sqlitestore/sqlitestore.go
@@ -51,10 +51,8 @@ type Store struct {
 	// behaviour under load predictable rather than dependent on a timeout.
 	write sync.Mutex
 
-	// rows counts the rows the database handed back. It is what the test that
-	// proves the permission filter is in the SQL asserts on: a reader who may
-	// see nothing has to cost zero rows, not a full walk that Go then discards.
-	rows atomic.Int64
+	// counters are what the performance gate asserts on. See [Counters].
+	counters counters
 
 	closed atomic.Bool
 }
@@ -63,7 +61,77 @@ var (
 	_ store.Store        = (*Store)(nil)
 	_ store.Retriever    = (*Store)(nil)
 	_ store.ContentStore = (*Store)(nil)
+	_ store.Ranker       = (*Store)(nil)
+	_ store.Statistician = (*Store)(nil)
+	_ store.Fetcher      = (*Store)(nil)
 )
+
+// Counters is the work one query cost, counted exactly.
+//
+// It is here because a latency assertion on a shared CI runner is a coin flip
+// and these are not. Rows read, statements issued, documents decoded and
+// candidates scored do not vary with how busy the machine is, they are where a
+// performance regression shows up first, and an assertion on them names the
+// mistake precisely: a per hit refetch reappearing in a year moves Decodes from
+// twenty to twenty plus the match set, on any runner, at any speed.
+type Counters struct {
+	// Rows is the rows the database handed back. It is what the test that
+	// proves the permission filter is in the SQL asserts on: a reader who may
+	// see nothing has to cost zero rows, not a full walk that Go then discards.
+	Rows int64
+
+	// Statements is the statements executed against the database, read paths
+	// only. A search that issues one per result rather than one per page is the
+	// regression this counts.
+	Statements int64
+
+	// Decodes is document JSON decoded into a [doc.Document]. A search should
+	// decode the page and nothing else.
+	Decodes int64
+
+	// Candidates is the documents handed to the ranker. It is bounded by the
+	// candidate pool rather than by the match set, which is the whole point of
+	// two phase retrieval.
+	Candidates int64
+}
+
+type counters struct {
+	rows       atomic.Int64
+	statements atomic.Int64
+	decodes    atomic.Int64
+	candidates atomic.Int64
+}
+
+// Counters reports the work this store has done since it was opened or last
+// reset.
+func (s *Store) Counters() Counters {
+	return Counters{
+		Rows:       s.counters.rows.Load(),
+		Statements: s.counters.statements.Load(),
+		Decodes:    s.counters.decodes.Load(),
+		Candidates: s.counters.candidates.Load(),
+	}
+}
+
+// ResetCounters zeroes them, so that a measurement can be scoped to one query.
+func (s *Store) ResetCounters() {
+	s.counters.rows.Store(0)
+	s.counters.statements.Store(0)
+	s.counters.decodes.Store(0)
+	s.counters.candidates.Store(0)
+}
+
+// query and queryRow are the only two ways this driver reads, so that the
+// statement counter cannot be forgotten at a new call site.
+func (s *Store) query(ctx context.Context, sql string, args ...any) (*sql.Rows, error) {
+	s.counters.statements.Add(1)
+	return s.db.QueryContext(ctx, sql, args...)
+}
+
+func (s *Store) queryRow(ctx context.Context, sql string, args ...any) *sql.Row {
+	s.counters.statements.Add(1)
+	return s.db.QueryRowContext(ctx, sql, args...)
+}
 
 // Open opens or creates a database at path and brings its schema up to date.
 //
@@ -84,12 +152,29 @@ func Open(ctx context.Context, path string) (*Store, error) {
 	if memory(path) {
 		db.SetMaxOpenConns(1)
 	}
-	if err := migrate(ctx, db); err != nil {
+	if err := migrate(ctx, db, migrations); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("sqlitestore: migrate %s: %w", path, err)
 	}
 	return &Store{db: db}, nil
 }
+
+// CacheBytes is the page cache each connection is given.
+//
+// SQLite's default is two thousand pages, which is eight megabytes, and it was
+// chosen for a world where a database was a settings file. It is far too small
+// for either of the things this store does. A write of five hundred documents
+// touches a few hundred thousand b-tree pages across the full text index and
+// the postings, and a cache that cannot hold them spills the difference to the
+// write ahead log and reads it back, which measured as ninety percent of
+// ingestion time spent in write syscalls. A search wants the same headroom for
+// the opposite reason: the latency budget assumes a warm cache, and a cache
+// that cannot hold the working set makes every query pay for a page fault.
+//
+// Sixty four megabytes is per connection, so a pool of eight is half a gigabyte
+// in the worst case. That is a deliberate trade and it is the right one for a
+// search server, which is a thing people run on a machine with memory.
+const CacheBytes = 64 << 20
 
 // dsn adds the pragmas every connection needs.
 //
@@ -100,10 +185,22 @@ func Open(ctx context.Context, path string) (*Store, error) {
 // it off by default.
 func dsn(path string) string {
 	q := url.Values{}
+	// There is deliberately no page_size here. Setting it looked like a win in
+	// a first measurement and turned out to do nothing at all: the pragma only
+	// takes effect before the first page is written, the driver applies these
+	// after the file exists, and a database opened with it reports the default
+	// four kilobytes. A setting that does not take effect is worse than one
+	// that is absent, because the next person reads it and believes it.
 	q.Add("_pragma", "journal_mode(WAL)")
 	q.Add("_pragma", "busy_timeout(5000)")
 	q.Add("_pragma", "foreign_keys(1)")
 	q.Add("_pragma", "synchronous(NORMAL)")
+	// Negative is kibibytes rather than pages, which is the only form of this
+	// pragma that means the same thing whatever the page size turns out to be.
+	q.Add("_pragma", fmt.Sprintf("cache_size(-%d)", CacheBytes/1024))
+	// Sorting and the intermediate results of a grouped aggregate, which the
+	// facet counts are. On disk they are a temporary file per query.
+	q.Add("_pragma", "temp_store(MEMORY)")
 	return path + "?" + q.Encode()
 }
 
@@ -138,8 +235,14 @@ func (s *Store) Put(ctx context.Context, docs ...doc.Document) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	w, err := newWriter(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: put: %w", err)
+	}
+	defer w.close()
+
 	for _, d := range docs {
-		if err := putOne(ctx, tx, d); err != nil {
+		if err := putOne(ctx, tx, w, d); err != nil {
 			return fmt.Errorf("sqlitestore: put %s: %w", d.ID, err)
 		}
 	}
@@ -154,7 +257,7 @@ func (s *Store) Put(ctx context.Context, docs ...doc.Document) error {
 // The upsert keeps the rowid, which matters because the full text index is
 // joined on it. A delete and insert would give the row a new identity and leave
 // the old terms behind under the old one.
-func putOne(ctx context.Context, tx *sql.Tx, d doc.Document) error {
+func putOne(ctx context.Context, tx *sql.Tx, w *writer, d doc.Document) error {
 	// The content comes off the document before it is encoded, so the data
 	// column stays the size of the text and Get cannot hand image bytes back to
 	// a query path that has no use for them.
@@ -171,12 +274,25 @@ func putOne(ctx context.Context, tx *sql.Tx, d doc.Document) error {
 		ownerKey = d.Permissions.Owner.UserKey()
 	}
 
+	// Whatever is stored under this id stops counting before the row that
+	// carries the numbers is overwritten, because after the write there is no
+	// way left to know what it used to contribute.
+	if _, _, err := w.retire(ctx, d.ID); err != nil {
+		return err
+	}
+
+	// One analysis, used three times over: the full text index row, the
+	// postings and the length columns. Running the analyzer once per use is how
+	// indexing ends up three times slower than it needs to be.
+	a := d.Analyze()
+
 	var rowid int64
 	err = tx.QueryRowContext(ctx, `
 		INSERT INTO document (
 			id, tenant, source, kind, container_fold, author_keys, owner_keys,
-			modified_at, mode, owner_key, queryable, data
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			modified_at, mode, owner_key, queryable,
+			title_tokens, body_tokens, container, author_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			tenant = excluded.tenant,
 			source = excluded.source,
@@ -188,13 +304,26 @@ func putOne(ctx context.Context, tx *sql.Tx, d doc.Document) error {
 			mode = excluded.mode,
 			owner_key = excluded.owner_key,
 			queryable = excluded.queryable,
-			data = excluded.data
+			title_tokens = excluded.title_tokens,
+			body_tokens = excluded.body_tokens,
+			container = excluded.container,
+			author_name = excluded.author_name
 		RETURNING rowid`,
 		d.ID, d.Tenant, d.Source, string(d.Kind),
 		store.Fold(d.Container), jsonKeys(store.PersonKeys(d.Author)), jsonKeys(store.PersonKeys(d.Owner)),
-		nullableTime(d.ModifiedAt), int(d.Permissions.Mode), ownerKey, boolInt(d.Queryable()), string(data),
+		nullableTime(d.ModifiedAt), int(d.Permissions.Mode), ownerKey, boolInt(d.Queryable()),
+		a.TitleTokens, a.BodyTokens, d.Container, d.Author.Display(),
 	).Scan(&rowid)
 	if err != nil {
+		return err
+	}
+
+	// The document itself goes to its own table. See the migration that split
+	// it out for why: it is the one part of a row no query path reads until it
+	// knows which twenty documents it is returning.
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO document_data (doc_id, data) VALUES (?, ?)
+		ON CONFLICT(doc_id) DO UPDATE SET data = excluded.data`, d.ID, string(data)); err != nil {
 		return err
 	}
 
@@ -233,8 +362,10 @@ func putOne(ctx context.Context, tx *sql.Tx, d doc.Document) error {
 	if !d.Queryable() {
 		return nil
 	}
-	_, err = tx.ExecContext(ctx, `INSERT INTO document_fts (rowid, terms) VALUES (?, ?)`, rowid, d.Analyzed())
-	return err
+	if _, err := tx.ExecContext(ctx, `INSERT INTO document_fts (rowid, terms) VALUES (?, ?)`, rowid, d.Analyzed()); err != nil {
+		return err
+	}
+	return w.index(ctx, rowid, d, a)
 }
 
 // ref is one row of document_ref.
@@ -280,16 +411,24 @@ func (s *Store) Delete(ctx context.Context, ids ...string) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	w, err := newWriter(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: delete: %w", err)
+	}
+	defer w.close()
+
 	for _, id := range ids {
 		// The rowid is read first because the full text index is keyed on it
 		// and knows nothing about document ids. Deleting a document that is not
-		// there is not an error, which is what makes a retry safe.
-		var rowid int64
-		switch err := tx.QueryRowContext(ctx, `SELECT rowid FROM document WHERE id = ?`, id).Scan(&rowid); {
-		case errors.Is(err, sql.ErrNoRows):
-			continue
-		case err != nil:
+		// there is not an error, which is what makes a retry safe. retire is
+		// what takes the document back out of the corpus statistics, which has
+		// to happen while its postings are still there to be counted.
+		rowid, found, err := w.retire(ctx, id)
+		if err != nil {
 			return fmt.Errorf("sqlitestore: delete %s: %w", id, err)
+		}
+		if !found {
+			continue
 		}
 		if _, err := tx.ExecContext(ctx, `DELETE FROM document_fts WHERE rowid = ?`, rowid); err != nil {
 			return fmt.Errorf("sqlitestore: delete %s: %w", id, err)
@@ -315,7 +454,10 @@ func (s *Store) Get(ctx context.Context, p *acl.Principal, id string) (doc.Docum
 
 	c := visible(p)
 	args := append([]any{id}, c.args...)
-	row := s.db.QueryRowContext(ctx, `SELECT d.data FROM document d WHERE d.id = ? AND `+c.where(), args...)
+	row := s.queryRow(ctx, `
+		SELECT x.data FROM document d
+		JOIN document_data x ON x.doc_id = d.id
+		WHERE d.id = ? AND `+c.where(), args...)
 
 	var data string
 	switch err := row.Scan(&data); {
@@ -326,8 +468,8 @@ func (s *Store) Get(ctx context.Context, p *acl.Principal, id string) (doc.Docum
 	case err != nil:
 		return doc.Document{}, fmt.Errorf("sqlitestore: get: %w", err)
 	}
-	s.rows.Add(1)
-	return decode(data)
+	s.counters.rows.Add(1)
+	return s.decoded(data)
 }
 
 // Content returns the bytes of one document if the principal may read it.
@@ -345,7 +487,7 @@ func (s *Store) Content(ctx context.Context, p *acl.Principal, id string) (doc.C
 
 	c := visible(p)
 	args := append([]any{id}, c.args...)
-	row := s.db.QueryRowContext(ctx, `
+	row := s.queryRow(ctx, `
 		SELECT c.width, c.height, c.bytes
 		FROM document_content c
 		JOIN document d ON d.id = c.doc_id
@@ -360,7 +502,7 @@ func (s *Store) Content(ctx context.Context, p *acl.Principal, id string) (doc.C
 	case err != nil:
 		return doc.Content{}, fmt.Errorf("sqlitestore: content: %w", err)
 	}
-	s.rows.Add(1)
+	s.counters.rows.Add(1)
 	return out, nil
 }
 
@@ -374,7 +516,10 @@ func (s *Store) Scan(ctx context.Context, p *acl.Principal, fn func(doc.Document
 	}
 
 	c := visible(p)
-	return s.stream(ctx, `SELECT d.data FROM document d WHERE `+c.where()+` ORDER BY d.id`, c.args, fn)
+	return s.stream(ctx, `
+		SELECT x.data FROM document d
+		JOIN document_data x ON x.doc_id = d.id
+		WHERE `+c.where()+` ORDER BY d.id`, c.args, fn)
 }
 
 // Retrieve answers a request out of the database's own indexes.
@@ -404,12 +549,15 @@ func (s *Store) Retrieve(ctx context.Context, p *acl.Principal, r store.Request,
 		c.add(`document_fts MATCH ?`, q)
 	}
 
-	return s.stream(ctx, `SELECT d.data FROM `+from+` WHERE `+c.where()+` ORDER BY d.id`, c.args, fn)
+	return s.stream(ctx, `
+		SELECT x.data FROM `+from+`
+		JOIN document_data x ON x.doc_id = d.id
+		WHERE `+c.where()+` ORDER BY d.id`, c.args, fn)
 }
 
 // stream runs a query returning document JSON and hands each row to fn.
 func (s *Store) stream(ctx context.Context, query string, args []any, fn func(doc.Document) bool) error {
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := s.query(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("sqlitestore: query: %w", err)
 	}
@@ -420,8 +568,8 @@ func (s *Store) stream(ctx context.Context, query string, args []any, fn func(do
 		if err := rows.Scan(&data); err != nil {
 			return fmt.Errorf("sqlitestore: scan: %w", err)
 		}
-		s.rows.Add(1)
-		d, err := decode(data)
+		s.counters.rows.Add(1)
+		d, err := s.decoded(data)
 		if err != nil {
 			return err
 		}
@@ -438,7 +586,7 @@ func (s *Store) Stats(ctx context.Context) (store.Stats, error) {
 		return store.Stats{}, err
 	}
 	var st store.Stats
-	err := s.db.QueryRowContext(ctx, `
+	err := s.queryRow(ctx, `
 		SELECT
 			coalesce(sum(queryable = 1), 0),
 			coalesce(sum(queryable = 0), 0)
@@ -477,6 +625,14 @@ func decode(data string) (doc.Document, error) {
 	return d, nil
 }
 
+// decoded is decode with the counter, for the read paths. The migration path
+// calls decode directly, because a rebuild is not a query and counting it would
+// make a reopened database look like a regression.
+func (s *Store) decoded(data string) (doc.Document, error) {
+	s.counters.decodes.Add(1)
+	return decode(data)
+}
+
 func jsonKeys(keys []string) string {
 	if keys == nil {
 		keys = []string{}
@@ -491,6 +647,10 @@ func nullableTime(t time.Time) any {
 	}
 	return t.UnixNano()
 }
+
+// unixNano is the other direction, in UTC, so that a document read back out of
+// a column compares equal to the one that went in.
+func unixNano(n int64) time.Time { return time.Unix(0, n).UTC() }
 
 func boolInt(b bool) int {
 	if b {

--- a/store/sqlitestore/sqlitestore_test.go
+++ b/store/sqlitestore/sqlitestore_test.go
@@ -1,7 +1,10 @@
 package sqlitestore
 
 import (
+	"database/sql"
+	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +32,10 @@ func TestConformance(t *testing.T) {
 
 func TestRetrieverConformance(t *testing.T) {
 	storetest.RunRetriever(t, newStore)
+}
+
+func TestRankerConformance(t *testing.T) {
+	storetest.RunRanker(t, newStore)
 }
 
 // TestMigrationsAreIdempotent opens the same file twice. The second open runs
@@ -66,6 +73,78 @@ func TestMigrationsAreIdempotent(t *testing.T) {
 	}
 }
 
+// TestUpgradeFromBeforeTheBodySplit opens a database written before the
+// document body moved into its own table, and checks the document survives.
+//
+// A migration that reshapes stored data is the one kind that cannot be tested
+// by creating a database and using it, because a fresh database runs the
+// migration against nothing. So this builds one at the older version, writes a
+// row the old way, and then opens it the way a running deployment would.
+func TestUpgradeFromBeforeTheBodySplit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.db")
+	before := migrations[:splitAt(t)]
+
+	db, err := sql.Open("sqlite", dsn(path))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := migrate(t.Context(), db, before); err != nil {
+		t.Fatalf("migrating to the older schema: %v", err)
+	}
+
+	// The old write path, in the shape it had then: everything in one row,
+	// including the document JSON. The permissions are the simple mode, so that
+	// what is being tested is the row and not the reference table.
+	d := readable("d1")
+	d.Permissions = acl.Permissions{Mode: acl.ModePublicToTenant}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO document (
+			id, tenant, source, kind, container_fold, author_keys, owner_keys,
+			modified_at, mode, owner_key, queryable, data,
+			title_tokens, body_tokens, container, author_name
+		) VALUES (?, ?, ?, ?, '', '[]', '[]', ?, ?, '', 1, ?, 0, 0, ?, '')`,
+		d.ID, d.Tenant, d.Source, string(d.Kind), d.ModifiedAt.UnixNano(),
+		int(d.Permissions.Mode), string(data), d.Container)
+	if err != nil {
+		t.Fatalf("writing a row the old way: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	s, err := Open(t.Context(), path)
+	if err != nil {
+		t.Fatalf("opening the upgraded database: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	got, err := s.Get(t.Context(), reader(), "d1")
+	if err != nil {
+		t.Fatalf("the document written before the upgrade is gone: %v", err)
+	}
+	if got.Title != d.Title || got.Body != d.Body {
+		t.Fatalf("the upgrade changed the document: %q, %q", got.Title, got.Body)
+	}
+}
+
+// splitAt is the migration that creates document_data, found by what it does
+// rather than by its number, so appending a migration does not silently move
+// the test to a different one.
+func splitAt(t *testing.T) int {
+	t.Helper()
+	for i, m := range migrations {
+		if strings.Contains(m.sql, "CREATE TABLE document_data") {
+			return i
+		}
+	}
+	t.Fatal("no migration creates document_data")
+	return 0
+}
+
 // TestPermissionFilterIsInTheQuery is the one that has to keep passing.
 //
 // It counts the rows the database handed back. A driver that asked SQLite for
@@ -84,7 +163,7 @@ func TestPermissionFilterIsInTheQuery(t *testing.T) {
 		t.Fatalf("Put: %v", err)
 	}
 
-	s.rows.Store(0)
+	s.ResetCounters()
 	var seen int
 	if err := s.Retrieve(t.Context(), stranger(), store.Request{}, func(doc.Document) bool {
 		seen++
@@ -95,7 +174,7 @@ func TestPermissionFilterIsInTheQuery(t *testing.T) {
 	if seen != 0 {
 		t.Fatalf("a reader with no access retrieved %d documents", seen)
 	}
-	if got := s.rows.Load(); got != 0 {
+	if got := s.Counters().Rows; got != 0 {
 		t.Fatalf("the database returned %d rows for a reader who may see nothing, so the permission filter ran in Go rather than in the query", got)
 	}
 
@@ -107,11 +186,11 @@ func TestPermissionFilterIsInTheQuery(t *testing.T) {
 		t.Fatalf("Put: %v", err)
 	}
 
-	s.rows.Store(0)
+	s.ResetCounters()
 	if err := s.Retrieve(t.Context(), stranger(), store.Request{}, func(doc.Document) bool { return true }); err != nil {
 		t.Fatalf("Retrieve: %v", err)
 	}
-	if got := s.rows.Load(); got != 1 {
+	if got := s.Counters().Rows; got != 1 {
 		t.Fatalf("the database returned %d rows where one document is readable, want 1", got)
 	}
 }
@@ -135,7 +214,7 @@ func TestTermsAreInTheQuery(t *testing.T) {
 		t.Fatalf("Put: %v", err)
 	}
 
-	s.rows.Store(0)
+	s.ResetCounters()
 	var got []string
 	if err := s.Retrieve(t.Context(), reader(), store.Request{Terms: []string{"sourdough"}}, func(d doc.Document) bool {
 		got = append(got, d.ID)
@@ -146,7 +225,7 @@ func TestTermsAreInTheQuery(t *testing.T) {
 	if len(got) != 1 || got[0] != "needle" {
 		t.Fatalf("retrieved %v, want just the one document carrying the term", got)
 	}
-	if rows := s.rows.Load(); rows != 1 {
+	if rows := s.Counters().Rows; rows != 1 {
 		t.Fatalf("the database returned %d rows for a term one document carries, so the term filter is not in the query", rows)
 	}
 }

--- a/store/sqlitestore/write.go
+++ b/store/sqlitestore/write.go
@@ -1,0 +1,211 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/tamnd/genba/doc"
+)
+
+// writer holds the statements a batch of writes reuses.
+//
+// Indexing one four hundred word document is a few hundred inserts into
+// posting, so preparing a statement per insert would be preparing a few hundred
+// statements per document. Preparing them once per transaction is the
+// difference between the ingestion budget and a tenth of it, and it is the
+// reason the write path is a type rather than a function.
+type writer struct {
+	stmts []*sql.Stmt
+
+	prior      *sql.Stmt
+	retireTerm *sql.Stmt
+	dropPost   *sql.Stmt
+	addPost    *sql.Stmt
+	addPosts   *sql.Stmt
+	bumpTerm   *sql.Stmt
+	corpusAdd  *sql.Stmt
+	corpusSub  *sql.Stmt
+	columns    *sql.Stmt
+
+	// terms is the scratch space one document's postings are sorted in, reused
+	// across a batch so that indexing five hundred documents does not allocate
+	// five hundred slices of a few hundred strings.
+	terms []string
+	args  []any
+}
+
+// postingChunk is how many postings go into one insert.
+//
+// The cost of writing a posting is almost entirely the cost of executing a
+// statement rather than the cost of the row, and a four hundred word document
+// has a few hundred distinct terms in it. Sending them one at a time is a few
+// hundred round trips through database/sql per document, which measured at
+// three hundred documents a second against a budget of two thousand. Sending
+// them sixty four at a time is the same rows and a sixty fourth of the
+// overhead.
+//
+// It is not larger because SQLite has a limit on bound parameters and because
+// the returns flatten out well before it: most of the win is in the first
+// factor of ten.
+const postingChunk = 64
+
+func newWriter(ctx context.Context, tx *sql.Tx) (*writer, error) {
+	w := &writer{}
+	prep := func(dst **sql.Stmt, query string) error {
+		s, err := tx.PrepareContext(ctx, query)
+		if err != nil {
+			return fmt.Errorf("prepare: %w", err)
+		}
+		w.stmts = append(w.stmts, s)
+		*dst = s
+		return nil
+	}
+
+	err := errors.Join(
+		prep(&w.prior, `SELECT rowid, tenant, title_tokens, body_tokens, queryable FROM document WHERE id = ?`),
+
+		// The decrement reads the terms out of the postings that are still in
+		// place, so the set it walks is exactly the set that was counted when
+		// the document was written. Deriving it from the document instead would
+		// be re-analysing text to undo an old analysis, and the two would
+		// disagree the moment the analyzer changed.
+		prep(&w.retireTerm, `
+			UPDATE term_stat SET documents = documents - 1
+			WHERE tenant = ? AND term IN (SELECT term FROM posting WHERE doc_rowid = ?)`),
+		prep(&w.dropPost, `DELETE FROM posting WHERE doc_rowid = ?`),
+		prep(&w.addPost, `INSERT INTO posting (doc_rowid, term, title_tf, body_tf) VALUES (?, ?, ?, ?)`),
+		prep(&w.addPosts, `INSERT INTO posting (doc_rowid, term, title_tf, body_tf) VALUES `+
+			strings.TrimSuffix(strings.Repeat(`(?, ?, ?, ?), `, postingChunk), `, `)),
+		prep(&w.bumpTerm, `
+			INSERT INTO term_stat (tenant, term, documents)
+			SELECT ?, term, 1 FROM posting WHERE doc_rowid = ?
+			ON CONFLICT(tenant, term) DO UPDATE SET documents = documents + 1`),
+		prep(&w.corpusAdd, `
+			INSERT INTO corpus (tenant, documents, title_tokens, body_tokens) VALUES (?, 1, ?, ?)
+			ON CONFLICT(tenant) DO UPDATE SET
+				documents    = documents + 1,
+				title_tokens = title_tokens + excluded.title_tokens,
+				body_tokens  = body_tokens + excluded.body_tokens`),
+		prep(&w.corpusSub, `
+			UPDATE corpus SET
+				documents    = documents - 1,
+				title_tokens = title_tokens - ?,
+				body_tokens  = body_tokens - ?
+			WHERE tenant = ?`),
+		prep(&w.columns, `UPDATE document SET title_tokens = ?, body_tokens = ?, container = ?, author_name = ? WHERE rowid = ?`),
+	)
+	if err != nil {
+		w.close()
+		return nil, err
+	}
+	return w, nil
+}
+
+func (w *writer) close() {
+	for _, s := range w.stmts {
+		_ = s.Close()
+	}
+	w.stmts = nil
+}
+
+// retire takes whatever the stored version of a document contributed back out
+// of the statistics and drops its postings.
+//
+// It runs before the row is rewritten, because the columns it reads are the
+// ones about to be overwritten. It returns whether the document was there at
+// all, which is what tells the delete path there is nothing to do.
+func (w *writer) retire(ctx context.Context, id string) (rowid int64, found bool, err error) {
+	var (
+		tenant            string
+		titleTok, bodyTok int64
+		queryable         int
+	)
+	switch err := w.prior.QueryRowContext(ctx, id).Scan(&rowid, &tenant, &titleTok, &bodyTok, &queryable); {
+	case errors.Is(err, sql.ErrNoRows):
+		return 0, false, nil
+	case err != nil:
+		return 0, false, err
+	}
+
+	// A quarantined document was never counted, so taking it out again would
+	// count it backwards.
+	if queryable == 1 {
+		if _, err := w.retireTerm.ExecContext(ctx, tenant, rowid); err != nil {
+			return 0, false, err
+		}
+		if _, err := w.corpusSub.ExecContext(ctx, titleTok, bodyTok, tenant); err != nil {
+			return 0, false, err
+		}
+	}
+	if _, err := w.dropPost.ExecContext(ctx, rowid); err != nil {
+		return 0, false, err
+	}
+	return rowid, true, nil
+}
+
+// index writes the postings for a document and folds it into the corpus
+// statistics.
+//
+// The analysis is passed in rather than recomputed, because the caller already
+// ran it to produce the full text index row and analysing a document twice per
+// write is half the ingestion budget spent on the same answer.
+func (w *writer) index(ctx context.Context, rowid int64, d doc.Document, a doc.Analysis) error {
+	if !d.Queryable() {
+		return nil
+	}
+	if err := w.postings(ctx, rowid, a); err != nil {
+		return err
+	}
+	if _, err := w.bumpTerm.ExecContext(ctx, d.Tenant, rowid); err != nil {
+		return err
+	}
+	_, err := w.corpusAdd.ExecContext(ctx, d.Tenant, a.TitleTokens, a.BodyTokens)
+	return err
+}
+
+// postings writes one document's term vector, in chunks.
+//
+// The terms are sorted first. posting is a WITHOUT ROWID table keyed by
+// document and then term, so sorted inserts land in one ascending run of a
+// b-tree page range instead of scattering across it, and map iteration order
+// stops being something the write cost depends on.
+func (w *writer) postings(ctx context.Context, rowid int64, a doc.Analysis) error {
+	w.terms = w.terms[:0]
+	for term := range a.Terms {
+		w.terms = append(w.terms, term)
+	}
+	slices.Sort(w.terms)
+
+	var at int
+	for ; at+postingChunk <= len(w.terms); at += postingChunk {
+		w.args = w.args[:0]
+		for _, term := range w.terms[at : at+postingChunk] {
+			c := a.Terms[term]
+			w.args = append(w.args, rowid, term, c.Title, c.Body)
+		}
+		if _, err := w.addPosts.ExecContext(ctx, w.args...); err != nil {
+			return err
+		}
+	}
+	for _, term := range w.terms[at:] {
+		c := a.Terms[term]
+		if _, err := w.addPost.ExecContext(ctx, rowid, term, c.Title, c.Body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// statistics rebuilds everything derived from one already stored document,
+// which is what a database written before any of this existed needs.
+func (w *writer) statistics(ctx context.Context, rowid int64, d doc.Document) error {
+	a := d.Analyze()
+	if _, err := w.columns.ExecContext(ctx, a.TitleTokens, a.BodyTokens, d.Container, d.Author.Display(), rowid); err != nil {
+		return err
+	}
+	return w.index(ctx, rowid, d, a)
+}

--- a/store/storetest/rank.go
+++ b/store/storetest/rank.go
@@ -1,0 +1,515 @@
+package storetest
+
+import (
+	"errors"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// RunRanker checks the three capabilities a driver can implement to answer a
+// search without materialising the corpus: [store.Ranker], [store.Statistician]
+// and [store.Fetcher].
+//
+// All three are optional and a case skips for a driver that lacks the one it
+// covers, so a driver is free to implement none of them and still pass. What a
+// driver is not free to do is implement one of them differently. Everything
+// here is checked against the same slow, obviously correct answer computed from
+// Scan, because the numbers these capabilities return feed the ranking, and a
+// ranking computed from statistics that quietly drifted is not something anyone
+// notices from the outside. It looks like search getting worse.
+func RunRanker(t *testing.T, newStore Factory) {
+	t.Helper()
+	for _, c := range rankCases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newStore(t)
+			t.Cleanup(func() { _ = s.Close() })
+			c.run(t, s)
+		})
+	}
+}
+
+type rankCase struct {
+	name string
+	run  func(t *testing.T, s store.Store)
+}
+
+var rankCases = []rankCase{
+	{"a pool larger than the match set returns all of it", testRankWholeMatchSet},
+	{"the total counts the match set and not the pool", testRankTotal},
+	{"truncated says whether the ranking saw everything", testRankTruncated},
+	{"facets are counted over the match set and not over the pool", testRankFacets},
+	{"the principal is applied inside rank", testRankPermission},
+	{"a nil principal ranks nothing", testRankNilPrincipal},
+	{"a candidate carries the token counts the analyzer produces", testRankTokens},
+	{"a candidate carries the query terms and only those", testRankTerms},
+	{"a recency selection takes the most recently modified", testRankRecent},
+	{"rank reflects a delete", testRankDelete},
+	{"statistics agree with the analyzer over the corpus", testStatisticsCorpus},
+	{"statistics are over the tenant and not over the reader", testStatisticsTenant},
+	{"statistics follow a replace", testStatisticsReplace},
+	{"statistics follow a delete", testStatisticsDelete},
+	{"a quarantined document is not in the statistics", testStatisticsQuarantine},
+	{"a nil principal has no statistics", testStatisticsNilPrincipal},
+	{"fetch returns the documents behind a page", testFetchPage},
+	{"fetch omits what the principal may not read", testFetchPermission},
+	{"a nil principal fetches nothing", testFetchNilPrincipal},
+}
+
+func ranker(t *testing.T, s store.Store) store.Ranker {
+	t.Helper()
+	rk, ok := s.(store.Ranker)
+	if !ok {
+		t.Skip("driver does not implement store.Ranker")
+	}
+	return rk
+}
+
+func statistician(t *testing.T, s store.Store) store.Statistician {
+	t.Helper()
+	st, ok := s.(store.Statistician)
+	if !ok {
+		t.Skip("driver does not implement store.Statistician")
+	}
+	return st
+}
+
+func fetcher(t *testing.T, s store.Store) store.Fetcher {
+	t.Helper()
+	f, ok := s.(store.Fetcher)
+	if !ok {
+		t.Skip("driver does not implement store.Fetcher")
+	}
+	return f
+}
+
+// mustRank is Rank with the error handling every case would otherwise repeat.
+func mustRank(t *testing.T, rk store.Ranker, p *acl.Principal, r store.Request, sel store.Selection) store.Ranked {
+	t.Helper()
+	got, err := rk.Rank(t.Context(), p, r, sel)
+	if err != nil {
+		t.Fatalf("Rank: %v", err)
+	}
+	return got
+}
+
+// candidateIDs is the pool, sorted, so a case can compare it against the Go
+// rule without depending on the order a driver happened to cut in.
+func candidateIDs(ranked store.Ranked) []string {
+	ids := make([]string, 0, len(ranked.Candidates))
+	for _, c := range ranked.Candidates {
+		ids = append(ids, c.ID)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// pool is a selection large enough that nothing in the fixture is cut.
+func pool() store.Selection { return store.Selection{Limit: 100} }
+
+// wantFacets counts the facets the slow way, from the documents the principal
+// can actually read.
+func wantFacets(t *testing.T, s store.Store, p *acl.Principal, r store.Request) map[string]map[string]int {
+	t.Helper()
+	out := map[string]map[string]int{
+		"source": {}, "kind": {}, "container": {}, "author": {},
+	}
+	count := func(field, value string) {
+		if value != "" {
+			out[field][value]++
+		}
+	}
+	if err := s.Scan(t.Context(), p, func(d doc.Document) bool {
+		if r.Matches(d) {
+			count("source", d.Source)
+			count("kind", string(d.Kind))
+			count("container", d.Container)
+			count("author", d.Author.Display())
+		}
+		return true
+	}); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	return out
+}
+
+// gotFacets turns a driver's answer into the same shape, which is also where a
+// duplicated facet value would show up as a lost count.
+func gotFacets(t *testing.T, ranked store.Ranked) map[string]map[string]int {
+	t.Helper()
+	out := map[string]map[string]int{
+		"source": {}, "kind": {}, "container": {}, "author": {},
+	}
+	for field, values := range ranked.Facets {
+		if _, ok := out[field]; !ok {
+			t.Fatalf("Rank reported a facet nobody asked for: %q", field)
+		}
+		for _, v := range values {
+			if v.Value == "" {
+				t.Fatalf("%s facet has an empty value, which is not a filter anyone can tick", field)
+			}
+			if _, seen := out[field][v.Value]; seen {
+				t.Fatalf("%s facet reports %q twice", field, v.Value)
+			}
+			out[field][v.Value] = v.Count
+		}
+	}
+	return out
+}
+
+func testRankWholeMatchSet(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	for _, r := range []store.Request{
+		{},
+		{Terms: []string{"payments"}},
+		{Sources: []string{"gdrive"}},
+		{Terms: []string{"queue"}, Kinds: []doc.Kind{doc.KindCode}},
+	} {
+		got := candidateIDs(mustRank(t, rk, reader(), r, pool()))
+		want := wantIDs(t, s, reader(), r)
+		if !slices.Equal(got, want) {
+			t.Fatalf("Rank and Scan disagree for %+v:\n     ranked: %v\n   expected: %v", r, got, want)
+		}
+	}
+}
+
+func testRankTotal(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	// The pool cuts to one candidate, and the total still counts everything that
+	// matched. A total that reports the pool would tell the interface there is
+	// one result when there are four, which is the number a person reads before
+	// deciding the search is broken.
+	got := mustRank(t, rk, reader(), store.Request{}, store.Selection{Limit: 1})
+	if len(got.Candidates) != 1 {
+		t.Fatalf("asked for one candidate and got %d", len(got.Candidates))
+	}
+	if want := len(wantIDs(t, s, reader(), store.Request{})); got.Total != want {
+		t.Fatalf("Total = %d, the match set has %d documents in it", got.Total, want)
+	}
+}
+
+func testRankTruncated(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	if got := mustRank(t, rk, reader(), store.Request{}, pool()); got.Truncated {
+		t.Fatal("Truncated is set for a pool that held the whole match set")
+	}
+	if got := mustRank(t, rk, reader(), store.Request{}, store.Selection{Limit: 2}); !got.Truncated {
+		t.Fatal("Truncated is not set for a pool that cut the match set in half")
+	}
+}
+
+func testRankFacets(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	want := wantFacets(t, s, reader(), store.Request{})
+	// Both selections, because the facets belong to the match set. Counting them
+	// over the pool would make the sidebar change as somebody pages, and the
+	// counts it shows would be a description of the current page rather than of
+	// what ticking the filter is about to do.
+	for _, sel := range []store.Selection{pool(), {Limit: 1}} {
+		got := gotFacets(t, mustRank(t, rk, reader(), store.Request{}, sel))
+		if !maps.EqualFunc(got, want, maps.Equal) {
+			t.Fatalf("facets for a pool of %d are %v, expected %v", sel.Limit, got, want)
+		}
+	}
+}
+
+func testRankPermission(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	got := mustRank(t, rk, stranger(), store.Request{}, pool())
+	if len(got.Candidates) != 0 || got.Total != 0 {
+		t.Fatalf("a stranger ranked %d of %d documents", len(got.Candidates), got.Total)
+	}
+	for field, values := range got.Facets {
+		if len(values) != 0 {
+			t.Fatalf("a stranger sees the %s facet: %v", field, values)
+		}
+	}
+}
+
+func testRankNilPrincipal(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	if _, err := rk.Rank(t.Context(), nil, store.Request{}, pool()); !errors.Is(err, genba.ErrNoPrincipal) {
+		t.Fatalf("Rank with no principal returned %v, expected ErrNoPrincipal", err)
+	}
+}
+
+func testRankTokens(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	docs := corpus()
+	mustPut(t, s, docs...)
+
+	want := make(map[string]doc.Analysis, len(docs))
+	for _, d := range docs {
+		want[d.ID] = d.Analyze()
+	}
+
+	// The lengths a driver reports were computed when the document was written,
+	// and the ranking divides by their mean. A driver that stores the character
+	// count, or the count before folding, produces a plausible number that
+	// penalises exactly the wrong documents.
+	for _, c := range mustRank(t, rk, reader(), store.Request{}, pool()).Candidates {
+		a := want[c.ID]
+		if c.TitleTokens != a.TitleTokens || c.BodyTokens != a.BodyTokens {
+			t.Fatalf("%s has %d title and %d body tokens, the analyzer produces %d and %d",
+				c.ID, c.TitleTokens, c.BodyTokens, a.TitleTokens, a.BodyTokens)
+		}
+	}
+}
+
+func testRankTerms(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	docs := corpus()
+	mustPut(t, s, docs...)
+
+	want := make(map[string]doc.Analysis, len(docs))
+	for _, d := range docs {
+		want[d.ID] = d.Analyze()
+	}
+
+	const term = "payments"
+	got := mustRank(t, rk, reader(), store.Request{Terms: []string{term}}, pool())
+	if len(got.Candidates) == 0 {
+		t.Fatal("nothing matched a term the fixture carries")
+	}
+	for _, c := range got.Candidates {
+		if len(c.Terms) > 1 {
+			t.Fatalf("%s carries %v, and the query asked about one term", c.ID, slices.Sorted(maps.Keys(c.Terms)))
+		}
+		if got, expected := c.Terms[term], want[c.ID].Terms[term]; got != expected {
+			t.Fatalf("%s counts %+v occurrences of %q, the analyzer counts %+v", c.ID, got, term, expected)
+		}
+	}
+}
+
+func testRankRecent(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	docs := corpus()
+	mustPut(t, s, docs...)
+
+	newest := slices.Clone(docs)
+	slices.SortFunc(newest, func(a, b doc.Document) int { return b.ModifiedAt.Compare(a.ModifiedAt) })
+
+	// A recency selection has to cut on the date rather than cut on relevance
+	// and sort what survives, or a search for what changed this week returns the
+	// most recent of whatever happened to match best.
+	got := mustRank(t, rk, reader(), store.Request{}, store.Selection{Limit: 2, Recent: true})
+	want := []string{newest[0].ID, newest[1].ID}
+	slices.Sort(want)
+	if ids := candidateIDs(got); !slices.Equal(ids, want) {
+		t.Fatalf("the two most recent documents are %v, the pool held %v", want, ids)
+	}
+}
+
+func testRankDelete(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	if err := s.Delete(t.Context(), "r1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got := mustRank(t, rk, reader(), store.Request{}, pool())
+	if slices.Contains(candidateIDs(got), "r1") {
+		t.Fatal("a deleted document is still a candidate")
+	}
+	if want := len(wantIDs(t, s, reader(), store.Request{})); got.Total != want {
+		t.Fatalf("Total = %d after a delete, expected %d", got.Total, want)
+	}
+}
+
+// wantCorpus computes the statistics the slow way, over every queryable
+// document in the tenant.
+func wantCorpus(docs []doc.Document, terms []string) store.Corpus {
+	want := make(map[string]bool, len(terms))
+	for _, t := range terms {
+		want[t] = true
+	}
+	c := store.Corpus{DocFreq: map[string]int{}}
+	for _, d := range docs {
+		if !d.Queryable() {
+			continue
+		}
+		a := d.Analyze()
+		c.Documents++
+		c.TitleTokens += int64(a.TitleTokens)
+		c.BodyTokens += int64(a.BodyTokens)
+		for term := range a.Terms {
+			if want[term] {
+				c.DocFreq[term]++
+			}
+		}
+	}
+	return c
+}
+
+func checkCorpus(t *testing.T, st store.Statistician, p *acl.Principal, docs []doc.Document, terms []string) {
+	t.Helper()
+	got, err := st.Statistics(t.Context(), p, terms)
+	if err != nil {
+		t.Fatalf("Statistics: %v", err)
+	}
+	want := wantCorpus(docs, terms)
+	if got.Documents != want.Documents {
+		t.Fatalf("Documents = %d, expected %d", got.Documents, want.Documents)
+	}
+	if got.TitleTokens != want.TitleTokens || got.BodyTokens != want.BodyTokens {
+		t.Fatalf("token sums are %d title and %d body, expected %d and %d",
+			got.TitleTokens, got.BodyTokens, want.TitleTokens, want.BodyTokens)
+	}
+	for term, n := range want.DocFreq {
+		if got.DocFreq[term] != n {
+			t.Fatalf("%d documents carry %q, expected %d", got.DocFreq[term], term, n)
+		}
+	}
+	for term, n := range got.DocFreq {
+		if want.DocFreq[term] == 0 {
+			t.Fatalf("%q is reported in %d documents and nothing carries it", term, n)
+		}
+	}
+}
+
+// statTerms covers a term in several documents, a term in one, and a term
+// nothing carries, which is the case a driver returning zero instead of nothing
+// gets wrong quietly.
+var statTerms = []string{"payments", "onboarding", "zeppelin"}
+
+func testStatisticsCorpus(t *testing.T, s store.Store) {
+	st := statistician(t, s)
+	docs := corpus()
+	mustPut(t, s, docs...)
+	checkCorpus(t, st, reader(), docs, statTerms)
+}
+
+func testStatisticsTenant(t *testing.T, s store.Store) {
+	st := statistician(t, s)
+	docs := corpus()
+	mustPut(t, s, docs...)
+
+	// The counts are a property of the corpus and not of the asker. See
+	// [store.Corpus] for why: a per asker document frequency costs a permission
+	// filtered aggregate over every document carrying the term, on every query,
+	// to move the ranking by a fraction of a percent. This case pins the choice
+	// so that a driver cannot make it differently.
+	checkCorpus(t, st, stranger(), docs, statTerms)
+}
+
+func testStatisticsReplace(t *testing.T, s store.Store) {
+	st := statistician(t, s)
+	docs := corpus()
+	mustPut(t, s, docs...)
+
+	// The replacement is shorter and drops a term the original carried, so a
+	// driver that adds the new numbers without taking the old ones back out is
+	// off in both the lengths and the frequency.
+	docs[0].Title = "Runbook"
+	docs[0].Body = "moved"
+	mustPut(t, s, docs[0])
+	checkCorpus(t, st, reader(), docs, statTerms)
+
+	// Twice, because writing the same document again is the ordinary case for a
+	// connector that re-syncs, and counting it twice is the ordinary bug.
+	mustPut(t, s, docs[0])
+	checkCorpus(t, st, reader(), docs, statTerms)
+}
+
+func testStatisticsDelete(t *testing.T, s store.Store) {
+	st := statistician(t, s)
+	docs := corpus()
+	mustPut(t, s, docs...)
+
+	if err := s.Delete(t.Context(), docs[0].ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	checkCorpus(t, st, reader(), docs[1:], statTerms)
+
+	// Deleting what is already gone must not take it out a second time.
+	if err := s.Delete(t.Context(), docs[0].ID); err != nil {
+		t.Fatalf("Delete again: %v", err)
+	}
+	checkCorpus(t, st, reader(), docs[1:], statTerms)
+}
+
+func testStatisticsQuarantine(t *testing.T, s store.Store) {
+	st := statistician(t, s)
+	docs := corpus()
+	// A document whose permissions did not resolve is served to nobody, so
+	// counting it would mean the ranking is normalised against documents that
+	// can never appear in a result.
+	docs[0].Permissions = acl.Permissions{}
+	mustPut(t, s, docs...)
+	checkCorpus(t, st, reader(), docs, statTerms)
+}
+
+func testStatisticsNilPrincipal(t *testing.T, s store.Store) {
+	st := statistician(t, s)
+	mustPut(t, s, corpus()...)
+
+	if _, err := st.Statistics(t.Context(), nil, statTerms); !errors.Is(err, genba.ErrNoPrincipal) {
+		t.Fatalf("Statistics with no principal returned %v, expected ErrNoPrincipal", err)
+	}
+}
+
+func testFetchPage(t *testing.T, s store.Store) {
+	f := fetcher(t, s)
+	docs := corpus()
+	mustPut(t, s, docs...)
+
+	got, err := f.Fetch(t.Context(), reader(), []string{"r3", "r1", "nothing"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	by := make(map[string]doc.Document, len(got))
+	for _, d := range got {
+		by[d.ID] = d
+	}
+	if len(by) != 2 {
+		t.Fatalf("fetched %d documents for two readable ids and one that does not exist", len(by))
+	}
+	// The body is the reason this call exists, so a fetch that returns the same
+	// metadata the ranking already had is a fetch that did nothing.
+	if by["r1"].Body != docs[0].Body || by["r1"].Title != docs[0].Title {
+		t.Fatalf("r1 came back as %q / %q", by["r1"].Title, by["r1"].Body)
+	}
+}
+
+func testFetchPermission(t *testing.T, s store.Store) {
+	f := fetcher(t, s)
+	docs := corpus()
+	mustPut(t, s, docs...)
+
+	got, err := f.Fetch(t.Context(), stranger(), []string{"r1", "r2", "r3", "r4"})
+	if err != nil {
+		// Not an error, on purpose. An id the asker may not read is absent,
+		// because the alternative is a page of twenty results failing because one
+		// document was revoked while it was being ranked.
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("a stranger fetched %d documents", len(got))
+	}
+}
+
+func testFetchNilPrincipal(t *testing.T, s store.Store) {
+	f := fetcher(t, s)
+	mustPut(t, s, corpus()...)
+
+	if _, err := f.Fetch(t.Context(), nil, []string{"r1"}); !errors.Is(err, genba.ErrNoPrincipal) {
+		t.Fatalf("Fetch with no principal returned %v, expected ErrNoPrincipal", err)
+	}
+}


### PR DESCRIPTION
Stacked on #67.

Closes #54 and #55.

A search used to hand the whole match set back to Go and throw almost all of it away.
`sqlitestore.Retrieve` selected the complete document JSON for every row that matched, `index.collect` ran the analyzer over every one of those bodies to recover term frequencies, and `index.Search` then called `store.Get` once per result to fetch documents it had decoded a moment earlier.
On five thousand documents a common term cost a second and a half, and the cost was proportional to the corpus rather than to the page.

This is the data model change that fixes that, and the measurement infrastructure that proves it, in that order.

## What changes

**Statistics are written at index time.**
`doc.Document.Analyze` runs the analyzer once, inside `Put`, where it was already running to build the full text row.
Its result feeds a `posting` table of per term title and body counts, token count columns on the document row, and per tenant `corpus` and `term_stat` tables maintained in the same transaction.
Nothing on the query path tokenizes anything any more.

**`store.Ranker` is a new optional driver capability.**
One method, so a driver issues whatever set of statements it likes inside one call.
It returns candidates rather than documents: an id, four display strings, a date, two token counts and the per query term frequencies, which is everything the ranking reads and nothing else.
The permission predicate stays inside the statement, so the total, the facet counts and the candidate list are all derived from rows the asker may read, and there is no second place for the rule to be forgotten.

**Ranking stays in Go.**
BM25F and the recency prior are unchanged and still exist once.
Ranking in SQL with the full text extension's own scorer would be faster and is rejected, because the ranking function would then exist once per driver and the cross driver test that proves nineteen queries give identical answers on both drivers would have to be weakened to "similar".

**The cut is five hundred candidates**, or ten times the requested window when paging deeper.
The floor is not the page size because the recency prior reorders.
A document ranked a hundred and eightieth on lexical match alone can reach the first page once the prior has been applied to everything above it, and cutting at twenty would make the prior invisible.

**The page is one statement.**
Twenty ids, one query, twenty decodes, replacing the per hit `Get` loop.

**`store/storetest` gains `RunRanker`**, which is what makes this safe.
It holds a driver to the match set a full scan produces: the total matches, every facet count matches, every candidate is in the match set, the candidate set equals the match set exactly when the pool is large enough, and a principal who may read nothing gets nothing and does not move the row counter.

## Two changes that came from measuring rather than from planning

**The document body moved into its own table.**
A row in SQLite is stored whole and a row longer than a page spills onto overflow pages.
The document JSON averages four kilobytes here, so every document row was a page plus a chain, and the candidate query reads columns off every matching row.
The bodies were never read on that path, they were in the way.
The candidate cut measured 75ms with the body in the row and 3ms without it, against a budget of 10ms for the whole query.

**Two statements needed `CROSS JOIN` to pin the join order.**
The planner has no idea how many rows a `json_each` produces and guesses high, so given the ids of a page in a join it preferred the tenant index and walked the tenant.
The counts statement had the same problem the other way round: it led with the tenant index over `document` and ran the full text match once per row.
That measured 1.09s where the same statement with the order fixed measures 0.139s cold and 1ms warm.
The candidate cut had been getting away with it only because its `ORDER BY bm25(document_fts)` pinned the order by accident, which is not a thing to rely on, so the join is stated once and both statements share it.

**The page size pragma is gone.**
It looked like a win in a first measurement and turned out to do nothing at all, because the pragma only takes effect before the first page is written and the driver applies pragmas after the file exists.
A database opened with it reports the default four kilobytes.
A setting that does not take effect is worse than one that is absent, because the next person reads it and believes it.

## The measurement

**`benchcorpus`** generates the corpus everything here is measured against, from distributions rather than from a loop.
Zipf term frequencies, log normal body lengths, uneven sources and group sizes, a hundred and eighty groups nested to depth four, and a benchmark principal who can read about sixty percent of it.
Everything derives from a seed, so the database is the same on any machine and a number recorded last month is comparable with one measured today.
The thousand query set is checked in because it is small, the database is not because it is a few hundred megabytes and it is reproducible.

**The counters are the part of the gate that is exact.**
Rows read, statements issued, documents decoded and candidates ranked are deterministic.
They do not vary with the runner, they cannot flake, and they catch the regression this whole milestone exists to fix.
`index/counters_test.go` asserts them per query class with every allowed row attributed to the statement that reads it, rather than against a round number with slack in it.
If somebody reintroduces a per hit `Get` in a year the decode count goes from 20 to 20 plus the match set and the test names the problem precisely.

**The benchmarks** run at three levels of the same corpus, so the difference between two numbers is the cost of the layer between them: the driver, the searcher and the HTTP handler including response encoding.

New targets: `make bench-corpus`, `make bench-search`, `make bench-counters`.
The last one runs in its own CI job with the corpus cached on the hash of the generator.

## Numbers

Twenty thousand documents, Apple M4, `modernc.org/sqlite`.
Full table in `benchcorpus/BASELINE.md`.

| | before | after |
| --- | --- | --- |
| search, common term | 104ms | 50ms |
| fetch a page by id | 8.3ms | 910µs |
| search, rare term | | 3.8ms |
| corpus statistics | | 31µs |

A rare term costs the same at five thousand documents and at twenty thousand, which is the shape the change was after: the cost of a query is now proportional to the number of documents the asker may read that match it, and to nothing else.

## What this does not reach yet

Three budgets are missed and they are written down rather than left out.

**Search under ten milliseconds.**
Met for a rare term and for a term with a filter, missed for a common term by a factor of five.
Two of the three statements a search runs walk the visible match set, the candidate cut to find the best five hundred and the counts statement to produce the total and the facets.
Closing the gap needs the second walk to go away and needs the repeated queries a real workload is mostly made of to be served from a cache, which is #56.

**Two thousand documents indexed per second.**
Measured at 510.
A document averages three hundred and thirty distinct terms and each one costs a posting insert and a term statistic upsert, so a document is about six hundred and sixty statements.
Batching them is the obvious fix and it is not in this change.

**Index overhead under sixty percent of the corpus.**
Measured at a hundred and forty three percent.
119MB of document JSON carries 131MB of postings, 35MB of full text index and 4MB of everything else.
The posting table stores the term as text on every row, so a term in eight thousand documents is stored eight thousand times, and a term dictionary with integer ids would take most of that back.

There is also one endpoint worth naming: `/api/v1/me` is 87ms and it is the first request the interface makes.
It runs a search with no terms and no filters, so the match set is every document the reader may see, and then keeps only the source and kind facet lists, which are identical on every page load and change only when somebody indexes a document.
That is a cache, and it is the next piece of work.

## Deviations from the spec

- Corpus statistics are per tenant rather than per principal. Counting document frequency over what one asker may read would make a term's weight depend on who is asking, so two people would get different rankings for the same query.
- `posting` is keyed `(doc_rowid, term)` rather than `(term, doc_rowid)`, and the frequencies are INTEGER counts rather than REAL. Nothing asks which documents carry a term: matching is FTS5's job and document frequency comes from `term_stat`. What the query path does ask is which of a few hundred chosen candidates carry the query terms, and this order answers that from the primary key.
- The generator lives at `benchcorpus/gen` rather than at `internal/benchcorpus`, because `arch_test.go` forbids an internal directory anywhere in the module.
- The baseline is `benchcorpus/BASELINE.md` rather than `testdata/bench-baseline.json`. A machine readable baseline is only useful to the gate that compares against it, and that gate has to record its own numbers on the runner it runs on, so the JSON belongs with #58. Written down here is what a person needs to read.

## Verification

- `go test -race ./...` green on the full suite
- `make bench-counters` green
- `gofmt`, `go vet` clean
