### PR TITLE
Define the segment file format

### DIFF
--- a/arch_test.go
+++ b/arch_test.go
@@ -39,7 +39,15 @@ var allowed = map[string][]string{
 	// deliberately not behind the permission check.
 	"metric": nil,
 
-	"store":             {"acl", "doc"},
+	"store": {"acl", "doc"},
+
+	// segment is the on disk format and imports nothing of ours, not even doc.
+	// A section is a run of bytes with a kind on it, and the encodings inside
+	// the sections belong to the packages that own them. A container that knew
+	// what a document was would be a format that has to change every time a
+	// document does, which is the opposite of what a file format is for.
+	"store/segment": nil,
+
 	"store/memstore":    {"", "acl", "doc", "store"},
 	"store/sqlitestore": {"", "acl", "doc", "store"},
 	"store/storetest":   {"", "acl", "doc", "store"},

--- a/docs/segment.md
+++ b/docs/segment.md
@@ -1,0 +1,144 @@
+# The segment format
+
+Everything the platform stores ends up in a segment.
+The format decides what is possible later, and it is expensive to undo once anybody has data in it, so this file says what it is and why each field is there.
+
+Version 1.
+The implementation is `store/segment`.
+
+## The shape of a file
+
+```
++------------------------------------------+
+| header        40 bytes                   |
++------------------------------------------+
+| offset table  24 bytes per section       |
++------------------------------------------+
+| body          the sections themselves    |
++------------------------------------------+
+```
+
+All integers are little endian.
+Every machine this runs on is little endian, and a byte swap on the open path to be polite to hardware nobody has is a cost paid forever for a benefit paid never.
+
+## The header
+
+| Offset | Size | Field | Why it is there |
+| --- | --- | --- | --- |
+| 0 | 8 | magic, `genbaseg` | Eight bytes rather than four, because four bytes of anything turn up by accident in files that are not this, and the other four cost nothing |
+| 8 | 2 | version | A refusal rather than a negotiation, see below |
+| 10 | 2 | flags | Reserved and zero, so that a future bit can be a refusal too |
+| 12 | 4 | sections | Bounds the offset table and nothing else |
+| 16 | 8 | sequence | What "a later segment" means when a tombstone has to win over the document it deletes |
+| 24 | 8 | length | The bytes after the header, so a reader knows the extent of the file before it trusts a single offset inside it |
+| 32 | 4 | checksum | crc32 Castagnoli over every other byte of the file |
+| 36 | 4 | reserved | Zero |
+
+## The offset table
+
+One entry per section, in ascending kind order.
+
+| Offset | Size | Field |
+| --- | --- | --- |
+| 0 | 4 | kind |
+| 4 | 4 | reserved, zero |
+| 8 | 8 | offset from the start of the file |
+| 16 | 8 | length |
+
+The offset is absolute rather than relative to the body.
+Every check a reader makes is against the length of the file, and an absolute offset is checked directly, whereas a relative one has to be added to something first and an addition is where an overflow gets in.
+
+## The sections
+
+| Kind | Name | What it holds |
+| --- | --- | --- |
+| 1 | terms | The term dictionary, mapping a term to the id the rest of the segment refers to it by |
+| 2 | postings | Which documents hold a term and how often |
+| 3 | fields | Everything a result needs to be displayed and nothing a query needs to be answered |
+| 4 | vectors | Embeddings, kept apart from the fields because they are read by a different query path and are an order of magnitude larger |
+| 5 | acl | The access control lists |
+| 6 | tombstones | The deletes |
+
+Kind values are permanent.
+A kind is a name written into files that outlive the code, so one is never reused for something else and a retired kind stays retired.
+
+The container does not know what is inside any of these.
+A section is a run of bytes with a kind on it, and the encodings live in the packages that own them, which is what allows the posting encoding to change without the file format changing.
+
+## Why the access control lists are in the segment
+
+The permission filter has to run against the same immutable bytes as the match.
+A permission that lives beside the segment rather than in it is a permission that can be stale relative to the document it guards, and the window in which it is stale is a window in which somebody reads a document they cannot read.
+
+## Why a delete is a tombstone
+
+Segments are immutable once published.
+Nothing edits one in place, which is what makes a segment safe to memory map, safe to share between readers without a lock, safe to copy while a writer is running and safe to cache by name.
+Every one of those properties disappears the first time something rewrites a byte of a published file.
+
+So a delete is a tombstone in a later segment, and the sequence in the header is what decides which of two statements about the same document is the current one.
+
+## What the checksum covers
+
+Every byte of the file except the four holding the checksum itself.
+
+Checksumming only the body is the obvious version and it is wrong twice over.
+It leaves the offsets that address the body unprotected, so one flipped bit in the table gives a segment that passes its integrity check and hands back the wrong bytes.
+And it leaves the sequence unprotected, so one flipped bit in the header silently changes which segment a tombstone belongs to, which is a deleted document coming back to life with nothing anywhere reporting a problem.
+
+This was not a design decision made up front.
+The first version checksummed the body, and the test that flips every byte of a valid segment in turn found byte 16, which is the sequence.
+
+## Version checking is a refusal
+
+A file written by a build the reader does not know is rejected with a clear error rather than parsed hopefully.
+A reader that parses an unknown version hopefully is a reader that will one day return the wrong answer instead of an error.
+
+The same goes for an unknown flag bit.
+A flag this build does not know changes the meaning of the bytes below it in a way it cannot guess, so it is the same refusal rather than something to ignore politely.
+
+An unknown *section kind* is the exception, and it is skipped rather than refused.
+That is the whole reason sections are addressed by kind rather than by position: adding a section has to be a change old readers survive, or the version goes up every time anything is added and every deployment becomes a lockstep upgrade.
+
+## Reading is hostile by assumption
+
+A segment can arrive from a disk with a bad sector, a half finished write, a truncated copy or somebody's fuzzer.
+Every one of those looks like a length field that says something untrue.
+
+`Open` takes the bytes it is given and never allocates anything sized from them.
+Every section it hands back is a subslice of the input, so a length claiming four gigabytes fails a bounds check rather than an allocation, and the difference between those two failures is the difference between an error and a dead process.
+
+The one allocation `Open` makes is the parsed table, and it is bounded by the length of the file before the section count is used for anything.
+
+The checks run in this order, and the order is the point:
+
+1. **Magic**, so a file that is not a segment says that rather than something about a version.
+2. **Version and flags**, because a newer format could put anything at all in the bytes that follow and nothing below this line is worth doing until the layout is known.
+3. **Declared length against actual length**, exactly. Shorter is a truncated file. Longer is refused too, because a segment with room after it is a segment somebody will one day put something after, and once one file has a use for that space the format has grown a feature nobody designed.
+4. **Checksum**, before the table, because a failed checksum explains every structural error that would otherwise be reported instead of it. "Malformed at offset 240" sends somebody looking for a bug in a writer when the answer is a bad disk.
+5. **Structure**: sections ascending by offset, non overlapping, starting after the table, ending inside the file, with kinds strictly ascending so no kind appears twice.
+
+Bounds are written as subtractions rather than additions, so an offset near the top of the range cannot be carried past it.
+
+## The errors
+
+| Error | Means | Usually |
+| --- | --- | --- |
+| `ErrMagic` | This is not a segment | A path bug |
+| `ErrVersion` | A segment from a build this one does not know | A rollback that went the wrong way |
+| `ErrChecksum` | This was a segment and is not any more | Hardware |
+| `ErrFormat` | Structurally impossible | A writer bug, or something hostile |
+
+They are separate values rather than one error with a string in it, because those four mean genuinely different things to whoever is on call.
+
+## Writing
+
+Sections are held until the whole file can be written at once, because the header carries a checksum over everything else and a length that bounds the file, and neither is known until the last section has arrived.
+Streaming would mean seeking back to fill those in, which rules out writing to a pipe and rules out the reader's assumption that a file it can read at all is a file that was finished.
+
+Sections come out in ascending kind order whatever order they went in, so the same sections produce the same bytes every time.
+That is what lets two machines building the same segment compare files rather than contents, and what lets a compaction that changed nothing be recognised as having changed nothing.
+
+The writer refuses a kind it does not know and a kind added twice.
+The reader accepts an unknown kind, for the forward compatibility reason above.
+That asymmetry is deliberate: be strict in what you write, and be exactly as permissive in what you accept as you decided in advance to be.

--- a/store/segment/read.go
+++ b/store/segment/read.go
@@ -1,0 +1,152 @@
+package segment
+
+import (
+	"fmt"
+)
+
+// Segment is a parsed segment.
+//
+// It holds the bytes it was opened over and a table of where the sections are
+// in them. It allocates nothing per section: [Segment.Section] returns a window
+// onto the original bytes, so a segment of a hundred megabytes costs a hundred
+// megabytes once, whether one reader has it open or fifty do.
+//
+// The bytes must not change while a segment is open. That is free for a
+// published segment, since a published segment is immutable, and it is the
+// caller's problem for anything else.
+type Segment struct {
+	b        []byte
+	sequence uint64
+	table    []entry
+}
+
+type entry struct {
+	kind   Kind
+	offset uint64
+	length uint64
+}
+
+// Open parses a segment over the bytes it is given.
+//
+// The order of the checks is deliberate. Magic first, so a file that is not a
+// segment says that rather than something about a version. Version next,
+// because a newer format could put anything at all in the bytes that follow and
+// nothing below this line is worth doing until the layout is known to be the
+// one this build understands. The checksum before the table, because a failed
+// checksum explains every structural error that would otherwise be reported
+// instead of it, and "malformed at offset 240" sends somebody looking for a bug
+// in a writer when the answer is a bad disk.
+func Open(b []byte) (*Segment, error) {
+	if len(b) < headerSize {
+		return nil, fmt.Errorf("%w: %d bytes is shorter than a header", ErrMagic, len(b))
+	}
+	if string(b[:len(Magic)]) != Magic {
+		return nil, ErrMagic
+	}
+	if v := le.Uint16(b[offVersion:]); v != Version {
+		return nil, fmt.Errorf("%w: version %d, this build reads %d", ErrVersion, v, Version)
+	}
+	// A flag this build does not know changes the meaning of the bytes below in
+	// a way it cannot guess, so an unknown flag is the same refusal as an
+	// unknown version rather than something to ignore politely.
+	if f := le.Uint16(b[offFlags:]); f != 0 {
+		return nil, fmt.Errorf("%w: flags %#04x are not known to this build", ErrVersion, f)
+	}
+	if r := le.Uint32(b[offReserved:]); r != 0 {
+		return nil, fmt.Errorf("%w: reserved header bytes are not zero", ErrFormat)
+	}
+
+	// The declared length has to match the bytes on hand exactly, and it is
+	// checked before it is used for anything. This is the field a truncated
+	// copy gets wrong, and it is the field that would otherwise be handed to a
+	// slice expression.
+	//
+	// Longer is refused as well as shorter. A segment with room after it is a
+	// segment somebody will one day put something after, and once one file has
+	// a use for that space the format has grown a feature nobody designed.
+	length := le.Uint64(b[offLength:])
+	if length != uint64(len(b)-headerSize) {
+		return nil, fmt.Errorf("%w: header claims %d bytes after it and the file holds %d", ErrFormat, length, len(b)-headerSize)
+	}
+	if got, want := checksum(b), le.Uint32(b[offChecksum:]); got != want {
+		return nil, fmt.Errorf("%w: computed %#08x and the header says %#08x", ErrChecksum, got, want)
+	}
+
+	count := uint64(le.Uint32(b[offSections:]))
+	// count is a uint32 and entrySize is 24, so this product cannot overflow a
+	// uint64, which is why it is safe to compute before it is bounded.
+	tableEnd := headerSize + count*entrySize
+	if tableEnd > uint64(len(b)) {
+		return nil, fmt.Errorf("%w: %d sections need %d bytes of table and the file holds %d", ErrFormat, count, count*entrySize, len(b)-headerSize)
+	}
+
+	s := &Segment{b: b, sequence: le.Uint64(b[offSequence:])}
+	// The table is the one allocation Open makes, and it is bounded by the file
+	// rather than by a field in it: count has already been shown to fit inside
+	// the bytes on hand, so a length that claims four billion sections fails the
+	// bound above rather than reserving memory for them.
+	s.table = make([]entry, 0, count)
+
+	prev := tableEnd
+	for i := range count {
+		e := b[headerSize+i*entrySize:]
+		if le.Uint32(e[entryPad:]) != 0 {
+			return nil, fmt.Errorf("%w: reserved bytes of section %d are not zero", ErrFormat, i)
+		}
+		kind := Kind(le.Uint32(e[entryKind:]))
+		offset, size := le.Uint64(e[entryOffset:]), le.Uint64(e[entryLength:])
+
+		// Ascending and non overlapping, checked as one condition against the
+		// end of the previous section. A table that may not overlap is a table
+		// where a section cannot be made to alias another one's bytes, and that
+		// is worth more than the freedom to write sections in an odd order.
+		if offset < prev {
+			return nil, fmt.Errorf("%w: section %d starts at %d, inside or before the section that ends at %d", ErrFormat, i, offset, prev)
+		}
+		// Written as a subtraction so that an offset near the top of the range
+		// cannot be carried past it by an addition.
+		if offset > uint64(len(b)) || size > uint64(len(b))-offset {
+			return nil, fmt.Errorf("%w: section %d runs from %d for %d bytes and the file holds %d", ErrFormat, i, offset, size, len(b))
+		}
+		if i > 0 && kind <= s.table[len(s.table)-1].kind {
+			return nil, fmt.Errorf("%w: section %d is %s and does not come after %s", ErrFormat, i, kind, s.table[len(s.table)-1].kind)
+		}
+		s.table = append(s.table, entry{kind: kind, offset: offset, length: size})
+		prev = offset + size
+	}
+	return s, nil
+}
+
+// Sequence is the order this segment was published in.
+//
+// It is what decides which of two statements about the same document is the
+// current one, so a tombstone in segment nine wins over the document in segment
+// four and nothing has to be rewritten for it to.
+func (s *Segment) Sequence() uint64 { return s.sequence }
+
+// Kinds returns the sections present, in ascending order.
+func (s *Segment) Kinds() []Kind {
+	out := make([]Kind, len(s.table))
+	for i, e := range s.table {
+		out[i] = e.kind
+	}
+	return out
+}
+
+// Section returns the bytes of a section and whether it is there.
+//
+// The bytes are a window onto the segment rather than a copy, so reading a
+// section costs nothing and writing to what comes back corrupts the segment for
+// every other reader of it. Callers do not write to it, which is the same
+// contract every reader of an immutable file works under.
+func (s *Segment) Section(kind Kind) ([]byte, bool) {
+	for _, e := range s.table {
+		if e.kind == kind {
+			return s.b[e.offset : e.offset+e.length : e.offset+e.length], true
+		}
+	}
+	return nil, false
+}
+
+// Size is the length of the whole segment in bytes.
+func (s *Segment) Size() int { return len(s.b) }

--- a/store/segment/segment.go
+++ b/store/segment/segment.go
@@ -1,0 +1,234 @@
+// Package segment is the on disk format everything the platform stores ends up
+// in.
+//
+// A segment is immutable once it has been written. Nothing edits one in place,
+// and a delete is a tombstone in a later segment rather than a change to an
+// earlier one. That is what makes a segment safe to memory map, safe to share
+// between readers without a lock, safe to copy while a writer is running and
+// safe to cache by name, and every one of those properties disappears the first
+// time something rewrites a byte of a published file.
+//
+// # The shape
+//
+//	header      40 bytes, fixed
+//	table       24 bytes per section, in ascending kind order
+//	body        the section bytes, in the same order
+//
+// The header names the file, the version, the sequence and the checksum. The
+// table says where each section is. The body is the sections themselves, and
+// this package does not know what is in any of them: a section is a run of
+// bytes with a kind on it, and the encodings live in the packages that own
+// them. Keeping the container ignorant of its contents is what allows the
+// posting encoding to change without the file format changing.
+//
+// # Reading is hostile by assumption
+//
+// A segment can arrive from a disk with a bad sector, a half finished write, a
+// truncated copy or somebody's fuzzer. Every one of those looks like a length
+// field that says something untrue, so [Open] takes the bytes it is given and
+// never allocates anything sized from them. Every section it hands back is a
+// subslice of the input. A length that claims four gigabytes therefore fails a
+// bounds check rather than an allocation, and the difference between those two
+// failures is the difference between an error and a dead process.
+//
+// Version checking is a refusal rather than a best effort. A file written by a
+// build this one does not know is rejected, because a reader that parses an
+// unknown version hopefully is a reader that will one day return the wrong
+// answer instead of an error.
+package segment
+
+import (
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
+)
+
+// Magic is what every segment starts with. Eight bytes rather than four,
+// because four bytes of anything turn up by accident in files that are not
+// this, and the cost of the other four is nothing.
+const Magic = "genbaseg"
+
+// Version is the format this build writes and the only one it reads.
+//
+// It is a refusal and not a negotiation. When the format changes in a way that
+// an old reader would misread, this goes up and the old reader says so. When it
+// changes in a way an old reader can ignore, it does not, and the change goes
+// in a new section kind instead: an unknown kind is skipped, which is the whole
+// reason sections are addressed by kind rather than by position.
+const Version uint16 = 1
+
+// The fixed sizes of the two structures a reader has to parse before it can
+// trust anything.
+const (
+	headerSize = 40
+	entrySize  = 24
+)
+
+// Header layout, byte for byte. Little endian throughout, because every machine
+// this runs on is little endian and a byte swap on the hot path to be polite to
+// hardware nobody has is a cost paid forever for a benefit paid never.
+//
+//	 0  8  magic, the eight bytes of Magic
+//	 8  2  version, which the reader refuses rather than interprets
+//	10  2  flags, reserved and zero, so that a future bit can be a refusal too
+//	12  4  the number of sections, which bounds the table and nothing else
+//	16  8  sequence, which is what "a later segment" means when a tombstone
+//	       has to win over the document it deletes
+//	24  8  length, the bytes after the header, so a reader knows the extent of
+//	       the file before it trusts a single offset inside it
+//	32  4  checksum, crc32 Castagnoli over every other byte of the file
+//	36  4  reserved, zero
+//
+// The checksum covers the header and the table as well as the body, which is
+// the whole file apart from the four bytes holding the checksum itself.
+// Checksumming only the body is the obvious version and it is wrong twice over.
+// It leaves the offsets that address the body unprotected, so one flipped bit
+// in the table gives a segment that passes its integrity check and hands back
+// the wrong bytes. And it leaves the sequence unprotected, so one flipped bit
+// in the header silently changes which of two segments a tombstone belongs to,
+// which is a deleted document coming back to life with nothing anywhere
+// reporting a problem.
+const (
+	offVersion  = 8
+	offFlags    = 10
+	offSections = 12
+	offSequence = 16
+	offLength   = 24
+	offChecksum = 32
+	offReserved = 36
+)
+
+// Table entry layout.
+//
+//	 0  4  kind
+//	 4  4  reserved, zero
+//	 8  8  offset, from the start of the file
+//	16  8  length
+//
+// The offset is absolute rather than relative to the body, because every check
+// a reader makes is against the length of the file and an absolute offset is
+// checked directly. A relative offset has to be added to something first, and
+// an addition is where an overflow gets in.
+const (
+	entryKind   = 0
+	entryPad    = 4
+	entryOffset = 8
+	entryLength = 16
+)
+
+// Kind names a section.
+//
+// A reader skips a kind it does not know, which is what makes adding a section
+// a change that old readers survive. The values are permanent: a kind is a name
+// written into files that outlive the code, so one is never reused for
+// something else, and a kind that is retired stays retired.
+type Kind uint32
+
+// The sections a segment can hold.
+const (
+	// KindTerms is the term dictionary, which maps a term to the id the rest of
+	// the segment refers to it by. It exists so that a term appearing in eight
+	// thousand documents is stored once rather than eight thousand times.
+	KindTerms Kind = 1
+
+	// KindPostings is the posting lists, which say which documents hold a term
+	// and how often.
+	KindPostings Kind = 2
+
+	// KindFields is the stored fields, which is everything a result needs to be
+	// displayed and nothing a query needs to be answered.
+	KindFields Kind = 3
+
+	// KindVectors is the embeddings, kept apart from the fields because they
+	// are read by a different query path and are an order of magnitude larger.
+	KindVectors Kind = 4
+
+	// KindACL is the access control lists, which are in the segment rather than
+	// beside it so that the permission filter runs against the same immutable
+	// bytes as the match. A permission that lives somewhere else is a permission
+	// that can be stale relative to the document it guards.
+	KindACL Kind = 5
+
+	// KindTombstones is the deletes. A delete never edits an earlier segment,
+	// so it is a tombstone here and the sequence in the header is what decides
+	// which of two statements about a document is the current one.
+	KindTombstones Kind = 6
+)
+
+// String names a kind for an error message.
+func (k Kind) String() string {
+	switch k {
+	case KindTerms:
+		return "terms"
+	case KindPostings:
+		return "postings"
+	case KindFields:
+		return "fields"
+	case KindVectors:
+		return "vectors"
+	case KindACL:
+		return "acl"
+	case KindTombstones:
+		return "tombstones"
+	}
+	return "kind(" + itoa(uint64(k)) + ")"
+}
+
+// known reports whether this build understands a kind. A writer refuses to
+// write one it does not know, because a segment naming a section nobody can
+// read is a file that will be argued about later. A reader accepts one, because
+// refusing would make every added section a breaking change.
+func (k Kind) known() bool {
+	switch k {
+	case KindTerms, KindPostings, KindFields, KindVectors, KindACL, KindTombstones:
+		return true
+	}
+	return false
+}
+
+// The errors a caller can act on differently.
+//
+// They are separate values rather than one error with a string in it because
+// the three of them mean genuinely different things to an operator. A bad magic
+// is a file that is not a segment, which is usually a path bug. An unknown
+// version is a segment written by a newer build, which is a rollback that went
+// the wrong way. A failed checksum is a segment that was a segment and is not
+// any more, which is hardware.
+var (
+	ErrMagic    = errors.New("segment: not a segment file")
+	ErrVersion  = errors.New("segment: unknown format version")
+	ErrChecksum = errors.New("segment: checksum mismatch")
+	ErrFormat   = errors.New("segment: malformed segment")
+)
+
+// castagnoli is the polynomial with hardware support on every architecture this
+// targets. The checksum is on the open path of every segment, so a software
+// implementation would be a cost paid on every read forever.
+var castagnoli = crc32.MakeTable(crc32.Castagnoli)
+
+// checksum is the sum over a whole segment except the four bytes that hold it.
+// Skipping those is what makes the field verifiable at all: a checksum that
+// covered itself would have no fixed point to compare against.
+func checksum(b []byte) uint32 {
+	c := crc32.Checksum(b[:offChecksum], castagnoli)
+	return crc32.Update(c, castagnoli, b[offChecksum+4:])
+}
+
+// itoa avoids pulling strconv into a package that otherwise touches nothing.
+func itoa(v uint64) string {
+	if v == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[i:])
+}
+
+// le is the byte order of everything in here, named once so that the choice is
+// made in one place.
+var le = binary.LittleEndian

