### PR TITLE
The CI latency gate, the browser gate, and production metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,79 @@ jobs:
       - name: test without the interface
         run: go test -tags noassets -count=1 ./...
 
+  # The performance gate, in two halves.
+  #
+  # The counters assert work rather than wall clock: rows read, statements
+  # issued, documents decoded, candidates ranked. A shared runner cannot measure
+  # a millisecond and it can count rows exactly, so that half fails on a change
+  # that makes a query walk the corpus and stays quiet when the runner is busy.
+  #
+  # The latency gate is the half the counters cannot do, which is a change that
+  # does the same work more slowly. It compares against a baseline recorded on
+  # this kind of runner, normalises by a calibration workload so a busy afternoon
+  # is not read as a regression, and writes its numbers out either way. Until a
+  # baseline recorded on the runner is committed it reports and does not fail,
+  # and it says so in the log rather than passing quietly.
+  #
+  # The corpus is generated rather than committed, and cached on the hash of the
+  # generator so that a run only pays for it when the generator changes. The
+  # baseline is not in that cache on purpose: a number a stale cache can
+  # overwrite is a number that stops meaning anything.
+  perf:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+      - name: cache the benchmark corpus
+        uses: actions/cache@v4
+        with:
+          path: testdata
+          key: benchcorpus-${{ hashFiles('benchcorpus/*.go', 'benchcorpus/gen/**', 'benchcorpus/queries.txt') }}
+      - name: the corpus
+        run: make bench-corpus
+      - name: counters
+        run: make bench-counters
+      - name: latency
+        env:
+          GENBA_GATE_BASELINE: ${{ github.workspace }}/benchcorpus/baseline-ci.json
+          GENBA_GATE_RUNNER: ubuntu-latest
+        run: make bench-gate
+      - name: keep the numbers
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-report
+          path: bench-report.json
+          if-no-files-found: warn
+
+  # The browser gate: asset budgets, markup safety, axe and Lighthouse.
+  #
+  # The Go tests are the part that cannot flake and they run first. axe reports
+  # violations of a standard rather than an opinion and it fails the job.
+  # Lighthouse is advisory here and enforced on the nightly run, because a
+  # performance score on a shared runner moves by ten points between two runs of
+  # the same commit.
+  ui:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: ui gate
+        run: make ui-gate
+
   # The binary is meant to run on Windows too, and cross compiling catches the
   # path handling and syscall mistakes that only show up there.
   cross:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,124 @@
+name: nightly
+
+# The slow half of the performance work, on its own schedule.
+#
+# The gate on a pull request has to be fast and it has to be quiet, so it takes
+# a few hundred samples per class and allows a thirty five percent move. This run
+# has the machine to itself and all night to use it, so it takes more samples and
+# allows ten, which is enough to see a drift that twenty pull requests each hid
+# inside the tolerance.
+#
+# Nothing here fails a build. A nightly job that goes red blocks nobody and gets
+# muted, so a move files an issue instead, with the numbers in it.
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      record:
+        description: Record a new baseline for this runner instead of comparing against it
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  perf:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+      - name: cache the benchmark corpus
+        uses: actions/cache@v4
+        with:
+          path: testdata
+          key: benchcorpus-${{ hashFiles('benchcorpus/*.go', 'benchcorpus/gen/**', 'benchcorpus/queries.txt') }}
+      - name: the corpus
+        run: make bench-corpus
+      - name: latency
+        id: gate
+        continue-on-error: true
+        shell: bash
+        env:
+          GENBA_GATE_BASELINE: ${{ github.workspace }}/benchcorpus/baseline-ci.json
+          GENBA_GATE_RUNNER: ubuntu-latest nightly
+          GENBA_GATE_SAMPLES: "2000"
+          GENBA_GATE_TOLERANCE: "1.10"
+          GENBA_GATE_RECORD: ${{ inputs.record && '1' || '' }}
+        run: |
+          set -o pipefail
+          make bench-gate 2>&1 | tee bench-gate.log
+      # Recording writes the baseline where the pull request gate will look for
+      # it, and the artifact is how it gets to somebody who can commit it. It is
+      # not committed from here on purpose: a baseline that updates itself is a
+      # ratchet that only turns one way.
+      - name: keep the numbers
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-bench
+          path: |
+            bench-report.json
+            bench-gate.log
+            benchcorpus/baseline-ci.json
+          if-no-files-found: warn
+      - name: file an issue when something moved
+        if: steps.gate.outcome == 'failure' && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "The nightly latency run on ${{ github.sha }} moved past the tighter nightly tolerance."
+            echo
+            echo "It takes more samples than the pull request gate and allows a ten percent move rather than thirty five, so this can fire on a drift that every individual pull request was within its tolerance for."
+            echo "The numbers are attached to the run as an artifact."
+            echo
+            echo '```'
+            tail -40 bench-gate.log
+            echo '```'
+            echo
+            echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } > issue.md
+          gh issue create \
+            --title "Nightly latency moved on $(date -u +%Y-%m-%d)" \
+            --body-file issue.md \
+            --label performance
+
+  # Lighthouse, enforced here rather than on a pull request, because a
+  # performance score on a shared runner moves by ten points between two runs of
+  # the same commit and a check that does that stops being read.
+  ui:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: ui gate
+        id: ui
+        continue-on-error: true
+        env:
+          GENBA_UI_STRICT: "1"
+        run: make ui-gate
+      - name: file an issue when the interface slipped
+        if: steps.ui.outcome == 'failure' && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --title "Nightly interface audit failed on $(date -u +%Y-%m-%d)" \
+            --body "The nightly run enforces the Lighthouse floors that are advisory on a pull request, and one of them was missed on ${{ github.sha }}. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --label performance

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 coverage.out
 .DS_Store
 
+# What the latency gate writes out on every run. The baseline it compares
+# against is checked in, this is the run that was compared against it.
+/bench-report.json
+
 # Local data directories a development server writes to.
 /data/
 *.db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,26 @@ make lint
 CI runs the same commands on Linux and macOS, plus a cross compile for Windows and FreeBSD, a build without the browser interface, `govulncheck`, a `go mod tidy` check and a license check.
 Running them locally is faster than finding out from a red badge.
 
+## If you touched the query path or the interface
+
+```
+make bench-counters
+make bench-gate
+make ui-gate
+```
+
+`bench-counters` is exact and fast.
+It counts rows read, statements run and documents decoded, and those numbers are the same on a laptop and on a busy runner, so it is the check that catches a query which started walking the corpus.
+
+`bench-gate` is the wall clock.
+It measures the search endpoint per query class in interleaved rounds, compares the median of the quietest round against `benchcorpus/baseline.json`, and normalises by a calibration workload so a busy machine is not read as a slow query.
+The first run generates the corpus and takes a few minutes.
+If the baseline itself needs to move, `make bench-gate-record` writes a new one and it belongs in a commit of its own that says why the number moved.
+
+`ui-gate` checks the asset budgets, then starts the binary over this repository as a corpus and runs axe and Lighthouse against the home page, a results page and a results page with the drawer open.
+It needs `npx` and a Chrome, and it says so and stops rather than failing when there is not one.
+A chromedriver that does not match the Chrome next to it is the usual reason it will not start, and `CHROMEDRIVER` points it at a matching one.
+
 ## The rule that is not negotiable
 
 Anything that can return document content takes a principal, and the permission filter runs inside the storage driver while it walks its own data.

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ bench-counters:
 # slow query. It writes its numbers to bench-report.json, which CI keeps as an
 # artifact.
 bench-gate:
-	GENBA_BENCH_DOCS=$(BENCH_DOCS) GENBA_GATE_REPORT=$(CURDIR)/bench-report.json go test -v -count=1 -timeout 30m -run 'LatencyGate' ./api/
+	GENBA_GATE=1 GENBA_BENCH_DOCS=$(BENCH_DOCS) GENBA_GATE_REPORT=$(CURDIR)/bench-report.json go test -v -count=1 -timeout 30m -run 'LatencyGate' ./api/
 
 # Record a new baseline for the machine this runs on.
 #
@@ -81,7 +81,7 @@ bench-gate:
 # is measuring is a baseline nobody can review, and one that updates itself is a
 # ratchet that only turns one way.
 bench-gate-record:
-	GENBA_BENCH_DOCS=$(BENCH_DOCS) GENBA_GATE_RECORD=1 GENBA_GATE_RUNNER="$(shell uname -sm)" GENBA_GATE_DATE="$(shell date -u +%Y-%m-%d)" \
+	GENBA_GATE=1 GENBA_BENCH_DOCS=$(BENCH_DOCS) GENBA_GATE_RECORD=1 GENBA_GATE_RUNNER="$(shell uname -sm)" GENBA_GATE_DATE="$(shell date -u +%Y-%m-%d)" \
 		go test -v -count=1 -timeout 30m -run 'LatencyGate' ./api/
 
 # The browser gate: asset budgets, markup safety, axe, and Lighthouse.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LDFLAGS := -s -w \
 
 export CGO_ENABLED := 0
 
-.PHONY: build cli install test race cover bench bench-corpus bench-search bench-counters vet fmt lint tidy vuln headless clean run
+.PHONY: build cli install test race cover bench bench-corpus bench-search bench-counters bench-gate bench-gate-record ui-gate vet fmt lint tidy vuln headless clean run
 
 # How large the benchmark corpus is. The budgets are stated against a hundred
 # thousand documents, which takes a couple of minutes to generate, so the
@@ -62,6 +62,36 @@ bench-search:
 # that makes a query read the corpus and stays quiet when the runner is busy.
 bench-counters:
 	go test -count=1 -run 'Counters' ./index/
+
+# The other half of the gate, which is the wall clock.
+#
+# The counters cannot see a change that does the same work more slowly, and this
+# can. It measures the search endpoint per query class in interleaved rounds,
+# compares the median of the quietest round against benchcorpus/baseline.json,
+# and normalises by a calibration workload so a slow runner is not read as a
+# slow query. It writes its numbers to bench-report.json, which CI keeps as an
+# artifact.
+bench-gate:
+	GENBA_BENCH_DOCS=$(BENCH_DOCS) GENBA_GATE_REPORT=$(CURDIR)/bench-report.json go test -v -count=1 -timeout 30m -run 'LatencyGate' ./api/
+
+# Record a new baseline for the machine this runs on.
+#
+# It belongs in a commit of its own that changes nothing else, with a message
+# saying why the number moved. A baseline that arrives alongside the change it
+# is measuring is a baseline nobody can review, and one that updates itself is a
+# ratchet that only turns one way.
+bench-gate-record:
+	GENBA_BENCH_DOCS=$(BENCH_DOCS) GENBA_GATE_RECORD=1 GENBA_GATE_RUNNER="$(shell uname -sm)" GENBA_GATE_DATE="$(shell date -u +%Y-%m-%d)" \
+		go test -v -count=1 -timeout 30m -run 'LatencyGate' ./api/
+
+# The browser gate: asset budgets, markup safety, axe, and Lighthouse.
+#
+# The Go tests are the part that never flakes and they run first. The browser
+# half needs npx and a Chrome, and says so and stops rather than failing when
+# there is not one.
+ui-gate: build
+	go test -count=1 -run 'Interface|Assets|Cache' ./web/
+	./scripts/ui-gate.sh
 
 vet:
 	go vet ./...

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The environment variable is the flag in upper case with a `GENBA_` prefix, and a
 | Variable | Default | What it does |
 | --- | --- | --- |
 | `GENBA_ADDR` | `127.0.0.1:8080` | listen address |
+| `GENBA_METRICS_ADDR` | empty | listen address for the metrics endpoint, empty to serve none |
 | `GENBA_STORE` | `memory` | storage driver: `memory`, `sqlite`, `postgres` or `kura` |
 | `GENBA_DSN` | empty | path or connection string for the driver |
 | `GENBA_TENANT` | empty | tenant served by a single tenant deployment |
@@ -153,6 +154,35 @@ The corpus flags have no environment variables, because a directory to index is 
 | `-corpus-name` | `files` | source name the documents carry, and what `-source` filters on |
 | `-corpus-acl` | `tenant` | who may read it: `tenant` for everybody in the tenant, `owners` to read OWNERS files |
 | `-corpus-refresh` | `0` | how often to sync again, zero for once at startup |
+
+## Metrics
+
+Set `GENBA_METRICS_ADDR` and the process opens a second listener that serves the Prometheus text format at any path on it.
+
+```
+GENBA_METRICS_ADDR=127.0.0.1:9100 genbad
+curl -s http://127.0.0.1:9100/metrics | head
+```
+
+It is a second listener rather than a route on the API on purpose.
+What it publishes is not secret and is not public either: it says how much traffic there is, how large the match sets are and how hard the caches are working.
+The deployment that gets this right binds it somewhere the outside cannot reach, and the API address never serves it.
+
+| Metric | What it is |
+| --- | --- |
+| `genba_request_duration_milliseconds` | histogram per endpoint, labelled with the route rather than the path |
+| `genba_search_duration_milliseconds` | histogram of the search itself, without request parsing or encoding |
+| `genba_search_candidates` | how many documents were ranked to produce one page |
+| `genba_search_matches` | how many matched, before paging |
+| `genba_cache_hits_total` | per layer, alongside misses, evictions and the entry count |
+| `genba_store_rows_total` | rows the driver returned, alongside statements and decodes |
+
+The buckets are 1, 2, 5, 10, 25, 50, 100, 250 and 500 milliseconds, which are tighter at the bottom than a default histogram because the question here is what fraction of requests came back in under ten milliseconds.
+
+Candidates against matches is the pair worth putting on a dashboard.
+A healthy two phase search has a candidate count bounded by the pool and a match count bounded by nothing, and the day the two start moving together is the day the first phase stopped cutting.
+
+[docs/alerts.yml](docs/alerts.yml) has the one alert to start with, and says what is deliberately not alerted on.
 
 ## Use it as a library
 

--- a/api/api.go
+++ b/api/api.go
@@ -69,6 +69,11 @@ type Server struct {
 
 	// heartbeat is how often an idle event stream sends a comment.
 	heartbeat time.Duration
+
+	// metrics is what the process publishes about itself. It is always
+	// recorded, because a histogram nobody scrapes costs a lock and nine
+	// comparisons, and it is only served where a caller mounts [Server.Metrics].
+	metrics *metrics
 }
 
 // Option configures a [Server].
@@ -126,6 +131,10 @@ func New(st store.Store, searcher *index.Searcher, auth Authenticator, opts ...O
 	for _, opt := range opts {
 		opt(s)
 	}
+	// After the options, because the cache layers and the storage driver are
+	// what the counters read and both arrive with the server rather than with
+	// the registry.
+	s.metrics = newMetrics(s)
 	return s
 }
 
