### PR TITLE
Cache the answer on both sides of the wire

### DIFF
--- a/acl/fingerprint.go
+++ b/acl/fingerprint.go
@@ -1,0 +1,84 @@
+package acl
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"slices"
+	"strconv"
+)
+
+// A cache key that does not name the asker's visibility is a permission bug.
+//
+// Two people typing the same query get different answers, and a cache that
+// hands one of those answers to the other has leaked a document. It will not
+// look like a leak in any log or any test. It will look like a search result.
+//
+// So nothing derived from a permission filtered query is cached under the query
+// alone. [Fingerprint] is the other half of every such key.
+
+// FingerprintBytes is how much of the hash a fingerprint keeps.
+//
+// Sixteen bytes, because a collision here is two different views sharing a
+// cache entry, which is the leak this file exists to prevent. At a hundred and
+// twenty eight bits an accidental collision is not something that happens to a
+// deployment, and the eight bytes saved by truncating further buy nothing worth
+// having.
+const FingerprintBytes = 16
+
+// Fingerprint is a short, stable name for everything the visibility rule reads
+// about a principal.
+//
+// Two principals share a fingerprint exactly when the set of documents they may
+// read is the same set, so far as the permission rule can tell. Anything
+// derived from a permission filtered query can be cached under it.
+//
+// It is built from the same key accessors the rule itself uses,
+// [Principal.UserKeys] and [Principal.GroupKeys], rather than from the fields
+// underneath them. A fingerprint computed from different fields than the rule
+// reads is a fingerprint that will eventually disagree with it, and the
+// disagreement is a leak rather than a stale result.
+//
+// The keys are sorted before they are hashed, because two principals whose
+// groups arrived in a different order are the same view and should share an
+// entry. Sorting is done on a copy: [Principal.GroupKeys] returns the
+// principal's own slice, and reordering it under a caller would be a rude
+// surprise.
+//
+// The group expansion version is part of it as well. It is the field the
+// permission model already designates as the safety catch on derived state, and
+// including it means a session holding a stale expansion cannot reach entries
+// built from a fresh one. That costs a cache entry when two sessions were
+// expanded either side of a directory change, which is correct: at that moment
+// they are not the same view.
+//
+// A nil principal fingerprints to the empty string. Nothing is cached under it,
+// because there is no anonymous read path to cache.
+func Fingerprint(p *Principal) string {
+	if p == nil {
+		return ""
+	}
+	h := sha256.New()
+
+	// Every component is written with its length in front of it, so that no
+	// choice of tenant, subject or group name can be rearranged into another
+	// principal's fingerprint. Without the lengths, a tenant of "ac" with a group
+	// "me:x" and a tenant of "acme" with a group ":x" hash the same.
+	write := func(s string) {
+		_, _ = h.Write([]byte(strconv.Itoa(len(s))))
+		_, _ = h.Write([]byte{':'})
+		_, _ = h.Write([]byte(s))
+	}
+
+	write(p.Tenant)
+	write(strconv.FormatUint(p.Groups.Version, 10))
+	for _, keys := range [][]string{p.UserKeys(), p.GroupKeys()} {
+		sorted := slices.Clone(keys)
+		slices.Sort(sorted)
+		sorted = slices.Compact(sorted)
+		write(strconv.Itoa(len(sorted)))
+		for _, k := range sorted {
+			write(k)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)[:FingerprintBytes])
+}

--- a/acl/fingerprint_test.go
+++ b/acl/fingerprint_test.go
@@ -1,0 +1,114 @@
+package acl_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// The fingerprint is the half of a cache key that says who is asking. Every
+// test here is really the same question asked from two sides: two principals
+// that see the same documents must share it, and two that do not must not.
+
+func TestFingerprintIsStable(t *testing.T) {
+	p := &acl.Principal{
+		Tenant:  "acme",
+		Subject: "u_mei",
+		Groups:  acl.GroupSet{Version: 3, Members: []string{"gdrive:eng@acme.com"}},
+	}
+	first := acl.Fingerprint(p)
+	if first == "" {
+		t.Fatal("a principal fingerprinted to nothing")
+	}
+	if got := acl.Fingerprint(p); got != first {
+		t.Fatalf("the same principal fingerprinted twice gave %q then %q", first, got)
+	}
+	if len(first) != 2*acl.FingerprintBytes {
+		t.Errorf("a fingerprint is %d characters, want %d", len(first), 2*acl.FingerprintBytes)
+	}
+}
+
+func TestFingerprintIgnoresGroupOrder(t *testing.T) {
+	one := &acl.Principal{
+		Tenant:  "acme",
+		Subject: "u_mei",
+		Groups:  acl.GroupSet{Version: 1, Members: []string{"gdrive:eng@acme.com", "gdrive:oncall@acme.com"}},
+	}
+	other := &acl.Principal{
+		Tenant:  "acme",
+		Subject: "u_mei",
+		Groups:  acl.GroupSet{Version: 1, Members: []string{"gdrive:oncall@acme.com", "gdrive:eng@acme.com"}},
+	}
+	if acl.Fingerprint(one) != acl.Fingerprint(other) {
+		t.Error("the same groups in a different order produced two fingerprints, so the cache would never hit")
+	}
+
+	// And the sort is on a copy, because the accessor hands back the principal's
+	// own slice and reordering it under the caller would be a rude surprise.
+	before := slices.Clone(other.Groups.Members)
+	acl.Fingerprint(other)
+	if !slices.Equal(before, other.Groups.Members) {
+		t.Errorf("fingerprinting reordered the principal's groups: %v became %v", before, other.Groups.Members)
+	}
+}
+
+func TestFingerprintSeparatesDifferentViews(t *testing.T) {
+	base := func() *acl.Principal {
+		return &acl.Principal{
+			Tenant:  "acme",
+			Subject: "u_mei",
+			Groups:  acl.GroupSet{Version: 1, Members: []string{"gdrive:eng@acme.com"}},
+		}
+	}
+	cases := []struct {
+		name   string
+		change func(*acl.Principal)
+	}{
+		{"another tenant", func(p *acl.Principal) { p.Tenant = "other" }},
+		{"another person", func(p *acl.Principal) { p.Subject = "u_sam" }},
+		{"another group", func(p *acl.Principal) { p.Groups.Members = []string{"gdrive:sales@acme.com"} }},
+		{"one group more", func(p *acl.Principal) {
+			p.Groups.Members = append(p.Groups.Members, "gdrive:sales@acme.com")
+		}},
+		{"no groups at all", func(p *acl.Principal) { p.Groups.Members = nil }},
+		{"a newer expansion", func(p *acl.Principal) { p.Groups.Version = 2 }},
+	}
+	original := acl.Fingerprint(base())
+	seen := map[string]string{original: "unchanged"}
+	for _, tc := range cases {
+		p := base()
+		tc.change(p)
+		got := acl.Fingerprint(p)
+		if was, ok := seen[got]; ok {
+			t.Errorf("%s fingerprints the same as %s, so their cache entries would be shared", tc.name, was)
+		}
+		seen[got] = tc.name
+	}
+}
+
+// TestFingerprintCannotBeConfusedByRearranging is why every component is
+// written with its length in front of it. Without that, a tenant of "ac" with a
+// group "me:x" hashes the same as a tenant of "acme" with a group ":x", and two
+// people who share nothing share a cache entry.
+func TestFingerprintCannotBeConfusedByRearranging(t *testing.T) {
+	one := &acl.Principal{
+		Tenant:  "ac",
+		Subject: "u",
+		Groups:  acl.GroupSet{Version: 1, Members: []string{"me:x"}},
+	}
+	other := &acl.Principal{
+		Tenant:  "acme",
+		Subject: "u",
+		Groups:  acl.GroupSet{Version: 1, Members: []string{":x"}},
+	}
+	if acl.Fingerprint(one) == acl.Fingerprint(other) {
+		t.Fatal("two principals of different tenants share a fingerprint")
+	}
+}
+
+func TestFingerprintOfNothingIsNothing(t *testing.T) {
+	if got := acl.Fingerprint(nil); got != "" {
+		t.Errorf("a nil principal fingerprinted to %q, want the empty string so that nothing is cached under it", got)
+	}
+}

--- a/api/api.go
+++ b/api/api.go
@@ -305,11 +305,23 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 	writeConditional(w, r, http.StatusOK, out, out.identity())
 }
 
-// identity is the response without the number that changes on every request.
-// Two searches that found the same documents have the same identity even though
-// one of them took a tenth of a millisecond longer.
+// identity is the response without the numbers that change on every request.
+//
+// Two of them do. How long the search took is the obvious one. The other is the
+// score, which carries a recency prior that decays against the wall clock, so
+// it is a slightly different number every time the same query is run and it
+// would make an entity tag that never matches, which is a revalidation that can
+// never succeed. What the tag has to mean is that the same documents came back
+// in the same order with the same content, and it still means exactly that:
+// scores that moved enough to matter moved the order too.
 func (r searchResponse) identity() any {
 	r.TookMS = 0
+	hits := make([]searchHit, len(r.Hits))
+	copy(hits, r.Hits)
+	for i := range hits {
+		hits[i].Score = 0
+	}
+	r.Hits = hits
 	return r
 }
 