--- a/store/segment/segment_test.go
+++ b/store/segment/segment_test.go
@@ -1,0 +1,479 @@
+package segment_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/tamnd/genba/store/segment"
+)
+
+var le = binary.LittleEndian
+
+// build is the segment most of these tests work over: every section populated,
+// with contents that are distinguishable from each other so that a reader
+// handing back the wrong window is a failure rather than a coincidence.
+func build(t testing.TB) []byte {
+	t.Helper()
+
+	b, err := populated()
+	if err != nil {
+		t.Fatalf("building a segment: %v", err)
+	}
+	return b
+}
+
+// populated is build without a testing.TB, so that the fuzz seed corpus can be
+// built at registration time rather than by handing a fabricated *testing.T to
+// something that would call Fatalf on it.
+func populated() ([]byte, error) {
+	w := segment.NewWriter(9)
+	for _, s := range []struct {
+		kind  segment.Kind
+		bytes []byte
+	}{
+		{segment.KindTerms, []byte("terms section")},
+		{segment.KindPostings, bytes.Repeat([]byte{0xAB}, 4096)},
+		{segment.KindFields, []byte(`{"title":"a document"}`)},
+		{segment.KindVectors, bytes.Repeat([]byte{0x01, 0x02, 0x03, 0x04}, 128)},
+		{segment.KindACL, []byte("group:everyone")},
+		{segment.KindTombstones, []byte{0, 0, 0, 0, 0, 0, 0, 7}},
+	} {
+		if err := w.Add(s.kind, s.bytes); err != nil {
+			return nil, err
+		}
+	}
+	return w.Bytes()
+}
+
+func TestAnEmptySegmentIsASegment(t *testing.T) {
+	// A compaction that removed everything still has to say so, so a segment
+	// with no sections has to be writable and readable rather than an edge case
+	// somebody discovers in production.
+	b, err := segment.NewWriter(0).Bytes()
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	s, err := segment.Open(b)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if len(s.Kinds()) != 0 {
+		t.Errorf("an empty segment holds %v", s.Kinds())
+	}
+	if _, ok := s.Section(segment.KindTerms); ok {
+		t.Error("an empty segment produced a terms section")
+	}
+	if s.Sequence() != 0 {
+		t.Errorf("Sequence = %d, want 0", s.Sequence())
+	}
+}
+
+func TestOneSectionRoundTrips(t *testing.T) {
+	w := segment.NewWriter(1)
+	want := []byte(`{"id":"repo:README.md","title":"README"}`)
+	if err := w.Add(segment.KindFields, want); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	b, err := w.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+
+	s, err := segment.Open(b)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	got, ok := s.Section(segment.KindFields)
+	if !ok {
+		t.Fatal("the section that was written is not there")
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Section = %q, want %q", got, want)
+	}
+	if _, ok := s.Section(segment.KindPostings); ok {
+		t.Error("a section that was never written came back")
+	}
+}
+
+func TestEverySectionRoundTrips(t *testing.T) {
+	s, err := segment.Open(build(t))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if s.Sequence() != 9 {
+		t.Errorf("Sequence = %d, want 9", s.Sequence())
+	}
+
+	kinds := s.Kinds()
+	want := []segment.Kind{
+		segment.KindTerms, segment.KindPostings, segment.KindFields,
+		segment.KindVectors, segment.KindACL, segment.KindTombstones,
+	}
+	if len(kinds) != len(want) {
+		t.Fatalf("Kinds = %v, want %v", kinds, want)
+	}
+	for i := range want {
+		if kinds[i] != want[i] {
+			t.Fatalf("Kinds = %v, want %v", kinds, want)
+		}
+	}
+
+	terms, _ := s.Section(segment.KindTerms)
+	if string(terms) != "terms section" {
+		t.Errorf("terms = %q", terms)
+	}
+	postings, _ := s.Section(segment.KindPostings)
+	if len(postings) != 4096 || postings[0] != 0xAB || postings[4095] != 0xAB {
+		t.Errorf("postings came back as %d bytes starting %#x", len(postings), postings[:min(4, len(postings))])
+	}
+	tombstones, _ := s.Section(segment.KindTombstones)
+	if len(tombstones) != 8 || tombstones[7] != 7 {
+		t.Errorf("tombstones = %v", tombstones)
+	}
+}
+
+func TestTheSameSectionsProduceTheSameBytes(t *testing.T) {
+	// Determinism is what lets two machines compare segments by name rather
+	// than by content, so the order sections are added in must not reach the
+	// file.
+	forward := segment.NewWriter(4)
+	backward := segment.NewWriter(4)
+	adds := []struct {
+		kind  segment.Kind
+		bytes []byte
+	}{
+		{segment.KindTerms, []byte("a")},
+		{segment.KindPostings, []byte("bb")},
+		{segment.KindACL, []byte("ccc")},
+	}
+	for _, a := range adds {
+		if err := forward.Add(a.kind, a.bytes); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+	}
+	for i := len(adds) - 1; i >= 0; i-- {
+		if err := backward.Add(adds[i].kind, adds[i].bytes); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+	}
+
+	a, err := forward.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	b, err := backward.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Error("the order sections were added in changed the file")
+	}
+}
+
+func TestWriteToWritesTheSameBytes(t *testing.T) {
+	w := segment.NewWriter(2)
+	if err := w.Add(segment.KindTerms, []byte("terms")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	want, err := w.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+
+	var buf bytes.Buffer
+	n, err := w.WriteTo(&buf)
+	if err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if n != int64(len(want)) || !bytes.Equal(buf.Bytes(), want) {
+		t.Errorf("WriteTo wrote %d bytes, want %d identical ones", n, len(want))
+	}
+}
+
+func TestAWriterRefusesWhatCannotBeReadBack(t *testing.T) {
+	w := segment.NewWriter(1)
+	if err := w.Add(segment.Kind(4242), []byte("x")); !errors.Is(err, segment.ErrFormat) {
+		t.Errorf("Add of an unknown kind = %v, want ErrFormat", err)
+	}
+	if err := w.Add(segment.KindTerms, []byte("x")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := w.Add(segment.KindTerms, []byte("y")); !errors.Is(err, segment.ErrFormat) {
+		t.Errorf("Add of a duplicate kind = %v, want ErrFormat", err)
+	}
+}
+
+func TestTheThreeRefusalsAreDistinct(t *testing.T) {
+	valid := build(t)
+
+	tests := []struct {
+		name string
+		bad  func([]byte) []byte
+		want error
+	}{
+		{"an empty file", func([]byte) []byte { return nil }, segment.ErrMagic},
+		{"something that is not a segment", func([]byte) []byte {
+			return bytes.Repeat([]byte("not a segment at all, just some bytes"), 8)
+		}, segment.ErrMagic},
+		{"a segment with one letter of the magic wrong", func(b []byte) []byte {
+			b[3] ^= 0x20
+			return b
+		}, segment.ErrMagic},
+		{"a version this build does not read", func(b []byte) []byte {
+			le.PutUint16(b[8:], 99)
+			return b
+		}, segment.ErrVersion},
+		{"a flag this build does not know", func(b []byte) []byte {
+			le.PutUint16(b[10:], 1)
+			return b
+		}, segment.ErrVersion},
+		{"a flipped bit in the body", func(b []byte) []byte {
+			b[len(b)-3] ^= 0x01
+			return b
+		}, segment.ErrChecksum},
+		{"a flipped bit in the offset table", func(b []byte) []byte {
+			b[48] ^= 0x01
+			return b
+		}, segment.ErrChecksum},
+		{"reserved header bytes that are not zero", func(b []byte) []byte {
+			le.PutUint32(b[36:], 1)
+			return b
+		}, segment.ErrFormat},
+		{"a length that claims more than the file holds", func(b []byte) []byte {
+			le.PutUint64(b[24:], math.MaxUint64)
+			return b
+		}, segment.ErrFormat},
+		{"bytes appended after the end", func(b []byte) []byte {
+			return append(b, 0, 0, 0, 0)
+		}, segment.ErrFormat},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := segment.Open(tt.bad(bytes.Clone(valid)))
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Open = %v, want %v", err, tt.want)
+			}
+		})
+	}
+
+	// The version check has to happen before anything below it is trusted, so
+	// a file that is a newer version and also fails its checksum must report
+	// the version. Reporting the checksum would send somebody looking at a disk
+	// when the answer is that they rolled a binary back.
+	b := bytes.Clone(valid)
+	le.PutUint16(b[8:], 99)
+	b[len(b)-1] ^= 0xFF
+	if _, err := segment.Open(b); !errors.Is(err, segment.ErrVersion) {
+		t.Errorf("a newer segment that is also corrupt reported %v, want ErrVersion", err)
+	}
+}
+
+// TestTruncationIsAnErrorAndNeverAPanic cuts a valid segment at every length
+// there is.
+//
+// This is the test the format exists to pass. A truncated segment is what a
+// half finished write, a full disk and an interrupted copy all look like, and
+// every one of them presents as a length field describing bytes that are not
+// there. Not one of them may reach a slice expression.
+func TestTruncationIsAnErrorAndNeverAPanic(t *testing.T) {
+	valid := build(t)
+	for n := range len(valid) {
+		s, err := segment.Open(valid[:n:n])
+		if err == nil {
+			t.Fatalf("a segment truncated to %d of %d bytes opened cleanly", n, len(valid))
+		}
+		if s != nil {
+			t.Fatalf("a segment truncated to %d bytes returned both a segment and an error", n)
+		}
+	}
+
+	// And the whole thing still opens, so the sweep above was not passing
+	// because everything fails.
+	if _, err := segment.Open(valid); err != nil {
+		t.Fatalf("the untruncated segment does not open: %v", err)
+	}
+}
+
+// TestEveryFlippedByteIsCaught is the other half of the sweep: a segment that
+// is the right length and the wrong bytes.
+func TestEveryFlippedByteIsCaught(t *testing.T) {
+	valid := build(t)
+	for i := range valid {
+		// The checksum field itself is skipped, since flipping a bit there is
+		// tested above and is the one byte whose corruption is detected by
+		// being different rather than by covering something different.
+		b := bytes.Clone(valid)
+		b[i] ^= 0xFF
+		if _, err := segment.Open(b); err == nil {
+			t.Fatalf("byte %d of %d could be changed without the segment noticing", i, len(valid))
+		}
+	}
+}
+
+// TestASectionCannotBeMadeToAliasAnother is the reason the table is checked for
+// order and overlap rather than only for bounds.
+//
+// A table that passes its bounds checks can still point two sections at the
+// same bytes, or point one backwards into the table itself, and a reader that
+// only checked bounds would hand those windows out.
+func TestASectionCannotBeMadeToAliasAnother(t *testing.T) {
+	valid := build(t)
+
+	tests := []struct {
+		name string
+		bad  func([]byte)
+	}{
+		{"a section that starts before the one before it", func(b []byte) {
+			// The second entry's offset, moved back over the first section.
+			le.PutUint64(b[40+24+8:], uint64(40+6*24))
+		}},
+		{"a section that reaches into the table", func(b []byte) {
+			le.PutUint64(b[40+8:], 40)
+		}},
+		{"two sections of the same kind", func(b []byte) {
+			le.PutUint32(b[40+24:], uint32(segment.KindTerms))
+		}},
+		{"a section that runs off the end", func(b []byte) {
+			le.PutUint64(b[40+16:], math.MaxUint64)
+		}},
+		{"reserved bytes of an entry that are not zero", func(b []byte) {
+			le.PutUint32(b[40+4:], 1)
+		}},
+		{"a section count larger than the table", func(b []byte) {
+			le.PutUint32(b[12:], math.MaxUint32)
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := bytes.Clone(valid)
+			tt.bad(b)
+			// The checksum is recomputed, because this is not about detecting
+			// corruption. It is about a segment that is internally consistent
+			// and structurally impossible, which is what a hostile writer
+			// produces.
+			reseal(b)
+			if _, err := segment.Open(b); !errors.Is(err, segment.ErrFormat) {
+				t.Fatalf("Open = %v, want ErrFormat", err)
+			}
+		})
+	}
+}
+
+// reseal recomputes the checksum over a segment that has been edited, so that a
+// test about structure is not accidentally a test about the checksum.
+func reseal(b []byte) {
+	le.PutUint32(b[32:], crc32c(b))
+}
+
+// crc32c is the same sum the package computes, written out the slow way so that
+// the tests prove the format rather than proving a function agrees with itself.
+// It covers every byte except the four holding the checksum.
+func crc32c(b []byte) uint32 {
+	const poly = 0x82f63b78
+	crc := ^uint32(0)
+	for i, v := range b {
+		if i >= 32 && i < 36 {
+			continue
+		}
+		crc ^= uint32(v)
+		for range 8 {
+			if crc&1 != 0 {
+				crc = crc>>1 ^ poly
+			} else {
+				crc >>= 1
+			}
+		}
+	}
+	return ^crc
+}
+
+func TestAnUnknownSectionIsSkippedRatherThanRefused(t *testing.T) {
+	// Adding a section has to be a change old readers survive, which is why a
+	// reader accepts a kind it cannot name. The writer refuses to produce one,
+	// so this builds it by hand the way a newer build would.
+	valid := build(t)
+	b := bytes.Clone(valid)
+	le.PutUint32(b[40+5*24:], 999) // the last entry, retyped to a kind from the future
+	reseal(b)
+
+	s, err := segment.Open(b)
+	if err != nil {
+		t.Fatalf("a segment with a section from the future does not open: %v", err)
+	}
+	if _, ok := s.Section(segment.KindTombstones); ok {
+		t.Error("the retyped section still answers to its old kind")
+	}
+	if _, ok := s.Section(segment.Kind(999)); !ok {
+		t.Error("a section this build cannot name is not readable by number either")
+	}
+	if got, _ := s.Section(segment.KindTerms); string(got) != "terms section" {
+		t.Errorf("a section from the future broke the ones around it: terms = %q", got)
+	}
+}
+
+func TestASectionIsAWindowAndNotACopy(t *testing.T) {
+	// The whole point of opening over bytes is that a hundred megabyte segment
+	// costs a hundred megabytes however many readers it has.
+	b := build(t)
+	s, err := segment.Open(b)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	postings, _ := s.Section(segment.KindPostings)
+	if cap(postings) != len(postings) {
+		t.Errorf("a section window has %d bytes of capacity past its length, so a caller can append into the next section", cap(postings)-len(postings))
+	}
+	b[len(b)-1] = 0xFF
+	tombstones, _ := s.Section(segment.KindTombstones)
+	if tombstones[len(tombstones)-1] != 0xFF {
+		t.Error("a section was copied rather than windowed")
+	}
+}
+
+func TestKindNamesItself(t *testing.T) {
+	for _, tt := range []struct {
+		kind segment.Kind
+		want string
+	}{
+		{segment.KindTerms, "terms"},
+		{segment.KindPostings, "postings"},
+		{segment.KindFields, "fields"},
+		{segment.KindVectors, "vectors"},
+		{segment.KindACL, "acl"},
+		{segment.KindTombstones, "tombstones"},
+		{segment.Kind(77), "kind(77)"},
+	} {
+		if got := tt.kind.String(); got != tt.want {
+			t.Errorf("Kind(%d).String() = %q, want %q", tt.kind, got, tt.want)
+		}
+	}
+}
+
+func FuzzOpenSurvivesAnything(f *testing.F) {
+	if b, err := populated(); err == nil {
+		f.Add(b)
+	}
+	f.Add([]byte(nil))
+	f.Add([]byte("genbaseg"))
+	f.Fuzz(func(t *testing.T, b []byte) {
+		s, err := segment.Open(b)
+		if err != nil {
+			return
+		}
+		// A segment that opened has to be usable, since the point of refusing
+		// early is that nothing downstream has to check again.
+		for _, k := range s.Kinds() {
+			if _, ok := s.Section(k); !ok {
+				t.Fatalf("Kinds reported %s and Section does not have it", k)
+			}
+		}
+		if s.Size() != len(b) {
+			t.Fatalf("Size = %d over %d bytes", s.Size(), len(b))
+		}
+	})
+}