@@ -144,7 +153,7 @@ func (s *Server) Handler() http.Handler {
 	if s.assets != nil {
 		mux.Handle("GET /", s.assets)
 	}
-	return s.recoverPanic(mux)
+	return s.recoverPanic(s.measure(mux))
 }
 
 // authenticated wraps a handler that needs a principal.
@@ -275,6 +284,8 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 		writeError(w, http.StatusInternalServerError, "internal", "the search could not be run")
 		return
 	}
+
+	s.metrics.observeSearch(res.Took, res.Candidates, res.Total)
 
 	out := searchResponse{
 		Query:   r.URL.Query().Get("q"),

--- a/api/latency_test.go
+++ b/api/latency_test.go
@@ -295,7 +295,7 @@ func TestSearchLatencyGate(t *testing.T) {
 // can either side of the handler because everything it does lands inside the
 // measurement.
 func gateServe(h http.Handler, target string, hdr map[string]string) int {
-	r := httptest.NewRequest(http.MethodGet, target, nil)
+	r := httptest.NewRequest(http.MethodGet, target, http.NoBody)
 	for k, v := range hdr {
 		r.Header.Set(k, v)
 	}
@@ -460,7 +460,7 @@ func gateCompare(now, base gateBaseline, haveBase bool, tol float64) (failures, 
 	for _, class := range slices.Sorted(maps.Keys(now.Classes)) {
 		got, was := now.Classes[class], base.Classes[class]
 		if was.Best == 0 {
-			notes = append(notes, fmt.Sprintf("%s is not in the baseline, so it was only held to the backstop", class))
+			notes = append(notes, class+" is not in the baseline, so it was only held to the backstop")
 			continue
 		}
 		best := got.Best * scale

--- a/api/latency_test.go
+++ b/api/latency_test.go
@@ -426,19 +426,32 @@ var gateSink int
 // gateCompare is the whole judgement, kept apart from the measurement so that
 // it can be tested with numbers instead of with a corpus.
 func gateCompare(now, base gateBaseline, haveBase bool, tol float64) (failures, notes []string) {
-	// The backstop, which needs no baseline. A class the recorded baseline
-	// already misses is exempt from it and is held to the baseline instead: the
-	// budgets are what the query path is aiming at rather than what it has hit,
-	// three of them are missed today and that is written down in
-	// benchcorpus/BASELINE.md, and a gate that failed every pull request until
-	// they are met is a gate that gets deleted in a week. The exemption expires
-	// on its own the moment a baseline inside the budget is recorded.
+	// The backstop, which is the one absolute number in here. A class the
+	// recorded baseline already misses is exempt from it and is held to the
+	// baseline instead: the budgets are what the query path is aiming at rather
+	// than what it has hit, three of them are missed today and that is written
+	// down in benchcorpus/BASELINE.md, and a gate that failed every pull request
+	// until they are met is a gate that gets deleted in a week. The exemption
+	// expires on its own the moment a baseline inside the budget is recorded.
+	//
+	// A machine with no baseline at all gets no backstop either, because the
+	// exemption is read out of the baseline and without one every class that is
+	// merely aiming at its budget looks like a regression. The budgets were
+	// stated against a laptop and a two core runner is several times slower than
+	// one, so an absolute millisecond applied to a machine nothing has
+	// characterised is the flake the rest of this design exists to avoid. Record
+	// a baseline on the machine and everything below turns on.
+	if !haveBase {
+		return nil, []string{"there is no baseline for this machine, so the numbers above were recorded and nothing was enforced, and " +
+			gatePath() + " is where one produced by make bench-gate-record belongs"}
+	}
+
 	for _, class := range slices.Sorted(maps.Keys(now.Classes)) {
 		got := now.Classes[class]
 		was, recorded := base.Classes[class]
 		switch {
 		case got.Budget <= 0 || got.Best <= got.Budget*gateBackstop:
-		case haveBase && recorded && was.Budget > 0 && was.Best > was.Budget:
+		case recorded && was.Budget > 0 && was.Best > was.Budget:
 			notes = append(notes, fmt.Sprintf(
 				"%s is over its budget of %.1fms at %.1fms, and the baseline records %.1fms, so it is held to the baseline until the budget is met",
 				class, got.Budget, got.Best, was.Best))
@@ -581,7 +594,7 @@ func TestGateComparisonIsHonest(t *testing.T) {
 			gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 20, Classes: reading(16)}, ""},
 		{"a slow machine and a real regression",
 			gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 20, Classes: reading(24)}, "tolerance"},
-		{"past the backstop with no baseline to compare against",
+		{"past the backstop on a class the baseline meets",
 			gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: reading(25)}, "backstop"},
 		{"a tail that moved and a median that did not",
 			// The one the percentiles would have failed and this deliberately
@@ -619,6 +632,16 @@ func TestGateComparisonIsHonest(t *testing.T) {
 	if failures, _ := gateCompare(gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: reading(30)},
 		overBudget, true, gateTolerance); len(failures) == 0 {
 		t.Error("a class exempt from the backstop stopped being held to its baseline as well")
+	}
+
+	// A machine with no baseline is a machine nothing is known about. It reports
+	// and it does not fail, because the budgets describe a laptop and a runner
+	// several times slower than one is not a regression.
+	slow := gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 40, Classes: reading(80)}
+	if failures, notes := gateCompare(slow, gateBaseline{}, false, gateTolerance); len(failures) > 0 {
+		t.Errorf("a run with no baseline failed anyway: %v", failures)
+	} else if !strings.Contains(strings.Join(notes, "\n"), "no baseline") {
+		t.Errorf("the report does not say there was no baseline: %v", notes)
 	}
 
 	// A corpus mismatch is not a regression and must not be reported as one.

--- a/api/latency_test.go
+++ b/api/latency_test.go
@@ -1,0 +1,672 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/benchcorpus"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/metric"
+)
+
+// The latency half of the performance gate.
+//
+// The counter assertions in the index package catch a query that starts doing
+// more work. They cannot catch a change that does the same amount of work more
+// slowly, and that is most of them: a lock held across a decode, an allocation
+// in a loop, a comparison that used to be a byte compare and is now a regexp.
+// Those show up in the wall clock and nowhere else.
+//
+// It measures the endpoint rather than the searcher, because the budget is
+// stated against what a browser waits for. Between the two there is header
+// parsing, query parsing, snippet building and JSON encoding, and every one of
+// them has been the surprise in somebody's latency budget at some point.
+//
+// A wall clock gate on a shared runner is the thing everybody warns about, so
+// this is built to be believed rather than to be strict, and what it compares
+// was chosen by measuring the same commit twice rather than by reasoning about
+// it. Two runs of an unchanged tree on a contended laptop disagreed by a factor
+// of two on the p95 of the most expensive class. The median of the quietest
+// round of those same runs held to within a quarter, and to within a tenth for
+// half the classes. So the number that fails a build is the quietest median,
+// the tolerance is set above what an unchanged tree was measured to do rather
+// than at a number that sounds strict, and the percentiles are recorded and
+// printed for a human to read and never compared.
+//
+// That is a real limit and it is worth being plain about: a regression that
+// only moves the tail will not fail this gate. Nothing that runs on a shared
+// machine can catch that, and a check that pretends otherwise is a check that
+// goes red on a Tuesday for no reason and gets deleted on the Wednesday.
+//
+// The caches are off. A gate that measured them would mostly be measuring the
+// hit rate of a synthetic query set, which is not a number anybody should be
+// making decisions about. What is measured here is what a cache miss costs,
+// which is what the caches are hiding and what regresses underneath them.
+
+const (
+	// gateWarmup is the queries run per class before any timer starts. The
+	// budgets are stated warm: a process that has been up for a while, with the
+	// working set in the page cache. A cold measurement measures the disk.
+	gateWarmup = 100
+
+	// gateSpend is roughly how long one class is allowed to take being
+	// measured, which is what sets the sample count. It is spent rather than
+	// timed: the number of samples is derived from the budget so that it is the
+	// same on every machine, because a sample count that depended on the clock
+	// would make two runs incomparable.
+	gateSpend = 15 * time.Second
+
+	// The sample count is held between these. Below two hundred a round holds
+	// too few samples for its median to settle, and above a thousand the gate
+	// stops being something anybody is willing to wait for.
+	gateMinSamples = 200
+	gateMaxSamples = 1000
+
+	// gateRounds is how many times the whole class list is measured.
+	//
+	// The classes are interleaved rather than each measured to completion, so a
+	// burst of load lands across all of them rather than in whichever one was
+	// unlucky, and every round runs the same queries in the same order so that
+	// two rounds differ only in when they ran.
+	gateRounds = 8
+
+	// gateTolerance is how far the quietest median may move before it is a
+	// regression. It is where it is because an unchanged tree measured twice on
+	// a contended laptop moved by a quarter, and a threshold below what the
+	// code does when nothing changed is a threshold that fails honest work.
+	gateTolerance = 1.35
+
+	// gateBackstop is the multiple of the stated budget that fails on its own,
+	// with no baseline involved. Twice the budget is not a busy runner.
+	gateBackstop = 2
+
+	// gateReportMove is the move worth mentioning in the report, in either
+	// direction. An improvement that nobody notices is an improvement that gets
+	// undone.
+	gateReportMove = 0.10
+
+	// gateCalibrationSpread is how far apart the calibration figures may be
+	// before two runs stop being comparable at all. A runner half the speed of
+	// the one the baseline came from is not a runner whose numbers can be
+	// scaled into agreement.
+	gateCalibrationSpread = 2.0
+
+	// gateCalibrationBand is how far apart they have to be before the
+	// correction is applied at all. Inside it the two machines are the same
+	// machine and the difference is the calibration's own noise.
+	gateCalibrationBand = 1.10
+)
+
+// baselineFile is where the recorded numbers live.
+//
+// It sits next to the corpus generator rather than under testdata, because
+// testdata is a cache directory that CI restores over the checkout, and a
+// baseline that a stale cache can overwrite is a baseline that quietly stops
+// meaning anything.
+//
+// GENBA_GATE_BASELINE points at another one. A number is a property of the
+// machine that produced it, so the runner keeps its own file and a laptop keeps
+// the one checked in here, rather than the two being averaged into something
+// that describes neither. It is opened as given, and a test runs in its own
+// package directory, so what belongs in that variable is an absolute path.
+const baselineFile = "../benchcorpus/baseline.json"
+
+func gatePath() string {
+	if p := os.Getenv("GENBA_GATE_BASELINE"); p != "" {
+		return p
+	}
+	return baselineFile
+}
+
+// gateBaseline is one recorded run.
+type gateBaseline struct {
+	// Seed and Documents identify the corpus. Numbers taken against a different
+	// corpus are not comparable and the gate says so rather than dividing them.
+	Seed      uint64 `json:"seed"`
+	Documents int    `json:"documents"`
+
+	// Recorded and Runner are for the person reading a failure. Neither is used
+	// in a comparison.
+	Recorded string `json:"recorded"`
+	Runner   string `json:"runner"`
+
+	// Calibration is how long the fixed workload in gateCalibrate took, in
+	// milliseconds. It is how a slower machine is told apart from a slower
+	// query.
+	Calibration float64 `json:"calibration_ms"`
+
+	Classes map[string]gateReading `json:"classes"`
+}
+
+// gateReading is one class of one run.
+type gateReading struct {
+	Samples int `json:"samples"`
+	Rounds  int `json:"rounds"`
+
+	// Best is the median of the quietest round, in milliseconds, and it is the
+	// only figure the gate compares. Ambient load can only ever make a round
+	// slower, so the lowest of them is the closest this machine got to
+	// measuring the code on its own.
+	Best float64 `json:"best_ms"`
+
+	// P50, P95 and P99 are over every sample of every round. They are the
+	// report. They are not compared, because on a shared machine they are not
+	// reproducible enough to be compared honestly.
+	P50 float64 `json:"p50_ms"`
+	P95 float64 `json:"p95_ms"`
+	P99 float64 `json:"p99_ms"`
+
+	Budget float64 `json:"budget_ms"`
+}
+
+// TestSearchLatencyGate measures every query class and compares it with the
+// recorded baseline.
+//
+// Recording a new baseline is GENBA_GATE_RECORD=1, and it belongs in a commit
+// of its own that changes nothing else, because a commit that moves the
+// baseline and the code together is a commit that cannot be reviewed.
+func TestSearchLatencyGate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("the latency gate needs the benchmark corpus")
+	}
+
+	st, spec := benchcorpus.Fixture(t)
+	// A fixed clock, because the recency prior is part of the score, and a
+	// score that moves with the wall clock changes which documents are ranked
+	// and therefore how long ranking them takes.
+	searcher := index.New(st, index.WithClock(func() time.Time { return benchcorpus.Epoch }))
+	t.Cleanup(func() { _ = searcher.Close() })
+	h := api.New(st, searcher, api.HeaderAuth{Tenant: benchcorpus.Tenant}).Handler()
+	hdr := headers(spec.Principal())
+
+	byClass := benchcorpus.ByClass(benchcorpus.Queries())
+	classes := gateClasses(byClass)
+
+	// Every class is warmed before any of them is timed, because the rounds
+	// interleave them and a class warmed in the first round would be measured
+	// cold in it.
+	targets := make(map[benchcorpus.Class][]string, len(classes))
+	perRound := make(map[benchcorpus.Class]int, len(classes))
+	for _, class := range classes {
+		queries := byClass[class]
+		list := make([]string, len(queries))
+		for i, q := range queries {
+			list[i] = "/api/v1/search?q=" + urlQuery(q.Text)
+		}
+		targets[class] = list
+		perRound[class] = max(gateSampleCount(benchcorpus.Budget[class])/gateRounds, 1)
+		for i := range gateWarmup {
+			gateGet(t, h, list[i%len(list)], hdr)
+		}
+	}
+
+	// The calibration is taken between the rounds rather than once at the
+	// start. A single reading describes the first instant of a run that lasts
+	// minutes, and the way a shared machine actually behaves is that the load
+	// arrives halfway through. That is a run whose numbers are slow and whose
+	// calibration says the machine was idle, which is the one case this must
+	// not get wrong.
+	cal := []float64{gateCalibrate()}
+	took := make(map[benchcorpus.Class][]float64, len(classes))
+	best := make(map[benchcorpus.Class]float64, len(classes))
+	round := make([]float64, 0, gateMaxSamples)
+
+	for range gateRounds {
+		for _, class := range classes {
+			list := targets[class]
+			round = round[:0]
+			for i := range perRound[class] {
+				// The request is built before the timer starts and the response
+				// is dropped after it stops, so what is timed is the endpoint
+				// and nothing around it. The query is picked by position within
+				// the round rather than by a running count, so every round
+				// measures the same queries.
+				target := list[i%len(list)]
+				start := time.Now()
+				code := gateServe(h, target, hdr)
+				ms := float64(time.Since(start).Microseconds()) / 1000
+				if code != http.StatusOK {
+					t.Fatalf("GET %s = %d", target, code)
+				}
+				round = append(round, ms)
+				took[class] = append(took[class], ms)
+			}
+			if median := metric.Percentile(round, 0.50); best[class] == 0 || median < best[class] {
+				best[class] = median
+			}
+		}
+		cal = append(cal, gateCalibrate())
+	}
+
+	now := gateBaseline{
+		Seed:        spec.Seed,
+		Documents:   spec.Documents,
+		Runner:      os.Getenv("GENBA_GATE_RUNNER"),
+		Recorded:    os.Getenv("GENBA_GATE_DATE"),
+		Calibration: metric.Percentile(cal, 0.50),
+		Classes:     make(map[string]gateReading, len(classes)),
+	}
+	for _, class := range classes {
+		samples := took[class]
+		now.Classes[string(class)] = gateReading{
+			Samples: len(samples),
+			Rounds:  gateRounds,
+			Best:    best[class],
+			P50:     metric.Percentile(samples, 0.50),
+			P95:     metric.Percentile(samples, 0.95),
+			P99:     metric.Percentile(samples, 0.99),
+			Budget:  float64(benchcorpus.Budget[class].Microseconds()) / 1000,
+		}
+	}
+	t.Logf("calibration %.2fms, from %d readings spread through the run, lowest %.2fms and highest %.2fms",
+		now.Calibration, len(cal), slices.Min(cal), slices.Max(cal))
+
+	if os.Getenv("GENBA_GATE_RECORD") != "" {
+		gateWrite(t, gatePath(), now)
+		t.Logf("recorded a new baseline in %s, commit it on its own", gatePath())
+		return
+	}
+	if path := os.Getenv("GENBA_GATE_REPORT"); path != "" {
+		gateWrite(t, path, now)
+	}
+
+	base, ok := gateRead(t, gatePath())
+	failures, notes := gateCompare(now, base, ok, gateToleranceOf())
+	t.Log("\n" + gateTable(now, base, ok))
+	for _, n := range notes {
+		t.Log(n)
+	}
+	for _, f := range failures {
+		t.Error(f)
+	}
+}
+
+// gateServe issues one request and returns the status, doing as little as it
+// can either side of the handler because everything it does lands inside the
+// measurement.
+func gateServe(h http.Handler, target string, hdr map[string]string) int {
+	r := httptest.NewRequest(http.MethodGet, target, nil)
+	for k, v := range hdr {
+		r.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w.Code
+}
+
+// gateGet is gateServe for the warmup, where a failure is worth reporting
+// before four thousand more requests are sent at it.
+func gateGet(t *testing.T, h http.Handler, target string, hdr map[string]string) {
+	t.Helper()
+	if code := gateServe(h, target, hdr); code != http.StatusOK {
+		t.Fatalf("GET %s = %d", target, code)
+	}
+}
+
+// gateClasses is the classes present in the query set, in a fixed order, so
+// that two runs measure the same thing in the same sequence.
+func gateClasses(byClass map[benchcorpus.Class][]benchcorpus.Query) []benchcorpus.Class {
+	out := make([]benchcorpus.Class, 0, len(byClass))
+	for class, queries := range byClass {
+		if len(queries) > 0 {
+			out = append(out, class)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// gateSampleCount derives how many queries a class is measured over from its
+// budget, so the expensive classes do not run for ten minutes and the cheap
+// ones still produce a median worth reading. It is the total across the rounds.
+//
+// GENBA_GATE_SAMPLES overrides it and is taken at face value, bounds and all.
+// That is for the nightly run, which is on a machine of its own with time to
+// spend.
+func gateSampleCount(budget time.Duration) int {
+	if n := gateEnvInt("GENBA_GATE_SAMPLES"); n > 0 {
+		return n
+	}
+	if budget <= 0 {
+		return gateMaxSamples
+	}
+	return min(max(int(gateSpend/(gateBackstop*budget)), gateMinSamples), gateMaxSamples)
+}
+
+// gateToleranceOf is how far a class may move before it is a regression.
+//
+// GENBA_GATE_TOLERANCE overrides it, and the nightly run tightens it. That run
+// is on a dedicated machine, so it can afford to notice a move that would be
+// noise on a shared runner, and it files an issue rather than failing anything.
+func gateToleranceOf() float64 {
+	if v := gateEnvFloat("GENBA_GATE_TOLERANCE"); v > 0 {
+		return v
+	}
+	return gateTolerance
+}
+
+func gateEnvInt(name string) int {
+	n, err := strconv.Atoi(os.Getenv(name))
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func gateEnvFloat(name string) float64 {
+	f, err := strconv.ParseFloat(os.Getenv(name), 64)
+	if err != nil {
+		return 0
+	}
+	return f
+}
+
+// gateCalibrate is how long a fixed unit of work takes on this machine right
+// now, in milliseconds. It is called between the rounds, and the median of
+// those readings is what the run is scaled by.
+//
+// It is deliberately not a search. Its job is to say how fast the machine is
+// today, and a calibration that ran the code under test would move with the
+// regression it is supposed to be correcting for, which is how a gate ends up
+// approving anything as long as everything got slower together.
+//
+// It does have to be shaped like a search, though, and the first version was
+// not. It hashed a buffer that fit in cache, which is pure arithmetic, and on a
+// contended laptop it reported the machine getting slower across two runs where
+// every search class got faster. What a search spends its time on is
+// allocating, sorting and hashing its way through a few megabytes, so that is
+// what this does, and it is the memory system rather than the arithmetic units
+// that it asks about.
+func gateCalibrate() float64 {
+	const n = 1 << 17
+	runs := make([]float64, 5)
+	for i := range runs {
+		start := time.Now()
+		xs := make([]int64, n)
+		// A linear congruential sequence, because the values need to be
+		// scattered and the run needs to be identical on every machine, and the
+		// standard generator is neither seeded the same way twice nor free.
+		x := int64(1)
+		for j := range xs {
+			x = x*6364136223846793005 + 1442695040888963407
+			xs[j] = x >> 33
+		}
+		slices.Sort(xs)
+		seen := make(map[int64]int, n/4)
+		for j := 0; j < n; j += 4 {
+			seen[xs[j]] = j
+		}
+		for j := 1; j < n; j += 4 {
+			if _, ok := seen[xs[j]]; ok {
+				gateSink++
+			}
+		}
+		gateSink += len(seen)
+		runs[i] = float64(time.Since(start).Microseconds()) / 1000
+	}
+	// The median of five, because the calibration runs on the same busy machine
+	// as everything else and one interrupted run should not decide what the
+	// whole comparison is scaled by.
+	return metric.Percentile(runs, 0.50)
+}
+
+// gateSink keeps the calibration from being optimised away.
+var gateSink int
+
+// gateCompare is the whole judgement, kept apart from the measurement so that
+// it can be tested with numbers instead of with a corpus.
+func gateCompare(now, base gateBaseline, haveBase bool, tol float64) (failures, notes []string) {
+	// The backstop, which needs no baseline. A class the recorded baseline
+	// already misses is exempt from it and is held to the baseline instead: the
+	// budgets are what the query path is aiming at rather than what it has hit,
+	// three of them are missed today and that is written down in
+	// benchcorpus/BASELINE.md, and a gate that failed every pull request until
+	// they are met is a gate that gets deleted in a week. The exemption expires
+	// on its own the moment a baseline inside the budget is recorded.
+	for _, class := range slices.Sorted(maps.Keys(now.Classes)) {
+		got := now.Classes[class]
+		was, recorded := base.Classes[class]
+		switch {
+		case got.Budget <= 0 || got.Best <= got.Budget*gateBackstop:
+		case haveBase && recorded && was.Budget > 0 && was.Best > was.Budget:
+			notes = append(notes, fmt.Sprintf(
+				"%s is over its budget of %.1fms at %.1fms, and the baseline records %.1fms, so it is held to the baseline until the budget is met",
+				class, got.Budget, got.Best, was.Best))
+		default:
+			failures = append(failures, fmt.Sprintf(
+				"%s is %.1fms against a budget of %.1fms, which is past the backstop of %dx and is not a busy runner",
+				class, got.Best, got.Budget, gateBackstop))
+		}
+	}
+
+	scale, ok, why := gateScale(now, base, haveBase)
+	if !ok {
+		return failures, append(notes, why+", so only the absolute backstop was applied")
+	}
+	if why != "" {
+		notes = append(notes, why)
+	}
+
+	for _, class := range slices.Sorted(maps.Keys(now.Classes)) {
+		got, was := now.Classes[class], base.Classes[class]
+		if was.Best == 0 {
+			notes = append(notes, fmt.Sprintf("%s is not in the baseline, so it was only held to the backstop", class))
+			continue
+		}
+		best := got.Best * scale
+		if best > was.Best*tol {
+			failures = append(failures, fmt.Sprintf(
+				"%s is %.1fms normalised against a baseline of %.1fms, a move of %+.0f%% and the tolerance is %+.0f%%",
+				class, best, was.Best, 100*(best/was.Best-1), 100*(tol-1)))
+		}
+		if move := best/was.Best - 1; move >= gateReportMove || move <= -gateReportMove {
+			notes = append(notes, fmt.Sprintf("%s moved %+.0f%%, from %.1fms to %.1fms normalised", class, 100*move, was.Best, best))
+		}
+	}
+	return failures, notes
+}
+
+// gateScale is the factor that turns this machine's milliseconds into the
+// baseline machine's, along with why it cannot be trusted when it cannot.
+func gateScale(now, base gateBaseline, haveBase bool) (scale float64, ok bool, why string) {
+	switch {
+	case !haveBase || len(base.Classes) == 0:
+		return 0, false, "there is no recorded baseline"
+	case base.Seed != now.Seed || base.Documents != now.Documents:
+		return 0, false, fmt.Sprintf("the baseline was recorded against seed %d at %d documents and this run is seed %d at %d",
+			base.Seed, base.Documents, now.Seed, now.Documents)
+	case base.Calibration <= 0 || now.Calibration <= 0:
+		return 1, true, "there is no calibration figure, so the numbers are compared unscaled"
+	}
+	scale = base.Calibration / now.Calibration
+	switch {
+	case scale > gateCalibrationSpread || scale < 1/gateCalibrationSpread:
+		return 0, false, fmt.Sprintf("this machine calibrates at %.2fms against the baseline's %.2fms, which is too far apart to scale into agreement",
+			now.Calibration, base.Calibration)
+	// The deadband. The calibration is a proxy and a proxy that is a tenth
+	// apart from where it was is saying nothing, so correcting by it would be
+	// putting its noise into every class rather than taking the machine's speed
+	// out of them.
+	case scale > 1/gateCalibrationBand && scale < gateCalibrationBand:
+		return 1, true, ""
+	}
+	return scale, true, fmt.Sprintf("this machine calibrates at %.2fms against the baseline's %.2fms, so the measurements are scaled by %.2f",
+		now.Calibration, base.Calibration, scale)
+}
+
+// gateTable is the report, as markdown, because it ends up in a CI log that
+// somebody has to read at the point they are least inclined to.
+func gateTable(now, base gateBaseline, haveBase bool) string {
+	var b strings.Builder
+	b.WriteString("| class | samples | best | p50 | p95 | p99 | budget | baseline best |\n")
+	b.WriteString("| --- | --- | --- | --- | --- | --- | --- | --- |\n")
+	for _, class := range slices.Sorted(maps.Keys(now.Classes)) {
+		got := now.Classes[class]
+		was := "not recorded"
+		if haveBase {
+			if r, ok := base.Classes[class]; ok {
+				was = fmt.Sprintf("%.1fms", r.Best)
+			}
+		}
+		fmt.Fprintf(&b, "| %s | %d | %.1fms | %.1fms | %.1fms | %.1fms | %.1fms | %s |\n",
+			class, got.Samples, got.Best, got.P50, got.P95, got.P99, got.Budget, was)
+	}
+	b.WriteString("\nbest is the median of the quietest of ")
+	fmt.Fprintf(&b, "%d rounds and is the only column compared, and the percentiles are over every sample of every round\n", gateRounds)
+	return b.String()
+}
+
+func gateRead(t *testing.T, path string) (gateBaseline, bool) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return gateBaseline{}, false
+	}
+	if err != nil {
+		t.Fatalf("reading the baseline: %v", err)
+	}
+	var b gateBaseline
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatalf("the baseline in %s does not parse: %v", path, err)
+	}
+	return b, true
+}
+
+func gateWrite(t *testing.T, path string, b gateBaseline) {
+	t.Helper()
+	raw, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		t.Fatalf("encoding the baseline: %v", err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+// TestGateComparisonIsHonest covers the judgement with numbers, so that the
+// gate's own logic is not something only a slow corpus run can exercise.
+func TestGateComparisonIsHonest(t *testing.T) {
+	reading := func(best float64) map[string]gateReading {
+		return map[string]gateReading{"common": {
+			Samples: 1000, Rounds: gateRounds, Best: best,
+			P50: best, P95: best * 3, P99: best * 4, Budget: 10,
+		}}
+	}
+	base := gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: reading(8)}
+
+	tests := []struct {
+		name string
+		now  gateBaseline
+		want string
+	}{
+		{"a run that matches the baseline",
+			gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: reading(8)}, ""},
+		{"a move inside the tolerance",
+			gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: reading(9.5)}, ""},
+		{"a move past the tolerance",
+			gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: reading(11)}, "tolerance"},
+		{"a slow machine measured the same query path",
+			// Twice the calibration and twice the latency is the same code on
+			// half the machine, and the gate has to stay quiet.
+			gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 20, Classes: reading(16)}, ""},
+		{"a slow machine and a real regression",
+			gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 20, Classes: reading(24)}, "tolerance"},
+		{"past the backstop with no baseline to compare against",
+			gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: reading(25)}, "backstop"},
+		{"a tail that moved and a median that did not",
+			// The one the percentiles would have failed and this deliberately
+			// does not, because two runs of an unchanged tree move the tail by
+			// more than this.
+			gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: map[string]gateReading{
+				"common": {Samples: 1000, Rounds: gateRounds, Best: 8, P50: 9, P95: 60, P99: 90, Budget: 10},
+			}}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failures, _ := gateCompare(tt.now, base, true, gateTolerance)
+			switch {
+			case tt.want == "" && len(failures) > 0:
+				t.Fatalf("the gate failed a run it should have passed: %v", failures)
+			case tt.want == "":
+				return
+			case len(failures) == 0:
+				t.Fatalf("the gate passed a run it should have failed")
+			}
+			if !strings.Contains(strings.Join(failures, "\n"), tt.want) {
+				t.Fatalf("the failure does not mention %q: %v", tt.want, failures)
+			}
+		})
+	}
+
+	// A class the baseline already misses is held to the baseline rather than to
+	// the budget, and is still held to something.
+	overBudget := gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: reading(22)}
+	if failures, notes := gateCompare(overBudget, overBudget, true, gateTolerance); len(failures) > 0 {
+		t.Errorf("a class the baseline itself misses failed the backstop: %v", failures)
+	} else if !strings.Contains(strings.Join(notes, "\n"), "over its budget") {
+		t.Errorf("the report does not say the class is over its budget: %v", notes)
+	}
+	if failures, _ := gateCompare(gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: reading(30)},
+		overBudget, true, gateTolerance); len(failures) == 0 {
+		t.Error("a class exempt from the backstop stopped being held to its baseline as well")
+	}
+
+	// A corpus mismatch is not a regression and must not be reported as one.
+	other := gateBaseline{Seed: 7, Documents: 20_000, Calibration: 10, Classes: reading(11)}
+	failures, notes := gateCompare(other, base, true, gateTolerance)
+	if len(failures) > 0 {
+		t.Errorf("a baseline from a different corpus was compared anyway: %v", failures)
+	}
+	if !strings.Contains(strings.Join(notes, "\n"), "seed") {
+		t.Errorf("the report does not say why the comparison was skipped: %v", notes)
+	}
+
+	// A baseline recorded before the gate measured rounds has no figure to
+	// compare against, and saying so beats dividing by zero.
+	old := gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: map[string]gateReading{
+		"common": {Samples: 1000, P50: 9, P95: 20, P99: 30, Budget: 10},
+	}}
+	if failures, notes := gateCompare(reading9(), old, true, gateTolerance); len(failures) > 0 {
+		t.Errorf("a baseline with no recorded figure was compared anyway: %v", failures)
+	} else if !strings.Contains(strings.Join(notes, "\n"), "not in the baseline") {
+		t.Errorf("the report does not say the class is missing from the baseline: %v", notes)
+	}
+}
+
+// reading9 is a run of one class at nine milliseconds, for the cases that need
+// a run rather than a class.
+func reading9() gateBaseline {
+	return gateBaseline{Seed: 2121, Documents: 20_000, Calibration: 10, Classes: map[string]gateReading{
+		"common": {Samples: 1000, Rounds: gateRounds, Best: 9, P50: 9, P95: 20, P99: 30, Budget: 10},
+	}}
+}
+
+// TestGateSampleCountFitsTheBudget, because a class that takes ten minutes to
+// measure is a class that gets dropped from the gate.
+func TestGateSampleCountFitsTheBudget(t *testing.T) {
+	for class, budget := range benchcorpus.Budget {
+		n := gateSampleCount(budget)
+		if n < gateMinSamples || n > gateMaxSamples {
+			t.Errorf("%s takes %d samples, which is outside the bounds", class, n)
+		}
+		if spend := time.Duration(n) * budget * gateBackstop; spend > gateSpend+time.Second {
+			t.Errorf("%s is measured for %v, and the class is allowed %v", class, spend, gateSpend)
+		}
+		if per := n / gateRounds; per < 20 {
+			t.Errorf("%s puts %d samples in a round, which is too few for a median", class, per)
+		}
+	}
+	if got := gateSampleCount(0); got != gateMaxSamples {
+		t.Errorf("a class with no budget takes %d samples, want %d", got, gateMaxSamples)
+	}
+}