@@ -405,6 +417,18 @@ type meResponse struct {
 	Tenant  string   `json:"tenant"`
 	Roles   []string `json:"roles,omitempty"`
 
+	// View names what this principal can see, and is the same fingerprint the
+	// server keys its own caches by.
+	//
+	// The interface holds results in memory and one tab can hold them for more
+	// than one identity over its life, because the identity switcher exists.
+	// Serving one identity's cached results to another is the same bug in a
+	// browser as it is in a server, so the browser prepends this to every cache
+	// key it makes. It is computed here rather than derived there so that the
+	// two cannot drift apart, and it says nothing about the principal that the
+	// rest of this response does not already say out loud.
+	View string `json:"view"`
+
 	// Sources is what this principal can actually see something from, which is
 	// what the interface builds its source filter out of. It is per principal
 	// rather than a list of configured connectors, because telling somebody a
@@ -417,7 +441,14 @@ type meResponse struct {
 // handleMe is what the interface loads before it can draw anything: who the
 // caller is and which filters are worth showing them.
 func (s *Server) handleMe(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
-	out := meResponse{Subject: p.Subject, Tenant: p.Tenant, Roles: p.Roles, Sources: []facet{}, Kinds: []facet{}}
+	out := meResponse{
+		Subject: p.Subject,
+		Tenant:  p.Tenant,
+		Roles:   p.Roles,
+		View:    acl.Fingerprint(p),
+		Sources: []facet{},
+		Kinds:   []facet{},
+	}
 	res, err := s.searcher.Search(r.Context(), p, index.Query{Limit: 1})
 	if err != nil {
 		s.log.Error("bootstrap failed", "error", err, "tenant", p.Tenant)
@@ -673,17 +704,30 @@ type statsResponse struct {
 	Cache       map[string]cache.Stats `json:"cache,omitempty"`
 }
 
+// handleStats reports the corpus and the cache counters.
+//
+// This is the one read endpoint with no entity tag, because the counters it
+// reports are moved by the act of reading them. A tag over a body that counts
+// its own reads can never match on the next request, so a conditional request
+// here is a full response with an extra header on it, and a tag that excluded
+// the counters would be worse: the client would hold the first hit rate it ever
+// saw and never be told a different one. The response is a couple of hundred
+// bytes and the client holds it for a TTL, so the round trip is cheap and the
+// number is always real.
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request, _ *acl.Principal) {
 	st, err := s.store.Stats(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal", "stats are not available")
 		return
 	}
-	writeConditional(w, r, http.StatusOK, statsResponse{
+	h := w.Header()
+	h.Set("Cache-Control", cacheControl)
+	h.Set(varyHeader, varyValue)
+	writeJSON(w, http.StatusOK, statsResponse{
 		Documents:   st.Documents,
 		Quarantined: st.Quarantined,
 		Cache:       s.searcher.CacheStats(),
-	}, nil)
+	})
 }
 
 func facets(in map[string][]index.Facet) map[string][]facet {

--- a/api/api.go
+++ b/api/api.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/tamnd/genba"
 	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/cache"
 	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/index"
 	"github.com/tamnd/genba/store"
@@ -64,6 +65,10 @@ type Server struct {
 
 	// started is when the process came up, reported by the health endpoint.
 	started time.Time
+	now     func() time.Time
+
+	// heartbeat is how often an idle event stream sends a comment.
+	heartbeat time.Duration
 }
 
 // Option configures a [Server].
@@ -85,9 +90,24 @@ func WithAssets(h http.Handler) Option {
 	return func(s *Server) { s.assets = h }
 }
 
-// WithClock sets the clock used for uptime reporting.
+// WithClock sets the clock used for uptime reporting and for timestamping
+// index events.
 func WithClock(now func() time.Time) Option {
-	return func(s *Server) { s.started = now() }
+	return func(s *Server) {
+		if now != nil {
+			s.now, s.started = now, now()
+		}
+	}
+}
+
+// WithHeartbeat sets how often an idle event stream sends a comment. It exists
+// so that a test does not have to wait [HeartbeatInterval] to see one.
+func WithHeartbeat(d time.Duration) Option {
+	return func(s *Server) {
+		if d > 0 {
+			s.heartbeat = d
+		}
+	}
 }
 
 // New returns a server. It does not listen: [Server.Handler] returns something
@@ -95,11 +115,13 @@ func WithClock(now func() time.Time) Option {
 // embeddable in an existing Go service.
 func New(st store.Store, searcher *index.Searcher, auth Authenticator, opts ...Option) *Server {
 	s := &Server{
-		store:    st,
-		searcher: searcher,
-		auth:     auth,
-		log:      slog.Default(),
-		started:  time.Now(),
+		store:     st,
+		searcher:  searcher,
+		auth:      auth,
+		log:       slog.Default(),
+		started:   time.Now(),
+		now:       time.Now,
+		heartbeat: HeartbeatInterval,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -118,6 +140,7 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("GET /api/v1/documents/{id}", s.authenticated(s.handleDocument))
 	mux.Handle("GET /api/v1/documents/{id}/content", s.authenticated(s.handleContent))
 	mux.Handle("GET /api/v1/stats", s.authenticated(s.handleStats))
+	mux.Handle("GET /api/v1/events", s.authenticated(s.handleEvents))
 	if s.assets != nil {
 		mux.Handle("GET /", s.assets)
 	}
@@ -279,7 +302,15 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 			Score:      h.Score,
 		})
 	}
-	writeJSON(w, http.StatusOK, out)
+	writeConditional(w, r, http.StatusOK, out, out.identity())
+}
+
+// identity is the response without the number that changes on every request.
+// Two searches that found the same documents have the same identity even though
+// one of them took a tenth of a millisecond longer.
+func (r searchResponse) identity() any {
+	r.TookMS = 0
+	return r
 }
 
 // parseQuery builds a query from the URL.
@@ -395,7 +426,7 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request, p *acl.Princip
 	}
 	out.Sources = facetValues(res.Facets["source"])
 	out.Kinds = facetValues(res.Facets["kind"])
-	writeJSON(w, http.StatusOK, out)
+	writeConditional(w, r, http.StatusOK, out, nil)
 }
 
 type suggestResponse struct {
@@ -425,7 +456,7 @@ func (s *Server) handleSuggest(w http.ResponseWriter, r *http.Request, p *acl.Pr
 	raw := strings.TrimSpace(r.URL.Query().Get("q"))
 	out := suggestResponse{Query: raw, Suggestions: []suggestion{}}
 	if raw == "" {
-		writeJSON(w, http.StatusOK, out)
+		writeConditional(w, r, http.StatusOK, out, out.identity())
 		return
 	}
 
@@ -438,7 +469,7 @@ func (s *Server) handleSuggest(w http.ResponseWriter, r *http.Request, p *acl.Pr
 	res, err := s.searcher.Search(r.Context(), p, q)
 	if err != nil {
 		s.log.Warn("suggest failed", "error", err, "tenant", p.Tenant)
-		writeJSON(w, http.StatusOK, out)
+		writeConditional(w, r, http.StatusOK, out, out.identity())
 		return
 	}
 	for _, h := range res.Hits {
@@ -454,7 +485,14 @@ func (s *Server) handleSuggest(w http.ResponseWriter, r *http.Request, p *acl.Pr
 		})
 	}
 	out.TookMS = float64(time.Since(start).Microseconds()) / 1000
-	writeJSON(w, http.StatusOK, out)
+	writeConditional(w, r, http.StatusOK, out, out.identity())
+}
+
+// identity is the suggestions without the timing, for the same reason as
+// [searchResponse.identity].
+func (r suggestResponse) identity() any {
+	r.TookMS = 0
+	return r
 }
 
 // operators is the list the typeahead offers, which is also the documentation
@@ -509,7 +547,7 @@ func (s *Server) handleDocument(w http.ResponseWriter, r *http.Request, p *acl.P
 		writeError(w, http.StatusInternalServerError, "internal", "the document could not be read")
 		return
 	}
-	writeJSON(w, http.StatusOK, documentResponse(d))
+	writeConditional(w, r, http.StatusOK, documentResponse(d), nil)
 }
 
 type documentBody struct {
@@ -622,16 +660,30 @@ func (s *Server) writeContent(w http.ResponseWriter, r *http.Request, d doc.Docu
 	http.ServeContent(w, r, "", d.ModifiedAt, bytes.NewReader(c.Bytes))
 }
 
+// statsResponse is what the corpus holds and what the caches have done with it.
+//
+// The cache numbers are here rather than behind an operator only endpoint
+// because a cache nobody can see the hit rate of is a cache nobody can tell is
+// broken. A layer sitting at a two percent hit rate is doing nothing but
+// spending memory, and the only way anyone finds that out is by being able to
+// look.
+type statsResponse struct {
+	Documents   int                    `json:"documents"`
+	Quarantined int                    `json:"quarantined"`
+	Cache       map[string]cache.Stats `json:"cache,omitempty"`
+}
+
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request, _ *acl.Principal) {
 	st, err := s.store.Stats(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal", "stats are not available")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]int{
-		"documents":   st.Documents,
-		"quarantined": st.Quarantined,
-	})
+	writeConditional(w, r, http.StatusOK, statsResponse{
+		Documents:   st.Documents,
+		Quarantined: st.Quarantined,
+		Cache:       s.searcher.CacheStats(),
+	}, nil)
 }
 
 func facets(in map[string][]index.Facet) map[string][]facet {

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -1,0 +1,429 @@
+package api_test
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/cache"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store"
+	"github.com/tamnd/genba/store/memstore"
+	"github.com/tamnd/genba/store/sqlitestore"
+)
+
+// cachingServer builds the server over the SQLite driver rather than the
+// reference one, because the layers under test are the ones a driver that ranks
+// for itself and reports its own writes turns on, and the reference driver does
+// neither.
+func cachingServer(t *testing.T, opts ...api.Option) (store.Store, http.Handler) {
+	t.Helper()
+	st, err := sqlitestore.Open(t.Context(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Put(t.Context(), cacheCorpus()...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	searcher := index.New(st, index.WithCache(index.NewCache()))
+	t.Cleanup(func() { _ = searcher.Close() })
+	return st, api.New(st, searcher, api.HeaderAuth{Tenant: "acme"}, opts...).Handler()
+}
+
+func cacheCorpus() []doc.Document {
+	perm := func(group string) acl.Permissions {
+		return acl.Permissions{
+			Mode:        acl.ModeACL,
+			Source:      "gdrive",
+			AllowGroups: []acl.Ref{{Source: "gdrive", Value: group}},
+			Version:     1,
+		}
+	}
+	return []doc.Document{
+		{
+			ID: "d1", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Payments failover runbook", Body: "Fail the payments queue over to the replica.",
+			Permissions: perm("eng@acme.com"),
+		},
+		{
+			ID: "d2", Tenant: "acme", Source: "salesforce", Kind: doc.KindTicket,
+			Title: "Renewal for Globex", Body: "The payments discount expires in March.",
+			Permissions: perm("sales@acme.com"),
+		},
+	}
+}
+
+func seller() map[string]string {
+	return map[string]string{
+		api.HeaderSubject: "u_sam",
+		api.HeaderGroups:  "gdrive:sales@acme.com",
+	}
+}
+
+// TestAuthenticatedResponsesCarryTheirCachingRules covers the headers that let
+// a browser hold a copy without a proxy in the middle holding one too.
+func TestAuthenticatedResponsesCarryTheirCachingRules(t *testing.T) {
+	_, h := cachingServer(t)
+	for _, path := range []string{
+		"/api/v1/me",
+		"/api/v1/search?q=payments",
+		"/api/v1/suggest?q=pay",
+		"/api/v1/documents/d1",
+		"/api/v1/stats",
+	} {
+		t.Run(path, func(t *testing.T) {
+			w := request(t, h, http.MethodGet, path, engineer())
+			if w.Code != http.StatusOK {
+				t.Fatalf("got %d, want 200", w.Code)
+			}
+			if got := w.Header().Get("Cache-Control"); got != "private, max-age=0, must-revalidate" {
+				t.Errorf("Cache-Control is %q, want a private response that must be revalidated", got)
+			}
+			if got := w.Header().Get("Vary"); !strings.Contains(got, "Authorization") || !strings.Contains(got, "Cookie") {
+				t.Errorf("Vary is %q, want the credential headers: without them a cache may serve one caller's answer to another", got)
+			}
+			if w.Header().Get("ETag") == "" {
+				t.Error("the response has no ETag, so a client can only revalidate by refetching the whole body")
+			}
+		})
+	}
+}
+
+func TestARepeatedRequestIsAnsweredWithoutABody(t *testing.T) {
+	_, h := cachingServer(t)
+
+	first := request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	tag := first.Header().Get("ETag")
+	if tag == "" {
+		t.Fatal("the first response has no ETag")
+	}
+
+	headers := engineer()
+	headers["If-None-Match"] = tag
+	second := request(t, h, http.MethodGet, "/api/v1/search?q=payments", headers)
+	if second.Code != http.StatusNotModified {
+		t.Fatalf("got %d, want 304: the answer has not changed", second.Code)
+	}
+	if second.Body.Len() != 0 {
+		t.Errorf("a 304 carried %d bytes of body", second.Body.Len())
+	}
+	if got := second.Header().Get("ETag"); got != tag {
+		t.Errorf("the 304 reports ETag %q, want %q", got, tag)
+	}
+
+	// A wildcard is a client saying it has some copy and would like to know
+	// whether anything is current.
+	headers["If-None-Match"] = "*"
+	if w := request(t, h, http.MethodGet, "/api/v1/search?q=payments", headers); w.Code != http.StatusNotModified {
+		t.Errorf("a wildcard conditional request got %d, want 304", w.Code)
+	}
+}
+
+// TestHowLongASearchTookIsNotPartOfTheTag is what makes the whole thing work.
+// The response reports its own latency, and hashing that would produce a tag
+// that never matches, which is a revalidation that can never succeed.
+func TestHowLongASearchTookIsNotPartOfTheTag(t *testing.T) {
+	_, h := cachingServer(t)
+
+	first := request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	second := request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	if first.Header().Get("ETag") != second.Header().Get("ETag") {
+		t.Fatalf("two identical searches produced two tags, %q and %q", first.Header().Get("ETag"), second.Header().Get("ETag"))
+	}
+}
+
+// TestTwoCallersNeverShareATag is the leak assertion at the HTTP layer. The two
+// people ask for the same URL and get different answers, so they must not be
+// able to satisfy each other's conditional requests.
+func TestTwoCallersNeverShareATag(t *testing.T) {
+	_, h := cachingServer(t)
+
+	mine := request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	theirs := request(t, h, http.MethodGet, "/api/v1/search?q=payments", seller())
+	if mine.Header().Get("ETag") == theirs.Header().Get("ETag") {
+		t.Fatal("two callers who see different documents share an ETag")
+	}
+
+	headers := seller()
+	headers["If-None-Match"] = mine.Header().Get("ETag")
+	w := request(t, h, http.MethodGet, "/api/v1/search?q=payments", headers)
+	if w.Code == http.StatusNotModified {
+		t.Fatal("one caller's tag satisfied another caller's conditional request")
+	}
+	if strings.Contains(w.Body.String(), "failover runbook") {
+		t.Fatalf("the seller was served the engineer's document: %s", w.Body.String())
+	}
+}
+
+func TestTheTagChangesWhenTheAnswerDoes(t *testing.T) {
+	st, h := cachingServer(t)
+
+	before := request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer()).Header().Get("ETag")
+	if err := st.Put(t.Context(), doc.Document{
+		ID: "d9", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+		Title: "Payments postmortem", Body: "The payments queue backed up for an hour.",
+		Permissions: acl.Permissions{
+			Mode:        acl.ModeACL,
+			Source:      "gdrive",
+			AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}},
+			Version:     1,
+		},
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	after := request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	if after.Header().Get("ETag") == before {
+		t.Fatal("a new matching document did not change the tag, so a client would never fetch it")
+	}
+	if !strings.Contains(after.Body.String(), "postmortem") {
+		t.Errorf("the new document is missing from the results: %s", after.Body.String())
+	}
+}
+
+func TestStatsReportEachCacheLayer(t *testing.T) {
+	_, h := cachingServer(t)
+	request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+
+	body := decode[struct {
+		Documents int                    `json:"documents"`
+		Cache     map[string]cache.Stats `json:"cache"`
+	}](t, request(t, h, http.MethodGet, "/api/v1/stats", engineer()))
+
+	if body.Documents != 2 {
+		t.Errorf("stats report %d documents, want 2", body.Documents)
+	}
+	for _, layer := range []string{"results", "corpus", "documents"} {
+		got, ok := body.Cache[layer]
+		if !ok {
+			t.Fatalf("stats do not report the %s cache layer", layer)
+		}
+		if got.Hits+got.Misses == 0 {
+			t.Errorf("the %s layer reports no lookups after two searches", layer)
+		}
+	}
+}
+
+// The event stream is checked over a real connection, because the thing under
+// test is what arrives and when, and a recorder that collects the whole
+// response before anybody looks at it cannot show that.
+
+func TestEventStreamReportsIndexChanges(t *testing.T) {
+	st, h := cachingServer(t, api.WithHeartbeat(50*time.Millisecond))
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	lines, cancel := stream(t, srv.URL+"/api/v1/events", engineer())
+	defer cancel()
+
+	if got := next(t, lines); got != ": open" {
+		t.Fatalf("the stream opened with %q, want a comment so the browser fires its open event", got)
+	}
+
+	// The write happens after the stream is open, so the subscription is
+	// registered and the test is not racing the handler.
+	if err := st.Put(t.Context(), doc.Document{
+		ID: "d9", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+		Title: "Payments postmortem", Body: "The payments queue backed up.",
+		Permissions: acl.Permissions{Mode: acl.ModeACL, Source: "gdrive", AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}}, Version: 1},
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	event, data := indexFrame(t, lines)
+	if event != "event: index" {
+		t.Fatalf("the frame names event %q, want index", event)
+	}
+	if !strings.Contains(data, `"tenant":"acme"`) || !strings.Contains(data, `"documents":1`) {
+		t.Errorf("the event says %q, want the tenant and how many documents moved", data)
+	}
+	if strings.Contains(data, "d9") || strings.Contains(data, "postmortem") {
+		t.Errorf("the event carries the document itself: %q", data)
+	}
+}
+
+func TestEventStreamIsScopedToTheCallersTenant(t *testing.T) {
+	st, h := cachingServer(t, api.WithHeartbeat(time.Hour))
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	lines, cancel := stream(t, srv.URL+"/api/v1/events", engineer())
+	defer cancel()
+	next(t, lines)
+
+	// A write in somebody else's tenant, then one in the caller's. If the first
+	// were reported the frame below would carry two documents rather than one,
+	// and the tenant of a company this caller has never heard of.
+	elsewhere := doc.Document{
+		ID: "x1", Tenant: "globex", Source: "gdrive", Kind: doc.KindPage,
+		Title: "Their runbook", Body: "Not for us.",
+		Permissions: acl.Permissions{Mode: acl.ModeACL, Source: "gdrive", AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}}, Version: 1},
+	}
+	mine := doc.Document{
+		ID: "d9", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+		Title: "Our runbook", Body: "For us.",
+		Permissions: acl.Permissions{Mode: acl.ModeACL, Source: "gdrive", AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}}, Version: 1},
+	}
+	if err := st.Put(t.Context(), elsewhere, mine); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	_, data := indexFrame(t, lines)
+	if !strings.Contains(data, `"tenant":"acme"`) {
+		t.Fatalf("the caller was told about another tenant: %q", data)
+	}
+	if !strings.Contains(data, `"documents":1`) {
+		t.Errorf("the event says %q, want the one document of this tenant", data)
+	}
+}
+
+func TestEventStreamKeepsItselfAlive(t *testing.T) {
+	_, h := cachingServer(t, api.WithHeartbeat(20*time.Millisecond))
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	lines, cancel := stream(t, srv.URL+"/api/v1/events", engineer())
+	defer cancel()
+	next(t, lines)
+
+	if got := next(t, lines); got != ": beat" {
+		t.Fatalf("an idle stream sent %q, want a heartbeat comment: the proxies in front of a deployment close a silent connection", got)
+	}
+}
+
+func TestEventStreamNeedsACredential(t *testing.T) {
+	_, h := cachingServer(t)
+	if w := request(t, h, http.MethodGet, "/api/v1/events", nil); w.Code != http.StatusUnauthorized {
+		t.Fatalf("an unauthenticated stream request got %d, want 401", w.Code)
+	}
+}
+
+// TestEventStreamIsAbsentWithoutADriverThatReportsWrites covers the deployment
+// on a driver that cannot say when it changed. It is not a broken deployment,
+// so it is a not found rather than an error, and the interface falls back to
+// its timer.
+func TestEventStreamIsAbsentWithoutADriverThatReportsWrites(t *testing.T) {
+	st := deafStore{memstore.New()}
+	t.Cleanup(func() { _ = st.Close() })
+	if _, ok := any(st).(store.Notifier); ok {
+		t.Fatal("deafStore reports its writes, so this test covers nothing")
+	}
+	searcher := index.New(st, index.WithCache(index.NewCache()))
+	t.Cleanup(func() { _ = searcher.Close() })
+	h := api.New(st, searcher, api.HeaderAuth{Tenant: "acme"}).Handler()
+
+	if w := request(t, h, http.MethodGet, "/api/v1/events", engineer()); w.Code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404", w.Code)
+	}
+}
+
+// deafStore is a driver that does not report its writes.
+type deafStore struct{ inner *memstore.Store }
+
+func (d deafStore) Put(ctx context.Context, docs ...doc.Document) error {
+	return d.inner.Put(ctx, docs...)
+}
+func (d deafStore) Delete(ctx context.Context, ids ...string) error {
+	return d.inner.Delete(ctx, ids...)
+}
+func (d deafStore) Get(ctx context.Context, p *acl.Principal, id string) (doc.Document, error) {
+	return d.inner.Get(ctx, p, id)
+}
+func (d deafStore) Scan(ctx context.Context, p *acl.Principal, fn func(doc.Document) bool) error {
+	return d.inner.Scan(ctx, p, fn)
+}
+func (d deafStore) Stats(ctx context.Context) (store.Stats, error) { return d.inner.Stats(ctx) }
+func (d deafStore) Close() error                                   { return d.inner.Close() }
+
+// stream opens an event stream and reads it line by line on a goroutine, so
+// that a test can wait for a line with a deadline instead of blocking forever
+// on a stream that is working correctly by staying quiet.
+func stream(t *testing.T, url string, headers map[string]string) (<-chan string, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("building the request: %v", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		cancel()
+		t.Fatalf("opening the stream: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		cancel()
+		t.Fatalf("the stream returned %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		cancel()
+		t.Fatalf("the stream is %q, want text/event-stream", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Errorf("the stream says Cache-Control %q, want no-store", got)
+	}
+
+	lines := make(chan string, 32)
+	go func() {
+		defer close(lines)
+		defer func() { _ = resp.Body.Close() }()
+		br := bufio.NewReader(resp.Body)
+		for {
+			line, err := br.ReadString('\n')
+			if line = strings.TrimRight(line, "\r\n"); line != "" {
+				select {
+				case lines <- line:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return lines, cancel
+}
+
+// next returns the next non blank line, or fails the test.
+func next(t *testing.T, lines <-chan string) string {
+	t.Helper()
+	select {
+	case line, ok := <-lines:
+		if !ok {
+			t.Fatal("the stream closed while the test was waiting for a line")
+		}
+		return line
+	case <-time.After(5 * time.Second):
+		t.Fatal("nothing arrived on the stream")
+		return ""
+	}
+}
+
+// indexFrame reads until it finds an index event and returns its two lines,
+// skipping the heartbeats that may be interleaved with it.
+func indexFrame(t *testing.T, lines <-chan string) (event, data string) {
+	t.Helper()
+	for range 20 {
+		line := next(t, lines)
+		if !strings.HasPrefix(line, "event:") {
+			continue
+		}
+		return line, next(t, lines)
+	}
+	t.Fatal("no index event arrived")
+	return "", ""
+}

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -47,16 +47,20 @@ func cacheCorpus() []doc.Document {
 			Version:     1,
 		}
 	}
+	// Both carry a modification time, because the recency prior is part of the
+	// score and a corpus of documents with no date has a prior of exactly one
+	// for every document, which is the one case where the score cannot drift.
+	written := time.Date(2026, 1, 14, 11, 0, 0, 0, time.UTC)
 	return []doc.Document{
 		{
 			ID: "d1", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
 			Title: "Payments failover runbook", Body: "Fail the payments queue over to the replica.",
-			Permissions: perm("eng@acme.com"),
+			ModifiedAt: written, Permissions: perm("eng@acme.com"),
 		},
 		{
 			ID: "d2", Tenant: "acme", Source: "salesforce", Kind: doc.KindTicket,
 			Title: "Renewal for Globex", Body: "The payments discount expires in March.",
-			Permissions: perm("sales@acme.com"),
+			ModifiedAt: written.AddDate(0, -3, 0), Permissions: perm("sales@acme.com"),
 		},
 	}
 }
@@ -72,12 +76,14 @@ func seller() map[string]string {
 // a browser hold a copy without a proxy in the middle holding one too.
 func TestAuthenticatedResponsesCarryTheirCachingRules(t *testing.T) {
 	_, h := cachingServer(t)
-	for _, path := range []string{
-		"/api/v1/me",
-		"/api/v1/search?q=payments",
-		"/api/v1/suggest?q=pay",
-		"/api/v1/documents/d1",
-		"/api/v1/stats",
+	// Stats is the one endpoint with no tag, for the reason given on its
+	// handler, so it is listed here for its headers and excused the tag.
+	for path, tagged := range map[string]bool{
+		"/api/v1/me":                true,
+		"/api/v1/search?q=payments": true,
+		"/api/v1/suggest?q=pay":     true,
+		"/api/v1/documents/d1":      true,
+		"/api/v1/stats":             false,
 	} {
 		t.Run(path, func(t *testing.T) {
 			w := request(t, h, http.MethodGet, path, engineer())
@@ -90,10 +96,34 @@ func TestAuthenticatedResponsesCarryTheirCachingRules(t *testing.T) {
 			if got := w.Header().Get("Vary"); !strings.Contains(got, "Authorization") || !strings.Contains(got, "Cookie") {
 				t.Errorf("Vary is %q, want the credential headers: without them a cache may serve one caller's answer to another", got)
 			}
-			if w.Header().Get("ETag") == "" {
+			if tagged && w.Header().Get("ETag") == "" {
 				t.Error("the response has no ETag, so a client can only revalidate by refetching the whole body")
 			}
 		})
+	}
+}
+
+// TestStatsCarryNoTagBecauseReadingThemMovesThem is the exception to the rule
+// above, written down so that adding the tag back looks like the regression it
+// would be. The body reports cache hits and misses, and serving it is itself a
+// read of those caches, so the tag computed for one response describes a state
+// the next response is no longer in. The client holds stats for a TTL instead,
+// which bounds the request rate without ever showing a number that is not real.
+func TestStatsCarryNoTagBecauseReadingThemMovesThem(t *testing.T) {
+	_, h := cachingServer(t)
+
+	// Warm the layers so the counters have somewhere to move to.
+	request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+
+	first := request(t, h, http.MethodGet, "/api/v1/stats", engineer())
+	if got := first.Header().Get("ETag"); got != "" {
+		t.Fatalf("stats carry ETag %q, which no later request can match", got)
+	}
+
+	request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	second := request(t, h, http.MethodGet, "/api/v1/stats", engineer())
+	if second.Body.String() == first.Body.String() {
+		t.Fatal("two stats responses either side of a search are identical, so the counters are not being reported")
 	}
 }
 
@@ -137,6 +167,73 @@ func TestHowLongASearchTookIsNotPartOfTheTag(t *testing.T) {
 	second := request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
 	if first.Header().Get("ETag") != second.Header().Get("ETag") {
 		t.Fatalf("two identical searches produced two tags, %q and %q", first.Header().Get("ETag"), second.Header().Get("ETag"))
+	}
+}
+
+// TestARankThatDriftsDoesNotMoveTheTag is the same problem as the one above
+// and much easier to miss. The score carries a recency prior that decays
+// against the wall clock, so a query run twice a second apart produces two
+// numbers that differ somewhere past the tenth decimal place and a tag that
+// never matches. The clock here jumps an hour between readings to make it
+// obvious, but on a real deployment a microsecond is enough.
+func TestARankThatDriftsDoesNotMoveTheTag(t *testing.T) {
+	st, err := sqlitestore.Open(t.Context(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Put(t.Context(), cacheCorpus()...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	at := time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+	clock := func() time.Time {
+		at = at.Add(time.Hour)
+		return at
+	}
+	searcher := index.New(st, index.WithCache(index.NewCache()), index.WithClock(clock))
+	t.Cleanup(func() { _ = searcher.Close() })
+	h := api.New(st, searcher, api.HeaderAuth{Tenant: "acme"}).Handler()
+
+	first := request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	second := request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	if first.Header().Get("ETag") != second.Header().Get("ETag") {
+		t.Fatalf("the same documents in the same order produced two tags, %q and %q", first.Header().Get("ETag"), second.Header().Get("ETag"))
+	}
+
+	headers := engineer()
+	headers["If-None-Match"] = first.Header().Get("ETag")
+	if w := request(t, h, http.MethodGet, "/api/v1/search?q=payments", headers); w.Code != http.StatusNotModified {
+		t.Fatalf("a revalidation of an unchanged search returned %d, want 304", w.Code)
+	}
+}
+
+// TestTheViewNamesWhoIsAsking is the same leak assertion one layer out. The
+// browser holds answers in memory and one tab holds them for more than one
+// identity over its life, so every key it makes starts with this value. Two
+// people who see different documents must not be able to produce the same key.
+func TestTheViewNamesWhoIsAsking(t *testing.T) {
+	_, h := cachingServer(t)
+
+	view := func(headers map[string]string) string {
+		t.Helper()
+		return decode[struct {
+			View string `json:"view"`
+		}](t, request(t, h, http.MethodGet, "/api/v1/me", headers)).View
+	}
+
+	mine := view(engineer())
+	if mine == "" {
+		t.Fatal("the me endpoint named no view, so the interface has nothing to key its cache by")
+	}
+	if again := view(engineer()); again != mine {
+		t.Errorf("the same caller was given two views, %q then %q, so nothing would ever be reused", mine, again)
+	}
+	if theirs := view(seller()); theirs == mine {
+		t.Error("two callers who see different documents were given the same view")
+	}
+	if wider := view(engineerWithBothGroups()); wider == mine {
+		t.Error("adding a group did not change the view, so entries from before the change stay reachable")
 	}
 }
 

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -448,7 +448,7 @@ func stream(t *testing.T, url string, headers map[string]string) (<-chan string,
 	t.Helper()
 	ctx, cancel := context.WithCancel(t.Context())
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		cancel()
 		t.Fatalf("building the request: %v", err)
@@ -461,13 +461,19 @@ func stream(t *testing.T, url string, headers map[string]string) (<-chan string,
 		cancel()
 		t.Fatalf("opening the stream: %v", err)
 	}
-	if resp.StatusCode != http.StatusOK {
+	// Every path out of here that is not the goroutine below has to close the
+	// body itself, because the goroutine that would have closed it is never
+	// started.
+	fail := func(format string, args ...any) {
 		cancel()
-		t.Fatalf("the stream returned %d, want 200", resp.StatusCode)
+		_ = resp.Body.Close()
+		t.Fatalf(format, args...)
+	}
+	if resp.StatusCode != http.StatusOK {
+		fail("the stream returned %d, want 200", resp.StatusCode)
 	}
 	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
-		cancel()
-		t.Fatalf("the stream is %q, want text/event-stream", got)
+		fail("the stream is %q, want text/event-stream", got)
 	}
 	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
 		t.Errorf("the stream says Cache-Control %q, want no-store", got)

--- a/api/conditional.go
+++ b/api/conditional.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// Every authenticated response is revalidated rather than reused.
+//
+// The interface keeps its own copy of what it has already seen, so the thing
+// worth optimising is not the first request, it is the ninth time somebody
+// comes back to a tab that is still showing the right answer. That is what the
+// entity tag is for: the client asks whether what it has is current, and a
+// server that has not changed its mind replies in a few hundred bytes with no
+// body at all.
+//
+// The caching directives are deliberately conservative. Nothing here may be
+// stored by a shared cache, because every one of these responses depends on who
+// asked, and a proxy that kept one would hand one person's search results to
+// the next. must-revalidate says the browser may keep a copy but may not use it
+// without asking, which is exactly the contract the client cache in the
+// interface is written against.
+const (
+	// cacheControl is sent on every authenticated response.
+	cacheControl = "private, max-age=0, must-revalidate"
+
+	// varyHeader and varyValue say what the response depends on besides the URL.
+	// Without it, a cache anywhere between here and the browser is entitled to
+	// treat two people's requests for the same path as the same request.
+	varyHeader = "Vary"
+	varyValue  = "Authorization, Cookie"
+)
+
+// writeConditional encodes v, tags it, and answers 304 when the caller already
+// has it.
+//
+// identity is what the tag is computed over, and it is separate from the body
+// because some responses carry a field that changes on every request without
+// the answer having changed. A search reports how long it took, and hashing
+// that would produce a tag that never matches, which is a revalidation that can
+// never succeed and therefore a cache that never works. A caller passes the
+// same value with those fields left out, and nil means the body itself.
+func writeConditional(w http.ResponseWriter, r *http.Request, status int, v, identity any) {
+	if identity == nil {
+		identity = v
+	}
+	body, err := json.Marshal(v)
+	if err != nil {
+		// None of these bodies can fail to encode, and a caller who has found the
+		// one that can is better served by an error than by half a response.
+		writeError(w, http.StatusInternalServerError, "internal", "the response could not be encoded")
+		return
+	}
+
+	tag := etag(identity)
+	h := w.Header()
+	h.Set("Content-Type", "application/json; charset=utf-8")
+	h.Set("X-Content-Type-Options", "nosniff")
+	h.Set("Cache-Control", cacheControl)
+	h.Set(varyHeader, varyValue)
+	h.Set("ETag", tag)
+
+	if status == http.StatusOK && matches(r.Header.Get("If-None-Match"), tag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+// etag is a strong tag over the canonical encoding of v.
+//
+// It is strong rather than weak because it is computed from the bytes that
+// would have been sent, so two responses with the same tag really are byte for
+// byte the same response, which is what lets the interface skip a repaint on a
+// revalidation and keep the scroll position and the keyboard cursor where they
+// were.
+func etag(v any) string {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(body)
+	return `"` + hex.EncodeToString(sum[:16]) + `"`
+}
+
+// matches reports whether an If-None-Match header names tag.
+//
+// The header is a comma separated list and a client is allowed to send the
+// wildcard, which means it has some copy and would like to be told if anything
+// at all is current. A weak comparison is used, since a weak tag from a proxy
+// that rewrote the body is still the same resource as far as this decision
+// goes.
+func matches(header, tag string) bool {
+	if header == "" || tag == "" {
+		return false
+	}
+	if strings.TrimSpace(header) == "*" {
+		return true
+	}
+	for candidate := range strings.SplitSeq(header, ",") {
+		if weak(strings.TrimSpace(candidate)) == weak(tag) {
+			return true
+		}
+	}
+	return false
+}
+
+func weak(tag string) string { return strings.TrimPrefix(tag, "W/") }

--- a/api/events.go
+++ b/api/events.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+// The event stream exists so that an open tab does not have to poll to find out
+// that the corpus moved.
+//
+// It carries no document content, no ids and no titles. It says that something
+// in the caller's own tenant changed, how many documents were involved and
+// whether they were removed, and the browser decides what to refetch through
+// the endpoints that already apply the permission rule. That is the whole
+// design: a push channel that leaks nothing is one that never carries anything
+// worth leaking, and every refetch it triggers goes through the same checks a
+// first load does.
+
+// HeartbeatInterval is how often the stream sends a comment when nothing has
+// happened.
+//
+// Twenty five seconds, because the proxies in front of a deployment tend to
+// close an idle connection at thirty and a stream that gets dropped every
+// thirty seconds is a reconnect storm rather than a live interface.
+const HeartbeatInterval = 25 * time.Second
+
+// eventBuffer is how many changes are held for a slow client before they start
+// being dropped.
+//
+// Dropping is the correct behaviour here rather than a compromise. Every event
+// carries the same instruction, which is to refetch, so a client that missed
+// four of them and received the fifth does exactly what a client that received
+// all five does. What must not happen is the store's write path blocking on a
+// browser on a train.
+const eventBuffer = 16
+
+// handleEvents streams index changes for the caller's tenant.
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	n, ok := s.store.(store.Notifier)
+	if !ok {
+		// A driver that cannot report its writes has no stream to offer. It is not
+		// an error in the deployment, so it is the same not found any absent
+		// resource produces, and the interface falls back to its refresh timer.
+		writeError(w, http.StatusNotFound, "not_found", "this deployment does not report index changes")
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "internal", "this server cannot stream")
+		return
+	}
+
+	changes := make(chan store.Change, eventBuffer)
+	stop := n.OnChange(func(c store.Change) {
+		if c.Tenant != p.Tenant {
+			return
+		}
+		select {
+		case changes <- c:
+		default:
+		}
+	})
+	defer stop()
+
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-store")
+	h.Set("X-Content-Type-Options", "nosniff")
+	// Proxies that buffer a response turn a live stream into a very slow one, and
+	// this is the header the common ones read.
+	h.Set("X-Accel-Buffering", "no")
+	h.Set(varyHeader, varyValue)
+	w.WriteHeader(http.StatusOK)
+
+	// A comment before anything has happened, so the browser sees the response
+	// start and fires its open event rather than sitting on a connection it
+	// cannot tell is working.
+	if _, err := w.Write([]byte(": open\n\n")); err != nil {
+		return
+	}
+	flusher.Flush()
+
+	beat := time.NewTicker(s.heartbeat)
+	defer beat.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case c := <-changes:
+			if _, err := w.Write(indexEvent(p.Tenant, len(c.IDs), c.Deleted, s.now())); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-beat.C:
+			if _, err := w.Write([]byte(": beat\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// indexEvent is the wire form of one change.
+//
+// It is written by hand rather than encoded, because the shape is four fields
+// that cannot fail to encode and because an event stream frame is a text format
+// with rules of its own about newlines. None of the values can contain one: the
+// tenant comes from the authenticated principal and is quoted, the count is an
+// integer, the timestamp is RFC 3339 and the last is a boolean.
+func indexEvent(tenant string, documents int, deleted bool, at time.Time) []byte {
+	return []byte(`event: index
+data: {"tenant":` + strconv.Quote(tenant) + `,"at":"` + at.UTC().Format(time.RFC3339) +
+		`","documents":` + strconv.Itoa(documents) +
+		`,"deleted":` + strconv.FormatBool(deleted) + "}\n\n")
+}

--- a/arch_test.go
+++ b/arch_test.go
@@ -23,17 +23,24 @@ const module = "github.com/tamnd/genba"
 // already been filtered. An edge that skips a layer is how a component ends up
 // holding a document it was never supposed to see.
 var allowed = map[string][]string{
-	"":                  nil,
-	"acl":               nil,
-	"doc":               {"acl"},
+	"":    nil,
+	"acl": nil,
+	"doc": {"acl"},
+
+	// cache is a map with a lock on it and imports nothing of ours, which is
+	// what lets index depend on it without the dependency meaning anything. A
+	// cache that knew about principals would be a second copy of the permission
+	// model in the package least equipped to hold one.
+	"cache": nil,
+
 	"store":             {"acl", "doc"},
 	"store/memstore":    {"", "acl", "doc", "store"},
 	"store/sqlitestore": {"", "acl", "doc", "store"},
 	"store/storetest":   {"", "acl", "doc", "store"},
-	"index":             {"acl", "doc", "store"},
+	"index":             {"acl", "cache", "doc", "store"},
 	"config":            nil,
 	"web":               nil,
-	"api":               {"", "acl", "doc", "index", "store"},
+	"api":               {"", "acl", "cache", "doc", "index", "store"},
 
 	// Ingestion sits beside the query path rather than under it. A connector
 	// describes documents and who may read them, the pipeline writes them, and

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,332 @@
+// Package cache is a sharded least recently used cache with an expiry and
+// single flight on a miss.
+//
+// It knows nothing about documents, principals or queries. That is deliberate:
+// the rule that a cache key has to name the asker's visibility is a rule about
+// what callers put in the key, and a cache that tried to enforce it would need
+// to understand the permission model, which would put a second copy of the
+// permission model in a package whose job is a map with a lock on it.
+//
+// # Why it is sharded
+//
+// The latency budget is stated at sixteen concurrent readers, and a cache
+// behind one mutex at sixteen concurrent readers is a queue rather than a
+// cache. Sixteen shards keyed on the hash of the key turn that into sixteen
+// independent queues of one, which is close enough to none.
+//
+// It is sixteen rather than a number derived from GOMAXPROCS because the
+// contention that matters is the contention the budget was measured at, and a
+// cache whose shape changes with the machine is a cache whose measurements do
+// not transfer between machines.
+//
+// # Why single flight is part of it and not a layer on top
+//
+// A popular key going cold is the case this exists for. Without single flight
+// the miss arrives at every reader at once and the backend gets sixteen
+// identical queries, which is the moment a cache is least able to help and
+// most likely to be blamed. Joining the call that is already running is a few
+// lines here and cannot be forgotten at a call site.
+package cache
+
+import (
+	"container/list"
+	"hash/fnv"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Shards is how many independent maps a cache is split across. See the package
+// comment for why it is a constant.
+const Shards = 16
+
+// The two expiry values that are not a duration.
+const (
+	// Off makes the cache hold nothing. Get always misses, Put does nothing and
+	// Do calls straight through.
+	//
+	// It exists because a deployment with a strict staleness requirement has to
+	// be able to turn result caching off, and the honest way to offer that is a
+	// value of the same setting rather than a second code path. The latency
+	// budget is met by the data model, so turning a cache off costs latency and
+	// never costs correctness.
+	Off time.Duration = 0
+
+	// Forever keeps entries until they are invalidated or evicted. It is for the
+	// layers whose staleness is bounded by an explicit drop on write rather than
+	// by a clock.
+	Forever time.Duration = -1
+)
+
+// Cache maps string keys to values of one type.
+//
+// The zero value is not usable. Use [New]. A cache is safe for concurrent use
+// and is meant to be shared.
+type Cache[V any] struct {
+	shards [Shards]shard[V]
+	ttl    time.Duration
+	now    func() time.Time
+
+	hits      atomic.Int64
+	misses    atomic.Int64
+	evictions atomic.Int64
+}
+
+// Option configures a [Cache].
+type Option[V any] func(*Cache[V])
+
+// WithClock replaces the clock. It is what lets a test walk an entry past its
+// expiry without sleeping through it.
+func WithClock[V any](now func() time.Time) Option[V] {
+	return func(c *Cache[V]) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+// New returns a cache holding at most capacity entries in total, each expiring
+// after ttl.
+//
+// The capacity is divided evenly across the shards, so a long run of keys that
+// hash to one shard is evicted rather than being allowed to fill the whole
+// cache. That is the price of sharding and it is the right side of the trade:
+// the alternative is a global list, which is a global lock, which is the thing
+// sharding is for.
+func New[V any](capacity int, ttl time.Duration, opts ...Option[V]) *Cache[V] {
+	c := &Cache[V]{ttl: ttl, now: time.Now}
+	for _, opt := range opts {
+		opt(c)
+	}
+	per := max(1, (capacity+Shards-1)/Shards)
+	for i := range c.shards {
+		c.shards[i].init(per)
+	}
+	return c
+}
+
+// Get returns the value stored under key.
+func (c *Cache[V]) Get(key string) (V, bool) {
+	var zero V
+	if c.ttl == Off {
+		return zero, false
+	}
+	s := c.shard(key)
+	s.mu.Lock()
+	v, ok := s.get(key, c.now())
+	s.mu.Unlock()
+	if ok {
+		c.hits.Add(1)
+	} else {
+		c.misses.Add(1)
+	}
+	return v, ok
+}
+
+// Put stores a value.
+func (c *Cache[V]) Put(key string, v V) {
+	if c.ttl == Off {
+		return
+	}
+	s := c.shard(key)
+	s.mu.Lock()
+	if s.put(key, v, c.expiry()) {
+		c.evictions.Add(1)
+	}
+	s.mu.Unlock()
+}
+
+// Do returns the value stored under key, calling fn to produce it on a miss.
+//
+// Concurrent calls for the same key run fn once and all return what it
+// produced. An error is returned to every caller waiting on that call and is
+// not stored, because a cache that remembers failures turns a moment of backend
+// trouble into a minute of it.
+func (c *Cache[V]) Do(key string, fn func() (V, error)) (V, error) {
+	if c.ttl == Off {
+		return fn()
+	}
+	s := c.shard(key)
+
+	s.mu.Lock()
+	if v, ok := s.get(key, c.now()); ok {
+		s.mu.Unlock()
+		c.hits.Add(1)
+		return v, nil
+	}
+	// The lookup and the decision to become the caller that runs fn happen under
+	// the same lock. Checking the map first and taking the lock afterwards would
+	// let sixteen readers all miss before any of them registered, which is the
+	// herd this is here to prevent.
+	if waiting, ok := s.inflight[key]; ok {
+		s.mu.Unlock()
+		c.misses.Add(1)
+		waiting.wg.Wait()
+		return waiting.val, waiting.err
+	}
+	running := &call[V]{}
+	running.wg.Add(1)
+	s.inflight[key] = running
+	s.mu.Unlock()
+	c.misses.Add(1)
+
+	running.val, running.err = fn()
+
+	s.mu.Lock()
+	delete(s.inflight, key)
+	if running.err == nil && s.put(key, running.val, c.expiry()) {
+		c.evictions.Add(1)
+	}
+	s.mu.Unlock()
+	running.wg.Done()
+	return running.val, running.err
+}
+
+// Delete removes keys. Deleting a key that is not there is not an error.
+func (c *Cache[V]) Delete(keys ...string) {
+	for _, key := range keys {
+		s := c.shard(key)
+		s.mu.Lock()
+		s.remove(key)
+		s.mu.Unlock()
+	}
+}
+
+// Clear empties the cache. It leaves the counters alone, because they describe
+// the traffic rather than the contents and a sweep is not a miss.
+func (c *Cache[V]) Clear() {
+	for i := range c.shards {
+		s := &c.shards[i]
+		s.mu.Lock()
+		s.init(s.cap)
+		s.mu.Unlock()
+	}
+}
+
+// Stats is what one cache layer has done. It is reported on the stats endpoint,
+// because a cache nobody can see the hit rate of is a cache nobody can tell is
+// broken.
+type Stats struct {
+	Hits      int64 `json:"hits"`
+	Misses    int64 `json:"misses"`
+	Evictions int64 `json:"evictions"`
+	Entries   int   `json:"entries"`
+}
+
+// Ratio is the fraction of lookups that hit, and zero when there were none.
+func (s Stats) Ratio() float64 {
+	total := s.Hits + s.Misses
+	if total == 0 {
+		return 0
+	}
+	return float64(s.Hits) / float64(total)
+}
+
+// Stats reports the counters and the current size.
+func (c *Cache[V]) Stats() Stats {
+	s := Stats{
+		Hits:      c.hits.Load(),
+		Misses:    c.misses.Load(),
+		Evictions: c.evictions.Load(),
+	}
+	for i := range c.shards {
+		sh := &c.shards[i]
+		sh.mu.Lock()
+		s.Entries += sh.ll.Len()
+		sh.mu.Unlock()
+	}
+	return s
+}
+
+func (c *Cache[V]) expiry() time.Time {
+	if c.ttl == Forever {
+		return time.Time{}
+	}
+	return c.now().Add(c.ttl)
+}
+
+func (c *Cache[V]) shard(key string) *shard[V] {
+	h := fnv.New32a()
+	// Writing to a hash never fails, and the errcheck linter would rather be
+	// told that here than at every call site.
+	_, _ = h.Write([]byte(key))
+	return &c.shards[h.Sum32()%Shards]
+}
+
+// call is one in flight production of a value, and everyone waiting on it.
+type call[V any] struct {
+	wg  sync.WaitGroup
+	val V
+	err error
+}
+
+// shard is one independent map, list and lock.
+type shard[V any] struct {
+	mu       sync.Mutex
+	cap      int
+	items    map[string]*list.Element
+	ll       *list.List
+	inflight map[string]*call[V]
+}
+
+// entry is what the list holds. The key is in it so that evicting the back of
+// the list can find the map entry to delete.
+type entry[V any] struct {
+	key     string
+	val     V
+	expires time.Time
+}
+
+func (s *shard[V]) init(capacity int) {
+	s.cap = capacity
+	s.items = make(map[string]*list.Element, capacity)
+	s.ll = list.New()
+	if s.inflight == nil {
+		s.inflight = make(map[string]*call[V])
+	}
+}
+
+// get returns a live value and moves it to the front. An expired entry is
+// dropped on the way past rather than left for a sweeper, which is why there is
+// no sweeper.
+func (s *shard[V]) get(key string, now time.Time) (V, bool) {
+	var zero V
+	el, ok := s.items[key]
+	if !ok {
+		return zero, false
+	}
+	e := el.Value.(*entry[V])
+	if !e.expires.IsZero() && !now.Before(e.expires) {
+		s.ll.Remove(el)
+		delete(s.items, key)
+		return zero, false
+	}
+	s.ll.MoveToFront(el)
+	return e.val, true
+}
+
+// put stores a value and reports whether storing it evicted another.
+func (s *shard[V]) put(key string, v V, expires time.Time) bool {
+	if el, ok := s.items[key]; ok {
+		e := el.Value.(*entry[V])
+		e.val, e.expires = v, expires
+		s.ll.MoveToFront(el)
+		return false
+	}
+	s.items[key] = s.ll.PushFront(&entry[V]{key: key, val: v, expires: expires})
+	if s.ll.Len() <= s.cap {
+		return false
+	}
+	if back := s.ll.Back(); back != nil {
+		s.ll.Remove(back)
+		delete(s.items, back.Value.(*entry[V]).key)
+	}
+	return true
+}
+
+func (s *shard[V]) remove(key string) {
+	if el, ok := s.items[key]; ok {
+		s.ll.Remove(el)
+		delete(s.items, key)
+	}
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -295,7 +295,10 @@ func (s *shard[V]) get(key string, now time.Time) (V, bool) {
 	if !ok {
 		return zero, false
 	}
-	e := el.Value.(*entry[V])
+	e, ok := entryIn[V](el)
+	if !ok {
+		return zero, false
+	}
 	if !e.expires.IsZero() && !now.Before(e.expires) {
 		s.ll.Remove(el)
 		delete(s.items, key)
@@ -308,10 +311,11 @@ func (s *shard[V]) get(key string, now time.Time) (V, bool) {
 // put stores a value and reports whether storing it evicted another.
 func (s *shard[V]) put(key string, v V, expires time.Time) bool {
 	if el, ok := s.items[key]; ok {
-		e := el.Value.(*entry[V])
-		e.val, e.expires = v, expires
-		s.ll.MoveToFront(el)
-		return false
+		if e, ok := entryIn[V](el); ok {
+			e.val, e.expires = v, expires
+			s.ll.MoveToFront(el)
+			return false
+		}
 	}
 	s.items[key] = s.ll.PushFront(&entry[V]{key: key, val: v, expires: expires})
 	if s.ll.Len() <= s.cap {
@@ -319,9 +323,23 @@ func (s *shard[V]) put(key string, v V, expires time.Time) bool {
 	}
 	if back := s.ll.Back(); back != nil {
 		s.ll.Remove(back)
-		delete(s.items, back.Value.(*entry[V]).key)
+		if e, ok := entryIn[V](back); ok {
+			delete(s.items, e.key)
+		}
 	}
 	return true
+}
+
+// entryIn reads an entry back out of a list element.
+//
+// The list holds anything, and everything this file puts in it is an entry, so
+// the assertion is here for the compiler rather than for a case that happens.
+// It is written as a check rather than as a bare assertion so that a change
+// which put something else in the list would drop a cache entry instead of
+// taking the process down inside a read.
+func entryIn[V any](el *list.Element) (*entry[V], bool) {
+	e, ok := el.Value.(*entry[V])
+	return e, ok
 }
 
 func (s *shard[V]) remove(key string) {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,301 @@
+package cache_test
+
+import (
+	"errors"
+	"hash/fnv"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/cache"
+)
+
+var epoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// clock is a hand wound clock, so that an expiry test measures the policy
+// rather than the machine it ran on.
+type clock struct{ nanos atomic.Int64 }
+
+func newClock() *clock {
+	c := &clock{}
+	c.nanos.Store(epoch.UnixNano())
+	return c
+}
+
+func (c *clock) now() time.Time      { return time.Unix(0, c.nanos.Load()) }
+func (c *clock) add(d time.Duration) { c.nanos.Add(int64(d)) }
+
+func TestGetReturnsWhatWasPut(t *testing.T) {
+	c := cache.New[string](64, time.Minute)
+	c.Put("k", "v")
+
+	got, ok := c.Get("k")
+	if !ok || got != "v" {
+		t.Fatalf("Get returned %q, %v, want \"v\", true", got, ok)
+	}
+	if _, ok := c.Get("absent"); ok {
+		t.Fatal("Get found a key that was never put")
+	}
+}
+
+func TestEntriesExpire(t *testing.T) {
+	tick := newClock()
+	c := cache.New(64, time.Minute, cache.WithClock[string](tick.now))
+	c.Put("k", "v")
+
+	tick.add(59 * time.Second)
+	if _, ok := c.Get("k"); !ok {
+		t.Fatal("an entry expired before its time")
+	}
+	tick.add(2 * time.Second)
+	if _, ok := c.Get("k"); ok {
+		t.Fatal("an expired entry was served")
+	}
+	if entries := c.Stats().Entries; entries != 0 {
+		t.Errorf("the expired entry is still held: %d entries", entries)
+	}
+}
+
+func TestForeverDoesNotExpire(t *testing.T) {
+	tick := newClock()
+	c := cache.New(64, cache.Forever, cache.WithClock[string](tick.now))
+	c.Put("k", "v")
+
+	tick.add(365 * 24 * time.Hour)
+	if _, ok := c.Get("k"); !ok {
+		t.Fatal("an entry with no expiry expired anyway")
+	}
+}
+
+// TestOffHoldsNothing covers the setting a deployment reaches for when it
+// cannot tolerate a stale answer. It has to be a real off rather than a very
+// short expiry, because a very short expiry still serves one stale answer.
+func TestOffHoldsNothing(t *testing.T) {
+	c := cache.New[string](64, cache.Off)
+	c.Put("k", "v")
+	if _, ok := c.Get("k"); ok {
+		t.Fatal("a cache that is off served an entry")
+	}
+
+	calls := 0
+	for range 3 {
+		if _, err := c.Do("k", func() (string, error) { calls++; return "v", nil }); err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+	}
+	if calls != 3 {
+		t.Errorf("a cache that is off called through %d times for three lookups, want 3", calls)
+	}
+}
+
+// TestEvictionTakesTheLeastRecentlyUsed works inside one shard, because that is
+// where the least recently used list is. The keys are chosen by the same hash
+// the cache uses, so the test does not depend on how many shards there are.
+func TestEvictionTakesTheLeastRecentlyUsed(t *testing.T) {
+	first, second, third := threeKeysInOneShard(t)
+
+	// Two entries per shard.
+	c := cache.New[string](2*cache.Shards, time.Minute)
+	c.Put(first, "1")
+	c.Put(second, "2")
+
+	// Touching the first makes the second the one to go.
+	if _, ok := c.Get(first); !ok {
+		t.Fatalf("the first key went missing before anything was evicted")
+	}
+	c.Put(third, "3")
+
+	if _, ok := c.Get(first); !ok {
+		t.Error("the recently used entry was evicted")
+	}
+	if _, ok := c.Get(second); ok {
+		t.Error("the least recently used entry survived a full shard")
+	}
+	if _, ok := c.Get(third); !ok {
+		t.Error("the entry that caused the eviction is not there")
+	}
+	if got := c.Stats().Evictions; got != 1 {
+		t.Errorf("the cache reports %d evictions, want 1", got)
+	}
+}
+
+func threeKeysInOneShard(t *testing.T) (a, b, d string) {
+	t.Helper()
+	byShard := make(map[uint32][]string)
+	for i := range 10_000 {
+		k := "key" + strconv.Itoa(i)
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(k))
+		s := h.Sum32() % cache.Shards
+		byShard[s] = append(byShard[s], k)
+		if len(byShard[s]) == 3 {
+			return byShard[s][0], byShard[s][1], byShard[s][2]
+		}
+	}
+	t.Fatal("could not find three keys in one shard")
+	return "", "", ""
+}
+
+// TestDoRunsOnceForConcurrentMisses is the case the cache exists for: a popular
+// key goes cold and every reader misses it at the same moment.
+func TestDoRunsOnceForConcurrentMisses(t *testing.T) {
+	c := cache.New[int](64, time.Minute)
+
+	const readers = cache.Shards
+	var (
+		calls   atomic.Int64
+		arrived atomic.Int64
+		release = make(chan struct{})
+		wg      sync.WaitGroup
+	)
+	got := make([]int, readers)
+	for i := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			arrived.Add(1)
+			v, err := c.Do("hot", func() (int, error) {
+				calls.Add(1)
+				<-release
+				return 42, nil
+			})
+			if err != nil {
+				t.Errorf("Do: %v", err)
+				return
+			}
+			got[i] = v
+		}()
+	}
+	for arrived.Load() < readers {
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if n := calls.Load(); n != 1 {
+		t.Errorf("%d readers produced %d calls, want 1", readers, n)
+	}
+	for i, v := range got {
+		if v != 42 {
+			t.Fatalf("reader %d got %d, want 42", i, v)
+		}
+	}
+}
+
+// TestDoDoesNotRememberFailures keeps a moment of backend trouble from becoming
+// a minute of it.
+func TestDoDoesNotRememberFailures(t *testing.T) {
+	c := cache.New[string](64, time.Minute)
+	boom := errors.New("boom")
+
+	calls := 0
+	produce := func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "", boom
+		}
+		return "v", nil
+	}
+
+	if _, err := c.Do("k", produce); !errors.Is(err, boom) {
+		t.Fatalf("Do returned %v, want the error from the call", err)
+	}
+	v, err := c.Do("k", produce)
+	if err != nil || v != "v" {
+		t.Fatalf("the second Do returned %q, %v, want the value", v, err)
+	}
+	if calls != 2 {
+		t.Errorf("the cache called through %d times, want 2: an error must not be stored", calls)
+	}
+}
+
+func TestDeleteAndClear(t *testing.T) {
+	c := cache.New[string](64, time.Minute)
+	c.Put("a", "1")
+	c.Put("b", "2")
+
+	c.Delete("a", "never-there")
+	if _, ok := c.Get("a"); ok {
+		t.Error("a deleted entry was served")
+	}
+	if _, ok := c.Get("b"); !ok {
+		t.Error("deleting one key removed another")
+	}
+
+	c.Clear()
+	if entries := c.Stats().Entries; entries != 0 {
+		t.Errorf("Clear left %d entries", entries)
+	}
+	c.Put("c", "3")
+	if _, ok := c.Get("c"); !ok {
+		t.Error("the cache stopped working after Clear")
+	}
+}
+
+func TestStatsCountLookups(t *testing.T) {
+	c := cache.New[string](64, time.Minute)
+	c.Put("k", "v")
+
+	c.Get("k")
+	c.Get("k")
+	c.Get("absent")
+
+	got := c.Stats()
+	if got.Hits != 2 || got.Misses != 1 {
+		t.Errorf("Stats reports %d hits and %d misses, want 2 and 1", got.Hits, got.Misses)
+	}
+	if got.Entries != 1 {
+		t.Errorf("Stats reports %d entries, want 1", got.Entries)
+	}
+	if ratio := got.Ratio(); ratio < 0.66 || ratio > 0.67 {
+		t.Errorf("Stats reports a ratio of %v, want two thirds", ratio)
+	}
+	if empty := (cache.Stats{}).Ratio(); empty != 0 {
+		t.Errorf("a cache nobody asked anything reports a ratio of %v, want 0", empty)
+	}
+}
+
+func TestCapacityIsRespected(t *testing.T) {
+	const capacity = 4 * cache.Shards
+	c := cache.New[int](capacity, time.Minute)
+	for i := range 10_000 {
+		c.Put(strconv.Itoa(i), i)
+	}
+	if got := c.Stats().Entries; got > capacity {
+		t.Errorf("the cache holds %d entries, over its capacity of %d", got, capacity)
+	}
+	if got := c.Stats().Evictions; got == 0 {
+		t.Error("ten thousand entries went into a cache of sixty four and nothing was evicted")
+	}
+}
+
+// TestConcurrentUseIsSafe is here for the race detector rather than for its
+// assertions.
+func TestConcurrentUseIsSafe(t *testing.T) {
+	c := cache.New[int](128, time.Minute)
+	var wg sync.WaitGroup
+	for i := range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range 200 {
+				k := strconv.Itoa((i*j)%50 + 1)
+				switch j % 4 {
+				case 0:
+					c.Put(k, j)
+				case 1:
+					c.Get(k)
+				case 2:
+					_, _ = c.Do(k, func() (int, error) { return j, nil })
+				case 3:
+					c.Delete(k)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	c.Stats()
+}

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -117,7 +117,13 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	if h := web.Handler(); h != nil {
 		opts = append(opts, api.WithAssets(h))
 	}
-	srv := api.New(st, index.New(st), api.HeaderAuth{Tenant: cfg.Tenant}, opts...)
+
+	// The searcher subscribes the cache to the store's writes, so it is closed
+	// before the store is, and it holds nothing else.
+	searcher := index.New(st, searchOptions(cfg)...)
+	defer func() { _ = searcher.Close() }()
+
+	srv := api.New(st, searcher, api.HeaderAuth{Tenant: cfg.Tenant}, opts...)
 
 	httpSrv := &http.Server{
 		Addr:              cfg.Addr,
@@ -132,6 +138,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		"addr", cfg.Addr,
 		"store", cfg.Store,
 		"interface", web.Enabled(),
+		"cache", cfg.Cache,
 	)
 
 	errc := make(chan error, 1)
@@ -184,4 +191,19 @@ func newLogger(w io.Writer, level string) *slog.Logger {
 		l = slog.LevelInfo
 	}
 	return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: l}))
+}
+
+// searchOptions builds the searcher from the configuration.
+//
+// A deployment that turns the cache off gets a searcher with no cache at all
+// rather than a cache that holds nothing, so that the option is visible in a
+// stack trace and in the stats response instead of being a set of layers
+// reporting zero.
+func searchOptions(cfg config.Config) []index.Option {
+	if !cfg.Cache {
+		return nil
+	}
+	return []index.Option{
+		index.WithCache(index.NewCache(index.WithResultExpiry(cfg.CacheResultExpiry))),
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,20 @@ type Config struct {
 
 	// LogLevel is one of debug, info, warn or error.
 	LogLevel string
+
+	// Cache turns the query caches on. Running without them is supported and
+	// correct: it costs latency on a repeated query and it costs nothing else,
+	// which is the property that makes a cache safe to have in the first place.
+	Cache bool
+
+	// CacheResultExpiry is the backstop on how long a ranked ordering may be
+	// reused. A write to the tenant drops its orderings whatever this says, so
+	// this is what bounds a driver that cannot report its writes.
+	//
+	// Zero turns result caching off while leaving the layers that are bounded by
+	// a write alone, which is what a deployment that cannot tolerate a stale
+	// ordering asks for.
+	CacheResultExpiry time.Duration
 }
 
 // Default returns the configuration a server starts with when nothing is set.
@@ -72,6 +86,11 @@ func Default() Config {
 		WriteTimeout:  60 * time.Second,
 		ShutdownGrace: 15 * time.Second,
 		LogLevel:      "info",
+		Cache:         true,
+		// The same thirty seconds as index.DefaultResultExpiry. It is written
+		// again rather than imported because configuration sits below everything
+		// and importing the query layer to read one constant would invert that.
+		CacheResultExpiry: 30 * time.Second,
 	}
 }
 
@@ -98,6 +117,8 @@ func Load(getenv func(string) string) (Config, error) {
 		dur(getenv, "GENBA_READ_TIMEOUT", &c.ReadTimeout),
 		dur(getenv, "GENBA_WRITE_TIMEOUT", &c.WriteTimeout),
 		dur(getenv, "GENBA_SHUTDOWN_GRACE", &c.ShutdownGrace),
+		dur(getenv, "GENBA_CACHE_RESULT_EXPIRY", &c.CacheResultExpiry),
+		boolean(getenv, "GENBA_CACHE", &c.Cache),
 	)
 	if err != nil {
 		return Config{}, err
@@ -135,6 +156,7 @@ func (c Config) Validate() error {
 		{"read timeout", c.ReadTimeout},
 		{"write timeout", c.WriteTimeout},
 		{"shutdown grace", c.ShutdownGrace},
+		{"cache result expiry", c.CacheResultExpiry},
 	} {
 		if d.value < 0 {
 			errs = append(errs, fmt.Errorf("config: %s is negative", d.name))
@@ -157,6 +179,23 @@ func str(getenv func(string) string, key string, dst *string) {
 	if v := getenv(key); v != "" {
 		*dst = v
 	}
+}
+
+// boolean reads a flag. The accepted spellings are the ones people type in a
+// unit file, rather than only the two Go parses.
+func boolean(getenv func(string) string, key string, dst *bool) error {
+	v := strings.ToLower(strings.TrimSpace(getenv(key)))
+	switch v {
+	case "":
+		return nil
+	case "1", "t", "true", "yes", "on":
+		*dst = true
+	case "0", "f", "false", "no", "off":
+		*dst = false
+	default:
+		return fmt.Errorf("config: %s = %q is not a yes or a no", key, v)
+	}
+	return nil
 }
 
 func dur(getenv func(string) string, key string, dst *time.Duration) error {

--- a/index/cache.go
+++ b/index/cache.go
@@ -1,0 +1,372 @@
+package index
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/cache"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// Caching comes after the data model, not instead of it.
+//
+// Every budget in this milestone is met by a query that does the right amount
+// of work, and the caches here take the repeated queries out of the path on top
+// of that. Turning all of them off is a supported way to run: it costs latency
+// and it does not cost correctness, which is the property that makes a cache
+// safe to have.
+//
+// # The rule
+//
+// A cache key that does not name the asker's visibility is a permission bug.
+// Two people typing the same query get different answers, and an entry that
+// crossed between them has leaked a document without looking like a leak.
+//
+// So the result cache is keyed by [acl.Fingerprint] and nothing here is keyed
+// by the query alone. The one layer that is not keyed by the fingerprint is the
+// document cache, and its justification is in [Cache.document].
+
+// The default sizes and expiries.
+const (
+	// DefaultResultExpiry is the backstop on how stale an ordering can be.
+	//
+	// A write drops the orderings of the tenant it touched, so this is not the
+	// mechanism that keeps results current. It is what bounds an ordering held
+	// by a driver that cannot report its writes, and what keeps a cache from
+	// holding a query nobody has asked in an hour.
+	//
+	// Thirty seconds, and the value cached is the ranked ids, the total and the
+	// facets rather than the documents. That is what makes even the backstop
+	// honest: a hit still fetches the bodies, so an edited document shows its new
+	// text on the very next request. The cache can serve a stale ordering and it
+	// cannot serve stale content.
+	DefaultResultExpiry = 30 * time.Second
+
+	// DefaultResultEntries is how many orderings are held. An entry is a few
+	// hundred candidates, so this is tens of megabytes at the limit and the
+	// limit is only reached by a deployment with thousands of distinct live
+	// queries, which is a deployment getting value from it.
+	DefaultResultEntries = 4_000
+
+	// DefaultCorpusEntries is how many corpus statistics are held. Terms follow
+	// a Zipf distribution, so a small cache covers most of the traffic and the
+	// tail that misses is the tail that was going to be cheap anyway.
+	DefaultCorpusEntries = 50_000
+
+	// DefaultDocumentEntries is how many documents are held. It is the layer
+	// that turns paging back and forth through a result set into no work at all.
+	DefaultDocumentEntries = 20_000
+)
+
+// Cache is the derived state a searcher reuses between requests.
+//
+// It is safe for concurrent use and is meant to be shared by every request in a
+// process. A nil *Cache is not usable: a searcher without one simply does not
+// take the option.
+type Cache struct {
+	results *cache.Cache[store.Ranked]
+	corpus  *cache.Cache[store.Corpus]
+	docs    *cache.Cache[doc.Document]
+
+	// blind is set when the driver does not report its writes, which turns off
+	// the two layers that have no other way to learn that they are wrong.
+	blind atomic.Bool
+
+	// gen is the per tenant generation counter that stands in for a sweep.
+	//
+	// Finding and deleting every key of a tenant in a sharded cache means walking
+	// every shard, under every lock, on a write. Bumping a counter that is part
+	// of the key makes the old entries unreachable instead, and the least
+	// recently used list retires them without anybody having to go looking. It
+	// is the same idea the fingerprint uses for a permission change, applied to
+	// a corpus change.
+	//
+	// One counter rather than one per layer, and any committed change bumps it.
+	// The tempting optimisation is to let a write keep the cached orderings,
+	// since working out which cached queries a new document would have joined
+	// costs more than the cache saves, and to bound the staleness with the
+	// expiry instead. It is the wrong trade for a search box. It means somebody
+	// saves a document, searches for it, and is told it does not exist, for as
+	// long as the expiry lasts. That is the complaint that makes people stop
+	// trusting a search box, and no hit rate is worth it. What the cache is
+	// actually for is the repeated reads between writes, which on any corpus
+	// anybody reads is nearly all of the time.
+	mu  sync.RWMutex
+	gen map[string]uint64
+}
+
+// CacheOption configures a [Cache].
+type CacheOption func(*cacheConfig)
+
+// cacheConfig is the settings a cache is built from. It exists because the
+// expiry of a layer is fixed when the layer is made, so that no entry can
+// outlive the policy it was stored under, and options therefore have to be
+// collected before anything is built rather than applied to a built cache.
+type cacheConfig struct {
+	resultExpiry          time.Duration
+	results, corpus, docs int
+	clock                 func() time.Time
+}
+
+// WithResultExpiry sets how long a ranked ordering is reused.
+//
+// Passing zero turns result caching off. A deployment that cannot tolerate a
+// thirty second old ordering is meant to be able to say so and to still meet
+// the latency budget afterwards, because the budget is met by the data model
+// rather than by the cache.
+func WithResultExpiry(d time.Duration) CacheOption {
+	return func(c *cacheConfig) { c.resultExpiry = d }
+}
+
+// WithCacheCapacity sets how many entries each layer holds. A non positive
+// value leaves that layer at its default.
+func WithCacheCapacity(results, corpus, documents int) CacheOption {
+	return func(c *cacheConfig) {
+		if results > 0 {
+			c.results = results
+		}
+		if corpus > 0 {
+			c.corpus = corpus
+		}
+		if documents > 0 {
+			c.docs = documents
+		}
+	}
+}
+
+// WithCacheClock replaces the clock the expiries are measured against, which is
+// what lets a test walk an entry past its expiry without sleeping through it.
+func WithCacheClock(now func() time.Time) CacheOption {
+	return func(c *cacheConfig) { c.clock = now }
+}
+
+// NewCache returns the three layers a searcher uses.
+func NewCache(opts ...CacheOption) *Cache {
+	cfg := cacheConfig{
+		resultExpiry: DefaultResultExpiry,
+		results:      DefaultResultEntries,
+		corpus:       DefaultCorpusEntries,
+		docs:         DefaultDocumentEntries,
+		clock:        time.Now,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &Cache{
+		results: cache.New(cfg.results, cfg.resultExpiry, cache.WithClock[store.Ranked](cfg.clock)),
+
+		// The corpus statistics and the documents never expire on a clock. They
+		// are exact until a write makes them wrong, and a write says so, so an
+		// expiry on top would only throw away answers that were still right.
+		corpus: cache.New(cfg.corpus, cache.Forever, cache.WithClock[store.Corpus](cfg.clock)),
+		docs:   cache.New(cfg.docs, cache.Forever, cache.WithClock[doc.Document](cfg.clock)),
+
+		gen: make(map[string]uint64),
+	}
+}
+
+// Watch subscribes to a store's writes and returns a function that
+// unsubscribes.
+//
+// A store that does not report its writes is not an error, and it is not
+// treated as one either. The two layers whose staleness is bounded by the write
+// rather than by a clock, the corpus statistics and the documents, are turned
+// off, because a layer that would only ever be invalidated by a notification it
+// will never receive is a layer that serves the corpus as it was when the
+// process started. Result caching stays on: its bound is the expiry, and the
+// expiry works whatever the driver can do.
+func (c *Cache) Watch(st store.Store) (stop func()) {
+	n, ok := st.(store.Notifier)
+	if !ok {
+		c.blind.Store(true)
+		return func() {}
+	}
+	c.blind.Store(false)
+	return n.OnChange(c.Invalidate)
+}
+
+// Invalidate applies one committed write.
+//
+// It is called from the goroutine that did the write, so it does no work beyond
+// bumping two integers and deleting the named documents.
+func (c *Cache) Invalidate(ch store.Change) {
+	c.docs.Delete(ch.IDs...)
+
+	c.mu.Lock()
+	c.gen[ch.Tenant]++
+	c.mu.Unlock()
+}
+
+// Clear empties every layer. It is what an operator reaches for and what a test
+// uses to make a second measurement cold.
+func (c *Cache) Clear() {
+	c.results.Clear()
+	c.corpus.Clear()
+	c.docs.Clear()
+}
+
+// Stats reports each layer separately, because a hit rate averaged over three
+// layers with three different jobs says nothing about any of them.
+func (c *Cache) Stats() map[string]cache.Stats {
+	return map[string]cache.Stats{
+		"results":   c.results.Stats(),
+		"corpus":    c.corpus.Stats(),
+		"documents": c.docs.Stats(),
+	}
+}
+
+func (c *Cache) generation(tenant string) uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.gen[tenant]
+}
+
+// ranked returns a cached ordering, or produces one and stores it.
+//
+// The key is the tenant's generation, the asker's visibility fingerprint and the
+// canonical form of the request. Nothing about the query alone reaches an
+// entry.
+func (c *Cache) ranked(p *acl.Principal, r store.Request, sel store.Selection, fn func() (store.Ranked, error)) (store.Ranked, error) {
+	fp := acl.Fingerprint(p)
+	if fp == "" {
+		return fn()
+	}
+	var key strings.Builder
+	key.WriteString(strconv.FormatUint(c.generation(p.Tenant), 10))
+	key.WriteByte('|')
+	key.WriteString(fp)
+	key.WriteByte('|')
+	writeRequest(&key, r, sel)
+	return c.results.Do(key.String(), fn)
+}
+
+// corpusStats returns the cached corpus numbers for a set of terms.
+//
+// The measurement spec asked for two layers here, corpus statistics per tenant
+// and document frequency per term. This driver surface answers both in one
+// call, [store.Statistician.Statistics], so there is one layer with the tighter
+// of the two policies: keyed by tenant and terms, dropped on any write to that
+// tenant.
+//
+// The key does not carry the fingerprint, because the value does not depend on
+// the asker. Corpus statistics are counted over the tenant rather than over what
+// one person may read, which is a decision made when the statistics were first
+// written down: a document frequency counted over one asker's view would make a
+// term's weight depend on who was asking, so the same query would rank
+// differently for two colleagues. Keying a tenant wide value by fingerprint
+// would spend an entry per asker to store the same numbers.
+func (c *Cache) corpusStats(p *acl.Principal, terms []string, fn func() (store.Corpus, error)) (store.Corpus, error) {
+	if p == nil || c.blind.Load() {
+		return fn()
+	}
+	sorted := slices.Clone(terms)
+	slices.Sort(sorted)
+	sorted = slices.Compact(sorted)
+
+	var key strings.Builder
+	key.WriteString(strconv.FormatUint(c.generation(p.Tenant), 10))
+	key.WriteByte('|')
+	key.WriteString(p.Tenant)
+	for _, t := range sorted {
+		key.WriteByte('|')
+		key.WriteString(t)
+	}
+	return c.corpus.Do(key.String(), fn)
+}
+
+// document returns cached documents for ids and the ids that were not cached.
+//
+// This layer is keyed by document id and not by the asker's visibility, which
+// is the one exception to the rule at the top of this file, and it needs its
+// justification stated rather than assumed.
+//
+// The cache sits behind the permission check rather than in front of it. The
+// only caller is [Searcher.fetch], and the only ids it is ever given are ids
+// that came out of the retrieval that applied the permission predicate to this
+// principal moments earlier. An entry is therefore only ever reached with an id
+// the caller has already proven they may read. Correctness comes from the order
+// of the two operations rather than from the shape of the key, so that ordering
+// has a test of its own: see TestDocumentCacheIsBehindThePermissionCheck.
+//
+// The two ways that ordering could go wrong are both closed. A revocation is a
+// write, so the document entry is dropped and the fetch behind the next request
+// goes back to the driver, which applies the predicate and returns nothing. A
+// group change changes the fingerprint, so the ordering that named the id is
+// unreachable and never reaches this layer at all.
+func (c *Cache) document(ids []string) (have map[string]doc.Document, missing []string) {
+	have = make(map[string]doc.Document, len(ids))
+	if c.blind.Load() {
+		return have, ids
+	}
+	for _, id := range ids {
+		if d, ok := c.docs.Get(id); ok {
+			have[id] = d
+			continue
+		}
+		missing = append(missing, id)
+	}
+	return have, missing
+}
+
+func (c *Cache) putDocuments(docs map[string]doc.Document) {
+	if c.blind.Load() {
+		return
+	}
+	for id, d := range docs {
+		c.docs.Put(id, d)
+	}
+}
+
+// writeRequest writes the canonical form of a request.
+//
+// Canonical matters twice. Two requests that describe the same match set have
+// to produce the same key or the cache never hits, and two that describe
+// different match sets must not, or it hits when it should not. Every list is
+// sorted and every field is written with a separator that cannot appear inside
+// it, so no rearrangement of one field's values can be read as another field's.
+func writeRequest(key *strings.Builder, r store.Request, sel store.Selection) {
+	lists := [][]string{
+		r.Terms,
+		r.Sources,
+		kindStrings(r.Kinds),
+		r.Containers,
+		r.Authors,
+		r.Owners,
+	}
+	for _, list := range lists {
+		sorted := slices.Clone(list)
+		slices.Sort(sorted)
+		sorted = slices.Compact(sorted)
+		for _, v := range sorted {
+			key.WriteString(strconv.Itoa(len(v)))
+			key.WriteByte(':')
+			key.WriteString(v)
+			key.WriteByte(',')
+		}
+		key.WriteByte('|')
+	}
+	key.WriteString(strconv.FormatInt(r.Since.UnixNano(), 10))
+	key.WriteByte('|')
+	key.WriteString(strconv.FormatInt(r.Until.UnixNano(), 10))
+	key.WriteByte('|')
+	key.WriteString(strconv.Itoa(sel.Limit))
+	key.WriteByte('|')
+	key.WriteString(strconv.FormatBool(sel.Recent))
+}
+
+func kindStrings(kinds []doc.Kind) []string {
+	if len(kinds) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(kinds))
+	for _, k := range kinds {
+		out = append(out, string(k))
+	}
+	return out
+}

--- a/index/cache_test.go
+++ b/index/cache_test.go
@@ -1,0 +1,590 @@
+package index_test
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// A cache is only ever as good as the assertion that it did not answer the
+// wrong person. So most of what is below is about who got what, and the two
+// tests about speed are the short ones.
+
+// counting is a driver that ranks and fetches like a real one and says how many
+// times it was asked.
+//
+// It is built on the reference driver rather than on SQLite because the thing
+// under test is the searcher's use of the cache, and a test that has to open a
+// database to prove that a second search did no work is a test that is measuring
+// two things.
+type counting struct {
+	*memstore.Store
+
+	mu      sync.Mutex
+	ranks   int
+	stats   int
+	fetches int
+	fetched []string
+
+	// hold blocks every rank until it is closed, which is how the single flight
+	// assertion gets sixteen readers onto one cold key.
+	hold chan struct{}
+}
+
+func newCounting(t *testing.T, fixtures []fixture) *counting {
+	t.Helper()
+	st := &counting{Store: memstore.New()}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Put(t.Context(), documents(fixtures)...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	return st
+}
+
+func (s *counting) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel store.Selection) (store.Ranked, error) {
+	s.mu.Lock()
+	s.ranks++
+	hold := s.hold
+	s.mu.Unlock()
+	if hold != nil {
+		<-hold
+	}
+
+	var out store.Ranked
+	err := s.Scan(ctx, p, func(d doc.Document) bool {
+		if !r.Matches(d) {
+			return true
+		}
+		out.Total++
+		a := d.Analyze()
+		c := store.Candidate{
+			ID:          d.ID,
+			Source:      d.Source,
+			Kind:        d.Kind,
+			Container:   d.Container,
+			Author:      d.Author.Display(),
+			ModifiedAt:  d.ModifiedAt,
+			TitleTokens: a.TitleTokens,
+			BodyTokens:  a.BodyTokens,
+			Terms:       make(map[string]doc.TermCount, len(r.Terms)),
+		}
+		for _, t := range r.Terms {
+			if n, ok := a.Terms[t]; ok {
+				c.Terms[t] = n
+			}
+		}
+		out.Candidates = append(out.Candidates, c)
+		return true
+	})
+	if err != nil {
+		return store.Ranked{}, err
+	}
+	slices.SortFunc(out.Candidates, func(a, b store.Candidate) int {
+		return int(b.ModifiedAt.Sub(a.ModifiedAt))
+	})
+	if sel.Limit > 0 && len(out.Candidates) > sel.Limit {
+		out.Candidates = out.Candidates[:sel.Limit]
+		out.Truncated = true
+	}
+	return out, nil
+}
+
+func (s *counting) Statistics(ctx context.Context, p *acl.Principal, terms []string) (store.Corpus, error) {
+	s.mu.Lock()
+	s.stats++
+	s.mu.Unlock()
+	return s.Store.Statistics(ctx, p, terms)
+}
+
+func (s *counting) Fetch(ctx context.Context, p *acl.Principal, ids []string) ([]doc.Document, error) {
+	s.mu.Lock()
+	s.fetches++
+	s.fetched = append(s.fetched, ids...)
+	s.mu.Unlock()
+
+	out := make([]doc.Document, 0, len(ids))
+	for _, id := range ids {
+		d, err := s.Store.Get(ctx, p, id)
+		if err != nil {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+func (s *counting) counts() (ranks, stats, fetches int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ranks, s.stats, s.fetches
+}
+
+// documents turns the shared fixtures into documents. It is the body of
+// newSearcher, split out so that a test can put the same corpus behind a
+// different driver.
+func documents(fixtures []fixture) []doc.Document {
+	docs := make([]doc.Document, 0, len(fixtures))
+	for _, f := range fixtures {
+		if f.source == "" {
+			f.source = "gdrive"
+		}
+		if f.kind == "" {
+			f.kind = doc.KindPage
+		}
+		var props map[string]string
+		if f.media != "" {
+			props = map[string]string{doc.MediaType: f.media}
+		}
+		docs = append(docs, doc.Document{
+			ID:          f.id,
+			Tenant:      "acme",
+			Source:      f.source,
+			Kind:        f.kind,
+			Title:       f.title,
+			Body:        f.body,
+			ModifiedAt:  f.modified,
+			Permissions: f.perm,
+			Properties:  props,
+		})
+	}
+	return docs
+}
+
+func cachedSearcher(t *testing.T, st store.Store, opts ...index.CacheOption) (*index.Searcher, *index.Cache) {
+	t.Helper()
+	c := index.NewCache(opts...)
+	s := index.New(st, index.WithClock(clock), index.WithCache(c))
+	t.Cleanup(func() { _ = s.Close() })
+	return s, c
+}
+
+func search(t *testing.T, s *index.Searcher, p *acl.Principal, q index.Query) index.Results {
+	t.Helper()
+	res, err := s.Search(t.Context(), p, q)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	return res
+}
+
+func TestRepeatedSearchIsAnsweredFromTheCache(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+	p := principal("gdrive:eng@acme.com")
+
+	first := search(t, s, p, index.Query{Text: "payments"})
+	second := search(t, s, p, index.Query{Text: "payments"})
+
+	if !slices.Equal(ids(first), ids(second)) {
+		t.Fatalf("the cached answer differs from the first: %v then %v", ids(first), ids(second))
+	}
+	ranks, stats, fetches := st.counts()
+	if ranks != 1 {
+		t.Errorf("the driver ranked %d times for two identical searches, want 1", ranks)
+	}
+	if stats != 1 {
+		t.Errorf("the driver computed statistics %d times for two identical searches, want 1", stats)
+	}
+	if fetches != 1 {
+		t.Errorf("the driver fetched %d times for two identical searches, want 1", fetches)
+	}
+}
+
+// TestCacheNeverCrossesVisibility is the assertion the whole design exists for.
+// Two people who may read different documents type the same query, and neither
+// of them may be handed the other's answer.
+func TestCacheNeverCrossesVisibility(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+
+	engineer := principal("gdrive:eng@acme.com")
+	seller := &acl.Principal{
+		Tenant:  "acme",
+		Subject: "u_sam",
+		Groups:  acl.GroupSet{Version: 1, Members: []string{"gdrive:sales@acme.com"}},
+	}
+
+	mine := ids(search(t, s, engineer, index.Query{Text: "payments"}))
+	theirs := ids(search(t, s, seller, index.Query{Text: "payments"}))
+
+	if len(mine) == 0 {
+		t.Fatal("the engineer found nothing, so the test proves nothing")
+	}
+	if slices.Contains(theirs, "d1") || slices.Contains(theirs, "d2") {
+		t.Fatalf("the seller was handed the engineer's documents: %v", theirs)
+	}
+	if ranks, _, _ := st.counts(); ranks != 2 {
+		t.Errorf("the driver ranked %d times for two different askers, want 2", ranks)
+	}
+
+	// And going back to the first asker still gets the first answer, rather than
+	// the entry the second asker left behind.
+	if again := ids(search(t, s, engineer, index.Query{Text: "payments"})); !slices.Equal(again, mine) {
+		t.Errorf("the engineer got %v on the second ask, want %v", again, mine)
+	}
+}
+
+// TestTenantsNeverShareAnEntry is the same assertion one level up. Two
+// principals with the same subject and the same groups in different tenants are
+// two different views of two different corpora.
+func TestTenantsNeverShareAnEntry(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+
+	here := principal("gdrive:eng@acme.com")
+	elsewhere := &acl.Principal{
+		Tenant:  "other",
+		Subject: "u_mei",
+		Groups:  acl.GroupSet{Version: 1, Members: []string{"gdrive:eng@acme.com"}},
+	}
+
+	if got := ids(search(t, s, here, index.Query{Text: "payments"})); len(got) == 0 {
+		t.Fatal("the acme principal found nothing, so the test proves nothing")
+	}
+	if got := ids(search(t, s, elsewhere, index.Query{Text: "payments"})); len(got) != 0 {
+		t.Fatalf("a principal of another tenant was handed acme's documents: %v", got)
+	}
+}
+
+// TestIdenticalViewsShareAnEntry is the other half. A fingerprint that named
+// something other than the visibility would be safe and useless, so the cache
+// has to hit for two principals the permission rule cannot tell apart.
+func TestIdenticalViewsShareAnEntry(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+
+	first := principal("gdrive:eng@acme.com")
+	second := principal("gdrive:eng@acme.com")
+	// The same view described in a different order is still the same view.
+	third := &acl.Principal{
+		Tenant:  "acme",
+		Subject: "u_mei",
+		Groups:  acl.GroupSet{Version: 1, Members: []string{"gdrive:eng@acme.com", "gdrive:eng@acme.com"}},
+	}
+
+	for _, p := range []*acl.Principal{first, second, third} {
+		search(t, s, p, index.Query{Text: "payments"})
+	}
+	if ranks, _, _ := st.counts(); ranks != 1 {
+		t.Errorf("the driver ranked %d times for three descriptions of one view, want 1", ranks)
+	}
+}
+
+// TestGroupChangeMakesPreviousEntriesUnreachable is the revocation path. Nobody
+// sweeps anything: the entries are still in the cache and the new fingerprint
+// cannot name them.
+func TestGroupChangeMakesPreviousEntriesUnreachable(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+
+	before := principal("gdrive:eng@acme.com")
+	if got := ids(search(t, s, before, index.Query{Text: "payments"})); len(got) == 0 {
+		t.Fatal("the engineer found nothing before the change, so the test proves nothing")
+	}
+
+	// The same person, expanded again after being removed from the group.
+	after := &acl.Principal{
+		Tenant:  "acme",
+		Subject: "u_mei",
+		Groups:  acl.GroupSet{Version: 2},
+	}
+	if got := ids(search(t, s, after, index.Query{Text: "payments"})); len(got) != 0 {
+		t.Fatalf("a principal whose group was taken away still saw %v", got)
+	}
+	if ranks, _, _ := st.counts(); ranks != 2 {
+		t.Errorf("the driver ranked %d times either side of a group change, want 2", ranks)
+	}
+}
+
+// TestWriteInvalidatesCorpusStatistics covers the layer whose staleness is
+// bounded by the write rather than by the clock.
+func TestWriteInvalidatesCorpusStatistics(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+	p := principal("gdrive:eng@acme.com")
+
+	search(t, s, p, index.Query{Text: "payments"})
+	search(t, s, p, index.Query{Text: "payments"})
+	if _, stats, _ := st.counts(); stats != 1 {
+		t.Fatalf("the driver computed statistics %d times before any write, want 1", stats)
+	}
+
+	if err := st.Put(t.Context(), documents([]fixture{
+		{id: "d9", title: "Payments postmortem", body: "The payments queue backed up.", perm: openTo("eng@acme.com")},
+	})...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	search(t, s, p, index.Query{Text: "payments"})
+	if _, stats, _ := st.counts(); stats != 2 {
+		t.Errorf("the driver computed statistics %d times after a write, want 2", stats)
+	}
+}
+
+// TestAnyChangeSweepsTheTenantsOrderings is the decision the cache exists
+// around, stated as a test so that anybody tempted by the obvious optimisation
+// has to argue with it first.
+//
+// A write could be allowed to keep the cached orderings, since working out
+// which of them a new document would have joined costs more than the cache
+// saves. It is the wrong trade for a search box: somebody saves a document,
+// searches for it, and is told it does not exist for as long as the expiry
+// lasts.
+func TestAnyChangeSweepsTheTenantsOrderings(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+	p := principal("gdrive:eng@acme.com")
+
+	search(t, s, p, index.Query{Text: "payments"})
+	if err := st.Put(t.Context(), documents([]fixture{
+		{id: "d9", title: "Payments postmortem", body: "The payments queue backed up.", perm: openTo("eng@acme.com")},
+	})...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got := ids(search(t, s, p, index.Query{Text: "payments"}))
+	if ranks, _, _ := st.counts(); ranks != 2 {
+		t.Errorf("the driver ranked %d times across a write, want 2", ranks)
+	}
+	if !slices.Contains(got, "d9") {
+		t.Errorf("a document written a moment ago is missing from the results: %v", got)
+	}
+
+	if err := st.Delete(t.Context(), "d9"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got = ids(search(t, s, p, index.Query{Text: "payments"}))
+	if ranks, _, _ := st.counts(); ranks != 3 {
+		t.Errorf("the driver ranked %d times across a delete, want 3", ranks)
+	}
+	if slices.Contains(got, "d9") {
+		t.Errorf("a deleted document is still in the results: %v", got)
+	}
+}
+
+// TestDocumentCacheIsBehindThePermissionCheck is the test the document layer
+// owes, because that layer is keyed by id alone and its safety comes from the
+// order of two operations rather than from the shape of its key.
+//
+// The order is: retrieve under the permission predicate, then fetch the ids the
+// retrieval produced. So the assertion is that no id ever reaches the fetch
+// except one this principal's own retrieval named, and that a document cached
+// for one person is not served to another who may not read it.
+func TestDocumentCacheIsBehindThePermissionCheck(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+
+	engineer := principal("gdrive:eng@acme.com")
+	seller := &acl.Principal{
+		Tenant:  "acme",
+		Subject: "u_sam",
+		Groups:  acl.GroupSet{Version: 1, Members: []string{"gdrive:sales@acme.com"}},
+	}
+
+	mine := ids(search(t, s, engineer, index.Query{Text: "payments"}))
+	if !slices.Contains(mine, "d1") {
+		t.Fatalf("the engineer did not get d1, so it was never cached: %v", mine)
+	}
+
+	// The seller asks for the same thing. The engineer's documents are sitting in
+	// the document cache under their ids, and the seller must not reach them.
+	theirs := ids(search(t, s, seller, index.Query{Text: "payments"}))
+	if slices.Contains(theirs, "d1") {
+		t.Fatalf("a cached document was served to a principal who may not read it: %v", theirs)
+	}
+
+	// Revocation. The document is rewritten so that only sales may read it, which
+	// is a write, so the cached copy is dropped and the next retrieval applies the
+	// new rule.
+	revoked := documents([]fixture{{id: "d1", title: "Payments failover runbook", body: "Failover the payments queue when the primary region is unhealthy.", perm: openTo("sales@acme.com")}})
+	if err := st.Put(t.Context(), revoked...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	after := ids(search(t, s, engineer, index.Query{Text: "payments"}))
+	if slices.Contains(after, "d1") {
+		t.Fatalf("a revoked document was served from the cache: %v", after)
+	}
+}
+
+func TestResultExpiryZeroTurnsResultCachingOff(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st, index.WithResultExpiry(0))
+	p := principal("gdrive:eng@acme.com")
+
+	first := ids(search(t, s, p, index.Query{Text: "payments"}))
+	second := ids(search(t, s, p, index.Query{Text: "payments"}))
+	if !slices.Equal(first, second) {
+		t.Fatalf("turning the cache off changed the answer: %v then %v", first, second)
+	}
+	ranks, stats, _ := st.counts()
+	if ranks != 2 {
+		t.Errorf("the driver ranked %d times with result caching off, want 2", ranks)
+	}
+	// The other two layers are bounded by the write rather than by the clock, so
+	// turning the result expiry off does not turn them off with it.
+	if stats != 1 {
+		t.Errorf("the driver computed statistics %d times with result caching off, want 1", stats)
+	}
+}
+
+func TestResultCacheExpires(t *testing.T) {
+	st := newCounting(t, corpus)
+	var now atomic.Int64
+	now.Store(epoch.UnixNano())
+	c := index.NewCache(index.WithCacheClock(func() time.Time { return time.Unix(0, now.Load()) }))
+	s := index.New(st, index.WithClock(clock), index.WithCache(c))
+	t.Cleanup(func() { _ = s.Close() })
+	p := principal("gdrive:eng@acme.com")
+
+	search(t, s, p, index.Query{Text: "payments"})
+	now.Add(int64(index.DefaultResultExpiry) + 1)
+	search(t, s, p, index.Query{Text: "payments"})
+
+	if ranks, _, _ := st.counts(); ranks != 2 {
+		t.Errorf("the driver ranked %d times either side of the expiry, want 2", ranks)
+	}
+}
+
+// TestSixteenReadersProduceOneQuery is the case a cache exists for: a popular
+// key goes cold and everybody misses it at once.
+func TestSixteenReadersProduceOneQuery(t *testing.T) {
+	st := newCounting(t, corpus)
+	st.hold = make(chan struct{})
+	s, _ := cachedSearcher(t, st)
+	p := principal("gdrive:eng@acme.com")
+
+	const readers = 16
+	var (
+		arrived atomic.Int64
+		wg      sync.WaitGroup
+	)
+	results := make([][]string, readers)
+	for i := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			arrived.Add(1)
+			res, err := s.Search(t.Context(), p, index.Query{Text: "payments"})
+			if err != nil {
+				t.Errorf("Search: %v", err)
+				return
+			}
+			results[i] = ids(res)
+		}()
+	}
+	for arrived.Load() < readers {
+		time.Sleep(time.Millisecond)
+	}
+	// Every reader is inside Search and the one that got there first is blocked
+	// in the driver, so the other fifteen are waiting on its call rather than
+	// making their own.
+	time.Sleep(20 * time.Millisecond)
+	close(st.hold)
+	wg.Wait()
+
+	if ranks, _, _ := st.counts(); ranks != 1 {
+		t.Errorf("sixteen concurrent readers made %d queries, want 1", ranks)
+	}
+	for i, got := range results {
+		if !slices.Equal(got, results[0]) {
+			t.Fatalf("reader %d got %v, reader 0 got %v", i, got, results[0])
+		}
+	}
+}
+
+// TestCacheStatsAreReportedPerLayer keeps the numbers an operator needs
+// separate. A hit rate averaged over three layers with three different jobs
+// says nothing about any of them.
+func TestCacheStatsAreReportedPerLayer(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+	p := principal("gdrive:eng@acme.com")
+
+	search(t, s, p, index.Query{Text: "payments"})
+	search(t, s, p, index.Query{Text: "payments"})
+
+	stats := s.CacheStats()
+	for _, layer := range []string{"results", "corpus", "documents"} {
+		got, ok := stats[layer]
+		if !ok {
+			t.Fatalf("the stats do not report the %s layer", layer)
+		}
+		if got.Hits == 0 {
+			t.Errorf("the %s layer reports no hits after a repeated search", layer)
+		}
+		if got.Entries == 0 {
+			t.Errorf("the %s layer reports no entries after a search", layer)
+		}
+		if got.Ratio() <= 0 {
+			t.Errorf("the %s layer reports a hit ratio of %v", layer, got.Ratio())
+		}
+	}
+}
+
+func TestSearcherWithoutACacheStillAnswers(t *testing.T) {
+	st := newCounting(t, corpus)
+	s := index.New(st, index.WithClock(clock))
+	p := principal("gdrive:eng@acme.com")
+
+	first := ids(search(t, s, p, index.Query{Text: "payments"}))
+	second := ids(search(t, s, p, index.Query{Text: "payments"}))
+	if !slices.Equal(first, second) {
+		t.Fatalf("two searches without a cache disagreed: %v then %v", first, second)
+	}
+	if ranks, _, _ := st.counts(); ranks != 2 {
+		t.Errorf("a searcher with no cache ranked %d times, want 2", ranks)
+	}
+}
+
+// deaf is a driver that ranks but does not report its writes, which is what a
+// driver over somebody else's search service looks like.
+type deaf struct{ inner *counting }
+
+func (d deaf) Put(ctx context.Context, docs ...doc.Document) error { return d.inner.Put(ctx, docs...) }
+func (d deaf) Delete(ctx context.Context, ids ...string) error     { return d.inner.Delete(ctx, ids...) }
+func (d deaf) Get(ctx context.Context, p *acl.Principal, id string) (doc.Document, error) {
+	return d.inner.Get(ctx, p, id)
+}
+func (d deaf) Scan(ctx context.Context, p *acl.Principal, fn func(doc.Document) bool) error {
+	return d.inner.Scan(ctx, p, fn)
+}
+func (d deaf) Stats(ctx context.Context) (store.Stats, error) { return d.inner.Stats(ctx) }
+func (d deaf) Close() error                                   { return nil }
+func (d deaf) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel store.Selection) (store.Ranked, error) {
+	return d.inner.Rank(ctx, p, r, sel)
+}
+func (d deaf) Statistics(ctx context.Context, p *acl.Principal, terms []string) (store.Corpus, error) {
+	return d.inner.Statistics(ctx, p, terms)
+}
+
+// TestADriverThatDoesNotReportWritesKeepsOnlyTheBoundedLayer covers the
+// deployment where the cache cannot be told that it is wrong. The layers whose
+// staleness is bounded by a write turn themselves off, and the one bounded by
+// the clock stays on.
+func TestADriverThatDoesNotReportWritesKeepsOnlyTheBoundedLayer(t *testing.T) {
+	inner := newCounting(t, corpus)
+	if _, ok := any(deaf{inner}).(store.Notifier); ok {
+		t.Fatal("deaf implements store.Notifier, so this test no longer covers the blind path")
+	}
+	s, _ := cachedSearcher(t, deaf{inner})
+	p := principal("gdrive:eng@acme.com")
+
+	search(t, s, p, index.Query{Text: "payments"})
+	search(t, s, p, index.Query{Text: "payments"})
+
+	ranks, stats, _ := inner.counts()
+	if ranks != 1 {
+		t.Errorf("the driver ranked %d times, want 1: the result layer is bounded by the expiry and stays on", ranks)
+	}
+	if stats != 2 {
+		t.Errorf("the driver computed statistics %d times, want 2: a layer that can never be told it is wrong is turned off", stats)
+	}
+}

--- a/index/cache_test.go
+++ b/index/cache_test.go
@@ -111,9 +111,13 @@ func (s *counting) Fetch(ctx context.Context, p *acl.Principal, ids []string) ([
 	s.fetched = append(s.fetched, ids...)
 	s.mu.Unlock()
 
+	// Held in a variable rather than reached through the embedded field on
+	// every pass, so that this stays a read of the wrapped store even if
+	// counting ever grows a Get of its own.
+	base := s.Store
 	out := make([]doc.Document, 0, len(ids))
 	for _, id := range ids {
-		d, err := s.Store.Get(ctx, p, id)
+		d, err := base.Get(ctx, p, id)
 		if err != nil {
 			continue
 		}

--- a/index/index.go
+++ b/index/index.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/cache"
 	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/store"
 )
@@ -166,6 +167,12 @@ type Searcher struct {
 	store store.Store
 	now   func() time.Time
 
+	// cache is the derived state a repeated query reuses, and is nil when the
+	// searcher was built without one. See cache.go for what is in it and for the
+	// rule its keys obey.
+	cache     *Cache
+	stopWatch func()
+
 	// halfLife is how long it takes for the recency prior to decay by half. A
 	// document that has not changed in a year should not outrank this week's
 	// runbook on a tie, and it should not be buried either.
@@ -186,13 +193,52 @@ func WithRecencyHalfLife(d time.Duration) Option {
 	return func(s *Searcher) { s.halfLife = d }
 }
 
+// WithCache gives the searcher somewhere to reuse the work a repeated query
+// would otherwise redo. A searcher without one is correct and slower, which is
+// the property that makes the cache safe to have.
+func WithCache(c *Cache) Option {
+	return func(s *Searcher) { s.cache = c }
+}
+
 // New returns a searcher over st.
+//
+// A searcher given a cache subscribes it to the store's writes here rather than
+// leaving that to the caller. Wiring a cache up and forgetting to invalidate it
+// is not a mistake that produces an error: it produces a search that quietly
+// answers from last week, so it is not left as a step somebody can miss.
 func New(st store.Store, opts ...Option) *Searcher {
 	s := &Searcher{store: st, now: time.Now, halfLife: 180 * 24 * time.Hour}
 	for _, opt := range opts {
 		opt(s)
 	}
+	if s.cache != nil {
+		s.stopWatch = s.cache.Watch(st)
+	}
 	return s
+}
+
+// Close releases what the searcher holds, which is at most a subscription to
+// the store's writes. It does not close the store: the searcher did not open it
+// and something else is still using it.
+//
+// A process wide searcher never needs this. It is here for a test, and for an
+// embedder that builds a searcher per tenant and would otherwise accumulate
+// subscriptions for tenants nobody is querying.
+func (s *Searcher) Close() error {
+	if s.stopWatch != nil {
+		s.stopWatch()
+		s.stopWatch = nil
+	}
+	return nil
+}
+
+// CacheStats reports what each cache layer has done, and nil when the searcher
+// has no cache.
+func (s *Searcher) CacheStats() map[string]cache.Stats {
+	if s.cache == nil {
+		return nil
+	}
+	return s.cache.Stats()
 }
 
 // Retrieving reports whether the store behind this searcher can serve a match
@@ -289,13 +335,21 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 	if err != nil {
 		return Results{}, err
 	}
+	// A candidate whose document did not come back is dropped rather than shown
+	// from the metadata that was ranked. The fetch is the last thing that applies
+	// the permission rule, so an id it declined is an id this person may not read
+	// now, whatever was true when the ordering was made. Showing the title, the
+	// container and the author of a document somebody just lost access to is a
+	// leak, and it is a leak that gets more likely the longer an ordering is
+	// allowed to be reused. Losing a row from the page is the cheaper mistake.
 	res.Hits = make([]Result, 0, len(window))
 	for _, r := range window {
-		hit := Result{Document: outline(r.cand), Score: r.score}
-		if full, ok := bodies[r.cand.ID]; ok {
-			hit.Document = full
-			hit.Snippet, hit.Passages = snippet(readable(full), req.Terms)
+		full, ok := bodies[r.cand.ID]
+		if !ok {
+			continue
 		}
+		hit := Result{Document: full, Score: r.score}
+		hit.Snippet, hit.Passages = snippet(readable(full), req.Terms)
 		res.Hits = append(res.Hits, hit)
 	}
 	res.Took = s.now().Sub(start)
@@ -313,9 +367,13 @@ type ranked struct {
 // A driver that can do it in one statement is asked to. One that cannot is
 // asked document by document, which is the old behaviour and is correct, just
 // twenty round trips instead of one. Either way an id that has stopped being
-// readable between the ranking and now is simply missing from the result, and
-// the caller falls back to the metadata it already ranked rather than failing
-// the page.
+// readable between the ranking and now is simply missing from what comes back,
+// and [Searcher.Search] drops it from the page rather than failing the request.
+//
+// That makes this the point where a stale ordering is checked against the
+// permission rule as it stands now, which is what lets an ordering be reused
+// for thirty seconds without a revocation in that window being visible for
+// thirty seconds.
 func (s *Searcher) fetch(ctx context.Context, p *acl.Principal, window []ranked) (map[string]doc.Document, error) {
 	out := make(map[string]doc.Document, len(window))
 	if len(window) == 0 {
@@ -326,6 +384,36 @@ func (s *Searcher) fetch(ctx context.Context, p *acl.Principal, window []ranked)
 		ids = append(ids, r.cand.ID)
 	}
 
+	// This is the one place the document cache is consulted, and the ids handed
+	// to it are the ids the retrieval above just produced under this principal's
+	// permission predicate. That ordering is what makes an entry keyed by id
+	// alone safe, and it is why the lookup is here rather than behind
+	// store.Store.Get where any id at all could arrive. See [Cache.document].
+	if s.cache != nil {
+		var missing []string
+		out, missing = s.cache.document(ids)
+		if len(missing) == 0 {
+			return out, nil
+		}
+		ids = missing
+	}
+
+	fetched, err := s.read(ctx, p, ids)
+	if err != nil {
+		return nil, err
+	}
+	if s.cache != nil {
+		s.cache.putDocuments(fetched)
+	}
+	for id, d := range fetched {
+		out[id] = d
+	}
+	return out, nil
+}
+
+// read is the fetch itself, with no cache in front of it.
+func (s *Searcher) read(ctx context.Context, p *acl.Principal, ids []string) (map[string]doc.Document, error) {
+	out := make(map[string]doc.Document, len(ids))
 	if f, ok := s.store.(store.Fetcher); ok {
 		docs, err := f.Fetch(ctx, p, ids)
 		if err != nil {
@@ -344,19 +432,6 @@ func (s *Searcher) fetch(ctx context.Context, p *acl.Principal, window []ranked)
 		out[id] = d
 	}
 	return out, nil
-}
-
-// outline is the document a result falls back to when the fetch could not read
-// it: everything the ranking already knew, and no body.
-func outline(c store.Candidate) doc.Document {
-	return doc.Document{
-		ID:         c.ID,
-		Source:     c.Source,
-		Kind:       c.Kind,
-		Container:  c.Container,
-		Author:     doc.Person{Name: c.Author},
-		ModifiedAt: c.ModifiedAt,
-	}
 }
 
 // page slices a sorted result set, tolerating an offset past the end.

--- a/index/score.go
+++ b/index/score.go
@@ -93,7 +93,22 @@ type pool struct {
 // changes is how much data had to be touched to get there.
 func (s *Searcher) collect(ctx context.Context, p *acl.Principal, r store.Request, sel store.Selection) (pool, error) {
 	if rk, ok := s.store.(store.Ranker); ok {
-		ranked, err := rk.Rank(ctx, p, r, sel)
+		// The cache goes around this branch and not around the other two. This is
+		// the branch a deployment actually runs, and it is the one whose result is
+		// a value the driver produced under the permission rule, which is what
+		// makes it something a fingerprint can name. The fallbacks are for a driver
+		// that has no index, where the cost is the scan and caching the tail of it
+		// would be measuring the wrong thing.
+		call := func() (store.Ranked, error) { return rk.Rank(ctx, p, r, sel) }
+		var (
+			ranked store.Ranked
+			err    error
+		)
+		if s.cache != nil {
+			ranked, err = s.cache.ranked(p, r, sel, call)
+		} else {
+			ranked, err = call()
+		}
 		if err != nil {
 			return pool{}, err
 		}
@@ -182,7 +197,11 @@ func candidateOf(d doc.Document, terms []string) store.Candidate {
 // all, and both drivers in the tree implement the capability.
 func (s *Searcher) statistics(ctx context.Context, p *acl.Principal, terms []string, from pool) (store.Corpus, error) {
 	if st, ok := s.store.(store.Statistician); ok {
-		return st.Statistics(ctx, p, terms)
+		call := func() (store.Corpus, error) { return st.Statistics(ctx, p, terms) }
+		if s.cache != nil {
+			return s.cache.corpusStats(p, terms, call)
+		}
+		return call()
 	}
 	c := store.Corpus{Documents: len(from.cands), DocFreq: make(map[string]int, len(terms))}
 	for _, cand := range from.cands {

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -22,6 +22,13 @@ import (
 
 // Store keeps documents in a map guarded by a read write mutex.
 type Store struct {
+	// Notify makes this driver report its own writes, which is what a cache
+	// invalidates on and what the browser's event stream carries. It is embedded
+	// rather than wrapped so that the reference driver has the same capability
+	// the SQLite one does, and a test of the caching does not have to reach for a
+	// database file to get it.
+	store.Notify
+
 	mu   sync.RWMutex
 	docs map[string]doc.Document
 
@@ -43,6 +50,7 @@ func New() *Store {
 var (
 	_ store.ContentStore = (*Store)(nil)
 	_ store.Statistician = (*Store)(nil)
+	_ store.Notifier     = (*Store)(nil)
 )
 
 // Put inserts or replaces documents.
@@ -50,14 +58,27 @@ func (s *Store) Put(ctx context.Context, docs ...doc.Document) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	written, err := s.put(docs)
+	if err != nil {
+		return err
+	}
+	// Subscribers are told after the write is visible and after the lock is
+	// back, so a subscriber that reads the store from inside its callback sees
+	// what it was told about instead of deadlocking on the way to it.
+	s.Changes(written, false)
+	return nil
+}
+
+func (s *Store) put(docs []doc.Document) (map[string][]string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
-		return genba.ErrClosed
+		return nil, genba.ErrClosed
 	}
+	written := make(map[string][]string)
 	for _, d := range docs {
 		if d.ID == "" {
-			return fmt.Errorf("memstore: put: %w", errNoID)
+			return nil, fmt.Errorf("memstore: put: %w", errNoID)
 		}
 		if d.Content != nil {
 			s.content[d.ID] = *d.Content
@@ -66,8 +87,9 @@ func (s *Store) Put(ctx context.Context, docs ...doc.Document) error {
 		}
 		d.Content = nil
 		s.docs[d.ID] = d
+		written[d.Tenant] = append(written[d.Tenant], d.ID)
 	}
-	return nil
+	return written, nil
 }
 
 // Delete removes documents by id.
@@ -75,16 +97,32 @@ func (s *Store) Delete(ctx context.Context, ids ...string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	removed, err := s.remove(ids)
+	if err != nil {
+		return err
+	}
+	s.Changes(removed, true)
+	return nil
+}
+
+func (s *Store) remove(ids []string) (map[string][]string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
-		return genba.ErrClosed
+		return nil, genba.ErrClosed
 	}
+	removed := make(map[string][]string)
 	for _, id := range ids {
+		// The tenant is read before the document goes, because afterwards there
+		// is nothing left to read it from, and a change reported with no tenant
+		// on it is a change a subscriber cannot act on.
+		if d, ok := s.docs[id]; ok {
+			removed[d.Tenant] = append(removed[d.Tenant], id)
+		}
 		delete(s.docs, id)
 		delete(s.content, id)
 	}
-	return nil
+	return removed, nil
 }
 
 // Get returns one document if the principal may read it.

--- a/store/notify.go
+++ b/store/notify.go
@@ -1,0 +1,97 @@
+package store
+
+import "sync"
+
+// Notifier is the optional capability of a driver that reports its own writes.
+//
+// Two things above the storage layer need to know that the corpus moved. A
+// cache has to drop what a write made wrong, and the browser has to be told
+// that the results on screen are no longer the whole story. Both were
+// previously a timer, which is the answer that is either too slow to be useful
+// or too expensive to be cheap.
+//
+// A driver reports a change after it has committed, never before. A subscriber
+// that acted on an uncommitted write would drop a cache entry and then refill
+// it from the state the write was about to replace, which is a worse cache than
+// no cache.
+type Notifier interface {
+	// OnChange registers fn and returns a function that unregisters it.
+	//
+	// fn is called from whichever goroutine performed the write, so it must not
+	// block. A subscriber that needs to do real work hands the change to its own
+	// goroutine and returns.
+	OnChange(fn func(Change)) (stop func())
+}
+
+// Change is what one committed write did.
+type Change struct {
+	// Tenant is whose corpus moved. A driver reports one change per tenant, so
+	// this is never a mixture and a subscriber never has to guess.
+	Tenant string
+
+	// IDs are the documents written or removed.
+	IDs []string
+
+	// Deleted distinguishes a removal from a write.
+	//
+	// The server cache treats the two the same, because either way everything it
+	// derived from the tenant's corpus is now a guess. The difference is for the
+	// browser: a write means what is on screen may be out of date and should be
+	// revalidated, and a delete means something on screen may already be gone,
+	// which is worth acting on before the revalidation comes back.
+	Deleted bool
+}
+
+// Notify is the broadcaster a driver embeds to implement [Notifier].
+//
+// The zero value is ready to use. It is in this package rather than in each
+// driver because there is nothing driver specific about it, and two copies of a
+// subscriber list is two chances to leak one.
+type Notify struct {
+	mu   sync.RWMutex
+	next uint64
+	fns  map[uint64]func(Change)
+}
+
+// OnChange registers fn.
+func (n *Notify) OnChange(fn func(Change)) (stop func()) {
+	if fn == nil {
+		return func() {}
+	}
+	n.mu.Lock()
+	if n.fns == nil {
+		n.fns = make(map[uint64]func(Change))
+	}
+	id := n.next
+	n.next++
+	n.fns[id] = fn
+	n.mu.Unlock()
+
+	return func() {
+		n.mu.Lock()
+		delete(n.fns, id)
+		n.mu.Unlock()
+	}
+}
+
+// Changed tells every subscriber. A driver calls it after the transaction has
+// committed, and never while holding a lock a subscriber might want.
+func (n *Notify) Changed(c Change) {
+	if c.Tenant == "" && len(c.IDs) == 0 {
+		return
+	}
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	for _, fn := range n.fns {
+		fn(c)
+	}
+}
+
+// Changes groups a batch of ids by tenant and reports each group. A driver
+// takes a batch that may span tenants, and a subscriber that had to split one
+// would be doing the driver's bookkeeping for it.
+func (n *Notify) Changes(byTenant map[string][]string, deleted bool) {
+	for tenant, ids := range byTenant {
+		n.Changed(Change{Tenant: tenant, IDs: ids, Deleted: deleted})
+	}
+}

--- a/store/sqlitestore/sqlitestore.go
+++ b/store/sqlitestore/sqlitestore.go
@@ -43,6 +43,12 @@ import (
 
 // Store is a [store.Store] over one SQLite database.
 type Store struct {
+	// Notify makes this driver report its own writes. A cache above it drops
+	// what the write made wrong, and the browser's event stream tells the page
+	// on screen that the corpus moved. Both used to be a timer, which is the
+	// answer that is either too slow to be useful or too expensive to be cheap.
+	store.Notify
+
 	db *sql.DB
 
 	// write serialises writers. SQLite allows one at a time and in WAL mode a
@@ -64,6 +70,7 @@ var (
 	_ store.Ranker       = (*Store)(nil)
 	_ store.Statistician = (*Store)(nil)
 	_ store.Fetcher      = (*Store)(nil)
+	_ store.Notifier     = (*Store)(nil)
 )
 
 // Counters is the work one query cost, counted exactly.
@@ -241,14 +248,20 @@ func (s *Store) Put(ctx context.Context, docs ...doc.Document) error {
 	}
 	defer w.close()
 
+	written := make(map[string][]string)
 	for _, d := range docs {
 		if err := putOne(ctx, tx, w, d); err != nil {
 			return fmt.Errorf("sqlitestore: put %s: %w", d.ID, err)
 		}
+		written[d.Tenant] = append(written[d.Tenant], d.ID)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("sqlitestore: put: %w", err)
 	}
+	// After the commit, never before. A subscriber that dropped a cache entry
+	// for a write that then rolled back would refill it from the state the write
+	// was about to replace, which is a worse cache than no cache.
+	s.Changes(written, false)
 	return nil
 }
 
@@ -277,7 +290,7 @@ func putOne(ctx context.Context, tx *sql.Tx, w *writer, d doc.Document) error {
 	// Whatever is stored under this id stops counting before the row that
 	// carries the numbers is overwritten, because after the write there is no
 	// way left to know what it used to contribute.
-	if _, _, err := w.retire(ctx, d.ID); err != nil {
+	if _, _, _, err := w.retire(ctx, d.ID); err != nil {
 		return err
 	}
 
@@ -417,13 +430,14 @@ func (s *Store) Delete(ctx context.Context, ids ...string) error {
 	}
 	defer w.close()
 
+	removed := make(map[string][]string)
 	for _, id := range ids {
 		// The rowid is read first because the full text index is keyed on it
 		// and knows nothing about document ids. Deleting a document that is not
 		// there is not an error, which is what makes a retry safe. retire is
 		// what takes the document back out of the corpus statistics, which has
 		// to happen while its postings are still there to be counted.
-		rowid, found, err := w.retire(ctx, id)
+		rowid, tenant, found, err := w.retire(ctx, id)
 		if err != nil {
 			return fmt.Errorf("sqlitestore: delete %s: %w", id, err)
 		}
@@ -436,10 +450,12 @@ func (s *Store) Delete(ctx context.Context, ids ...string) error {
 		if _, err := tx.ExecContext(ctx, `DELETE FROM document WHERE id = ?`, id); err != nil {
 			return fmt.Errorf("sqlitestore: delete %s: %w", id, err)
 		}
+		removed[tenant] = append(removed[tenant], id)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("sqlitestore: delete: %w", err)
 	}
+	s.Changes(removed, true)
 	return nil
 }
 

--- a/store/sqlitestore/write.go
+++ b/store/sqlitestore/write.go
@@ -117,34 +117,36 @@ func (w *writer) close() {
 //
 // It runs before the row is rewritten, because the columns it reads are the
 // ones about to be overwritten. It returns whether the document was there at
-// all, which is what tells the delete path there is nothing to do.
-func (w *writer) retire(ctx context.Context, id string) (rowid int64, found bool, err error) {
+// all, which is what tells the delete path there is nothing to do, and the
+// tenant it belonged to, which the delete path has no other way to learn: after
+// the row is gone there is nothing left to read it from, and a change reported
+// with no tenant on it is a change a subscriber cannot act on.
+func (w *writer) retire(ctx context.Context, id string) (rowid int64, tenant string, found bool, err error) {
 	var (
-		tenant            string
 		titleTok, bodyTok int64
 		queryable         int
 	)
 	switch err := w.prior.QueryRowContext(ctx, id).Scan(&rowid, &tenant, &titleTok, &bodyTok, &queryable); {
 	case errors.Is(err, sql.ErrNoRows):
-		return 0, false, nil
+		return 0, "", false, nil
 	case err != nil:
-		return 0, false, err
+		return 0, "", false, err
 	}
 
 	// A quarantined document was never counted, so taking it out again would
 	// count it backwards.
 	if queryable == 1 {
 		if _, err := w.retireTerm.ExecContext(ctx, tenant, rowid); err != nil {
-			return 0, false, err
+			return 0, "", false, err
 		}
 		if _, err := w.corpusSub.ExecContext(ctx, titleTok, bodyTok, tenant); err != nil {
-			return 0, false, err
+			return 0, "", false, err
 		}
 	}
 	if _, err := w.dropPost.ExecContext(ctx, rowid); err != nil {
-		return 0, false, err
+		return 0, "", false, err
 	}
-	return rowid, true, nil
+	return rowid, tenant, true, nil
 }
 
 // index writes the postings for a document and folds it into the corpus

--- a/store/storetest/notify.go
+++ b/store/storetest/notify.go
@@ -1,0 +1,110 @@
+package storetest
+
+import (
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/tamnd/genba/store"
+)
+
+// Reporting writes is an optional capability, and the two things that consume
+// it are a cache and a live interface. Both of them are wrong in a way nobody
+// notices if a driver reports a write before it is readable: the cache drops an
+// entry and immediately refills it from the state the write was about to
+// replace, and the browser is told to refetch something that is not there yet.
+//
+// So the conformance case is not only that a change arrives. It is that a
+// subscriber which reads the store from inside the callback sees the write it
+// was just told about.
+
+// notified collects what a driver reported.
+type notified struct {
+	mu      sync.Mutex
+	changes []store.Change
+}
+
+func (n *notified) record(c store.Change) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.changes = append(n.changes, c)
+}
+
+func (n *notified) all() []store.Change {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return slices.Clone(n.changes)
+}
+
+func testNotifyWrites(t *testing.T, s store.Store) {
+	n, ok := s.(store.Notifier)
+	if !ok {
+		t.Skip("this driver does not report its writes")
+	}
+
+	var (
+		got     notified
+		visible = make(map[string]bool)
+	)
+	stop := n.OnChange(func(c store.Change) {
+		got.record(c)
+		// Reading the store from inside the callback is the point. A driver that
+		// reports a write while still holding its own lock deadlocks here, and one
+		// that reports before committing returns not found.
+		for _, id := range c.IDs {
+			if _, err := s.Get(t.Context(), reader(), id); err == nil {
+				visible[id] = true
+			}
+		}
+	})
+
+	mustPut(t, s, document("d1", readable()), document("d2", readable()))
+	changes := got.all()
+	if len(changes) != 1 {
+		t.Fatalf("a put of two documents reported %d changes, want 1 per tenant", len(changes))
+	}
+	if changes[0].Tenant != "acme" {
+		t.Errorf("the change names tenant %q, want acme: a change without a tenant is one a subscriber cannot act on", changes[0].Tenant)
+	}
+	if changes[0].Deleted {
+		t.Error("a put reported itself as a delete")
+	}
+	ids := slices.Clone(changes[0].IDs)
+	slices.Sort(ids)
+	if !slices.Equal(ids, []string{"d1", "d2"}) {
+		t.Errorf("the change names %v, want both documents", ids)
+	}
+	if !visible["d1"] || !visible["d2"] {
+		t.Error("a document was reported before it could be read, so a subscriber would cache the state the write replaced")
+	}
+
+	if err := s.Delete(t.Context(), "d1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	changes = got.all()
+	if len(changes) != 2 {
+		t.Fatalf("a delete reported %d changes in total, want 2", len(changes))
+	}
+	last := changes[1]
+	if !last.Deleted {
+		t.Error("a delete did not report itself as a delete, so a cache would keep serving the document in its result lists")
+	}
+	if last.Tenant != "acme" || !slices.Equal(last.IDs, []string{"d1"}) {
+		t.Errorf("the delete reported tenant %q and ids %v, want acme and [d1]", last.Tenant, last.IDs)
+	}
+
+	// Deleting an id that is not there is not a write, so there is nothing to
+	// report and a subscriber is not woken for it.
+	if err := s.Delete(t.Context(), "never-there"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if now := got.all(); len(now) != 2 {
+		t.Errorf("deleting an absent id reported a change: %d changes in total, want 2", len(now))
+	}
+
+	stop()
+	mustPut(t, s, document("d3", readable()))
+	if now := got.all(); len(now) != 2 {
+		t.Errorf("a subscriber that unsubscribed was still called: %d changes in total, want 2", len(now))
+	}
+}

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -59,6 +59,7 @@ var cases = []testCase{
 	{"content is served only to a reader who may see the document", testContent},
 	{"content never rides along on a query path", testContentIsNotInTheDocument},
 	{"deleting a document deletes its content", testContentDelete},
+	{"writes are reported after they are visible", testNotifyWrites},
 }
 
 // contentStore skips a case for a driver that does not hold bytes.

--- a/web/dist/assets/api.js
+++ b/web/dist/assets/api.js
@@ -56,7 +56,16 @@ export class ApiError extends Error {
   }
 }
 
-async function get(path, params, signal) {
+/**
+ * get reads one JSON endpoint and reports whether the answer moved.
+ *
+ * Every read returns an envelope rather than the body, because every one of
+ * these responses is revalidated rather than refetched. Passing back the entity
+ * tag lets the next call ask whether what the client holds is still current,
+ * and a server that has not changed its mind answers that in a few hundred
+ * bytes with no body at all, which is the whole point of cache.js.
+ */
+async function get(path, params, opts = {}) {
   const url = new URL(BASE + path, location.origin);
   for (const [key, value] of Object.entries(params || {})) {
     if (value === undefined || value === null || value === "") continue;
@@ -65,7 +74,10 @@ async function get(path, params, signal) {
     }
   }
 
-  const res = await fetch(url, { headers: headers(), signal });
+  const sent = headers();
+  if (opts.etag) sent["If-None-Match"] = opts.etag;
+  const res = await fetch(url, { headers: sent, signal: opts.signal });
+  if (res.status === 304) return { modified: false, etag: opts.etag };
   if (!res.ok) {
     let code = "error";
     let message = `the server returned ${res.status}`;
@@ -81,7 +93,50 @@ async function get(path, params, signal) {
     }
     throw new ApiError(res.status, code, message);
   }
-  return res.json();
+  return { modified: true, etag: res.headers.get("ETag") || "", data: await res.json() };
+}
+
+/**
+ * events reads the index change stream.
+ *
+ * EventSource would be the obvious way to do this and cannot be used, because
+ * it sends no headers of its own and every request here carries the caller's
+ * identity in one. So the stream is read from a normal fetch, which means the
+ * frame parsing is ours: frames are separated by a blank line, a line starting
+ * with a colon is a comment and is how the server keeps the connection alive,
+ * and anything we cannot parse is ignored rather than thrown, because a
+ * malformed frame is not a reason to tear down a working stream.
+ *
+ * It resolves when the server closes the stream, so the caller reconnects.
+ */
+async function events(onEvent, signal) {
+  const res = await fetch(BASE + "/events", { headers: headers(), signal });
+  if (!res.ok || !res.body) {
+    throw new ApiError(res.status, "error", `the event stream returned ${res.status}`);
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) return;
+    buffer += decoder.decode(value, { stream: true });
+    for (let cut = buffer.indexOf("\n\n"); cut >= 0; cut = buffer.indexOf("\n\n")) {
+      const frame = buffer.slice(0, cut);
+      buffer = buffer.slice(cut + 2);
+      const data = frame
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).trim())
+        .join("");
+      if (!data) continue;
+      try {
+        onEvent(JSON.parse(data));
+      } catch {
+        // A frame this client does not understand is a frame it does not need.
+      }
+    }
+  }
 }
 
 /**
@@ -92,8 +147,8 @@ async function get(path, params, signal) {
  * server decides, from the same headers as every other request, and a document
  * somebody may not read is a 404 here exactly as it is everywhere else.
  */
-async function bytes(path, signal) {
-  const res = await fetch(BASE + path, { headers: headers(), signal });
+async function bytes(path, opts = {}) {
+  const res = await fetch(BASE + path, { headers: headers(), signal: opts.signal });
   if (!res.ok) throw new ApiError(res.status, "error", `the server returned ${res.status}`);
   const dims = (res.headers.get("X-Content-Dimensions") || "").split("x");
   return {
@@ -104,12 +159,16 @@ async function bytes(path, signal) {
   };
 }
 
+// Every JSON read takes the same options, { signal, etag }, and returns the
+// same envelope. The two that do not are content, which is bytes rather than a
+// document, and the stream, which never finishes.
 export const api = {
-  me: (signal) => get("/me", {}, signal),
-  stats: (signal) => get("/stats", {}, signal),
-  search: (query, signal) => get("/search", query, signal),
-  suggest: (q, signal) => get("/suggest", { q }, signal),
-  document: (id, signal) => get(`/documents/${encodeURIComponent(id)}`, {}, signal),
-  content: (id, signal) => bytes(`/documents/${encodeURIComponent(id)}/content`, signal),
+  me: (opts) => get("/me", {}, opts),
+  stats: (opts) => get("/stats", {}, opts),
+  search: (query, opts) => get("/search", query, opts),
+  suggest: (q, opts) => get("/suggest", { q }, opts),
+  document: (id, opts) => get(`/documents/${encodeURIComponent(id)}`, {}, opts),
+  content: (id, opts) => bytes(`/documents/${encodeURIComponent(id)}/content`, opts),
+  events,
   health: (signal) => fetch("/healthz", { signal }).then((r) => r.json()),
 };

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -123,9 +123,13 @@ time {
 .app {
   display: grid;
   grid-template-columns: var(--rail-width) minmax(0, 1fr);
-  grid-template-rows: var(--header-height) minmax(0, 1fr);
+  /* Three rows, and the middle one is the connection banner. It is auto rather
+     than a fixed height so that it takes no space at all when it is hidden,
+     which is almost always. */
+  grid-template-rows: var(--header-height) auto minmax(0, 1fr);
   grid-template-areas:
     "rail header"
+    "rail banner"
     "rail main";
   height: 100vh;
 }
@@ -1684,6 +1688,33 @@ h6.prose__h {
  * almost never. Stale content underneath it is not dimmed: it is the previous
  * answer and it is almost always still the right one.
  */
+/* The offline banner.
+   It states a fact and nothing else. It does not dim the page, cover it or
+   offer a retry button, because what is underneath it is the last thing the
+   server said and is very probably still true. */
+.banner {
+  grid-area: banner;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--gutter);
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+}
+
+.banner[hidden] {
+  display: none;
+}
+
+.banner__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--warning-600);
+  flex: none;
+}
+
 .progress {
   position: sticky;
   top: var(--filterbar-height);
@@ -1947,6 +1978,7 @@ h6.prose__h {
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
       "header"
+      "banner"
       "main";
   }
 

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -7,8 +7,10 @@
 
 import { h, replace, svg } from "./dom.js";
 import { api, identity, setIdentity, ApiError } from "./api.js";
+import { cache } from "./cache.js";
+import { Live } from "./live.js";
 import * as urlState from "./state.js";
-import { icon, initials, label, sourceColor } from "./format.js";
+import { icon, initials, label, sourceColor, when } from "./format.js";
 import { Omnibox, shortcutLabel } from "./omnibox.js";
 import { Results, VERTICALS } from "./results.js";
 import { Drawer } from "./drawer.js";
@@ -26,21 +28,45 @@ const DENSITY_KEY = "genba.density";
 // and the transition is a single paint.
 const LOADING_DELAY = 120;
 
+// How long each prefetch waits before it decides somebody meant it.
+//
+// All three are bets, and the delay is what keeps a bet cheap. Passing the
+// pointer over eight rows on the way to the ninth should cost nothing, and
+// arrow keying down a suggestion list should not fire eight searches.
+const PREFETCH_PAGE = 300;
+const PREFETCH_HOVER = 150;
+const PREFETCH_SUGGESTION = 200;
+
+// At most four documents are being guessed at once. Beyond that the prefetches
+// are competing with the request somebody is actually waiting for.
+const PREFETCH_LIMIT = 4;
+
+// How often the offline banner recounts the age of what is on screen. It only
+// runs while the connection is gone, which is the only time anybody is reading
+// it.
+const BANNER_TICK = 30_000;
+
 class App {
   constructor(root) {
     this.root = root;
     this.session = null;
     this.query = urlState.read();
-    this.pending = null;
     this.loadingTimer = null;
+    this.currentKey = "";
+    this.hoverTimer = null;
+    this.pageTimer = null;
+    this.suggestionTimer = null;
+    this.guessing = 0;
 
     this.omnibox = new Omnibox({
       onSearch: (text) => this.go({ ...this.query, q: text, offset: 0, open: "" }),
       onOpen: (id) => this.open(id),
+      onHighlight: (item) => this.guessSuggestion(item),
     });
     this.results = new Results({
       onQuery: (q) => this.go(q),
       onOpen: (id) => this.open(id),
+      onHover: (id) => this.guessDocument(id),
     });
     this.home = new Home({
       onQuery: (q) => this.go({ ...urlState.read(""), ...q }),
@@ -69,10 +95,21 @@ class App {
       "aria-atomic": "true",
     });
 
+    this.banner = h("div", { class: "banner", role: "status", hidden: true });
+
     this.rail = this.buildRail();
     this.header = this.buildHeader();
     this.build();
     this.bindKeys();
+
+    // The page checks itself against the server on four triggers, none of which
+    // is a person pressing reload. What is on screen was correct when it was
+    // painted, and the only question this answers is whether it still is.
+    this.refresher = new Live({
+      onRefresh: () => this.sync(),
+      onConnection: (online) => this.connection(online),
+      onIndex: () => cache.invalidate(),
+    });
 
     window.addEventListener("popstate", () => {
       this.query = urlState.read();
@@ -89,6 +126,7 @@ class App {
         h("a", { class: "visually-hidden", href: "#main" }, "Skip to results"),
         this.rail,
         this.header,
+        this.banner,
         this.main,
       ),
       this.drawer.scrim,
@@ -235,13 +273,18 @@ class App {
 
   async start() {
     try {
-      this.session = await api.me();
+      this.session = (await api.me()).data;
+      // Everything the cache holds is keyed under this, so it is set before
+      // anything is read and the switcher below empties the cache by changing
+      // it. Nothing cached under one identity is reachable from another.
+      cache.as(this.session.view || "");
       this.renderSources();
     } catch (err) {
       this.fail(err);
       return;
     }
     this.sync();
+    this.refresher.start();
   }
 
   renderSources() {
@@ -303,10 +346,25 @@ class App {
   }
 
   async search() {
-    const mounted = this.main.firstChild === this.results.el;
-    if (!mounted) replace(this.main, this.results.el);
+    const showing = this.main.firstChild === this.results.el;
+    if (!showing) replace(this.main, this.results.el);
 
     const request = urlState.params(this.query, VERTICALS);
+    const k = cache.key("search", request);
+    this.currentKey = k;
+
+    let painted = false;
+    const paint = (res) => {
+      // The address bar moved on while this was in flight, so this answer is to
+      // a question nobody is asking any more.
+      if (this.currentKey !== k) return;
+      painted = true;
+      clearTimeout(this.loadingTimer);
+      this.results.revalidating(false);
+      this.results.render(this.query, res);
+      this.announce(res);
+      this.guessNextPage(res);
+    };
 
     // A first search has nothing on screen to keep, so it gets the skeleton
     // after the delay. A subsequent one keeps the previous answer visible and
@@ -314,25 +372,109 @@ class App {
     // always still the right one and dimming it says otherwise.
     clearTimeout(this.loadingTimer);
     this.loadingTimer = setTimeout(() => {
-      if (mounted) this.results.revalidating(true);
+      if (this.currentKey !== k) return;
+      if (painted || showing) this.results.revalidating(true);
       else this.results.loading(this.query);
     }, LOADING_DELAY);
 
-    if (this.pending) this.pending.abort();
-    const controller = new AbortController();
-    this.pending = controller;
     try {
-      const res = await api.search(request, controller.signal);
-      if (controller.signal.aborted) return;
-      this.results.render(this.query, res);
-      this.announce(res);
+      await cache.swr(k, (opts) => api.search(request, opts), paint);
     } catch (err) {
       if (err.name === "AbortError") return;
-      this.fail(err);
+      // A check that failed behind an answer already on screen keeps the
+      // answer. Replacing a page somebody is reading with an error page because
+      // a background request failed is worse than being a minute out of date,
+      // and the banner already says the connection is gone.
+      if (!painted && this.currentKey === k) this.fail(err);
     } finally {
       clearTimeout(this.loadingTimer);
-      if (!controller.signal.aborted) this.results.revalidating(false);
+      if (this.currentKey === k) this.results.revalidating(false);
     }
+  }
+
+  /**
+   * connection shows or hides the offline banner.
+   *
+   * Nothing is dimmed and nothing is hidden while offline. What is on screen
+   * was true when it was fetched, the banner says when that was, and that is a
+   * more useful page than an error.
+   */
+  connection(online) {
+    this.banner.hidden = online;
+    clearInterval(this.bannerTimer);
+    if (online) return;
+    this.sayHowOld();
+    // The age is the whole point of the banner, so it keeps counting. A tab
+    // left open through a long outage would otherwise still claim its results
+    // are six seconds old.
+    this.bannerTimer = setInterval(() => this.sayHowOld(), BANNER_TICK);
+  }
+
+  /** sayHowOld writes the offline banner, naming the age of what is on screen. */
+  sayHowOld() {
+    const held = this.currentKey ? cache.read(this.currentKey) : { state: "miss" };
+    const age = held.state === "miss" ? "" : when(new Date(held.at).toISOString());
+    replace(
+      this.banner,
+      h("span", { class: "banner__dot" }),
+      age ? `You are offline. These are the results from ${age}.` : "You are offline. This is the last answer the server gave.",
+    );
+  }
+
+  /**
+   * guessNextPage fills the cache with the page after this one.
+   *
+   * Paging is the most predictable thing anybody does on a results page, and
+   * one page ahead is where the guessing stops. Two pages ahead is a request
+   * for something most people never look at.
+   */
+  guessNextPage(res) {
+    clearTimeout(this.pageTimer);
+    const limit = this.query.limit || 20;
+    if (!res.hits || res.hits.length < limit) return;
+    const next = urlState.params({ ...this.query, offset: (this.query.offset || 0) + limit }, VERTICALS);
+    this.pageTimer = setTimeout(() => this.guess("search", next, (opts) => api.search(next, opts)), PREFETCH_PAGE);
+  }
+
+  /** guessDocument fetches what the pointer has been resting on. */
+  guessDocument(id) {
+    clearTimeout(this.hoverTimer);
+    if (!id || this.guessing >= PREFETCH_LIMIT) return;
+    this.hoverTimer = setTimeout(() => {
+      this.guessing++;
+      this.guess("document", { id }, (opts) => api.document(id, opts)).finally(() => this.guessing--);
+    }, PREFETCH_HOVER);
+  }
+
+  /** guessSuggestion fetches the search behind a highlighted suggestion. */
+  guessSuggestion(item) {
+    clearTimeout(this.suggestionTimer);
+    if (!item || item.kind === "operator") return;
+    const text = item.value || item.text;
+    if (!text) return;
+    const request = urlState.params({ ...urlState.read(""), q: text }, VERTICALS);
+    this.suggestionTimer = setTimeout(
+      () => this.guess("search", request, (opts) => api.search(request, opts)),
+      PREFETCH_SUGGESTION,
+    );
+  }
+
+  /**
+   * guess fills a cache entry for something nobody has asked for yet.
+   *
+   * A prefetch that fails is a prefetch that did not happen. It is not retried
+   * and it never reaches the error state, because the real request will report
+   * the failure properly and with something on screen to attach it to.
+   */
+  guess(name, params, run) {
+    const k = cache.key(name, params);
+    if (cache.read(k).state !== "miss") return Promise.resolve();
+    return cache
+      .once(k, (signal) => run({ signal }))
+      .then((res) => {
+        if (res.modified) cache.write(k, res.data, res.etag);
+      })
+      .catch(() => {});
   }
 
   /**
@@ -346,6 +488,9 @@ class App {
 
   fail(err) {
     const unauthenticated = err instanceof ApiError && err.status === 401;
+    // The one failure that empties the cache. Everything in it was read under a
+    // session that is now over, and the next session is not entitled to it.
+    if (unauthenticated) cache.clear();
     replace(
       this.main,
       h(

--- a/web/dist/assets/cache.js
+++ b/web/dist/assets/cache.js
@@ -1,0 +1,182 @@
+// The browser's copy of what the server already answered.
+//
+// The server budget makes a response fast. This makes the common case need no
+// response at all. Going back, changing a sort, unticking a facet, reopening a
+// preview: every one of those asks for something this tab already had.
+//
+// Nothing here is written to disk. Search results are titles and excerpts from
+// a permissioned corpus, and localStorage would leave them on the machine after
+// the session that was allowed to see them ended. Memory is the right lifetime
+// because it is the session's lifetime.
+//
+// This module is the store and the stale while revalidate flow over it.
+// Deciding when to revalidate is live.js.
+
+// TTL is how old an entry may be and still be worth painting. Beyond it the
+// entry is a miss, because painting a several minute old answer while a new one
+// loads is not a fast interface, it is a wrong one.
+//
+// STALE is the line between an answer that needs no request and one that is
+// painted and then checked. Somebody arrow keying through results asks the same
+// question repeatedly and none of those needs a round trip.
+const TTL = 30_000;
+const STALE = 5_000;
+const MAX_ENTRIES = 200;
+
+export class Store {
+  constructor({ maxEntries = MAX_ENTRIES, ttl = TTL, staleAfter = STALE, now = Date.now } = {}) {
+    this.max = maxEntries;
+    this.ttl = ttl;
+    this.staleAfter = staleAfter;
+    this.now = now;
+    this.view = "";
+    this.entries = new Map();
+    this.running = new Map();
+  }
+
+  /**
+   * as names whose results these are, and empties everything when that changes.
+   *
+   * The value comes from the me endpoint rather than being derived here, so it
+   * is the fingerprint the server keys its own caches by and the two cannot
+   * drift. Prepending it is what makes the identity switcher safe: one tab
+   * holds results for more than one identity over its life, and serving one
+   * identity's results to another is the same bug in a browser as in a server.
+   */
+  as(view) {
+    if (view === this.view) return;
+    this.view = view;
+    this.clear();
+  }
+
+  /**
+   * key canonicalises a request so two spellings of one question share an entry.
+   *
+   * Parameter order and the order of a repeated parameter carry no meaning, so
+   * both are sorted. Case is left alone: the server matches a container or an
+   * author exactly, so folding it here would merge two requests whose answers
+   * differ.
+   */
+  key(name, params) {
+    const out = new URLSearchParams();
+    for (const field of Object.keys(params || {}).sort()) {
+      const value = params[field];
+      for (const one of Array.isArray(value) ? [...value].sort() : [value]) {
+        if (one === "" || one === undefined || one === null) continue;
+        out.append(field, String(one));
+      }
+    }
+    return `${this.view}|${name}|${out}`;
+  }
+
+  /**
+   * read reports what is held for a key and how far it can be trusted. Three
+   * states rather than two, because cached is not one condition: "miss" is
+   * nothing to paint, "fresh" is paint it and send nothing, "stale" is paint it
+   * and check behind it.
+   */
+  read(k) {
+    const entry = this.entries.get(k);
+    if (!entry) return { state: "miss" };
+    const age = this.now() - entry.at;
+    if (age > this.ttl) {
+      this.entries.delete(k);
+      return { state: "miss" };
+    }
+    // Reading is use, so the entry moves to the end and eviction takes the one
+    // nobody has looked at.
+    this.entries.delete(k);
+    this.entries.set(k, entry);
+    return {
+      state: entry.stale || age > this.staleAfter ? "stale" : "fresh",
+      data: entry.data,
+      etag: entry.etag,
+      at: entry.at,
+    };
+  }
+
+  /** write records a response and evicts the least recently used if it has to. */
+  write(k, data, etag = "") {
+    this.entries.delete(k);
+    this.entries.set(k, { data, etag, at: this.now(), stale: false });
+    while (this.entries.size > this.max) {
+      this.entries.delete(this.entries.keys().next().value);
+    }
+  }
+
+  /** touch marks an entry current again, which is what a 304 means. */
+  touch(k) {
+    const entry = this.entries.get(k);
+    if (!entry) return undefined;
+    entry.at = this.now();
+    entry.stale = false;
+    return entry.data;
+  }
+
+  /**
+   * once runs a fetch for a key, or joins the one already running. A prefetch
+   * and the click it predicted ask for the same key seconds apart, and the
+   * second should cost nothing. Same single flight as the server, same reason.
+   */
+  once(k, run) {
+    const running = this.running.get(k);
+    if (running) return running.promise;
+    const controller = new AbortController();
+    const record = { controller };
+    record.promise = run(controller.signal).finally(() => {
+      if (this.running.get(k) === record) this.running.delete(k);
+    });
+    this.running.set(k, record);
+    return record.promise;
+  }
+
+  /**
+   * swr paints what is cached and checks it behind the paint.
+   *
+   * paint is called at most twice, and the second time only if the answer is
+   * really different. That is what the entity tag buys: a revalidation that
+   * confirms the page costs a few hundred bytes and produces no repaint, so
+   * the scroll position and the keyboard cursor survive it.
+   */
+  async swr(k, run, paint) {
+    const held = this.read(k);
+    if (held.data !== undefined) paint(held.data, held.state);
+    if (held.state === "fresh") return held.data;
+
+    const res = await this.once(k, (signal) => run({ signal, etag: held.etag }));
+    if (!res.modified) {
+      const kept = this.touch(k);
+      return kept === undefined ? held.data : kept;
+    }
+    // Changed is measured against what this caller painted rather than against
+    // the map, because a second caller joined to the same request arrives after
+    // the first has already written it. Without a tag on either side there is
+    // nothing to compare, so the answer is assumed to be new.
+    const changed = !res.etag || !held.etag || res.etag !== held.etag;
+    this.write(k, res.data, res.etag);
+    if (changed) paint(res.data, "fresh");
+    return res.data;
+  }
+
+  /**
+   * invalidate marks entries stale rather than dropping them. Dropping would be
+   * correct and would also mean the next thing anybody looks at is a skeleton.
+   * Stale keeps the answer paintable and keeps its tag, so the revalidation it
+   * triggers is usually a 304.
+   */
+  invalidate(prefix = "") {
+    for (const [k, entry] of this.entries) {
+      if (!prefix || k.startsWith(prefix)) entry.stale = true;
+    }
+  }
+
+  /** clear drops everything and abandons what is in flight. */
+  clear() {
+    this.entries.clear();
+    for (const { controller } of this.running.values()) controller.abort();
+    this.running.clear();
+  }
+}
+
+/** cache is the one store the interface shares. */
+export const cache = new Store();

--- a/web/dist/assets/drawer.js
+++ b/web/dist/assets/drawer.js
@@ -9,6 +9,7 @@
 
 import { h, replace, svg } from "./dom.js";
 import { api } from "./api.js";
+import { cache } from "./cache.js";
 import { icon, label, sourceColor, when, exact } from "./format.js";
 import { body as renderBody, shapeOf } from "./content.js";
 
@@ -16,7 +17,7 @@ export class Drawer {
   constructor({ onClose }) {
     this.onClose = onClose;
     this.returnTo = null;
-    this.pending = null;
+    this.currentKey = "";
 
     this.title = h("h2", { class: "drawer__title", id: "drawer-title" });
     this.meta = h("div", { class: "drawer__meta" });
@@ -57,6 +58,34 @@ export class Drawer {
     this.returnTo = document.activeElement;
     this.el.hidden = false;
     this.scrim.hidden = false;
+    this.el.focus();
+
+    const k = cache.key("document", { id });
+    this.currentKey = k;
+
+    // A document the pointer rested on for a moment is usually already here, in
+    // which case the drawer never shows a loading state at all. The skeleton is
+    // only for the ones that are not.
+    if (cache.read(k).state === "miss") this.skeleton();
+
+    let painted = false;
+    try {
+      await cache.swr(
+        k,
+        (opts) => api.document(id, opts),
+        (d) => {
+          if (this.currentKey !== k) return;
+          painted = true;
+          this.render(d);
+        },
+      );
+    } catch (err) {
+      if (err.name === "AbortError") return;
+      if (!painted && this.currentKey === k) this.renderError(err);
+    }
+  }
+
+  skeleton() {
     replace(this.title, "Loading");
     replace(this.meta);
     replace(
@@ -66,19 +95,6 @@ export class Drawer {
       h("div", { class: "skeleton", style: { width: "70%", height: "14px" } }),
     );
     replace(this.foot);
-    this.el.focus();
-
-    if (this.pending) this.pending.abort();
-    const controller = new AbortController();
-    this.pending = controller;
-    try {
-      const d = await api.document(id, controller.signal);
-      if (controller.signal.aborted) return;
-      this.render(d);
-    } catch (err) {
-      if (err.name === "AbortError") return;
-      this.renderError(err);
-    }
   }
 
   render(d) {
@@ -134,7 +150,10 @@ export class Drawer {
 
   close() {
     if (!this.open) return;
-    if (this.pending) this.pending.abort();
+    // A request already in flight is left to finish and fill the cache, because
+    // reopening the same document is the most likely next thing to happen. It
+    // is the key that is dropped, so nothing it returns is painted.
+    this.currentKey = "";
     this.el.hidden = true;
     this.scrim.hidden = true;
     if (this.returnTo && this.returnTo.focus) this.returnTo.focus();

--- a/web/dist/assets/home.js
+++ b/web/dist/assets/home.js
@@ -7,7 +7,13 @@
 
 import { h, replace } from "./dom.js";
 import { api } from "./api.js";
+import { cache } from "./cache.js";
 import { label, sourceColor, when, number, initials } from "./format.js";
+
+// RECENT is the query behind the what changed panel. It is a constant because
+// it is also a cache key, and a request built twice must be built the same way
+// twice or the second build is a miss.
+const RECENT = { sort: "recent", limit: 6 };
 
 export class Home {
   constructor({ onQuery, onOpen }) {
@@ -16,23 +22,45 @@ export class Home {
     this.el = h("div", { class: "home" });
   }
 
+  /**
+   * render paints the home screen, from cache if there is one.
+   *
+   * Home is the destination of the back button and of the brand in the rail, so
+   * it is loaded far more often than it is loaded for the first time. Both
+   * panels are painted from whatever is held, and repainted only if the check
+   * behind them comes back with something different.
+   */
   async render(session) {
-    replace(
-      this.el,
-      h(
-        "header",
-        { class: "home__greeting" },
-        h("h1", { class: "home__title" }, greeting(session)),
-        h("p", { class: "home__subtitle" }, "Everything your company knows, in one search."),
-      ),
-      h("div", { class: "home__grid" }, this.skeletonPanels()),
-    );
+    const recentKey = cache.key("search", RECENT);
+    const statsKey = cache.key("stats", {});
+    let recent = cache.read(recentKey).data || null;
+    let stats = cache.read(statsKey).data || null;
+    this.paint(session, recent, stats);
 
-    const [recent, stats] = await Promise.all([
-      api.search({ sort: "recent", limit: 6 }).catch(() => null),
-      api.stats().catch(() => null),
+    let changed = false;
+    // The paint callbacks fire once with what was already on screen, which is
+    // not a change, and again only if the server disagreed with it.
+    await Promise.all([
+      cache
+        .swr(recentKey, (opts) => api.search(RECENT, opts), (d) => {
+          if (d === recent) return;
+          recent = d;
+          changed = true;
+        })
+        .catch(() => {}),
+      cache
+        .swr(statsKey, (opts) => api.stats(opts), (d) => {
+          if (d === stats) return;
+          stats = d;
+          changed = true;
+        })
+        .catch(() => {}),
     ]);
+    if (changed) this.paint(session, recent, stats);
+  }
 
+  /** paint draws the screen, with skeletons standing in for what is not here. */
+  paint(session, recent, stats) {
     replace(
       this.el,
       h(
@@ -41,14 +69,16 @@ export class Home {
         h("h1", { class: "home__title" }, greeting(session)),
         h("p", { class: "home__subtitle" }, "Everything your company knows, in one search."),
       ),
-      h(
-        "div",
-        { class: "home__grid" },
-        this.recentPanel(recent),
-        this.sourcesPanel(session, recent),
-        this.statsPanel(stats, session),
-        this.tipsPanel(),
-      ),
+      recent
+        ? h(
+            "div",
+            { class: "home__grid" },
+            this.recentPanel(recent),
+            this.sourcesPanel(session, recent),
+            this.statsPanel(stats, session),
+            this.tipsPanel(),
+          )
+        : h("div", { class: "home__grid" }, this.skeletonPanels()),
     );
   }
 

--- a/web/dist/assets/live.js
+++ b/web/dist/assets/live.js
@@ -1,0 +1,117 @@
+// When to check whether the page is still right.
+//
+// A results tab left open on a second monitor should be correct rather than a
+// snapshot of nine minutes ago. There are four ways to learn that it is not,
+// and they are in descending order of how much they cost the server: the index
+// says so, the connection came back, the tab came back, and a timer.
+//
+// The timer is the fallback rather than the mechanism. It runs only while the
+// tab is visible, so a page left open for a week is not a client that made ten
+// thousand requests. A hidden tab makes none at all: an index change that
+// arrives while nobody is looking marks the cache stale, and the refresh
+// happens when somebody looks.
+
+import { api } from "./api.js";
+
+// INTERVAL is the ceiling on how stale a visible page can get with nothing
+// else happening. Sixty seconds because that is the point at which somebody
+// glancing back at a page would want it to have noticed.
+const INTERVAL = 60_000;
+
+// The stream reconnects with a backoff, because the two reasons it drops are a
+// proxy timing out, which is instant to recover from, and a server that is
+// down, which is not helped by being asked again immediately.
+const RETRY = 2_000;
+const RETRY_MAX = 30_000;
+
+export class Live {
+  /**
+   * onRefresh is called with why, one of "timer", "visible", "online" or
+   * "index". onConnection is called with whether the browser thinks it is
+   * online, and only when that changes.
+   */
+  constructor({ onRefresh, onConnection, onIndex, interval = INTERVAL }) {
+    this.onRefresh = onRefresh;
+    this.onConnection = onConnection;
+    this.onIndex = onIndex || (() => {});
+    this.interval = interval;
+    this.timer = null;
+    this.stream = null;
+    this.retry = RETRY;
+    this.missed = false;
+    this.online = navigator.onLine !== false;
+  }
+
+  start() {
+    document.addEventListener("visibilitychange", () => this.visibility());
+    window.addEventListener("online", () => this.connection(true));
+    window.addEventListener("offline", () => this.connection(false));
+    this.tick();
+    this.listen();
+  }
+
+  /** visible reports whether anybody is looking at this tab. */
+  get visible() {
+    return document.visibilityState !== "hidden";
+  }
+
+  tick() {
+    clearInterval(this.timer);
+    this.timer = null;
+    if (!this.visible) return;
+    this.timer = setInterval(() => this.onRefresh("timer"), this.interval);
+  }
+
+  visibility() {
+    this.tick();
+    if (!this.visible) return;
+    // Something changed while this tab was in the background, and this is the
+    // first moment at which acting on it is worth a request.
+    if (this.missed) {
+      this.missed = false;
+      this.onRefresh("visible");
+    }
+  }
+
+  connection(online) {
+    if (online === this.online) return;
+    this.online = online;
+    this.onConnection(online);
+    if (!online) return;
+    this.retry = RETRY;
+    this.onRefresh("online");
+    this.listen();
+  }
+
+  /**
+   * listen keeps one stream open and reconnects when it ends.
+   *
+   * A deployment whose driver cannot report writes answers 404 here, which is
+   * not a failure: the timer is the fallback and the interface is exactly as
+   * correct, only slower to notice. So a 404 stops trying rather than
+   * reconnecting forever against an endpoint that will never exist.
+   */
+  listen() {
+    if (this.stream) return;
+    const controller = new AbortController();
+    this.stream = controller;
+    api
+      .events((event) => {
+        this.retry = RETRY;
+        this.onIndex(event);
+        if (this.visible) this.onRefresh("index");
+        else this.missed = true;
+      }, controller.signal)
+      .catch((err) => {
+        if (err && err.status === 404) this.retry = 0;
+      })
+      .finally(() => {
+        if (this.stream !== controller) return;
+        this.stream = null;
+        if (!this.retry) return;
+        const wait = this.retry;
+        this.retry = Math.min(this.retry * 2, RETRY_MAX);
+        setTimeout(() => this.listen(), wait);
+      });
+  }
+}

--- a/web/dist/assets/omnibox.js
+++ b/web/dist/assets/omnibox.js
@@ -10,6 +10,7 @@
 
 import { h, replace, svg } from "./dom.js";
 import { api } from "./api.js";
+import { cache } from "./cache.js";
 import { icon } from "./format.js";
 
 // DEBOUNCE is how long the box waits before asking the server. The suggestion
@@ -18,13 +19,14 @@ import { icon } from "./format.js";
 const DEBOUNCE = 90;
 
 export class Omnibox {
-  constructor({ onSearch, onOpen }) {
+  constructor({ onSearch, onOpen, onHighlight }) {
     this.onSearch = onSearch;
     this.onOpen = onOpen;
+    this.onHighlight = onHighlight || (() => {});
     this.items = [];
     this.active = -1;
     this.timer = null;
-    this.pending = null;
+    this.latest = "";
 
     this.input = h("input", {
       class: "omnibox__input",
@@ -91,18 +93,23 @@ export class Omnibox {
   }
 
   async fetch(q) {
-    // Only the newest request may render. Without this a slow response for a
-    // two letter prefix lands after the fast one for five letters and the list
-    // goes backwards while somebody is still typing.
-    if (this.pending) this.pending.abort();
-    const controller = new AbortController();
-    this.pending = controller;
+    // Only the newest prefix may render. Without this a slow response for two
+    // letters lands after the fast one for five and the list goes backwards
+    // while somebody is still typing. The request itself is not cancelled: it
+    // is on its way to the cache, and backspacing one letter is the single most
+    // likely next thing anybody does in a search box.
+    this.latest = q;
     try {
-      const res = await api.suggest(q, controller.signal);
-      if (controller.signal.aborted) return;
-      this.render(res.suggestions || []);
+      await cache.swr(
+        cache.key("suggest", { q }),
+        (opts) => api.suggest(q, opts),
+        (res) => {
+          if (this.latest !== q) return;
+          this.render(res.suggestions || []);
+        },
+      );
     } catch (err) {
-      if (err.name !== "AbortError") this.close();
+      if (this.latest === q && err.name !== "AbortError") this.close();
     }
   }
 
@@ -161,6 +168,9 @@ export class Omnibox {
     } else {
       this.input.removeAttribute("aria-activedescendant");
     }
+    // The shell decides whether a highlighted row is worth fetching ahead of
+    // Enter being pressed, and how long it has to stay highlighted first.
+    this.onHighlight(this.items[i] || null);
   }
 
   choose(i) {

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -34,9 +34,10 @@ const FACETS = [
 const FACET_VISIBLE = 8;
 
 export class Results {
-  constructor({ onQuery, onOpen }) {
+  constructor({ onQuery, onOpen, onHover }) {
     this.onQuery = onQuery;
     this.onOpen = onOpen;
+    this.onHover = onHover || (() => {});
     this.expanded = new Set();
     this.selected = -1;
     this.hits = [];
@@ -249,6 +250,11 @@ export class Results {
         class: "result",
         role: "listitem",
         dataset: { index: String(i) },
+        // A pointer resting on a row is a good guess at the next preview, and
+        // the shell is what decides how long resting means and how many of
+        // those guesses may be in the air at once.
+        onMouseenter: () => this.onHover(hit.id),
+        onMouseleave: () => this.onHover(null),
         onClick: (e) => {
           // A click on the title follows the source link. A click anywhere else
           // on the row opens the preview, which is the cheaper of the two and

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="/assets/tokens.css" />
     <link rel="stylesheet" href="/assets/app.css" />
     <link rel="modulepreload" href="/assets/api.js" />
+    <link rel="modulepreload" href="/assets/cache.js" />
     <link rel="modulepreload" href="/assets/dom.js" />
     <script>
       // The theme and the density are read before the first paint. Doing it in

--- a/web/web.go
+++ b/web/web.go
@@ -22,6 +22,23 @@
 // gets a 304 for anything it already has, which costs one conditional request
 // per asset and is always correct, including the case that matters: an operator
 // upgrading the binary under a browser that has the old one cached.
+//
+// # What the interface holds
+//
+// assets/cache.js keeps answers in memory for the life of the tab, so that going
+// back to a search paints before the network is asked anything. The same rule
+// the server cache is built on holds here: a key that does not name the asker's
+// visibility is a permission bug. The client cannot work out its own view, so
+// [github.com/tamnd/genba/api] hands it one in the me response and every key is
+// written under it. Switching identity throws the whole store away rather than
+// filtering it, because a tab holds results for more than one person over its
+// life and an entry that survived the switch has leaked a document.
+//
+// Nothing is written to disk. The theme, the density and the development
+// identity live in localStorage and are the whole of what persists, because
+// they are the only things there that the corpus did not say. Results and
+// documents are memory only, since memory is the session's lifetime and the
+// session is exactly how long anybody was allowed to read them.
 package web
 
 import (

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1,6 +1,8 @@
 package web_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
@@ -64,6 +66,92 @@ func TestAssetsBuildNodesRatherThanMarkup(t *testing.T) {
 			if strings.Contains(string(body), bad) {
 				t.Errorf("%s uses %s, which turns a string into markup", name, bad)
 			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the assets: %v", err)
+	}
+}
+
+// The interface has a transfer budget and no build step, so the files on disk
+// are the files on the wire and this is the only place the budget can be
+// checked. The numbers are per file gzipped and summed, because every module is
+// fetched separately and a bundler is not going to appear to fix it.
+func TestTheInterfaceFitsItsTransferBudget(t *testing.T) {
+	const (
+		scriptBudget = 180 << 10
+		styleBudget  = 40 << 10
+	)
+
+	totals := map[string]int{}
+	err := fs.WalkDir(os.DirFS("dist"), ".", func(name string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		ext := path.Ext(name)
+		if ext != ".js" && ext != ".css" {
+			return nil
+		}
+		body, err := os.ReadFile(path.Join("dist", name))
+		if err != nil {
+			return err
+		}
+		var buf bytes.Buffer
+		w := gzip.NewWriter(&buf)
+		if _, err := w.Write(body); err != nil {
+			return err
+		}
+		if err := w.Close(); err != nil {
+			return err
+		}
+		totals[ext] += buf.Len()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the assets: %v", err)
+	}
+
+	if totals[".js"] > scriptBudget {
+		t.Errorf("the scripts are %d bytes gzipped, over the %d budget", totals[".js"], scriptBudget)
+	}
+	if totals[".css"] > styleBudget {
+		t.Errorf("the styles are %d bytes gzipped, over the %d budget", totals[".css"], styleBudget)
+	}
+	t.Logf("scripts %d bytes gzipped of %d, styles %d of %d", totals[".js"], scriptBudget, totals[".css"], styleBudget)
+}
+
+// Nothing the server said about the corpus is written to disk.
+//
+// Search results are titles and body excerpts from a permissioned corpus, and
+// putting those in localStorage or IndexedDB leaves them on the machine after
+// the session that was allowed to see them has ended. Memory is the correct
+// lifetime because it is the session's lifetime, and this is a test rather than
+// a convention because the tempting change is one line long and would look like
+// an improvement.
+func TestTheCacheKeepsNothingOnDisk(t *testing.T) {
+	// The theme, the density and the development identity are the whole of what
+	// may persist, and none of them is anything the corpus said.
+	persist := map[string]bool{"api.js": true, "app.js": true}
+
+	err := fs.WalkDir(os.DirFS("dist"), ".", func(name string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || path.Ext(name) != ".js" {
+			return err
+		}
+		body, err := os.ReadFile(path.Join("dist", name))
+		if err != nil {
+			return err
+		}
+		// The trailing dot is what separates a use from a mention, since these
+		// names are worth writing down in the comment that explains why they are
+		// not used.
+		for _, store := range []string{"indexedDB.", "sessionStorage.", "caches."} {
+			if strings.Contains(string(body), store) {
+				t.Errorf("%s uses %s, which outlives the session that was allowed to read the corpus", name, store)
+			}
+		}
+		if strings.Contains(string(body), "localStorage.") && !persist[path.Base(name)] {
+			t.Errorf("%s writes to localStorage, which is only for the theme, the density and the identity", name)
 		}
 		return nil
 	})


### PR DESCRIPTION
Closes #56
Closes #57

This is the second of two pull requests for M10. The first, #68, was the data model and the query plan, and this one is the cache on both sides of the wire. The third, for #58, will be the CI gate and the production metrics, kept separate because it is CI configuration and an exposition format rather than anything in the request path.

## The rule

A cache key that does not name the asker's visibility is a permission bug.

Two people typing the same query get different answers, and an entry that crosses between them has leaked a document without looking like a leak in any log. So `acl.Fingerprint` is half of every key: it is built from the same key accessors the visibility predicate reads, sorted so that two descriptions of one view share an entry, and length prefixed so that no rearrangement of a tenant and a group name can be read as another principal.

## Server side

Three layers, all sharded sixteen ways with single flight on miss.

Ranked orderings are keyed by fingerprint and canonical request, and hold ids, totals and facets rather than documents, so an edited document shows its new body on the next request even on a hit. Corpus statistics are keyed by tenant and terms, deliberately not by fingerprint, because they are counted over the tenant rather than over one person's view. Documents are keyed by id alone, which is the one exception, and it holds because the layer sits behind the permission check rather than in front of it. That ordering has a test of its own.

Invalidation needs the driver to speak, so `store.Notifier` is new and the conformance suite reads the store from inside the callback to prove the change is visible when the callback fires. A write bumps one generation counter per tenant, which makes every entry of that tenant unreachable without walking sixteen shards under sixteen locks on the write path.

`GET /api/v1/events` is a server sent event stream carrying one event type, with no document content and no ids in it, so the stream itself leaks nothing.

## Browser side

`assets/cache.js` is the store, about 3KB of code, no dependency, in keeping with the rest of the frontend. Keys are canonicalised the same way the server does with the view prepended, and the view comes from the me endpoint rather than being derived on the client, so it cannot drift from the server's. Switching identity clears the store rather than filtering it, because a tab holds results for more than one person over its life.

Reads have three states. Under five seconds an answer is fresh and no request is made at all. Past that it is painted immediately and checked behind the paint, and the check is conditional, so the usual outcome is a 304 with no body and no repaint, which is what keeps the scroll position and the keyboard cursor. Past thirty seconds the entry is gone. Requests for the same key are collapsed into one.

`assets/live.js` is the refresher. It reads the event stream and marks everything stale when an index event arrives, falls back to a sixty second timer where there is no stream, and does neither while the tab is hidden. A hidden tab makes no requests at all and picks up what it missed when it is looked at again. Three prefetches, all bounded, all cancellable, none retried: the next page after 300ms, a hovered result after 150ms with at most four in flight, and a highlighted suggestion after 200ms.

Offline keeps the page and adds a banner that says how old the answer is and keeps counting while the connection is gone. A failed revalidation behind content already on screen keeps the content. A 401 clears everything, since the session that authorised those results is over.

Nothing that came out of the corpus is written to disk. `TestTheCacheKeepsNothingOnDisk` fails if somebody reaches for localStorage, sessionStorage, IndexedDB or the Cache API outside the three things that may persist, which are the theme, the density and the development identity.

## Two things the browser work found on the server

**Search scores are no longer part of the entity tag.** The recency prior decays against the wall clock, so two identical searches a second apart produced scores differing in the tenth decimal place and therefore different tags. Every conditional request was a full response and nothing said so, because the failure is silent: it all still works, it is just never a 304. The tag now means the same documents came back in the same order with the same content, and scores that moved enough to matter moved the order too. The test that was meant to catch this had been passing by luck on fixtures with no modified date, so the fixtures gained one and `TestARankThatDriftsDoesNotMoveTheTag` runs a clock that jumps an hour between two searches.

**Stats carry no entity tag at all.** The body reports cache hits and misses, and serving it is itself a read of those caches, so a tag computed for one response describes a state the next response is no longer in. Excluding the counters would be worse than having no tag: the client would hold the first hit rate it ever saw and never be told another one. It is a couple of hundred bytes held for a TTL instead, and the number is always real. `TestStatsCarryNoTagBecauseReadingThemMovesThem` is there so that adding the tag back looks like the regression it would be.

## Deviations from the spec

`cache.js` is 6.8KB rather than the 4KB the spec asked for. About 2.6KB of that is executable code and the rest is comments at the density the rest of this repository is written at. The gzip budget that actually matters is met with room: scripts are 43KB of the 180KB budget and styles are 14KB of 40KB, and `TestTheInterfaceFitsItsTransferBudget` now enforces both.

`subscribe` was dropped from the store. The spec had views registering for changes, and it turned out to have no callers, because every view already drives its own reads through `swr` and repaints from the paint callback.

## Checks

Verified against a 600 document corpus in a browser rather than only in tests. A cold search costs two requests, the search and the page two prefetch. Going back to it inside five seconds paints twenty rows from cache with zero requests. Past five seconds it paints from cache first and then revalidates to a 304 with no repaint. Console is clean.

`go test -race -count=1 ./...` passes, `go vet` is clean, gofmt is clean.