--- a/store/segment/write.go
+++ b/store/segment/write.go
@@ -1,0 +1,114 @@
+package segment
+
+import (
+	"fmt"
+	"io"
+	"slices"
+)
+
+// Writer assembles a segment.
+//
+// It holds the sections until the whole file can be written at once, because
+// the header carries a checksum over everything after it and a length that
+// bounds the file, and neither is known until the last section has arrived.
+// Streaming a segment would mean seeking back to fill those in, which rules out
+// writing to a pipe and rules out the reader's assumption that a file it can
+// read at all is a file that was finished.
+//
+// The zero value is usable and writes a segment with sequence zero and no
+// sections, which is a valid segment. An empty one is worth being able to write:
+// a compaction that removes everything still has to say so.
+type Writer struct {
+	sequence uint64
+	sections []section
+}
+
+type section struct {
+	kind  Kind
+	bytes []byte
+}
+
+// NewWriter returns a writer for a segment at the given sequence.
+//
+// The sequence is the caller's, not this package's. Segments are published by
+// something that knows the order they were published in, and a package that
+// invented its own counter would be a second opinion about which of two
+// statements on a document is current.
+func NewWriter(sequence uint64) *Writer {
+	return &Writer{sequence: sequence}
+}
+
+// Add stores a section.
+//
+// The bytes are not copied. A writer is a short lived thing that exists between
+// building the sections and writing them, and copying a hundred megabytes of
+// postings to be defensive about a caller that is about to drop them anyway
+// would be the most expensive line in the package. The contract is that the
+// caller leaves them alone until [Writer.WriteTo] returns.
+//
+// A duplicate kind and an unknown kind are both refused. Two sections of the
+// same kind have no defined meaning, and a section this build cannot name is a
+// section nothing can read back.
+func (w *Writer) Add(kind Kind, b []byte) error {
+	if !kind.known() {
+		return fmt.Errorf("%w: cannot write unknown section %s", ErrFormat, kind)
+	}
+	if slices.ContainsFunc(w.sections, func(s section) bool { return s.kind == kind }) {
+		return fmt.Errorf("%w: section %s added twice", ErrFormat, kind)
+	}
+	w.sections = append(w.sections, section{kind: kind, bytes: b})
+	return nil
+}
+
+// Bytes returns the finished segment.
+//
+// Sections come out in ascending kind order whatever order they went in, so the
+// same sections produce the same bytes every time. That is what lets two
+// machines building the same segment compare the files rather than the
+// contents, and it is what lets a compaction that changed nothing be recognised
+// as having changed nothing.
+func (w *Writer) Bytes() ([]byte, error) {
+	sections := slices.Clone(w.sections)
+	slices.SortFunc(sections, func(a, b section) int { return int(a.kind) - int(b.kind) })
+
+	table := headerSize + entrySize*len(sections)
+	size := table
+	for _, s := range sections {
+		size += len(s.bytes)
+	}
+
+	out := make([]byte, size)
+	copy(out, Magic)
+	le.PutUint16(out[offVersion:], Version)
+	le.PutUint16(out[offFlags:], 0)
+	le.PutUint32(out[offSections:], uint32(len(sections)))
+	le.PutUint64(out[offSequence:], w.sequence)
+	le.PutUint64(out[offLength:], uint64(size-headerSize))
+	le.PutUint32(out[offReserved:], 0)
+
+	at := table
+	for i, s := range sections {
+		e := out[headerSize+i*entrySize:]
+		le.PutUint32(e[entryKind:], uint32(s.kind))
+		le.PutUint32(e[entryPad:], 0)
+		le.PutUint64(e[entryOffset:], uint64(at))
+		le.PutUint64(e[entryLength:], uint64(len(s.bytes)))
+		copy(out[at:], s.bytes)
+		at += len(s.bytes)
+	}
+
+	// Last, because it covers every other byte of the file: the header above it,
+	// the table and the body.
+	le.PutUint32(out[offChecksum:], checksum(out))
+	return out, nil
+}
+
+// WriteTo writes the finished segment.
+func (w *Writer) WriteTo(dst io.Writer) (int64, error) {
+	b, err := w.Bytes()
+	if err != nil {
+		return 0, err
+	}
+	n, err := dst.Write(b)
+	return int64(n), err
+}