--- a/api/latency_test.go
+++ b/api/latency_test.go
@@ -172,12 +172,18 @@ type gateReading struct {
 // TestSearchLatencyGate measures every query class and compares it with the
 // recorded baseline.
 //
+// It is opt in, because it builds a twenty thousand document corpus and then
+// spends fifteen seconds per query class measuring it, and a plain go test
+// ./... that quietly does that is a plain go test ./... that people stop
+// running. Benchmarks get this for free by needing -bench, and a test has to
+// ask for it.
+//
 // Recording a new baseline is GENBA_GATE_RECORD=1, and it belongs in a commit
 // of its own that changes nothing else, because a commit that moves the
 // baseline and the code together is a commit that cannot be reviewed.
 func TestSearchLatencyGate(t *testing.T) {
-	if testing.Short() {
-		t.Skip("the latency gate needs the benchmark corpus")
+	if os.Getenv("GENBA_GATE") == "" {
+		t.Skip("the latency gate builds the benchmark corpus and measures it, so it is opt in: make bench-gate")
 	}
 
 	st, spec := benchcorpus.Fixture(t)

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/metric"
+	"github.com/tamnd/genba/store"
+)
+
+// Metric names. They are constants because the alert in docs/alerts.yml names
+// them, and a rename that only edits the code leaves an alert that will never
+// fire again and will never say so.
+const (
+	MetricRequestDuration = "genba_request_duration_milliseconds"
+	MetricSearchDuration  = "genba_search_duration_milliseconds"
+	MetricCandidates      = "genba_search_candidates"
+	MetricMatches         = "genba_search_matches"
+	MetricCacheHits       = "genba_cache_hits_total"
+	MetricCacheMisses     = "genba_cache_misses_total"
+	MetricCacheEvictions  = "genba_cache_evictions_total"
+	MetricCacheEntries    = "genba_cache_entries"
+	MetricStoreRows       = "genba_store_rows_total"
+	MetricStoreStatements = "genba_store_statements_total"
+	MetricStoreDecodes    = "genba_store_decodes_total"
+)
+
+// metrics is everything the server publishes.
+//
+// The histograms are recorded into on the request path. The counters are read
+// at scrape time out of the structures that were already keeping them, which is
+// why there is no counting done twice anywhere in here: the cache layers and
+// the storage driver have their own counters because their own tests assert on
+// them, and this publishes those rather than shadowing them.
+type metrics struct {
+	registry *metric.Registry
+
+	requests   *metric.Histogram
+	searches   *metric.Histogram
+	candidates *metric.Histogram
+	matches    *metric.Histogram
+}
+
+// newMetrics registers the families of one server.
+func newMetrics(s *Server) *metrics {
+	r := metric.New()
+	m := &metrics{
+		registry: r,
+		requests: r.NewHistogram(MetricRequestDuration,
+			"How long a request took, from the first line read to the last byte written.",
+			"endpoint", metric.Duration),
+		searches: r.NewHistogram(MetricSearchDuration,
+			"How long the search itself took, excluding request parsing and encoding.",
+			"", metric.Duration),
+		candidates: r.NewHistogram(MetricCandidates,
+			"How many documents were ranked to produce one page of results.",
+			"", metric.Size),
+		matches: r.NewHistogram(MetricMatches,
+			"How many documents matched, before paging.",
+			"", metric.Size),
+	}
+
+	// The cache layers appear and disappear with the configuration, so the
+	// label values come from the scrape rather than from registration. A
+	// deployment with result caching turned off publishes two layers instead of
+	// three, which is the truth and is more useful than a zero.
+	cacheStat := func(pick func(hits, misses, evictions, entries int64) int64) func() map[string]float64 {
+		return func() map[string]float64 {
+			out := map[string]float64{}
+			for layer, st := range s.searcher.CacheStats() {
+				out[layer] = float64(pick(st.Hits, st.Misses, st.Evictions, int64(st.Entries)))
+			}
+			return out
+		}
+	}
+	r.Counters(MetricCacheHits, "Cache reads that found an entry, per layer.", "layer", "counter",
+		cacheStat(func(hits, _, _, _ int64) int64 { return hits }))
+	r.Counters(MetricCacheMisses, "Cache reads that had to do the work, per layer.", "layer", "counter",
+		cacheStat(func(_, misses, _, _ int64) int64 { return misses }))
+	r.Counters(MetricCacheEvictions, "Entries dropped to stay within capacity, per layer.", "layer", "counter",
+		cacheStat(func(_, _, evictions, _ int64) int64 { return evictions }))
+	r.Counters(MetricCacheEntries, "Entries currently held, per layer.", "layer", "gauge",
+		cacheStat(func(_, _, _, entries int64) int64 { return entries }))
+
+	// A driver is not obliged to be measurable. One that is publishes the same
+	// numbers the CI gate asserts on, so a slow deployment can be compared with
+	// a green pull request instead of argued about.
+	if counted, ok := s.store.(store.Counted); ok {
+		single := func(pick func(store.Counters) int64) func() map[string]float64 {
+			return func() map[string]float64 { return map[string]float64{"": float64(pick(counted.Counters()))} }
+		}
+		r.Counters(MetricStoreRows, "Rows the storage driver has returned on read paths.", "", "counter",
+			single(func(c store.Counters) int64 { return c.Rows }))
+		r.Counters(MetricStoreStatements, "Statements the storage driver has run on read paths.", "", "counter",
+			single(func(c store.Counters) int64 { return c.Statements }))
+		r.Counters(MetricStoreDecodes, "Stored documents the driver has decoded.", "", "counter",
+			single(func(c store.Counters) int64 { return c.Decodes }))
+	}
+	return m
+}
+
+// Metrics returns a handler serving the Prometheus text format.
+//
+// It is not mounted on the API router. Metrics say how much traffic there is,
+// how large the match sets are and how hard the caches are working, which is
+// not secret and is not public either, and the deployment shape that gets this
+// right is a second listener on an address the outside cannot reach.
+// [Server.Handler] therefore never serves it, and a caller that wants it
+// mounted somewhere has to say so.
+func (s *Server) Metrics() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		_, _ = s.metrics.registry.WriteTo(w)
+	})
+}
+
+// measure times every request and files it under the route that served it.
+//
+// The label is the registered pattern rather than the path, because the path
+// carries document ids and a metric with one series per document is not a
+// metric. Routing runs twice per request to get it, which is a map lookup
+// against a fixed set of patterns and is not measurable next to the handler.
+func (s *Server) measure(mux *http.ServeMux) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := s.now()
+		mux.ServeHTTP(w, r)
+
+		// An event stream is open for as long as somebody is looking at the
+		// page, so timing it would put a number in the tail that describes a
+		// person's attention span rather than the server.
+		_, pattern := mux.Handler(r)
+		if pattern == "" || pattern == "GET /api/v1/events" {
+			return
+		}
+		s.metrics.requests.Observe(float64(s.now().Sub(start).Microseconds())/1000, endpoint(pattern))
+	})
+}
+
+// endpoint strips the method from a route pattern, since the label is a place
+// and the method is already the reason there are separate patterns.
+func endpoint(pattern string) string {
+	if i := strings.IndexByte(pattern, ' '); i >= 0 {
+		return pattern[i+1:]
+	}
+	return pattern
+}
+
+// observeSearch records what one search cost, whatever the response looked
+// like.
+func (m *metrics) observeSearch(took time.Duration, candidates, total int) {
+	m.searches.Observe(float64(took.Microseconds())/1000, "")
+	m.candidates.Observe(float64(candidates), "")
+	m.matches.Observe(float64(total), "")
+}

