### PR TITLE
Record the nightly baseline with the shape it is compared against

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,11 +49,18 @@ jobs:
         env:
           GENBA_GATE_BASELINE: ${{ github.workspace }}/benchcorpus/baseline-ci.json
           GENBA_GATE_RUNNER: ubuntu-latest nightly
-          GENBA_GATE_SAMPLES: "2000"
-          GENBA_GATE_TOLERANCE: "1.10"
+          # A recording run takes its sample count from the code rather than
+          # from here, because the figure being recorded is the one a pull
+          # request will be compared against and the two have to be the same
+          # shape. A round of two hundred and fifty has a steadier median than a
+          # round of forty, so a baseline recorded that way is a baseline every
+          # pull request is measured against with a ruler it was not drawn with.
+          GENBA_GATE_SAMPLES: ${{ inputs.record && '' || '2000' }}
+          GENBA_GATE_TOLERANCE: ${{ inputs.record && '' || '1.10' }}
           GENBA_GATE_RECORD: ${{ inputs.record && '1' || '' }}
         run: |
           set -o pipefail
+          export GENBA_GATE_DATE=$(date -u +%Y-%m-%d)
           make bench-gate 2>&1 | tee bench-gate.log
       # Recording writes the baseline where the pull request gate will look for
       # it, and the artifact is how it gets to somebody who can commit it. It is


### PR DESCRIPTION
The nightly run takes ten times the samples of the pull request gate, so it can notice a drift that twenty pull requests each hid inside the tolerance. A recording run must not.

The figure the gate compares is the median of the quietest round, and a round of two hundred and fifty samples has a steadier median than a round of forty. Recording with the nightly sample count would produce a baseline drawn with one ruler and then measure every pull request against it with another, which biases the comparison in a direction nobody chose. So the sample count and the tolerance come from the code on a recording run and from here on a comparing one.

It also stamps the date on what it records. That field was empty on anything the nightly produced, and the date is half of what makes a baseline reviewable.