### PR DESCRIPTION
Closes #2.

First issue of M1. The format decides what is possible later and it is expensive to undo once anybody has data in it, so this is the file written before the first byte is.

`store/segment` holds it and `docs/segment.md` explains it, field by field, with the reason for each one rather than only its width.

## The shape

A 40 byte header, an offset table of 24 bytes per section, and a body of sections.

The header carries magic, version, flags, a section count, a sequence, a length and a checksum. The sequence is what makes a tombstone work: segments are immutable once published, a delete is a tombstone in a later segment rather than an edit to an earlier one, and the sequence is what decides which of two statements about the same document is current.

Sections are addressed by kind rather than by position: terms, postings, fields, vectors, acl and tombstones. The container does not know what is inside any of them. A section is a run of bytes with a kind on it, and the encodings belong to the packages that own them, which is what lets the posting encoding change without the file format changing.

The access control lists are in the segment rather than beside it, because the permission filter has to run against the same immutable bytes as the match. A permission that lives somewhere else is a permission that can be stale relative to the document it guards, and that window is a window where somebody reads a document they cannot read.

## Reading assumes every byte is hostile

A bad sector, a half finished write, a truncated copy and a fuzzer all present the same way, which is a length field that says something untrue. `Open` works over the bytes it is handed and never allocates anything sized from them, so every section it returns is a subslice of the input and a length claiming four gigabytes fails a bounds check rather than an allocation.