--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -1,0 +1,169 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/sqlitestore"
+)
+
+// measuredServer is cachingServer with the server itself handed back, because
+// the metrics handler is deliberately not on the router.
+func measuredServer(t *testing.T) (*api.Server, http.Handler) {
+	t.Helper()
+	st, err := sqlitestore.Open(t.Context(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Put(t.Context(), cacheCorpus()...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	searcher := index.New(st, index.WithCache(index.NewCache()))
+	t.Cleanup(func() { _ = searcher.Close() })
+
+	s := api.New(st, searcher, api.HeaderAuth{Tenant: "acme"})
+	return s, s.Handler()
+}
+
+// scrape reads the metrics handler.
+func scrape(t *testing.T, s *api.Server) string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	s.Metrics().ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("the metrics handler returned %d", w.Code)
+	}
+	return w.Body.String()
+}
+
+// value reads one series out of an exposition.
+func value(t *testing.T, body, series string) float64 {
+	t.Helper()
+	re := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(series) + ` (\S+)$`)
+	m := re.FindStringSubmatch(body)
+	if m == nil {
+		t.Fatalf("no series %q in:\n%s", series, body)
+	}
+	v, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		t.Fatalf("series %q has value %q: %v", series, m[1], err)
+	}
+	return v
+}
+
+// TestTheMetricsAreNotOnTheApiRouter is the deployment shape, asserted rather
+// than described in a comment. Metrics say how many documents a tenant holds
+// and how hard the caches are working, and the address that serves them is not
+// the address the world can reach.
+func TestTheMetricsAreNotOnTheApiRouter(t *testing.T) {
+	_, h := measuredServer(t)
+	for _, path := range []string{"/metrics", "/api/v1/metrics"} {
+		w := request(t, h, http.MethodGet, path, engineer())
+		if w.Code == http.StatusOK {
+			t.Errorf("%s is served by the API router", path)
+		}
+	}
+}
+
+// TestARequestIsFiledUnderItsRoute covers the label, which is the part that
+// turns a metric into a bill. A path carries document ids, and one series per
+// document is not a metric, it is an outage in the monitoring system.
+func TestARequestIsFiledUnderItsRoute(t *testing.T) {
+	s, h := measuredServer(t)
+
+	request(t, h, http.MethodGet, "/api/v1/documents/d1", engineer())
+	request(t, h, http.MethodGet, "/api/v1/documents/d2", engineer())
+	request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+
+	body := scrape(t, s)
+	if got := value(t, body, `genba_request_duration_milliseconds_count{endpoint="/api/v1/documents/{id}"}`); got != 2 {
+		t.Errorf("the document route recorded %v requests, want 2", got)
+	}
+	if got := value(t, body, `genba_request_duration_milliseconds_count{endpoint="/api/v1/search"}`); got != 1 {
+		t.Errorf("the search route recorded %v requests, want 1", got)
+	}
+	if strings.Contains(body, `endpoint="/api/v1/documents/d1"`) {
+		t.Error("a document id reached a label, which is one series per document")
+	}
+}
+
+// TestASearchReportsTheWorkItDid is the pair of numbers that says whether the
+// two phase retrieval is still cutting. Candidates is what was ranked, matches
+// is what was found, and the day they start moving together the first phase has
+// stopped doing its job.
+func TestASearchReportsTheWorkItDid(t *testing.T) {
+	s, h := measuredServer(t)
+	request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+
+	body := scrape(t, s)
+	if got := value(t, body, "genba_search_candidates_count"); got != 1 {
+		t.Errorf("candidates recorded %v searches, want 1", got)
+	}
+	if got := value(t, body, "genba_search_matches_count"); got != 1 {
+		t.Errorf("matches recorded %v searches, want 1", got)
+	}
+	if got := value(t, body, "genba_search_matches_sum"); got == 0 {
+		t.Error("the search matched nothing, so this test is measuring an empty query")
+	}
+	if got := value(t, body, "genba_search_candidates_sum"); got == 0 {
+		t.Error("the search ranked nothing, so the candidate count is not being reported")
+	}
+}
+
+// TestTheCacheCountersComeFromTheCache, rather than from a second set of
+// counters kept alongside them that can disagree.
+func TestTheCacheCountersComeFromTheCache(t *testing.T) {
+	s, h := measuredServer(t)
+
+	request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	first := value(t, scrape(t, s), `genba_cache_misses_total{layer="results"}`)
+	if first == 0 {
+		t.Fatal("the first search was not a miss, so the results layer is not being read")
+	}
+
+	request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	body := scrape(t, s)
+	if got := value(t, body, `genba_cache_hits_total{layer="results"}`); got == 0 {
+		t.Error("the repeated search was not a hit")
+	}
+	if got := value(t, body, `genba_cache_misses_total{layer="results"}`); got != first {
+		t.Errorf("the miss count moved to %v on a hit, want %v", got, first)
+	}
+	if !strings.Contains(body, `genba_cache_entries{layer="results"}`) {
+		t.Error("the entry gauge is missing, which is how a layer at capacity is spotted")
+	}
+}
+
+// TestTheStoreCountersAreThere because they are the numbers the CI gate asserts
+// on, and a production slowdown that cannot be compared with a green pull
+// request is a slowdown that gets argued about instead of found.
+func TestTheStoreCountersAreThere(t *testing.T) {
+	s, h := measuredServer(t)
+	request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+
+	body := scrape(t, s)
+	for _, series := range []string{"genba_store_rows_total", "genba_store_statements_total", "genba_store_decodes_total"} {
+		if got := value(t, body, series); got == 0 {
+			t.Errorf("%s is zero after a search that read the store", series)
+		}
+	}
+}
+
+// TestAnOpenEventStreamIsNotTimed. It is open for as long as somebody is
+// looking at the page, so its duration describes an attention span rather than
+// the server, and one of them in the tail moves every percentile above it.
+func TestAnOpenEventStreamIsNotTimed(t *testing.T) {
+	s, h := measuredServer(t)
+	request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+
+	if body := scrape(t, s); strings.Contains(body, `endpoint="/api/v1/events"`) {
+		t.Errorf("the event stream is being timed:\n%s", body)
+	}
+}

--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -29,7 +29,8 @@ func measuredServer(t *testing.T) (*api.Server, http.Handler) {
 	t.Cleanup(func() { _ = searcher.Close() })
 
 	s := api.New(st, searcher, api.HeaderAuth{Tenant: "acme"})
-	return s, s.Handler()
+	h := s.Handler()
+	return s, h
 }
 
 // scrape reads the metrics handler.

--- a/arch_test.go
+++ b/arch_test.go
@@ -33,6 +33,12 @@ var allowed = map[string][]string{
 	// model in the package least equipped to hold one.
 	"cache": nil,
 
+	// metric is the same shape as cache: a lock over some numbers, importing
+	// nothing of ours. A metrics package that knew about principals or
+	// documents would be a place for either to leak into an endpoint that is
+	// deliberately not behind the permission check.
+	"metric": nil,
+
 	"store":             {"acl", "doc"},
 	"store/memstore":    {"", "acl", "doc", "store"},
 	"store/sqlitestore": {"", "acl", "doc", "store"},
@@ -40,7 +46,7 @@ var allowed = map[string][]string{
 	"index":             {"acl", "cache", "doc", "store"},
 	"config":            nil,
 	"web":               nil,
-	"api":               {"", "acl", "cache", "doc", "index", "store"},
+	"api":               {"", "acl", "cache", "doc", "index", "metric", "store"},
 
 	// Ingestion sits beside the query path rather than under it. A connector
 	// describes documents and who may read them, the pipeline writes them, and

--- a/benchcorpus/BASELINE.md
+++ b/benchcorpus/BASELINE.md
@@ -48,6 +48,10 @@ The absolute budgets are still in the code, as a backstop at twice the budget.
 A class that the recorded baseline itself misses is exempt from that backstop and is held to the baseline instead, which is what keeps the three misses below from failing every pull request while they are being worked on.
 The exemption ends by itself on the day a baseline inside the budget is recorded.
 
+A machine with no baseline at all gets no backstop either.
+The exemption is read out of the baseline, so without one every class that is aiming at a budget it has not met yet looks like a failure, and the budgets were stated against the laptop in the table above rather than against a two core runner that is several times slower than it.
+An absolute millisecond applied to a machine nothing has characterised is the flake the rest of this design exists to avoid, so that run records its numbers, says in the log that it enforced nothing, and leaves the counters to be the half that runs everywhere.
+
 The checked in baseline is the laptop in the table above.
 CI points `GENBA_GATE_BASELINE` at `benchcorpus/baseline-ci.json`, which the nightly workflow produces as an artifact for somebody to commit, because a baseline that updates itself is a ratchet that only turns one way.
 

--- a/benchcorpus/BASELINE.md
+++ b/benchcorpus/BASELINE.md
@@ -17,7 +17,39 @@ The point of writing it down is that the next person who changes any of this has
 
 Read these as orientation, not as a gate.
 They were taken on a laptop that was doing other things, and the same commit measured 43ms and 50ms for the same benchmark twenty minutes apart.
-That is exactly why the thing CI enforces is `make bench-counters`, which counts rows and statements and cannot flake, and why the latency gate that will sit beside it compares against a baseline recorded on the runner it runs on.
+That is exactly why the thing CI enforces is `make bench-counters`, which counts rows and statements and cannot flake, and why the latency gate that sits beside it compares against a baseline recorded on the runner it runs on.
+
+## The latency gate
+
+`make bench-gate` is the wall clock half, and `benchcorpus/baseline.json` is what it compares against.
+
+It drives the search endpoint rather than the searcher, because the budget is what a browser waits for and request parsing and JSON encoding are part of that wait.
+It warms every class, then measures them all eight times over, and reports p50, p95 and p99 for each.
+
+What it compares was picked by measuring the same commit twice rather than by reasoning about it.
+Two runs of an unchanged tree, on the same laptop, disagreed by a factor of two on the p95 of the most expensive class.
+The median of the quietest round of those same runs held to within a quarter, and to within a tenth for half the classes.
+So the number that fails a build is the quietest median, the tolerance is set above what an unchanged tree was measured to do rather than at a number that sounds strict, and the percentiles are recorded and printed and never compared.
+
+That limit is worth stating plainly: a regression that only moves the tail will not fail this gate.
+Nothing that runs on a shared machine can catch that, and a check that pretends otherwise goes red on a Tuesday for no reason and is deleted on the Wednesday.
+
+Four things keep it honest:
+
+- It compares against a baseline rather than against an absolute number, and allows a thirty five percent move.
+- It measures the classes in interleaved rounds rather than one class at a time, so a burst of load lands across all of them rather than in whichever one was unlucky, and every round runs the same queries in the same order.
+- It times a calibration workload that does not touch the search path, between every round rather than once at the start, and scales the comparison by the median of those readings.
+  A runner half the speed of the one that recorded the baseline shows up in the calibration rather than in every class, and load that arrives halfway through a run shows up there too.
+  The workload allocates and sorts its way through a few megabytes rather than hashing a buffer that fits in cache, because the first version did the latter and reported the machine getting slower across two runs where every search class got faster.
+  It is a proxy, so it is applied only once the two figures are a tenth apart, and below that the run is compared unscaled rather than corrected by the proxy's own noise.
+- It refuses to compare at all when the calibration is more than twice apart, or when the corpus differs, and says so instead of passing quietly.
+
+The absolute budgets are still in the code, as a backstop at twice the budget.
+A class that the recorded baseline itself misses is exempt from that backstop and is held to the baseline instead, which is what keeps the three misses below from failing every pull request while they are being worked on.
+The exemption ends by itself on the day a baseline inside the budget is recorded.
+
+The checked in baseline is the laptop in the table above.
+CI points `GENBA_GATE_BASELINE` at `benchcorpus/baseline-ci.json`, which the nightly workflow produces as an artifact for somebody to commit, because a baseline that updates itself is a ratchet that only turns one way.
 
 ## The endpoints
 

--- a/benchcorpus/baseline.json
+++ b/benchcorpus/baseline.json
@@ -1,0 +1,63 @@
+{
+  "seed": 2121,
+  "documents": 20000,
+  "recorded": "2026-08-19",
+  "runner": "Darwin arm64",
+  "calibration_ms": 7.969,
+  "classes": {
+    "common": {
+      "samples": 744,
+      "rounds": 8,
+      "best_ms": 59.455,
+      "p50_ms": 68.591,
+      "p95_ms": 172.374,
+      "p99_ms": 377.999,
+      "budget_ms": 10
+    },
+    "filter": {
+      "samples": 936,
+      "rounds": 8,
+      "best_ms": 17.334,
+      "p50_ms": 21.341,
+      "p95_ms": 65.835,
+      "p99_ms": 128.538,
+      "budget_ms": 8
+    },
+    "multi": {
+      "samples": 744,
+      "rounds": 8,
+      "best_ms": 44.135,
+      "p50_ms": 54.043,
+      "p95_ms": 94.968,
+      "p99_ms": 132.099,
+      "budget_ms": 10
+    },
+    "pathological": {
+      "samples": 296,
+      "rounds": 8,
+      "best_ms": 126.482,
+      "p50_ms": 152.756,
+      "p95_ms": 251.166,
+      "p99_ms": 297.9,
+      "budget_ms": 25
+    },
+    "rare": {
+      "samples": 1000,
+      "rounds": 8,
+      "best_ms": 3.702,
+      "p50_ms": 4.768,
+      "p95_ms": 21.935,
+      "p99_ms": 29.398,
+      "budget_ms": 3
+    },
+    "term-filter": {
+      "samples": 744,
+      "rounds": 8,
+      "best_ms": 20.848,
+      "p50_ms": 25.941,
+      "p95_ms": 61.005,
+      "p99_ms": 83.519,
+      "budget_ms": 10
+    }
+  }
+}

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -62,6 +62,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	fs := flag.NewFlagSet("genbad", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.StringVar(&cfg.Addr, "addr", cfg.Addr, "listen address")
+	fs.StringVar(&cfg.MetricsAddr, "metrics-addr", cfg.MetricsAddr, "listen address for the metrics endpoint, empty to serve no metrics")
 	fs.StringVar((*string)(&cfg.Store), "store", string(cfg.Store), "storage driver: memory, sqlite, postgres or kura")
 	fs.StringVar(&cfg.DSN, "dsn", cfg.DSN, "storage data source")
 	fs.StringVar(&cfg.Tenant, "tenant", cfg.Tenant, "tenant served by a single tenant deployment")
@@ -133,39 +134,73 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		WriteTimeout:      cfg.WriteTimeout,
 	}
 
+	// The metrics endpoint gets its own listener, on its own address, and is off
+	// unless one is configured. What it publishes is not secret and is not
+	// public either, and the deployment that gets this right binds it somewhere
+	// the outside cannot reach rather than mounting it on the API and relying on
+	// a proxy rule to hide it again.
+	servers := []*http.Server{httpSrv}
+	if cfg.MetricsAddr != "" {
+		servers = append(servers, &http.Server{
+			Addr:              cfg.MetricsAddr,
+			Handler:           srv.Metrics(),
+			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       cfg.ReadTimeout,
+			WriteTimeout:      cfg.WriteTimeout,
+		})
+	}
+
 	log.Info("starting",
 		"version", genba.Version,
 		"addr", cfg.Addr,
+		"metrics", cfg.MetricsAddr,
 		"store", cfg.Store,
 		"interface", web.Enabled(),
 		"cache", cfg.Cache,
 	)
 
-	errc := make(chan error, 1)
-	go func() {
-		if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errc <- err
-			return
-		}
-		errc <- nil
-	}()
+	errc := make(chan error, len(servers))
+	for _, s := range servers {
+		go func() {
+			if err := s.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errc <- err
+				return
+			}
+			errc <- nil
+		}()
+	}
 
+	// One listener falling over takes the other down with it. A process that
+	// went on serving the API after the metrics address failed to bind is half
+	// of what was asked for and looks entirely healthy from the outside.
+	var first error
+	running := len(servers)
 	select {
-	case err := <-errc:
-		return err
+	case first = <-errc:
+		running--
 	case <-ctx.Done():
 	}
 
 	log.Info("shutting down", "grace", cfg.ShutdownGrace)
 	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cfg.ShutdownGrace)
 	defer cancel()
-	if err := httpSrv.Shutdown(shutdownCtx); err != nil {
-		// A shutdown that runs out of grace is worth reporting but is not a
-		// failure of the process: the requests it was waiting on were already
-		// over budget.
-		log.Warn("shutdown did not finish in time", "error", err)
+	for _, s := range servers {
+		if err := s.Shutdown(shutdownCtx); err != nil {
+			// A shutdown that runs out of grace is worth reporting but is not a
+			// failure of the process: the requests it was waiting on were
+			// already over budget.
+			log.Warn("shutdown did not finish in time", "addr", s.Addr, "error", err)
+		}
 	}
-	return <-errc
+
+	// Every listener reports before this returns, so nothing is still serving a
+	// request out of the store when the deferred close runs.
+	for range running {
+		if err := <-errc; err != nil && first == nil {
+			first = err
+		}
+	}
+	return first
 }
 
 // openStore builds the storage driver named in the configuration.

--- a/cmd/genbad/main_test.go
+++ b/cmd/genbad/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -56,6 +57,83 @@ func TestServerServesAndShutsDown(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("the server did not shut down after its context was cancelled")
 	}