The order of the checks is the design, and it is written down in the package and in the doc. Magic, so a file that is not a segment says that rather than something about a version. Version and flags, because a newer format could put anything at all in the bytes below and nothing after that line is worth doing until the layout is known. Declared length against actual length, exactly, longer as well as shorter. Then the checksum, before the table, because a failed checksum explains every structural error that would otherwise be reported instead of it, and "malformed at offset 240" sends somebody looking for a writer bug when the answer is a bad disk. Then structure: ascending, non overlapping, inside the file, kinds strictly increasing.

Version checking is a refusal, and so is an unknown flag bit. An unknown section kind is skipped, and that asymmetry is the point of addressing sections by kind: adding one has to be a change old readers survive, or every addition is a lockstep upgrade.

## The checksum covers the whole file, and that came from a test

The first version checksummed the body, which is the obvious choice and is wrong twice over. It leaves the offsets that address the body unprotected, so one flipped bit in the table gives a segment that passes its integrity check and hands back the wrong bytes. And it leaves the sequence unprotected, so one flipped bit in the header silently moves a tombstone to a different segment, which is a deleted document coming back to life with nothing anywhere reporting a problem.

I did not reason my way to that. The test that flips every byte of a valid segment in turn failed on byte 16, which is the sequence. It is in the doc as the reason the field is what it is.

## How I convinced myself

- A truncation sweep cuts a valid segment at every length from zero to its full size and asserts an error and never a panic, and then asserts the untruncated segment still opens, so the sweep is not passing because everything fails.
- A corruption sweep flips every byte in turn and asserts every one is caught.
- Six structural attacks that are internally consistent and impossible, resealed with a correct checksum so they are about structure rather than about corruption: a section that starts inside the one before it, one that reaches back into the table, two of the same kind, one that runs off the end, non zero reserved bytes and a section count larger than the table.
- Distinct errors asserted for a bad magic, an unknown version, an unknown flag and a failed checksum, including that a file which is both a newer version and corrupt reports the version, since telling somebody their disk is bad when they rolled a binary back is worse than useless.
- Round trips for an empty segment, a single section and every section populated.
- A determinism test asserting the order sections were added in does not reach the file.
- A test that a section is a window rather than a copy, including that its capacity does not run into the next section.
- `go test -fuzz` over `Open` for a minute with no crashes, and the fuzz target is committed so it keeps running.
- `gofmt -s`, `go vet ./...`, `golangci-lint run` and the full test suite are clean.

## What is not in here

Any encoding inside a section. The term dictionary and the run length encoded column store are #3, and they are what the terms and postings sections will hold. This is the container, and it is deliberately possible to build those without touching this file again.