+}
+
+// TestMetricsAreOnTheirOwnAddress is the deployment shape the whole second
+// listener exists for. The numbers are published where an operator can scrape
+// them and nowhere the API is reachable from.
+func TestMetricsAreOnTheirOwnAddress(t *testing.T) {
+	addr, metricsAddr := freeAddr(t), freeAddr(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, []string{"-addr", addr, "-metrics-addr", metricsAddr, "-log-level", "error"}, env(nil), &out, &errOut)
+	}()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	if body := get(t, "http://"+metricsAddr+"/metrics"); !strings.Contains(body, "genba_request_duration_milliseconds") {
+		t.Errorf("the metrics listener served:\n%s", body)
+	}
+	if body := get(t, "http://"+addr+"/metrics"); strings.Contains(body, "genba_request_duration_milliseconds") {
+		t.Error("the API address is serving metrics")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run returned %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the server did not shut down after its context was cancelled")
+	}
+}
+
+// TestMetricsAreOffByDefault, because a port that opens itself is a port
+// somebody has to find out about from a scan.
+func TestMetricsAreOffByDefault(t *testing.T) {
+	addr, metricsAddr := freeAddr(t), freeAddr(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() {
+		var out, errOut bytes.Buffer
+		_ = run(ctx, []string{"-addr", addr, "-log-level", "error"}, env(nil), &out, &errOut)
+	}()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	conn, err := net.DialTimeout("tcp", metricsAddr, time.Second)
+	if err == nil {
+		_ = conn.Close()
+		t.Errorf("something is listening on %s with no metrics address configured", metricsAddr)
+	}
+}
+
+// get reads a URL, returning an empty body for a connection that is refused or
+// a response that is not a 200, because both mean the same thing here.
+func get(t *testing.T, url string) string {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+	if err != nil {
+		t.Fatalf("building the request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading %s: %v", url, err)
+	}
+	return string(body)
 }
 
 func freeAddr(t *testing.T) string {

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,14 @@ type Config struct {
 	// Addr is the listen address of the HTTP server.
 	Addr string
 
+	// MetricsAddr is the listen address of the metrics server, and is empty by
+	// default because a metrics endpoint is not something to turn on by
+	// accident. Metrics say how much traffic there is and how hard the caches
+	// are working, which is not secret and is not public either, so they get a
+	// second listener on an address the outside cannot reach rather than a route
+	// on the API that somebody has to remember to block.
+	MetricsAddr string
+
 	// Store selects the storage driver.
 	Store Store
 
@@ -106,6 +114,7 @@ func Load(getenv func(string) string) (Config, error) {
 	c := Default()
 
 	str(getenv, "GENBA_ADDR", &c.Addr)
+	str(getenv, "GENBA_METRICS_ADDR", &c.MetricsAddr)
 	str(getenv, "GENBA_DSN", &c.DSN)
 	str(getenv, "GENBA_TENANT", &c.Tenant)
 	str(getenv, "GENBA_LOG_LEVEL", &c.LogLevel)
@@ -135,6 +144,13 @@ func (c Config) Validate() error {
 	errs := make([]error, 0, 4)
 	if c.Addr == "" {
 		errs = append(errs, errors.New("config: addr is empty"))
+	}
+	// Serving metrics on the API address would put them behind whatever the API
+	// address is exposed to, which is the one thing the second listener exists
+	// to avoid. A config that asks for it is a mistake worth catching at
+	// startup rather than a listener that fails to bind.
+	if c.MetricsAddr != "" && c.MetricsAddr == c.Addr {
+		errs = append(errs, errors.New("config: metrics addr is the same as addr"))
 	}
 	switch c.Store {
 	case StoreMemory, StoreSQLite, StorePostgres, StoreKura:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,6 +21,7 @@ func TestDefaultIsValid(t *testing.T) {
 func TestLoadAppliesTheEnvironment(t *testing.T) {
 	c, err := config.Load(env(map[string]string{
 		"GENBA_ADDR":           ":9000",
+		"GENBA_METRICS_ADDR":   "127.0.0.1:9100",
 		"GENBA_STORE":          "SQLite",
 		"GENBA_DSN":            "/var/lib/genba/genba.db",
 		"GENBA_READ_TIMEOUT":   "5s",
@@ -31,6 +32,12 @@ func TestLoadAppliesTheEnvironment(t *testing.T) {
 	}
 	if c.Addr != ":9000" {
 		t.Errorf("Addr = %q", c.Addr)
+	}
+	if c.MetricsAddr != "127.0.0.1:9100" {
+		t.Errorf("MetricsAddr = %q", c.MetricsAddr)
+	}
+	if config.Default().MetricsAddr != "" {
+		t.Error("the default opens a metrics port that nobody asked for")
 	}
 	if c.Store != config.StoreSQLite {
 		t.Errorf("Store = %q, the name should be case insensitive", c.Store)
@@ -50,6 +57,7 @@ func TestLoadRejectsBadValues(t *testing.T) {
 		want string
 	}{
 		{"unknown store", map[string]string{"GENBA_STORE": "cassandra"}, "unknown store"},
+		{"metrics on the api address", map[string]string{"GENBA_METRICS_ADDR": config.Default().Addr}, "same as addr"},
 		{"store without a dsn", map[string]string{"GENBA_STORE": "postgres"}, "needs a dsn"},
 		{"unknown log level", map[string]string{"GENBA_LOG_LEVEL": "trace"}, "unknown log level"},
 		{"duration without a unit", map[string]string{"GENBA_READ_TIMEOUT": "30"}, "needs a unit"},

--- a/docs/alerts.yml
+++ b/docs/alerts.yml
@@ -1,0 +1,46 @@
+# Prometheus alerting rules for genba.
+#
+# There is one alert in here, and that is on purpose.
+# An alert that nobody acts on trains everybody to ignore the ones that matter, so a rule earns its place by naming something a person would get out of bed for.
+# Everything else worth watching is on a dashboard, where a number that is drifting can be looked at during working hours.
+#
+# The metric names come from api/metrics.go, where they are constants for exactly this reason.
+# A rename that only edits the code leaves a rule here that will never fire again and will never say so.
+#
+# The metrics are served by the address in GENBA_METRICS_ADDR, which is off unless it is set and is meant to be somewhere the outside cannot reach.
+# The API address does not serve them.
+groups:
+  - name: genba
+    rules:
+      # Search latency is the product.
+      # Everything else genba does is in service of a query returning quickly, and when this fires the interface feels broken to everybody using it at once.
+      #
+      # The threshold is the pathological budget rather than the ordinary one.
+      # The p95 of a healthy mix sits well under ten milliseconds, so twenty five means either the expensive query class has become the common one or something underneath has stopped using an index.
+      # It is a bucket boundary too, which is what makes the quantile estimate here worth reading at all.
+      #
+      # Five minutes of it, because a single slow scrape is a garbage collection pause or a noisy neighbour and neither is a page.
+      - alert: SearchIsSlow
+        expr: histogram_quantile(0.95, sum by (le) (rate(genba_search_duration_milliseconds_bucket[5m]))) > 25
+        for: 5m
+        labels:
+          severity: page
+        annotations:
+          summary: Search p95 is over 25ms
+          description: >-
+            The 95th percentile of search latency has been above 25ms for five minutes.
+            Check genba_search_candidates first: a candidate count that has moved with the match count means the first phase of retrieval has stopped cutting.
+            Check genba_cache_hits_total against genba_cache_misses_total next: a hit rate that has collapsed usually means something is writing to the corpus continuously and dropping the cached orderings as fast as they are built.
+
+# What is deliberately not alerted on, and why.
+#
+# Cache hit rate.
+# It is a number to look at when something else is wrong rather than a reason to wake somebody, because a cold process and a busy crawl both push it down and neither is an incident.
+#
+# Quarantined documents.
+# A document whose permissions did not resolve is held back rather than served, which is the safe outcome, so a growing count is a bug report and not a page.
+# It belongs on the dashboard next to the document count.
+#
+# Request duration per endpoint.
+# It is the first thing to look at during an incident and it is too easy to page on: one slow endpoint that nobody uses would fire this every deploy.
+# Search has its own alert above because search is the one endpoint that being slow means the product is down.

--- a/index/index.go
+++ b/index/index.go
@@ -156,6 +156,14 @@ type Results struct {
 	// what makes them usable as filters.
 	Facets map[string][]Facet
 
+	// Candidates is how many documents were ranked to produce this page.
+	//
+	// It is the work the search actually did, as opposed to Total, which is
+	// what it found. A healthy two phase search has a candidate count bounded
+	// by the pool and a total bounded by nothing, and the day those two numbers
+	// start moving together is the day the first phase stopped cutting.
+	Candidates int
+
 	// Took is how long the search ran for. It is reported rather than logged
 	// because the interface shows it, and a number a user can see is a number
 	// somebody will keep honest.
@@ -289,9 +297,10 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 	}
 
 	res := Results{
-		Total:     found.total,
-		Truncated: found.truncated,
-		Facets:    found.facets,
+		Total:      found.total,
+		Truncated:  found.truncated,
+		Facets:     found.facets,
+		Candidates: len(found.cands),
 	}
 	if len(found.cands) == 0 {
 		res.Took = s.now().Sub(start)

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -1,0 +1,284 @@
+// Package metric exposes what the process is doing, in the Prometheus text
+// format, with nothing imported to do it.
+//
+// The whole of this package is a few hundred lines because the exposition
+// format is a few hundred lines, and the alternative is a dependency tree an
+// order of magnitude larger than the thing being measured. This repository has
+// no non SQLite dependencies and it is not spending that budget on a text
+// encoder. What is here is the subset a search server needs: histograms it
+// records into, and counters it reads out of the structures that already keep
+// them.
+//
+// # What is measured
+//
+// A latency gate in CI proves a regression did not ship. It does not prove the
+// system is fast for the person using it, because the runner is not the
+// deployment and the benchmark corpus is not the corpus. These are the numbers
+// that answer the second question, and they are deliberately the same
+// quantities the gate asserts on, so that a slowdown in production can be
+// reproduced by the gate rather than argued about.
+//
+// Durations are in milliseconds rather than the seconds that Prometheus
+// conventionally wants, and the buckets are tight at the bottom. The budget for
+// this system is stated in single digit milliseconds, so the interesting
+// question is what fraction of requests were under ten. A default bucket set
+// answers what fraction were under a hundred, which here is all of them, and a
+// histogram whose every observation lands in the first bucket has measured
+// nothing.
+package metric
+
+import (
+	"io"
+	"maps"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Duration is the bucket set for anything measured in milliseconds.
+//
+// It is tighter at the bottom than a default set because the budgets are, and
+// it stops at half a second because a search that took longer than that has a
+// problem no percentile is going to describe.
+var Duration = []float64{1, 2, 5, 10, 25, 50, 100, 250, 500}
+
+// Size is the bucket set for anything counted rather than timed: candidates
+// ranked, documents matched. It is logarithmic because the interesting
+// difference is between ten and a thousand rather than between ten and twenty.
+var Size = []float64{1, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000}
+
+// Registry holds the families a process publishes.
+//
+// Families are written in the order they were registered, which makes the
+// output diffable between two scrapes of the same binary and puts the numbers
+// somebody is looking for near the top.
+type Registry struct {
+	mu       sync.Mutex
+	order    []string
+	families map[string]family
+}
+
+// family is one metric name and everything needed to write it out.
+type family struct {
+	help string
+	kind string
+	// write appends the series of this family. It runs at scrape time, which is
+	// what lets a counter read a structure that was already counting rather
+	// than requiring every counter in the process to be a metric.
+	write func(*encoder)
+}
+
+// New returns an empty registry.
+func New() *Registry {
+	return &Registry{families: map[string]family{}}
+}
+
+// register adds a family, panicking on a duplicate name.
+//
+// A duplicate is a programming error found at startup rather than a scrape that
+// silently reports one of two meanings for the same name, which is the failure
+// that wastes an afternoon during an incident.
+func (r *Registry) register(name, help, kind string, write func(*encoder)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.families[name]; ok {
+		panic("metric: " + name + " is registered twice")
+	}
+	r.order = append(r.order, name)
+	r.families[name] = family{help: help, kind: kind, write: write}
+}
+
+// Histogram records observations into fixed buckets, optionally split by one
+// label.
+//
+// One label rather than several because the only split this system has needed
+// is by endpoint, and every label is a multiplier on the series count. A
+// cardinality mistake in a metrics library is not a small bug: it is a
+// monitoring system falling over at the moment somebody needs it.
+type Histogram struct {
+	buckets []float64
+	label   string
+
+	mu     sync.Mutex
+	series map[string]*bucketSet
+}
+
+// bucketSet is the counts for one label value.
+type bucketSet struct {
+	counts []uint64
+	sum    float64
+	total  uint64
+}
+
+// NewHistogram registers a histogram. Passing an empty label makes it a single
+// series with no labels at all.
+func (r *Registry) NewHistogram(name, help, label string, buckets []float64) *Histogram {
+	h := &Histogram{
+		buckets: slices.Clone(buckets),
+		label:   label,
+		series:  map[string]*bucketSet{},
+	}
+	slices.Sort(h.buckets)
+	r.register(name, help, "histogram", func(e *encoder) { h.write(e, name) })
+	return h
+}
+
+// Observe records one value under a label. Pass an empty value for a histogram
+// registered without a label.
+func (h *Histogram) Observe(value float64, label string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	set := h.series[label]
+	if set == nil {
+		set = &bucketSet{counts: make([]uint64, len(h.buckets))}
+		h.series[label] = set
+	}
+	// A linear walk over nine bounds beats a binary search on any real bucket
+	// set, and the common case exits on the first comparison because the common
+	// case is fast.
+	for i, bound := range h.buckets {
+		if value <= bound {
+			set.counts[i]++
+			break
+		}
+	}
+	set.sum += value
+	set.total++
+}
+
+// write emits the cumulative form the format asks for.
+func (h *Histogram) write(e *encoder, name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, value := range slices.Sorted(maps.Keys(h.series)) {
+		set := h.series[value]
+		var running uint64
+		for i, bound := range h.buckets {
+			running += set.counts[i]
+			e.series(name+"_bucket", h.pairs(value, "le", trim(bound)), float64(running))
+		}
+		e.series(name+"_bucket", h.pairs(value, "le", "+Inf"), float64(set.total))
+		e.series(name+"_sum", h.pairs(value), set.sum)
+		e.series(name+"_count", h.pairs(value), float64(set.total))
+	}
+}
+
+// pairs builds the label list for one series, dropping the histogram's own
+// label when it was registered without one.
+func (h *Histogram) pairs(value string, extra ...string) []string {
+	if h.label == "" {
+		return extra
+	}
+	return append([]string{h.label, value}, extra...)
+}
+
+// Counters registers a family read at scrape time from something that was
+// already counting.
+//
+// The read returns a value per label value, and an empty key means a series
+// with no labels. This is how the cache layers and the storage driver are
+// published: they keep their own counters because their own tests assert on
+// them, and turning those into metrics should not mean counting anything twice.
+//
+// kind is "counter" for anything that only goes up and "gauge" for anything
+// that can go down, which the format needs and which a reader needs more.
+func (r *Registry) Counters(name, help, label, kind string, read func() map[string]float64) {
+	r.register(name, help, kind, func(e *encoder) {
+		values := read()
+		for _, key := range slices.Sorted(maps.Keys(values)) {
+			if label == "" {
+				e.series(name, nil, values[key])
+				continue
+			}
+			e.series(name, []string{label, key}, values[key])
+		}
+	})
+}
+
+// WriteTo writes an exposition of every family.
+func (r *Registry) WriteTo(w io.Writer) (int64, error) {
+	r.mu.Lock()
+	names := slices.Clone(r.order)
+	families := maps.Clone(r.families)
+	r.mu.Unlock()
+
+	e := &encoder{}
+	for _, name := range names {
+		f := families[name]
+		e.buf.WriteString("# HELP " + name + " " + strings.NewReplacer("\\", `\\`, "\n", `\n`).Replace(f.help) + "\n")
+		e.buf.WriteString("# TYPE " + name + " " + f.kind + "\n")
+		f.write(e)
+	}
+	n, err := io.WriteString(w, e.buf.String())
+	return int64(n), err
+}
+
+// String returns the exposition, which is what the tests read.
+func (r *Registry) String() string {
+	var sb strings.Builder
+	_, _ = r.WriteTo(&sb)
+	return sb.String()
+}
+
+// encoder accumulates the text of one scrape.
+type encoder struct{ buf strings.Builder }
+
+// series writes one line. Labels are name and value alternating.
+func (e *encoder) series(name string, labels []string, value float64) {
+	e.buf.WriteString(name)
+	if len(labels) > 1 {
+		e.buf.WriteByte('{')
+		for i := 0; i+1 < len(labels); i += 2 {
+			if i > 0 {
+				e.buf.WriteByte(',')
+			}
+			e.buf.WriteString(labels[i])
+			e.buf.WriteString(`="`)
+			e.buf.WriteString(escape(labels[i+1]))
+			e.buf.WriteByte('"')
+		}
+		e.buf.WriteByte('}')
+	}
+	e.buf.WriteByte(' ')
+	e.buf.WriteString(trim(value))
+	e.buf.WriteByte('\n')
+}
+
+// escape makes a label value safe to put between quotes. A label value here can
+// come from a request path, so this is not a formality.
+func escape(v string) string {
+	return strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`).Replace(v)
+}
+
+// trim renders a float the way the format expects, without a trailing .000000
+// on the whole numbers that most of these are.
+func trim(v float64) string {
+	switch {
+	case math.IsInf(v, 1):
+		return "+Inf"
+	case math.IsInf(v, -1):
+		return "-Inf"
+	case v == math.Trunc(v) && math.Abs(v) < 1e15:
+		return strconv.FormatInt(int64(v), 10)
+	}
+	return strconv.FormatFloat(v, 'g', -1, 64)
+}
+
+// Percentile returns the value at q over a sorted copy of samples, by the
+// nearest rank method.
+//
+// It is here rather than in the benchmark that uses it because the gate and the
+// metrics have to agree on what p95 means. Two definitions of a percentile in
+// one repository is how a gate passes on a number a dashboard calls a
+// regression.
+func Percentile(samples []float64, q float64) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	sorted := slices.Clone(samples)
+	slices.Sort(sorted)
+	rank := int(math.Ceil(q * float64(len(sorted))))
+	return sorted[min(max(rank, 1), len(sorted))-1]
+}

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -1,0 +1,155 @@
+package metric_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tamnd/genba/metric"
+)
+
+// TestAHistogramIsCumulative covers the one part of the format that is easy to
+// get wrong and impossible to notice: a bucket count includes every bucket
+// below it. A Prometheus server reading non cumulative buckets does not error,
+// it draws a wrong graph.
+func TestAHistogramIsCumulative(t *testing.T) {
+	r := metric.New()
+	h := r.NewHistogram("genba_test_ms", "how long a thing took", "endpoint", []float64{1, 10, 100})
+	for _, v := range []float64{0.5, 3, 3, 40, 4000} {
+		h.Observe(v, "/search")
+	}
+
+	got := r.String()
+	for _, want := range []string{
+		`genba_test_ms_bucket{endpoint="/search",le="1"} 1`,
+		`genba_test_ms_bucket{endpoint="/search",le="10"} 3`,
+		`genba_test_ms_bucket{endpoint="/search",le="100"} 4`,
+		`genba_test_ms_bucket{endpoint="/search",le="+Inf"} 5`,
+		`genba_test_ms_count{endpoint="/search"} 5`,
+		`genba_test_ms_sum{endpoint="/search"} 4046.5`,
+		"# TYPE genba_test_ms histogram",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the exposition is missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestAHistogramWithoutALabelHasNoBraces is the case a single series family
+// hits, and an empty label set written as {} is a parse error rather than a
+// cosmetic problem.
+func TestAHistogramWithoutALabelHasNoBraces(t *testing.T) {
+	r := metric.New()
+	h := r.NewHistogram("genba_test_size", "how big a thing was", "", []float64{1, 10})
+	h.Observe(5, "")
+
+	got := r.String()
+	if strings.Contains(got, "{}") {
+		t.Errorf("a series carries an empty label set:\n%s", got)
+	}
+	if !strings.Contains(got, `genba_test_size_bucket{le="10"} 1`) {
+		t.Errorf("the le label is missing:\n%s", got)
+	}
+	if !strings.Contains(got, "genba_test_size_count 1") {
+		t.Errorf("the count is missing or labelled:\n%s", got)
+	}
+}
+
+// TestALabelValueCannotBreakTheFormat matters because one of these values is a
+// request path, and a path is somebody else's input.
+func TestALabelValueCannotBreakTheFormat(t *testing.T) {
+	r := metric.New()
+	h := r.NewHistogram("genba_test_ms", "how long a thing took", "endpoint", []float64{1})
+	h.Observe(1, "/a\"b\\c\nd")
+
+	got := r.String()
+	if !strings.Contains(got, `endpoint="/a\"b\\c\nd"`) {
+		t.Errorf("the label value was not escaped:\n%s", got)
+	}
+	// Two header lines and four series. A raw newline would split a series in
+	// half and give a scraper two lines it cannot parse.
+	if lines := strings.Count(strings.TrimSuffix(got, "\n"), "\n") + 1; lines != 6 {
+		t.Errorf("the exposition is %d lines, want 6, so something broke a series in half:\n%s", lines, got)
+	}
+}
+
+// TestCountersAreReadAtScrapeTime is the property that lets the cache and the
+// storage driver publish the counters their own tests already assert on,
+// instead of the process counting everything twice.
+func TestCountersAreReadAtScrapeTime(t *testing.T) {
+	r := metric.New()
+	live := map[string]float64{"results": 1}
+	r.Counters("genba_test_hits_total", "cache hits", "layer", "counter", func() map[string]float64 {
+		return live
+	})
+
+	if got := r.String(); !strings.Contains(got, `genba_test_hits_total{layer="results"} 1`) {
+		t.Fatalf("the first scrape is wrong:\n%s", got)
+	}
+	live["results"] = 9
+	live["documents"] = 4
+	got := r.String()
+	if !strings.Contains(got, `genba_test_hits_total{layer="results"} 9`) {
+		t.Errorf("the second scrape did not re read the source:\n%s", got)
+	}
+	if !strings.Contains(got, `genba_test_hits_total{layer="documents"} 4`) {
+		t.Errorf("a layer that appeared between scrapes is missing:\n%s", got)
+	}
+}
+
+// TestAFamilyRegisteredTwiceIsFoundAtStartup, rather than at three in the
+// morning when two meanings of one name are being averaged together.
+func TestAFamilyRegisteredTwiceIsFoundAtStartup(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("registering the same name twice was accepted")
+		}
+	}()
+	r := metric.New()
+	r.NewHistogram("genba_test_ms", "first", "", []float64{1})
+	r.NewHistogram("genba_test_ms", "second", "", []float64{1})
+}
+
+// TestObservingFromEveryGoroutineIsSafe, because that is the only way this is
+// ever used: one handler per request, all writing the same family.
+func TestObservingFromEveryGoroutineIsSafe(t *testing.T) {
+	r := metric.New()
+	h := r.NewHistogram("genba_test_ms", "how long a thing took", "endpoint", metric.Duration)
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 200 {
+				h.Observe(float64(i), "/search")
+			}
+			_ = r.String()
+		}()
+	}
+	wg.Wait()
+
+	if !strings.Contains(r.String(), `genba_test_ms_count{endpoint="/search"} 1600`) {
+		t.Errorf("observations were lost:\n%s", r.String())
+	}
+}
+
+func TestPercentileIsTheNearestRank(t *testing.T) {
+	samples := []float64{5, 1, 4, 2, 3, 10, 9, 8, 7, 6}
+	for _, c := range []struct {
+		q    float64
+		want float64
+	}{
+		{0.5, 5},
+		{0.95, 10},
+		{0.99, 10},
+		{1, 10},
+	} {
+		if got := metric.Percentile(samples, c.q); got != c.want {
+			t.Errorf("Percentile(%v) = %v, want %v", c.q, got, c.want)
+		}
+	}
+	if got := metric.Percentile(nil, 0.95); got != 0 {
+		t.Errorf("Percentile of nothing = %v, want 0", got)
+	}
+}

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# The browser half of the performance gate.
+#
+# It starts the real binary over a real corpus, which is this repository, and
+# audits the three screens somebody actually looks at: the home page, a results
+# page, and a results page with the document drawer open. Auditing a static
+# fixture instead would audit the fixture, and every accessibility bug this is
+# meant to catch lives in the markup the interface builds after a fetch.
+#
+# axe is the part that fails a build. It reports violations of a standard rather
+# than an opinion, it does not move when the runner is busy, and a violation is
+# a person who cannot use the page.
+#
+# Lighthouse is advisory here and enforced on the nightly run, because a
+# Lighthouse performance score on a shared runner moves by ten points between
+# two runs of the same commit. Set GENBA_UI_STRICT=1 to have it fail.
+set -eu
+
+BIN=${BIN:-bin/genbad}
+PORT=${PORT:-8123}
+BASE="http://127.0.0.1:$PORT"
+TENANT=demo
+LIGHTHOUSE_MIN=${LIGHTHOUSE_MIN:-95}
+SERVER=
+
+cleanup() {
+	if [ -n "$SERVER" ]; then
+		kill "$SERVER" 2>/dev/null || true
+		wait "$SERVER" 2>/dev/null || true
+	fi
+}
+trap cleanup EXIT INT TERM
+
+if ! command -v npx >/dev/null 2>&1; then
+	echo "ui-gate: npx is not on the path, so axe and Lighthouse cannot run"
+	echo "ui-gate: the asset budgets and the markup safety tests already ran, and they are the part that never flakes"
+	exit 0
+fi
+
+if [ ! -x "$BIN" ]; then
+	echo "ui-gate: $BIN is not there, run make build first" >&2
+	exit 1
+fi
+
+# The corpus is this repository. It is a few hundred documents of real prose and
+# code, which is enough for a results page with snippets, facets and a drawer,
+# and it needs nothing downloaded.
+"$BIN" -addr "127.0.0.1:$PORT" -store memory -tenant "$TENANT" -corpus . -corpus-name repo -log-level error &
+SERVER=$!
+
+i=0
+until curl -fsS "$BASE/healthz" >/dev/null 2>&1; do
+	i=$((i + 1))
+	if [ "$i" -gt 100 ]; then
+		echo "ui-gate: the server never became healthy" >&2
+		exit 1
+	fi
+	sleep 0.2
+done
+
+# The drawer is opened by an id in the URL, so one has to be looked up. The
+# headers are what a trusted proxy would pass down, and the corpus is readable
+# by the whole tenant, so any subject in it will do.
+ID=$(curl -fsS "$BASE/api/v1/search?q=cache&limit=1" \
+	-H "X-Genba-Tenant: $TENANT" \
+	-H "X-Genba-Subject: dev@example.com" \
+	-H "X-Genba-Groups: everyone" |
+	grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+if [ -z "$ID" ]; then
+	echo "ui-gate: the corpus produced no results, so there is no results page to audit" >&2
+	exit 1
+fi
+
+# A document id carries a source prefix and a path, so it goes through the URL
+# encoder rather than into the string.
+ID=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$ID")
+
+# A chromedriver that does not match the Chrome next to it is the most common
+# way this fails on a laptop. CHROMEDRIVER points at a matching one.
+DRIVER=""
+if [ -n "${CHROMEDRIVER:-}" ]; then
+	DRIVER="--chromedriver-path $CHROMEDRIVER"
+fi
+
+status=0
+for path in "/" "/?q=cache" "/?q=cache&open=$ID"; do
+	echo "ui-gate: axe $path"
+	# The interface renders after a fetch, so the audit waits for the first
+	# paint to have happened. Auditing an empty document passes and proves
+	# nothing.
+	# shellcheck disable=SC2086
+	if ! npx --yes @axe-core/cli "$BASE$path" \
+		--tags wcag2a,wcag2aa,wcag21a,wcag21aa \
+		--load-delay 2000 \
+		$DRIVER \
+		--chrome-options="headless,no-sandbox,disable-gpu"; then
+		status=1
+	fi
+done
+
+echo "ui-gate: lighthouse"
+report=$(mktemp -t genba-lighthouse.XXXXXX).json
+if npx --yes lighthouse "$BASE/?q=cache" \
+	--quiet --output json --output-path "$report" \
+	--only-categories performance,accessibility,best-practices \
+	--chrome-flags="--headless --no-sandbox --disable-gpu"; then
+	# The report is read with node rather than with grep, because the categories
+	# hold nested objects and a regular expression over them is a way of being
+	# wrong on some other day.
+	scores=$(node -e '
+		const r = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+		for (const [key, c] of Object.entries(r.categories)) console.log(key, Math.round(c.score * 100));
+	' "$report")
+	echo "$scores" | while read -r category score; do
+		echo "ui-gate: lighthouse $category $score"
+	done
+	if [ "${GENBA_UI_STRICT:-}" = "1" ]; then
+		low=$(echo "$scores" | awk -v floor="$LIGHTHOUSE_MIN" '$2 < floor {print $1" "$2}')
+		if [ -n "$low" ]; then
+			echo "ui-gate: below the floor of $LIGHTHOUSE_MIN: $low" >&2
+			status=1
+		fi
+	fi
+else
+	echo "ui-gate: lighthouse did not run, which is advisory and not a failure"
+fi
+rm -f "$report"
+
+exit $status

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -76,9 +76,17 @@ fi
 ID=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$ID")
 
 # A chromedriver that does not match the Chrome next to it is the most common
-# way this fails on a laptop. CHROMEDRIVER points at a matching one.
+# way this fails, on a laptop and on a runner alike. axe downloads whichever
+# chromedriver is current, and a runner image whose Chrome is one release behind
+# then refuses every session. CHROMEDRIVER points at a matching one, and
+# CHROMEWEBDRIVER is where a GitHub runner keeps the one that matches its own
+# Chrome, so the default needs no plumbing in the workflow.
 DRIVER=""
+if [ -z "${CHROMEDRIVER:-}" ] && [ -x "${CHROMEWEBDRIVER:-}/chromedriver" ]; then
+	CHROMEDRIVER="$CHROMEWEBDRIVER/chromedriver"
+fi
 if [ -n "${CHROMEDRIVER:-}" ]; then
+	echo "ui-gate: chromedriver $CHROMEDRIVER"
 	DRIVER="--chromedriver-path $CHROMEDRIVER"
 fi
 

--- a/store/sqlitestore/sqlitestore.go
+++ b/store/sqlitestore/sqlitestore.go
@@ -57,7 +57,7 @@ type Store struct {
 	// behaviour under load predictable rather than dependent on a timeout.
 	write sync.Mutex
 
-	// counters are what the performance gate asserts on. See [Counters].
+	// counters are what the performance gate asserts on. See [store.Counters].
 	counters counters
 
 	closed atomic.Bool
@@ -71,36 +71,8 @@ var (
 	_ store.Statistician = (*Store)(nil)
 	_ store.Fetcher      = (*Store)(nil)
 	_ store.Notifier     = (*Store)(nil)
+	_ store.Counted      = (*Store)(nil)
 )
-
-// Counters is the work one query cost, counted exactly.
-//
-// It is here because a latency assertion on a shared CI runner is a coin flip
-// and these are not. Rows read, statements issued, documents decoded and
-// candidates scored do not vary with how busy the machine is, they are where a
-// performance regression shows up first, and an assertion on them names the
-// mistake precisely: a per hit refetch reappearing in a year moves Decodes from
-// twenty to twenty plus the match set, on any runner, at any speed.
-type Counters struct {
-	// Rows is the rows the database handed back. It is what the test that
-	// proves the permission filter is in the SQL asserts on: a reader who may
-	// see nothing has to cost zero rows, not a full walk that Go then discards.
-	Rows int64
-
-	// Statements is the statements executed against the database, read paths
-	// only. A search that issues one per result rather than one per page is the
-	// regression this counts.
-	Statements int64
-
-	// Decodes is document JSON decoded into a [doc.Document]. A search should
-	// decode the page and nothing else.
-	Decodes int64
-
-	// Candidates is the documents handed to the ranker. It is bounded by the
-	// candidate pool rather than by the match set, which is the whole point of
-	// two phase retrieval.
-	Candidates int64
-}
 
 type counters struct {
 	rows       atomic.Int64
@@ -111,8 +83,8 @@ type counters struct {
 
 // Counters reports the work this store has done since it was opened or last
 // reset.
-func (s *Store) Counters() Counters {
-	return Counters{
+func (s *Store) Counters() store.Counters {
+	return store.Counters{
 		Rows:       s.counters.rows.Load(),
 		Statements: s.counters.statements.Load(),
 		Decodes:    s.counters.decodes.Load(),

--- a/store/store.go
+++ b/store/store.go
@@ -89,3 +89,54 @@ type Stats struct {
 	// is a bug when it grows.
 	Quarantined int
 }
+
+// Counters is the work one query cost, counted exactly.
+//
+// A driver that keeps these is a driver whose performance can be asserted on,
+// because a latency assertion on a shared CI runner is a coin flip and these
+// are not. Rows read, statements issued, documents decoded and candidates
+// scored do not vary with how busy the machine is, they are where a regression
+// shows up first, and an assertion on them names the mistake precisely: a per
+// hit refetch reappearing in a year moves Decodes from twenty to twenty plus
+// the match set, on any runner, at any speed.
+//
+// They are cumulative for the life of the store rather than per query, so a
+// caller measuring one query resets them first and a caller publishing them as
+// metrics does not reset them at all.
+type Counters struct {
+	// Rows is the rows the database handed back. It is what the test that
+	// proves the permission filter is in the query itself asserts on: a reader
+	// who may see nothing has to cost zero rows, not a full walk that the
+	// driver then discards.
+	Rows int64
+
+	// Statements is the statements executed, read paths only. A search that
+	// issues one per result rather than one per page is the regression this
+	// counts.
+	Statements int64
+
+	// Decodes is stored documents decoded into a [doc.Document]. A search
+	// should decode the page and nothing else.
+	Decodes int64
+
+	// Candidates is the documents handed to the ranker. It is bounded by the
+	// candidate pool rather than by the match set, which is the whole point of
+	// two phase retrieval.
+	Candidates int64
+}
+
+// Counted is a store that reports the work it has done.
+//
+// It is optional because a driver is not obliged to be measurable, and the
+// layers above check for it rather than requiring it. The interface is here
+// rather than in the driver so that anything above the storage layer can read
+// the numbers without importing a driver, which the layering forbids for good
+// reasons.
+type Counted interface {
+	// Counters returns the totals since the store was opened or last reset.
+	Counters() Counters
+
+	// ResetCounters zeroes them, so that a measurement can be scoped to one
+	// query.
+	ResetCounters()
+}

--- a/web/dist/assets/content.js
+++ b/web/dist/assets/content.js
@@ -106,7 +106,10 @@ export function body(d) {
   if (shape === "code") {
     return h("div", { class: "preview preview--code" }, codeBlock(d.body, languageOf(d)));
   }
-  return h("div", { class: "preview" }, h("pre", { class: "plain" }, d.body));
+  // Reachable by keyboard for the same reason a code block is: the preview
+  // scrolls, and a scrolling region a keyboard cannot reach is a document a
+  // keyboard cannot read.
+  return h("div", { class: "preview" }, h("pre", { class: "plain", tabindex: "0" }, d.body));
 }
 
 /** same compares two headings the way a reader would, ignoring spacing and case. */

--- a/web/dist/assets/markdown.js
+++ b/web/dist/assets/markdown.js
@@ -268,7 +268,10 @@ function table(rows, options) {
  */
 export function codeBlock(source, lang) {
   const code = h("code", { class: "code__text" }, highlight(source, lang));
-  const pre = h("pre", { class: "code__pre" }, code);
+  // A code block scrolls sideways when a line is long, and a region that
+  // scrolls has to be reachable by keyboard or the only way to read the end of
+  // that line is a mouse.
+  const pre = h("pre", { class: "code__pre", tabindex: "0" }, code);
   const long = source.split("\n").length > 6;
   if (!lang && !long) return h("div", { class: "code" }, pre);
 

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -69,6 +69,7 @@ export class Results {
     this.chips = h("div", { class: "chips" });
     this.head = h("div", { class: "results__head" });
     this.list = h("div", { class: "results__list", role: "list" });
+    this.aside = h("div", { class: "results__aside" });
 
     this.el = h(
       "div",
@@ -80,7 +81,7 @@ export class Results {
         "div",
         { class: "results" },
         this.facets,
-        h("div", { class: "results__main" }, this.head, this.list),
+        h("div", { class: "results__main" }, this.head, this.list, this.aside),
       ),
     );
   }
@@ -101,7 +102,10 @@ export class Results {
       Array.from({ length: 6 }, () =>
         h(
           "div",
-          { class: "skeleton-result" },
+          // The skeleton rows sit inside the list, so they carry the role its
+          // children are supposed to carry. A placeholder that is not an item
+          // makes the list itself invalid while it is loading.
+          { class: "skeleton-result", role: "listitem" },
           h("div", { class: "skeleton skeleton-result__tile" }),
           h("div", { class: "skeleton", style: { width: "60%", height: "20px" } }),
           h("div", { class: "skeleton", style: { width: "40%", height: "14px" } }),
@@ -110,6 +114,7 @@ export class Results {
         ),
       ),
     );
+    replace(this.aside);
     replace(this.facets);
   }
 
@@ -221,17 +226,22 @@ export class Results {
     );
   }
 
+  // The list holds results and nothing else. A list that also holds its own
+  // pager or its empty state is a list whose every child is announced as an
+  // item, so a reader on a screen reader is told there are twenty one results
+  // and the last one is a pair of buttons.
   renderList(query, res) {
     if (!this.hits.length) {
-      replace(this.list, emptyState(query, res, this.onQuery));
+      replace(this.list);
+      replace(this.aside, emptyState(query, res, this.onQuery));
       return;
     }
 
     replace(
       this.list,
       this.hits.map((hit, i) => this.row(hit, i)),
-      pager(query, res, this.onQuery),
     );
+    replace(this.aside, pager(query, res, this.onQuery));
   }
 
   /**


### PR DESCRIPTION
Closes #58.

Third and last pull request of M10. It adds the two things a performance budget needs to stop being a comment: a check that fails when the query path gets slower, and numbers from the running server so a slow deployment can be compared with a green pull request rather than argued about.

## The latency gate

`make bench-gate` drives the search endpoint over the twenty thousand document corpus, per query class. The endpoint rather than the searcher, because the budget is what a browser waits for and request parsing and JSON encoding are part of that wait.

The issue asks for a relative failure at twenty percent on p95 and thirty five on p99. I built that first and it does not survive contact with a real machine. Two runs of an unchanged tree, on the same laptop, with the calibration figure steady to within a percent, disagreed by a factor of two on the p95 of the most expensive class. A gate that fails on an unchanged tree is a gate somebody deletes, so I changed what it compares and kept the intent.

Every class is measured eight times over, interleaved, and every round runs the same queries in the same order. The figure that fails a build is the median of the quietest round. Ambient load can only ever make a round slower, so the lowest of them is the closest the machine got to measuring the code on its own. Across the same two runs that figure held to within a quarter, and to within a tenth for half the classes, so the tolerance is thirty five percent: above what an unchanged tree was measured to do, rather than at a number that sounds strict.

The percentiles are still measured, recorded and printed. They are never compared, and that limit is written down rather than glossed over. A regression that only moves the tail will not fail this gate, and nothing that runs on a shared machine can catch that.

The calibration got the same treatment. The first version hashed a buffer that fit in cache, and across two runs where every search class got faster it reported the machine getting slower, which is worse than useless when the correction lands on every class. It now allocates and sorts its way through a few megabytes, which is the sort of work a search actually does, it is timed between rounds rather than once at the start, and it is only applied once the two figures are a tenth apart.

The absolute backstop at twice the stated budget stays, with one exemption. Three of the budgets are missed today and that has been on the record in `benchcorpus/BASELINE.md` since the retrieval work. A class the recorded baseline itself misses is exempt from the backstop and held to the baseline instead, and the exemption expires by itself the day a baseline inside the budget is recorded. The alternative was failing every pull request until the budgets are met, which gets the gate deleted, or lowering the budgets, which erases what the query path is aiming at.

The baseline lives in `benchcorpus/baseline.json` rather than under `testdata`, because `testdata` is a cache directory CI restores over the checkout and a number a stale cache can overwrite stops meaning anything. CI points at `benchcorpus/baseline-ci.json`, which the nightly `workflow_dispatch` produces as an artifact for a human to commit.

Until that file exists the CI step records its numbers, enforces nothing, and says so in the log rather than passing quietly. The first run of this branch is why: the backstop needs the exemption to be read out of a baseline, there was none, and a runner that is several times slower than the laptop the budgets were stated against failed every class. An absolute millisecond applied to a machine nothing has characterised is the same flake the rest of this is built to avoid, so the backstop now needs a baseline too and `bench-counters` is the half that runs everywhere.

## The browser gate

`make ui-gate` runs the asset budgets and the markup tests, then starts the real binary over this repository as a corpus and audits three screens with axe and Lighthouse: the home page, a results page, and a results page with the document drawer open. Auditing a static fixture would audit the fixture, and every accessibility bug worth catching lives in the markup the interface builds after a fetch.

axe fails the job. Lighthouse is advisory on a pull request and enforced nightly, because a performance score on a shared runner moves by ten points between two runs of the same commit.

It found two real violations on its first run, which is the whole argument for having it. The pager and the empty state were children of an element with `role="list"`, so a screen reader was announcing a count that included things that are not results. And a preview pane a mouse can scroll and a keyboard cannot reach is a document a keyboard cannot read. Both are fixed here. Three screens, zero violations, accessibility 95 to 100.

## Metrics

The gate proves a regression did not ship. It does not prove the system is fast for the person using it, because the runner is not the deployment and the benchmark corpus is not the corpus.

The server publishes request duration per endpoint, search duration, candidates ranked, documents matched, cache hits and misses per layer, and the driver's rows, statements and decodes. Deliberately the same quantities the gate asserts on, so a production slowdown can be reproduced by the gate.

The exposition format is written out by hand in `metric/`. A few hundred lines, because the format is a few hundred lines, and the alternative was a dependency tree an order of magnitude larger than the thing being measured. This repository has no non SQLite dependencies and it is not spending that budget on a text encoder.

Durations are in milliseconds with buckets at 1, 2, 5, 10, 25, 50, 100, 250 and 500. The budget is stated in single digit milliseconds, so the question is what fraction of requests came back under ten. A default bucket set answers what fraction came back under a hundred, which here is all of them, and a histogram whose every observation lands in the first bucket has measured nothing.

The counters are read at scrape time out of the structures that already keep them, so nothing is counted twice. That is what `store.Counters` and `store.Counted` are for: the sqlite driver already kept those numbers because its own tests assert on them, and the type moved up to the store package so a layer above can read them without importing a driver.

None of it is on the API address. `GENBA_METRICS_ADDR` opens a second listener and is empty by default, because a metrics endpoint is not something to turn on by accident. `docs/alerts.yml` has one alert, p95 search latency over twenty five milliseconds for five minutes, and a note on what is deliberately not alerted on.

## How I convinced myself

- `gofmt -s`, `go vet ./...`, `go build ./...` and `go test -race -count=1 -short ./...` are clean.
- The gate was recorded and then run twice against its own recording, both green, and the numbers of those runs are what set the tolerance.
- A deliberately reintroduced per hit fetch fails `make bench-counters` and names it exactly, "Search(...) ran 25 statements, at most 8", rather than showing up as a wall clock wobble. That is one of the boxes on the issue.
- `make ui-gate` is green end to end against a real corpus, zero axe violations on all three screens, Lighthouse performance 96, accessibility 100, best practices 100.
- The metrics endpoint was checked against a running binary: the metrics address serves the exposition, the API address does not, and the cache counters move when queries run.

## What is not in here

The p99 comparison the issue asks for, for the reason above. It is measured and reported, and it is not something a shared machine can fail a build on honestly.

The CI baseline, for the reason above. The nightly workflow produces one and it cannot be dispatched until this is on `main`, so the first thing after merging is to run it and commit `benchcorpus/baseline-ci.json`, which is what turns the perf job from reporting into enforcing.
