### PR TITLE
Column store with a dictionary and run length encoding

### DIFF
--- a/arch_test.go
+++ b/arch_test.go
@@ -48,6 +48,14 @@ var allowed = map[string][]string{
 	// document does, which is the opposite of what a file format is for.
 	"store/segment": nil,
 
+	// column is one of those encodings, and it imports nothing of ours either,
+	// not even segment. It deals in rows and codes and has never heard of a
+	// document or a principal. That is what lets the permission filter be an
+	// intersection between two bitmaps: a column package that knew what an ACL
+	// was would be a second place for the permission model to live, in the
+	// package least equipped to hold one.
+	"store/column": nil,
+
 	"store/memstore":    {"", "acl", "doc", "store"},
 	"store/sqlitestore": {"", "acl", "doc", "store"},
 	"store/storetest":   {"", "acl", "doc", "store"},

--- a/docs/columns.md
+++ b/docs/columns.md
@@ -1,0 +1,152 @@
+# Columns
+
+A segment's sections hold columns, and a column is one field across every row of the segment.
+Which source a document came from, when it was last modified, who owns it, whether it is archived.
+
+Version 1.
+The implementation is `store/column`, and the container it lives inside is [the segment format](segment.md).
+
+## What a scan returns
+
+A bitmap of row numbers, and never the rows.
+
+That is the whole design.
+A filter that materialises a row before deciding whether to keep it has paid for every row it is about to throw away, and on a corpus where a source filter cuts a million rows to a thousand that is three orders of magnitude of decoding nobody asked for.
+So a scan hands back which rows matched, the permission model hands back which rows a principal may read, and the answer is the intersection.
+Only what survives both is ever turned back into a document.
+
+The bitmap is dense, one bit per row.
+A compressed bitmap would win on the selective filters and lose on the ones that match half the segment, and it would put a decoder in front of the one operation on this path that has to be as fast as an AND instruction.
+
+## One physical representation
+
+Every type is stored as a sequence of unsigned integer codes, and the codes are in the same order as the values they stand for.
+
+| Type | What the code is | Base |
+| --- | --- | --- |
+| string | a rank in the column's sorted dictionary | 0 |
+| int | the value less the smallest value in the column | that smallest value |
+| time | the same, on Unix milliseconds | that smallest millisecond |
+| bool | 0 or 1 | 0 |
+
+Two things fall out of that table.
+
+The first is that a range on values is a range on codes for every type, including strings, because the dictionary is sorted before it is written.
+There is one scan loop underneath equality, set membership, prefix, integer range, date range and boolean, and it compares integers.
+A filter for six sources over a million rows reads no text at all: the six values are resolved against the dictionary first, which costs a binary search each, and what the scan then walks is codes.
+
+The second is that a column of timestamps a week apart needs the bits to tell a week apart, not the bits to hold a Unix epoch.
+Subtracting the smallest value is what makes that true.
+
+## Two encodings
+
+Plain packs every code at the narrowest width that fits.
+A thousand distinct sources is ten bits a row, not a string and not a pointer.
+
+Runs stores each value once with the number of rows it covers, for the columns that arrive sorted or nearly so, which in a search index is most of the interesting ones.
+
+The builder measures both and keeps the smaller.
+There is no knob for it, because the builder has the data in front of it and the caller does not.
+A column of a thousand rows in four runs wants run lengths, the same column shuffled wants packing, and nothing about the schema says which one arrived.
+
+A column whose every value is the same stores no codes at all.
+The width comes out at zero and the scan answers all rows or none without reading anything.
+
+## Nulls
+
+A null is absence, not a value, so it does not get a code.
+
+A column that has any carries a presence bitmap, one bit per row, and every scan intersects with it.
+A null never matches a predicate, including a range that happens to contain whatever placeholder sits in the code stream, and asking for the nulls deliberately is what `Nulls` is for.
+
+That case is easy to get wrong and there is a test for exactly it.
+A column holding 5, null, 7, null has a base of five, so a null's placeholder code of zero stands for the value five, and a range over every integer there is must still match two rows rather than four.
+
+## Bit packing
+
+Codes are packed least significant bit first, and a code is read by loading eight bytes at the byte its first bit lives in and shifting.
+
+That load has to be able to see the whole code, so a code has to end within eight bytes of the byte it starts in: seven bits of offset plus the width has to stay inside sixty four.
+Widths up to 57 satisfy it.
+Anything wider is stored at the full sixty four, where every code starts on a byte boundary and the question does not arise.
+It takes a column of more than a hundred quintillion distinct values to reach that, so the rule costs nothing and removes a case from the reader.
+
+The packed section carries eight bytes of slack on the end so the load for the last code is always in bounds.
+Without it the last code is a read past the end of a mapped file.
+
+## The header
+
+Fixed size, at the front, and the version is the first byte so a reader can refuse an unknown one before it has interpreted anything else.
+
+| Offset | Size | Field |
+| --- | --- | --- |
+| 0 | 1 | version |
+| 1 | 1 | type |
+| 2 | 1 | encoding |
+| 3 | 1 | bits per packed code |
+| 4 | 4 | rows |
+| 8 | 4 | dictionary entries, zero unless the type is string |
+| 12 | 1 | flags, bit 0 says a presence bitmap follows |
+| 13 | 3 | reserved, zero |
+| 16 | 8 | base |
+
+Then, in this order: the presence bitmap when there is one, the codes, and the dictionary when the type is string.
+
+All integers are little endian, for the same reason they are in the segment format.
+
+## Reading bytes that may be anything
+
+These bytes come off a disk.
+A reader that panics on a damaged file turns a recoverable segment into an outage, so `Open` checks the structure before it believes any of it, and there is a fuzz target whose only contract is that nothing it is fed ever panics.
+
+| Error | What it means |
+| --- | --- |
+| `ErrVersion` | a column written by something newer, so go and find that thing |
+| `ErrFormat` | bytes that were damaged or were never a column |
+| `ErrType` | a query asking a string column for a date range, which is a caller bug rather than a data one |
+
+Two of those are worth separating on purpose.
+An operator told "malformed" about a file that is merely from a newer build goes looking in the wrong place.
+
+The checks that matter:
+
+- The declared sizes have to add up to exactly the bytes given, with nothing left over.
+- A run's length has to be non zero and has to fit in the rows that are left, and the runs together have to cover the rows the header claims.
+- The run count is a number read out of hostile bytes, so nothing is allocated from it directly.
+  Every run costs at least two bytes, so the capacity comes from the smaller of the declared count and half the bytes remaining.
+- Dictionary offsets are cumulative, so they have to start at zero and never go backwards.
+  A pair that slices backwards would be a panic in an accessor, and checking it once here is what lets every accessor below skip it.
+- A code that indexes past the end of the dictionary is possible in bytes that were tampered with, because the packed width can hold more values than the dictionary has.
+  It is not checked at open, which would be a full scan of the column, so it is bounds checked where it is used: such a row reads back as having no value, and it matches nothing.
+
+## What it costs
+
+On an Apple M4, a million rows, a thousand distinct string values:
+
+| Scan | rows a second |
+| --- | --- |
+| string equality, packed | 526 million |
+| string set of four, packed | 537 million |
+| string prefix, packed | 441 million |
+| integer range, packed | 326 million |
+| date range, packed | 195 million |
+| boolean, packed | 298 million |
+| any of them, run length encoded | above 60 billion |
+
+The gap between the two halves of that table is the argument for measuring both encodings and keeping the smaller.
+A run length scan does work per run rather than per row and fills whole words of the answer at a time, so a column that arrives sorted is read two to three hundred times faster than the same column shuffled.
+`go test -bench . ./store/column/` is where those numbers come from.
+
+The dictionary is worth what it costs.
+A million rows of a thousand distinct values, 33 MB of text, encodes to 1.29 MB at ten bits a row, which is 25.6 times smaller.
+There is a test that fails if that ratio drops below ten.
+
+## What is deliberately not here yet
+
+A time column keeps milliseconds, and a column whose values are all on an hour boundary spends twenty two bits a row on zeros that a common divisor would remove.
+That shows up in the table above as the date range being the slowest of the packed scans, and it is the obvious next thing.
+
+Facet counts, which are a tally per code over a bitmap rather than a new encoding.
+`Dict` and `CodeAt` are what that will be built on, and they are exported for it.
+
+Delta encoding for a sorted numeric column, which the run length encoding already covers whenever the values repeat and does not cover when they are sorted and distinct.

--- a/store/column/bench_test.go
+++ b/store/column/bench_test.go
@@ -1,0 +1,232 @@
+package column_test
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/store/column"
+)
+
+// The scan throughput per column type, which is the fourth box on the issue.
+//
+// Every one of them reports rows a second, because that is the figure a query
+// planner needs. A filter over a segment costs rows divided by this, and the
+// interesting comparison is not between two runs of the same benchmark but
+// between the two encodings of the same data: a sorted column is read a run at
+// a time and a shuffled one a row at a time, and the gap between them is the
+// whole argument for measuring both and keeping the smaller.
+//
+// They are also what would catch a change that makes the packed reader do more
+// per row. Nothing in the counters gate can see that, because the work stays
+// the same and only the time moves.
+
+const benchRows = 1_000_000
+
+func BenchmarkScanString(b *testing.B) {
+	for _, sorted := range []bool{false, true} {
+		c := stringCorpus(b, sorted)
+		b.Run(c.Encoding().String(), func(b *testing.B) {
+			for b.Loop() {
+				if _, err := c.MatchStrings("source-0007"); err != nil {
+					b.Fatal(err)
+				}
+			}
+			rowsPerSecond(b)
+		})
+		b.Run(c.Encoding().String()+"-oneof", func(b *testing.B) {
+			set := []string{"source-0007", "source-0031", "source-0099", "source-0500"}
+			for b.Loop() {
+				if _, err := c.MatchStrings(set...); err != nil {
+					b.Fatal(err)
+				}
+			}
+			rowsPerSecond(b)
+		})
+		b.Run(c.Encoding().String()+"-prefix", func(b *testing.B) {
+			for b.Loop() {
+				if _, err := c.MatchPrefix("source-00"); err != nil {
+					b.Fatal(err)
+				}
+			}
+			rowsPerSecond(b)
+		})
+	}
+}
+
+func BenchmarkScanInt(b *testing.B) {
+	for _, sorted := range []bool{false, true} {
+		c := intCorpus(b, sorted)
+		b.Run(c.Encoding().String(), func(b *testing.B) {
+			for b.Loop() {
+				if _, err := c.MatchInts(1000, 2000); err != nil {
+					b.Fatal(err)
+				}
+			}
+			rowsPerSecond(b)
+		})
+	}
+}
+
+func BenchmarkScanTime(b *testing.B) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, sorted := range []bool{false, true} {
+		r := rand.New(rand.NewPCG(2121, 23))
+		offsets := make([]int, benchRows)
+		for i := range offsets {
+			offsets[i] = r.IntN(365 * 24)
+		}
+		if sorted {
+			slices.Sort(offsets)
+		}
+		bu := column.NewBuilder(column.TypeTime)
+		for _, o := range offsets {
+			bu.AppendTime(start.Add(time.Duration(o) * time.Hour))
+		}
+		c := open(b, bu)
+		b.Run(c.Encoding().String(), func(b *testing.B) {
+			lo, hi := start.AddDate(0, 3, 0), start.AddDate(0, 6, 0)
+			for b.Loop() {
+				if _, err := c.MatchTimes(lo, hi); err != nil {
+					b.Fatal(err)
+				}
+			}
+			rowsPerSecond(b)
+		})
+	}
+}
+
+func BenchmarkScanBool(b *testing.B) {
+	for _, sorted := range []bool{false, true} {
+		r := rand.New(rand.NewPCG(2121, 29))
+		values := make([]int, benchRows)
+		for i := range values {
+			values[i] = r.IntN(4)
+		}
+		if sorted {
+			slices.Sort(values)
+		}
+		bu := column.NewBuilder(column.TypeBool)
+		for _, v := range values {
+			bu.AppendBool(v == 0)
+		}
+		c := open(b, bu)
+		b.Run(c.Encoding().String(), func(b *testing.B) {
+			for b.Loop() {
+				if _, err := c.MatchBool(true); err != nil {
+					b.Fatal(err)
+				}
+			}
+			rowsPerSecond(b)
+		})
+	}
+}
+
+// BenchmarkIntersect is the permission filter on its own, without a scan in
+// front of it. It is the operation every query does at least once and the
+// reason the bitmap is dense.
+func BenchmarkIntersect(b *testing.B) {
+	left, right := column.NewBitmap(benchRows), column.NewBitmap(benchRows)
+	r := rand.New(rand.NewPCG(2121, 31))
+	for i := range benchRows {
+		if r.IntN(2) == 0 {
+			left.Set(i)
+		}
+		if r.IntN(4) != 0 {
+			right.Set(i)
+		}
+	}
+	for b.Loop() {
+		left.And(right)
+	}
+	rowsPerSecond(b)
+}
+
+// BenchmarkValueAt is the other side of a scan: once the bitmap has been
+// intersected down to the rows that will be shown, something has to turn them
+// back into values.
+func BenchmarkValueAt(b *testing.B) {
+	for _, sorted := range []bool{false, true} {
+		c := stringCorpus(b, sorted)
+		b.Run(c.Encoding().String(), func(b *testing.B) {
+			i := 0
+			for b.Loop() {
+				if _, ok := c.StringAt(i % benchRows); !ok {
+					b.Fatal("a row with no value")
+				}
+				i += 7919 // A prime, so the reads are spread rather than sequential.
+			}
+		})
+	}
+}
+
+func BenchmarkBuild(b *testing.B) {
+	values := benchStrings(false)
+	b.Run("string", func(b *testing.B) {
+		for b.Loop() {
+			bu := column.NewBuilder(column.TypeString)
+			for _, v := range values {
+				bu.AppendString(v)
+			}
+			if _, err := bu.Build(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		rowsPerSecond(b)
+	})
+}
+
+func stringCorpus(b *testing.B, sorted bool) *column.Column {
+	b.Helper()
+	values := benchStrings(sorted)
+	bu := column.NewBuilder(column.TypeString)
+	for _, v := range values {
+		bu.AppendString(v)
+	}
+	return open(b, bu)
+}
+
+// benchStrings is a thousand distinct values over a million rows, which is the
+// shape of a source or an owner column on a real corpus.
+func benchStrings(sorted bool) []string {
+	terms := make([]string, 1000)
+	for i := range terms {
+		terms[i] = fmt.Sprintf("source-%04d", i)
+	}
+	r := rand.New(rand.NewPCG(2121, 19))
+	out := make([]string, benchRows)
+	for i := range out {
+		out[i] = terms[r.IntN(len(terms))]
+	}
+	if sorted {
+		slices.Sort(out)
+	}
+	return out
+}
+
+func intCorpus(b *testing.B, sorted bool) *column.Column {
+	b.Helper()
+	r := rand.New(rand.NewPCG(2121, 37))
+	values := make([]int64, benchRows)
+	for i := range values {
+		values[i] = int64(r.IntN(10_000))
+	}
+	if sorted {
+		slices.Sort(values)
+	}
+	bu := column.NewBuilder(column.TypeInt)
+	for _, v := range values {
+		bu.AppendInt(v)
+	}
+	return open(b, bu)
+}
+
+// rowsPerSecond is the figure these benchmarks exist to report. Nanoseconds per
+// operation is a number that moves with the corpus size and rows a second is
+// not, so it is the one that can be compared between two of these.
+func rowsPerSecond(b *testing.B) {
+	b.Helper()
+	b.ReportMetric(float64(benchRows)*float64(b.N)/b.Elapsed().Seconds(), "rows/s")
+}

--- a/store/column/bitmap.go
+++ b/store/column/bitmap.go
@@ -1,0 +1,204 @@
+package column
+
+import "math/bits"
+
+// Bitmap is a set of row numbers, one bit per row.
+//
+// It is dense on purpose. A scan already costs one pass over every row of a
+// column, so the answer it produces is a word per sixty four rows whether one
+// row matched or all of them, and a compressed bitmap would win on the selective
+// filters and lose on the ones that match half the segment. More to the point,
+// the operation this type exists for is the intersection between what a filter
+// matched and what a principal is allowed to read, and that intersection is on
+// the hot path of every query. Dense words make it an AND instruction. Anything
+// compressed puts a decoder in front of it.
+type Bitmap struct {
+	n     int
+	words []uint64
+}
+
+// NewBitmap returns an empty bitmap over n rows.
+func NewBitmap(n int) *Bitmap {
+	if n < 0 {
+		n = 0
+	}
+	return &Bitmap{n: n, words: make([]uint64, (n+63)/64)}
+}
+
+// Len is the number of rows the bitmap is over, not the number set.
+func (b *Bitmap) Len() int { return b.n }
+
+// Set adds a row. A row outside the bitmap is ignored rather than a panic,
+// because a scan that walks a run past the end of a truncated column should
+// produce a wrong answer at worst and never take the process down.
+func (b *Bitmap) Set(i int) {
+	if i < 0 || i >= b.n {
+		return
+	}
+	b.words[i>>6] |= 1 << (uint(i) & 63)
+}
+
+// Clear removes a row.
+func (b *Bitmap) Clear(i int) {
+	if i < 0 || i >= b.n {
+		return
+	}
+	b.words[i>>6] &^= 1 << (uint(i) & 63)
+}
+
+// Get reports whether a row is in the set.
+func (b *Bitmap) Get(i int) bool {
+	if i < 0 || i >= b.n {
+		return false
+	}
+	return b.words[i>>6]&(1<<(uint(i)&63)) != 0
+}
+
+// SetRange adds every row in [lo, hi). It is what a run length encoded scan
+// calls once per matching run, so it fills whole words rather than looping over
+// bits.
+func (b *Bitmap) SetRange(lo, hi int) {
+	if lo < 0 {
+		lo = 0
+	}
+	if hi > b.n {
+		hi = b.n
+	}
+	if lo >= hi {
+		return
+	}
+	first, last := lo>>6, (hi-1)>>6
+	head := ^uint64(0) << (uint(lo) & 63)
+	tail := ^uint64(0) >> (63 - (uint(hi-1) & 63))
+	if first == last {
+		b.words[first] |= head & tail
+		return
+	}
+	b.words[first] |= head
+	for i := first + 1; i < last; i++ {
+		b.words[i] = ^uint64(0)
+	}
+	b.words[last] |= tail
+}
+
+// Count is the number of rows in the set.
+func (b *Bitmap) Count() int {
+	n := 0
+	for _, w := range b.words {
+		n += bits.OnesCount64(w)
+	}
+	return n
+}
+
+// Empty reports whether nothing is set, without counting all of it.
+func (b *Bitmap) Empty() bool {
+	for _, w := range b.words {
+		if w != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// And intersects in place. This is the permission filter: a scan produces the
+// rows a predicate matched, the ACL produces the rows a principal may read, and
+// the answer is what survives both.
+//
+// The two bitmaps do not have to be the same length. Rows the other side does
+// not have are treated as unset, so intersecting with a shorter bitmap clears
+// the tail rather than leaving rows in the answer that nothing vouched for.
+func (b *Bitmap) And(o *Bitmap) {
+	for i := range b.words {
+		if i < len(o.words) {
+			b.words[i] &= o.words[i]
+		} else {
+			b.words[i] = 0
+		}
+	}
+}
+
+// Or unions in place. Rows past the end of the receiver are dropped, because
+// the receiver is what says how many rows there are.
+func (b *Bitmap) Or(o *Bitmap) {
+	for i := range b.words {
+		if i >= len(o.words) {
+			break
+		}
+		b.words[i] |= o.words[i]
+	}
+	b.trim()
+}
+
+// AndNot removes every row the other bitmap has.
+func (b *Bitmap) AndNot(o *Bitmap) {
+	for i := range b.words {
+		if i >= len(o.words) {
+			break
+		}
+		b.words[i] &^= o.words[i]
+	}
+}
+
+// Not flips every row in place.
+func (b *Bitmap) Not() {
+	for i := range b.words {
+		b.words[i] = ^b.words[i]
+	}
+	b.trim()
+}
+
+// Clone returns a copy that shares nothing with the original.
+func (b *Bitmap) Clone() *Bitmap {
+	c := &Bitmap{n: b.n, words: make([]uint64, len(b.words))}
+	copy(c.words, b.words)
+	return c
+}
+
+// Equal compares two bitmaps by the rows they hold. It exists for tests: the
+// query path compares counts, not sets.
+func (b *Bitmap) Equal(o *Bitmap) bool {
+	if b.n != o.n {
+		return false
+	}
+	for i := range b.words {
+		if b.words[i] != o.words[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Each calls f with every row in the set, ascending, and stops early when f
+// returns false. It allocates nothing, which is the difference between it and
+// Rows.
+func (b *Bitmap) Each(f func(row int) bool) {
+	for i, w := range b.words {
+		for w != 0 {
+			if !f(i*64 + bits.TrailingZeros64(w)) {
+				return
+			}
+			w &= w - 1
+		}
+	}
+}
+
+// Rows materialises the set as row numbers, ascending. A caller that is about
+// to fetch every one of them wants this. A caller that is about to intersect
+// with something else wants And.
+func (b *Bitmap) Rows() []int {
+	out := make([]int, 0, b.Count())
+	b.Each(func(row int) bool {
+		out = append(out, row)
+		return true
+	})
+	return out
+}
+
+// trim clears the bits past the last row. Every operation that can set them has
+// to call it, because Count and Each read the last word whole and a stray bit
+// up there is a row number that does not exist.
+func (b *Bitmap) trim() {
+	if rem := uint(b.n) & 63; rem != 0 && len(b.words) > 0 {
+		b.words[len(b.words)-1] &= ^uint64(0) >> (64 - rem)
+	}
+}

--- a/store/column/bitmap_test.go
+++ b/store/column/bitmap_test.go
@@ -1,0 +1,166 @@
+package column_test
+
+import (
+	"math/rand/v2"
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/store/column"
+)
+
+func TestABitmapHoldsTheRowsPutInIt(t *testing.T) {
+	b := column.NewBitmap(200)
+	for _, row := range []int{0, 1, 63, 64, 65, 127, 128, 199} {
+		b.Set(row)
+	}
+	if got := b.Rows(); !slices.Equal(got, []int{0, 1, 63, 64, 65, 127, 128, 199}) {
+		t.Errorf("the rows are %v", got)
+	}
+	b.Clear(64)
+	if b.Get(64) || !b.Get(65) {
+		t.Error("clearing row 64 took row 65 with it")
+	}
+	if got := b.Count(); got != 7 {
+		t.Errorf("%d rows are set and seven should be", got)
+	}
+}
+
+// TestARowOutsideTheBitmapIsIgnored keeps a truncated column from taking the
+// process down. A run that claims more rows than there are is a wrong answer,
+// not a crash.
+func TestARowOutsideTheBitmapIsIgnored(t *testing.T) {
+	b := column.NewBitmap(10)
+	b.Set(-1)
+	b.Set(10)
+	b.Set(1 << 40)
+	b.Clear(-1)
+	b.Clear(10)
+	if !b.Empty() || b.Get(-1) || b.Get(10) {
+		t.Errorf("%d rows outside the bitmap got in", b.Count())
+	}
+	b.SetRange(-5, 1000)
+	if got := b.Count(); got != 10 {
+		t.Errorf("a range over everything set %d of ten rows", got)
+	}
+}
+
+// TestSetRangeAgreesWithSettingEachRow is what the run length scan depends on.
+// It fills whole words, so every boundary between them is a chance to be off by
+// one.
+func TestSetRangeAgreesWithSettingEachRow(t *testing.T) {
+	const n = 300
+	for lo := range n {
+		for _, hi := range []int{lo, lo + 1, lo + 63, lo + 64, lo + 65, lo + 130, n} {
+			got := column.NewBitmap(n)
+			got.SetRange(lo, hi)
+			want := column.NewBitmap(n)
+			for i := lo; i < hi && i < n; i++ {
+				want.Set(i)
+			}
+			if !got.Equal(want) {
+				t.Fatalf("SetRange(%d, %d) set %d rows and setting each gives %d", lo, hi, got.Count(), want.Count())
+			}
+		}
+	}
+}
+
+func TestTheOperationsAgreeWithSets(t *testing.T) {
+	const n = 500
+	r := rand.New(rand.NewPCG(2121, 17))
+	left, right := column.NewBitmap(n), column.NewBitmap(n)
+	var inLeft, inRight [n]bool
+	for i := range n {
+		if inLeft[i] = r.IntN(2) == 0; inLeft[i] {
+			left.Set(i)
+		}
+		if inRight[i] = r.IntN(2) == 0; inRight[i] {
+			right.Set(i)
+		}
+	}
+
+	cases := []struct {
+		name string
+		op   func(*column.Bitmap)
+		want func(i int) bool
+	}{
+		{"and", func(b *column.Bitmap) { b.And(right) }, func(i int) bool { return inLeft[i] && inRight[i] }},
+		{"or", func(b *column.Bitmap) { b.Or(right) }, func(i int) bool { return inLeft[i] || inRight[i] }},
+		{"andnot", func(b *column.Bitmap) { b.AndNot(right) }, func(i int) bool { return inLeft[i] && !inRight[i] }},
+		{"not", func(b *column.Bitmap) { b.Not() }, func(i int) bool { return !inLeft[i] }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := left.Clone()
+			tc.op(got)
+			want := column.NewBitmap(n)
+			for i := range n {
+				if tc.want(i) {
+					want.Set(i)
+				}
+			}
+			if !got.Equal(want) {
+				t.Errorf("%s gave %d rows and the set answer is %d", tc.name, got.Count(), want.Count())
+			}
+		})
+	}
+	if left.Count() == 0 {
+		t.Error("the operations wrote through to the original")
+	}
+}
+
+// TestNotDoesNotInventRows is the reason trim exists. Five hundred rows is not
+// a multiple of sixty four, and flipping the last word turns the padding above
+// the last row into rows that do not exist.
+func TestNotDoesNotInventRows(t *testing.T) {
+	b := column.NewBitmap(100)
+	b.Not()
+	if got := b.Count(); got != 100 {
+		t.Errorf("flipping an empty bitmap of a hundred rows gives %d", got)
+	}
+	for _, row := range b.Rows() {
+		if row >= 100 {
+			t.Fatalf("row %d exists after flipping a bitmap of a hundred rows", row)
+		}
+	}
+}
+
+// TestIntersectingWithAShorterBitmapClearsTheTail is the safe direction to be
+// wrong in. Rows the other side never vouched for must not survive the
+// permission filter.
+func TestIntersectingWithAShorterBitmapClearsTheTail(t *testing.T) {
+	long := column.NewBitmap(200)
+	long.SetRange(0, 200)
+	short := column.NewBitmap(70)
+	short.SetRange(0, 70)
+
+	got := long.Clone()
+	got.And(short)
+	if c := got.Count(); c != 70 {
+		t.Errorf("intersecting two hundred rows with seventy left %d", c)
+	}
+
+	got = long.Clone()
+	got.AndNot(short)
+	if c := got.Count(); c != 130 {
+		t.Errorf("subtracting seventy rows from two hundred left %d", c)
+	}
+
+	got = short.Clone()
+	got.Or(long)
+	if c := got.Count(); c != 70 {
+		t.Errorf("a union into a seventy row bitmap holds %d rows", c)
+	}
+}
+
+func TestEachStopsWhenItIsToldTo(t *testing.T) {
+	b := column.NewBitmap(1000)
+	b.SetRange(0, 1000)
+	seen := 0
+	b.Each(func(int) bool {
+		seen++
+		return seen < 3
+	})
+	if seen != 3 {
+		t.Errorf("Each visited %d rows after being told to stop at three", seen)
+	}
+}

--- a/store/column/build.go
+++ b/store/column/build.go
@@ -1,0 +1,352 @@
+package column
+
+import (
+	"encoding/binary"
+	"fmt"
+	"slices"
+	"time"
+)
+
+// Builder collects values and encodes them.
+//
+// The append methods do not return errors. A column is built by a loop over a
+// million rows and an error check on every one of them is noise around the two
+// mistakes that are actually possible, which are appending the wrong type and
+// appending more rows than a column can hold. Both are recorded and both come
+// back from [Builder.Build], which refuses to produce bytes rather than
+// producing bytes that are wrong.
+type Builder struct {
+	typ  Type
+	err  error
+	rows int
+
+	// codes holds a dictionary id for a string column and the value itself for
+	// the others. It is turned into the final codes by Build, once it knows the
+	// smallest value or the sorted order of the dictionary.
+	codes []uint64
+
+	// present is a row per bit and is only written out when something was null.
+	present *Bitmap
+	nulls   bool
+
+	// terms is the distinct strings in the order they arrived and ids maps back
+	// into it. The sort happens once, in Build.
+	terms []string
+	ids   map[string]uint64
+}
+
+// NewBuilder returns a builder for a column of the given type.
+func NewBuilder(t Type) *Builder {
+	b := &Builder{typ: t}
+	if !t.known() {
+		b.err = fmt.Errorf("%w: %s", ErrType, t)
+	}
+	if t == TypeString {
+		b.ids = make(map[string]uint64)
+	}
+	return b
+}
+
+// Type is what the builder was made for.
+func (b *Builder) Type() Type { return b.typ }
+
+// Rows is how many values have been appended, nulls included.
+func (b *Builder) Rows() int { return b.rows }
+
+// AppendString adds a value to a string column.
+func (b *Builder) AppendString(s string) {
+	if !b.check(TypeString) {
+		return
+	}
+	id, ok := b.ids[s]
+	if !ok {
+		id = uint64(len(b.terms))
+		// The map key is the string the caller handed over. Go's map keeps its
+		// own copy of the key bytes for a string key, so nothing here pins the
+		// caller's buffer, and terms holds the same immutable value.
+		b.ids[s] = id
+		b.terms = append(b.terms, s)
+	}
+	b.push(id)
+}
+
+// AppendInt adds a value to an integer column.
+func (b *Builder) AppendInt(v int64) {
+	if !b.check(TypeInt) {
+		return
+	}
+	b.push(uint64(v))
+}
+
+// AppendTime adds a value to a time column.
+//
+// Time is kept to the millisecond. A facet by month and a sort by modified date
+// are what a time column is read for, neither of them can see a nanosecond, and
+// the six digits below a millisecond are six digits of entropy that widen every
+// code in the column and compress away to nothing.
+func (b *Builder) AppendTime(t time.Time) {
+	if !b.check(TypeTime) {
+		return
+	}
+	b.push(uint64(t.UnixMilli()))
+}
+
+// AppendBool adds a value to a boolean column.
+func (b *Builder) AppendBool(v bool) {
+	if !b.check(TypeBool) {
+		return
+	}
+	if v {
+		b.push(1)
+		return
+	}
+	b.push(0)
+}
+
+// AppendNull adds a row with no value. It is legal on every type.
+func (b *Builder) AppendNull() {
+	if b.err != nil {
+		return
+	}
+	if b.present == nil {
+		b.present = NewBitmap(0)
+	}
+	b.nulls = true
+	b.push(0)
+	// push already marked the row present, and a null is the one row that is
+	// not.
+	b.present.Clear(b.rows - 1)
+}
+
+func (b *Builder) check(want Type) bool {
+	if b.err != nil {
+		return false
+	}
+	if b.typ != want {
+		b.err = fmt.Errorf("%w: appended a %s to a %s column", ErrType, want, b.typ)
+		return false
+	}
+	return true
+}
+
+func (b *Builder) push(code uint64) {
+	if b.rows >= maxRows {
+		b.err = fmt.Errorf("%w: %d is the most a column can hold", ErrRows, maxRows)
+		return
+	}
+	b.codes = append(b.codes, code)
+	b.rows++
+	if b.present != nil {
+		b.growPresence()
+		b.present.Set(b.rows - 1)
+	}
+}
+
+// growPresence extends the presence bitmap to cover every row appended so far,
+// including the ones that arrived before the first null.
+func (b *Builder) growPresence() {
+	if b.present.Len() >= b.rows {
+		return
+	}
+	next := NewBitmap(max(b.rows, 2*b.present.Len()))
+	copy(next.words, b.present.words)
+	// Every row before the first null had a value, and none of them set a bit
+	// because there was no bitmap yet.
+	for i := b.present.Len(); i < b.rows-1; i++ {
+		next.Set(i)
+	}
+	b.present = next
+}
+
+// Build encodes the column.
+//
+// It picks the encoding by measuring both and keeping the smaller, which is the
+// only honest way to choose: a column of a thousand rows in four runs wants run
+// lengths, the same column shuffled wants packing, and nothing about the schema
+// says which one arrived.
+func (b *Builder) Build() ([]byte, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+
+	codes, base, entries, dict := b.encode()
+	var maxCode uint64
+	for _, c := range codes {
+		maxCode = max(maxCode, c)
+	}
+	bits, _ := width(maxCode)
+
+	runs, runBytes := b.runs(codes)
+	encoding := EncodingPlain
+	body := codeBytes(b.rows, bits)
+	if runBytes <= body {
+		encoding, body = EncodingRuns, runBytes
+	}
+
+	presence := 0
+	if b.nulls {
+		presence = ((b.rows + 63) / 64) * 8
+	}
+
+	out := make([]byte, headerSize, headerSize+presence+body+len(dict))
+	out[offVersion] = Version
+	out[offType] = uint8(b.typ)
+	out[offEncoding] = uint8(encoding)
+	out[offBits] = bits
+	le.PutUint32(out[offRows:], uint32(b.rows))
+	le.PutUint32(out[offEntries:], uint32(entries))
+	if b.nulls {
+		out[offFlags] = flagNulls
+	}
+	le.PutUint64(out[offBase:], uint64(base))
+
+	if b.nulls {
+		for i := range presence / 8 {
+			out = le.AppendUint64(out, b.present.words[i])
+		}
+	}
+
+	if encoding == EncodingRuns {
+		out = le.AppendUint32(out, uint32(len(runs)))
+		for _, r := range runs {
+			out = binary.AppendUvarint(out, r.code)
+			out = binary.AppendUvarint(out, uint64(r.length))
+		}
+	} else {
+		out = appendPacked(out, codes, bits)
+	}
+
+	return append(out, dict...), nil
+}
+
+// encode turns the collected values into their final codes, and returns the
+// base that was subtracted, the dictionary size and the encoded dictionary.
+func (b *Builder) encode() (codes []uint64, base int64, entries int, dict []byte) {
+	if b.typ == TypeString {
+		return b.encodeStrings()
+	}
+	if b.typ == TypeBool || b.rows == 0 {
+		return b.codes, 0, 0, nil
+	}
+	// The smallest value present, which becomes zero. Nulls are skipped: a
+	// column whose only null happens to sit at a placeholder of zero should not
+	// have its base dragged down to zero along with it.
+	first := true
+	var lo int64
+	for i, c := range b.codes {
+		if b.nulls && !b.present.Get(i) {
+			continue
+		}
+		if v := int64(c); first || v < lo {
+			lo, first = v, false
+		}
+	}
+	if first {
+		// Every row is null, so there is nothing to offset against.
+		return b.codes, 0, 0, nil
+	}
+	out := make([]uint64, len(b.codes))
+	for i, c := range b.codes {
+		if b.nulls && !b.present.Get(i) {
+			continue
+		}
+		out[i] = c - uint64(lo)
+	}
+	return out, lo, 0, nil
+}
+
+// encodeStrings sorts the dictionary and remaps every row onto a rank in it.
+//
+// The sort is what makes a prefix or a range on a string column a range on
+// codes, so the scan loop underneath is the same one the numeric columns use
+// and it never touches a byte of text.
+func (b *Builder) encodeStrings() (codes []uint64, base int64, entries int, dict []byte) {
+	sorted := slices.Clone(b.terms)
+	slices.Sort(sorted)
+
+	rank := make([]uint64, len(b.terms))
+	for i, s := range sorted {
+		rank[b.ids[s]] = uint64(i)
+	}
+	out := make([]uint64, len(b.codes))
+	for i, id := range b.codes {
+		out[i] = rank[id]
+	}
+
+	// Offsets first, then the bytes. The offsets are cumulative and there is one
+	// more of them than there are entries, so the length of the last one needs
+	// no special case in the reader.
+	blob := 0
+	for _, s := range sorted {
+		blob += len(s)
+	}
+	dict = make([]byte, 0, 4*(len(sorted)+1)+blob)
+	at := uint32(0)
+	for _, s := range sorted {
+		dict = le.AppendUint32(dict, at)
+		at += uint32(len(s))
+	}
+	dict = le.AppendUint32(dict, at)
+	for _, s := range sorted {
+		dict = append(dict, s...)
+	}
+	return out, 0, len(sorted), dict
+}
+
+type run struct {
+	code   uint64
+	length int
+}
+
+// runs collapses the codes into runs and reports what encoding them would cost.
+// It is called before the encoding is chosen, so it does the counting whether
+// or not the answer is used.
+func (b *Builder) runs(codes []uint64) (out []run, encoded int) {
+	if len(codes) == 0 {
+		return nil, 4
+	}
+	out = []run{{code: codes[0], length: 1}}
+	for _, c := range codes[1:] {
+		if last := &out[len(out)-1]; last.code == c {
+			last.length++
+			continue
+		}
+		out = append(out, run{code: c, length: 1})
+	}
+	encoded = 4
+	for _, r := range out {
+		encoded += uvarintLen(r.code) + uvarintLen(uint64(r.length))
+	}
+	return out, encoded
+}
+
+func uvarintLen(v uint64) int {
+	n := 1
+	for v >= 0x80 {
+		v >>= 7
+		n++
+	}
+	return n
+}
+
+// appendPacked writes the codes at a fixed width, least significant bit first,
+// and pads the end so a reader may always load eight bytes at the byte a code
+// starts in.
+func appendPacked(out []byte, codes []uint64, bits uint8) []byte {
+	if bits == 0 {
+		return out
+	}
+	at := len(out)
+	out = append(out, make([]byte, codeBytes(len(codes), bits))...)
+	// No code ever straddles the eight bytes written here. A width up to
+	// maxPackedBits leaves room for the seven bits of offset it can start at,
+	// and the only wider width is the full sixty four, where every code starts
+	// on a byte. That is what maxPackedBits is for, and it is why this is one
+	// read, one or, one write.
+	for i, c := range codes {
+		p := uint(i) * uint(bits)
+		j := at + int(p>>3)
+		le.PutUint64(out[j:], le.Uint64(out[j:])|c<<(p&7))
+	}
+	return out
+}

--- a/store/column/column.go
+++ b/store/column/column.go
@@ -1,0 +1,187 @@
+// Package column encodes a segment's columns and scans them into bitmaps.
+//
+// A column is one field across every row of a segment: the source a document
+// came from, the time it was modified, its author, whether it is archived. The
+// query path reads columns for two things, filtering and faceting, and both of
+// them want the same shape of answer. Which rows match. Not the rows
+// themselves, which is the point: a filter that materialises a row before
+// deciding whether to keep it has paid for every row it is about to discard,
+// and on a corpus where a filter cuts a million rows to a thousand that is
+// three orders of magnitude of wasted decoding.
+//
+// So a scan returns a [Bitmap], and the permission filter is an AND against
+// another one. Only what survives both gets read.
+//
+// # One physical representation
+//
+// Every type is stored as a sequence of unsigned integer codes, and the codes
+// are in the same order as the values they stand for. That single decision is
+// what keeps this package small:
+//
+//   - A string column has a dictionary of its distinct values, sorted, and the
+//     code is a rank in it. Equality, set membership and prefix all resolve
+//     against the dictionary first, so a scan compares integers and never looks
+//     at a string.
+//   - An integer or time column subtracts the smallest value it saw and stores
+//     the difference. A column of timestamps a week apart needs the bits to
+//     tell a week apart, not the bits to hold a Unix epoch.
+//   - A boolean column is one bit.
+//
+// Because the codes preserve order, a range on values is a range on codes for
+// every type, including strings. There is one scan loop underneath all of it.
+//
+// # Two encodings
+//
+// Plain packs the codes at the narrowest width that fits: a thousand distinct
+// values is ten bits a row, not a string and not a pointer. Runs stores each
+// value once with a length, for the columns that arrive sorted or nearly so,
+// which in a search index is most of the interesting ones.
+//
+// The builder measures both and keeps the smaller. There is no knob, because
+// the builder has the data in front of it and the caller does not.
+//
+// # Nulls
+//
+// A null is absence, not a value, so it does not get a code. Columns that have
+// any carry a presence bitmap, and every scan intersects with it. A null never
+// matches a predicate, including a range that would contain whatever the
+// placeholder happens to be, and [Column.Nulls] is how you ask for them
+// deliberately.
+package column
+
+import (
+	"encoding/binary"
+	"errors"
+	"strconv"
+)
+
+// Version is the encoding this package writes. A reader that meets a version it
+// does not know refuses the bytes rather than guessing at them, the same way
+// the segment format does.
+const Version uint8 = 1
+
+// Type is what a column holds.
+type Type uint8
+
+// The supported types. A search index needs to filter on which source a
+// document came from, when it changed, who owns it and whether it is archived,
+// and that is a string, a time, a string and a boolean.
+const (
+	TypeString Type = 1
+	TypeInt    Type = 2
+	TypeTime   Type = 3
+	TypeBool   Type = 4
+)
+
+func (t Type) String() string {
+	switch t {
+	case TypeString:
+		return "string"
+	case TypeInt:
+		return "int"
+	case TypeTime:
+		return "time"
+	case TypeBool:
+		return "bool"
+	}
+	return "type(" + strconv.Itoa(int(t)) + ")"
+}
+
+func (t Type) known() bool {
+	return t == TypeString || t == TypeInt || t == TypeTime || t == TypeBool
+}
+
+// Encoding is how the codes are laid out. It is chosen by the builder from the
+// data rather than by the caller, and it is on the reader only so that a
+// benchmark and a size report can say which one they got.
+type Encoding uint8
+
+// The supported encodings.
+const (
+	// EncodingPlain packs every code at a fixed width.
+	EncodingPlain Encoding = 1
+	// EncodingRuns stores each value once with the number of rows it covers.
+	EncodingRuns Encoding = 2
+)
+
+func (e Encoding) String() string {
+	switch e {
+	case EncodingPlain:
+		return "plain"
+	case EncodingRuns:
+		return "runs"
+	}
+	return "encoding(" + strconv.Itoa(int(e)) + ")"
+}
+
+// The errors this package returns. They are distinct because they mean
+// different things to an operator: a version is a column written by something
+// newer, a format error is bytes that were damaged or were never a column, and
+// a type error is a query asking a string column for a date range.
+var (
+	ErrVersion = errors.New("column: unknown version")
+	ErrFormat  = errors.New("column: malformed")
+	ErrType    = errors.New("column: wrong type for this predicate")
+	ErrRows    = errors.New("column: too many rows")
+)
+
+// The header. Fixed size, at the front, and the version is the first byte so a
+// reader can refuse an unknown one before it has interpreted anything else.
+const headerSize = 24
+
+const (
+	offVersion  = 0  // uint8
+	offType     = 1  // uint8
+	offEncoding = 2  // uint8
+	offBits     = 3  // uint8, width of a packed code
+	offRows     = 4  // uint32
+	offEntries  = 8  // uint32, dictionary entries, zero unless the type is string
+	offFlags    = 12 // uint8
+	offReserved = 13 // three bytes, must be zero
+	offBase     = 16 // int64, subtracted from every value before it was packed
+)
+
+// flagNulls says a presence bitmap follows the header.
+const flagNulls = 1 << 0
+
+// maxRows is what fits in the header's row count. It is far above any segment
+// this will ever hold, and it is checked anyway, because the alternative is a
+// silent wrap that produces a column claiming to be short.
+const maxRows = 1<<32 - 1
+
+// maxPackedBits is the widest a packed code may be short of the full sixty four.
+//
+// A code is read by loading eight bytes at the byte its first bit lives in and
+// shifting, so the code has to end inside those bytes: seven bits of offset
+// plus the width has to stay within sixty four. Anything wider than this is
+// stored at the full width, where the packing is byte aligned and the question
+// does not arise. It takes a column of more than a hundred quintillion distinct
+// values to reach that, so this costs nothing and removes a case.
+const maxPackedBits = 57
+
+var le = binary.LittleEndian
+
+// width returns the number of bits needed to hold every code up to max, and the
+// mask that extracts one.
+func width(largest uint64) (bits uint8, mask uint64) {
+	for largest > 0 {
+		bits++
+		largest >>= 1
+	}
+	if bits > maxPackedBits {
+		bits = 64
+	}
+	if bits >= 64 {
+		return 64, ^uint64(0)
+	}
+	return bits, 1<<bits - 1
+}
+
+// codeBytes is the size of a plain codes section, including the eight bytes of
+// slack the reader's eight byte load needs at the end.
+func codeBytes(rows int, bits uint8) int {
+	if bits == 0 {
+		return 0
+	}
+	return (rows*int(bits)+7)/8 + 8
+}

--- a/store/column/column_test.go
+++ b/store/column/column_test.go
@@ -1,0 +1,611 @@
+package column_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/store/column"
+)
+
+// The four boxes on the issue, in order: every type round trips including
+// nulls, a dictionary column is an order of magnitude smaller than the raw
+// strings, scans produce bitmaps the permission filter intersects directly, and
+// the throughput per type is measured in bench_test.go.
+
+func TestAStringColumnRoundTrips(t *testing.T) {
+	want := []string{"github", "slack", "drive", "github", "", "drive", "zzz", "a"}
+	b := column.NewBuilder(column.TypeString)
+	for _, s := range want {
+		b.AppendString(s)
+	}
+	c := open(t, b)
+
+	if got := c.Rows(); got != len(want) {
+		t.Fatalf("the column has %d rows and %d went in", got, len(want))
+	}
+	for i, w := range want {
+		got, ok := c.StringAt(i)
+		if !ok || got != w {
+			t.Errorf("row %d is %q %v and should be %q", i, got, ok, w)
+		}
+	}
+	if got := c.Dict(); !slices.Equal(got, []string{"", "a", "drive", "github", "slack", "zzz"}) {
+		t.Errorf("the dictionary is %q, which is either not distinct or not sorted", got)
+	}
+}
+
+func TestAnIntColumnRoundTrips(t *testing.T) {
+	want := []int64{0, -1, 1, math.MinInt64, math.MaxInt64, 42, -42}
+	b := column.NewBuilder(column.TypeInt)
+	for _, v := range want {
+		b.AppendInt(v)
+	}
+	c := open(t, b)
+	for i, w := range want {
+		got, ok := c.IntAt(i)
+		if !ok || got != w {
+			t.Errorf("row %d is %d %v and should be %d", i, got, ok, w)
+		}
+	}
+}
+
+func TestATimeColumnRoundTripsToTheMillisecond(t *testing.T) {
+	base := time.Date(2026, 8, 20, 9, 30, 0, 0, time.UTC)
+	want := []time.Time{base, base.Add(time.Hour), base.AddDate(-3, 0, 0), base.Add(1500 * time.Microsecond), {}}
+	b := column.NewBuilder(column.TypeTime)
+	for _, v := range want {
+		b.AppendTime(v)
+	}
+	c := open(t, b)
+	for i, w := range want {
+		got, ok := c.TimeAt(i)
+		if !ok || !got.Equal(w.Truncate(time.Millisecond)) {
+			t.Errorf("row %d is %s %v and should be %s to the millisecond", i, got, ok, w)
+		}
+	}
+}
+
+func TestABoolColumnRoundTrips(t *testing.T) {
+	want := []bool{true, false, false, true, true}
+	b := column.NewBuilder(column.TypeBool)
+	for _, v := range want {
+		b.AppendBool(v)
+	}
+	c := open(t, b)
+	for i, w := range want {
+		got, ok := c.BoolAt(i)
+		if !ok || got != w {
+			t.Errorf("row %d is %v %v and should be %v", i, got, ok, w)
+		}
+	}
+	// One bit a row, and five rows is well inside the padding, so this is
+	// really a check that a boolean column does not reserve a byte per row.
+	if c.Bits() != 1 {
+		t.Errorf("a boolean column packs at %d bits a row", c.Bits())
+	}
+}
+
+func TestAnEmptyColumnIsAColumn(t *testing.T) {
+	for _, typ := range []column.Type{column.TypeString, column.TypeInt, column.TypeTime, column.TypeBool} {
+		c := open(t, column.NewBuilder(typ))
+		if c.Rows() != 0 || c.Type() != typ {
+			t.Errorf("an empty %s column came back as %d rows of %s", typ, c.Rows(), c.Type())
+		}
+		if !c.Nulls().Empty() || !c.Present().Empty() {
+			t.Errorf("an empty %s column has rows in it", typ)
+		}
+	}
+}
+
+// TestNullsRoundTripAndNeverMatch is the half of the first box that is easy to
+// get wrong. A null carries a placeholder code, and a range predicate that
+// happens to contain the placeholder must still not match the row.
+func TestNullsRoundTripAndNeverMatch(t *testing.T) {
+	b := column.NewBuilder(column.TypeInt)
+	b.AppendInt(5)
+	b.AppendNull()
+	b.AppendInt(7)
+	b.AppendNull()
+	c := open(t, b)
+
+	if _, ok := c.IntAt(1); ok {
+		t.Error("a null row came back with a value")
+	}
+	if got, ok := c.IntAt(2); !ok || got != 7 {
+		t.Errorf("the row after a null is %d %v and should be 7", got, ok)
+	}
+	if got := c.Nulls().Rows(); !slices.Equal(got, []int{1, 3}) {
+		t.Errorf("the null rows are %v and should be 1 and 3", got)
+	}
+	if got := c.Present().Rows(); !slices.Equal(got, []int{0, 2}) {
+		t.Errorf("the rows with a value are %v and should be 0 and 2", got)
+	}
+	// The base is five, so a null's placeholder code of zero stands for five.
+	// A range that contains five must not pick up the nulls.
+	rows := match(t, func() (*column.Bitmap, error) { return c.MatchInts(math.MinInt64, math.MaxInt64) })
+	if got := rows.Rows(); !slices.Equal(got, []int{0, 2}) {
+		t.Errorf("a range over everything matched %v, which includes a row with no value", got)
+	}
+}
+
+func TestANullBeforeAnyValueIsStillANull(t *testing.T) {
+	b := column.NewBuilder(column.TypeString)
+	b.AppendNull()
+	b.AppendString("drive")
+	c := open(t, b)
+	if got := c.Nulls().Rows(); !slices.Equal(got, []int{0}) {
+		t.Errorf("the null rows are %v and should be just 0", got)
+	}
+	if got, ok := c.StringAt(1); !ok || got != "drive" {
+		t.Errorf("row 1 is %q %v", got, ok)
+	}
+}
+
+func TestAColumnOfNothingButNulls(t *testing.T) {
+	b := column.NewBuilder(column.TypeTime)
+	for range 100 {
+		b.AppendNull()
+	}
+	c := open(t, b)
+	if got := c.Nulls().Count(); got != 100 {
+		t.Errorf("%d of the hundred rows are null", got)
+	}
+	rows := match(t, func() (*column.Bitmap, error) {
+		return c.MatchTimes(time.Unix(0, 0), time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC))
+	})
+	if !rows.Empty() {
+		t.Errorf("a range matched %d rows of a column that has no values", rows.Count())
+	}
+}
+
+// TestADictionaryColumnIsAnOrderOfMagnitudeSmaller is the issue's second box: a
+// thousand distinct values over a million rows against the raw strings.
+func TestADictionaryColumnIsAnOrderOfMagnitudeSmaller(t *testing.T) {
+	const rows, distinct = 1_000_000, 1000
+
+	values := make([]string, distinct)
+	for i := range values {
+		values[i] = fmt.Sprintf("engineering/platform/service-%04d", i)
+	}
+	// Shuffled on purpose. Sorted input would be run length encoded and the
+	// number would be a hundred times better and would prove nothing about the
+	// dictionary, which is what this box is about.
+	r := rand.New(rand.NewPCG(2121, 7))
+	b := column.NewBuilder(column.TypeString)
+	raw := 0
+	for range rows {
+		v := values[r.IntN(distinct)]
+		b.AppendString(v)
+		raw += len(v)
+	}
+	c := open(t, b)
+
+	if c.Encoding() != column.EncodingPlain {
+		t.Fatalf("a shuffled column was encoded as %s, so this is not measuring the dictionary", c.Encoding())
+	}
+	ratio := float64(raw) / float64(c.Size())
+	t.Logf("%d bytes of strings became %d bytes at %d bits a row, which is %.1fx", raw, c.Size(), c.Bits(), ratio)
+	if ratio < 10 {
+		t.Errorf("the encoded column is %.1fx smaller than the raw strings and the bar is 10x", ratio)
+	}
+	// A thousand distinct values needs ten bits and nothing says it needs
+	// eleven. This is the check that the width came from the cardinality.
+	if c.Bits() != 10 {
+		t.Errorf("a thousand distinct values packed at %d bits a row", c.Bits())
+	}
+}
+
+// TestASortedColumnIsRunLengthEncoded is the other half of the encoding
+// decision. Nothing asks for it, the builder measures both and keeps the
+// smaller.
+func TestASortedColumnIsRunLengthEncoded(t *testing.T) {
+	b := column.NewBuilder(column.TypeString)
+	for _, s := range []string{"drive", "github", "slack"} {
+		for range 10_000 {
+			b.AppendString(s)
+		}
+	}
+	c := open(t, b)
+	if c.Encoding() != column.EncodingRuns {
+		t.Fatalf("thirty thousand rows in three runs were encoded as %s", c.Encoding())
+	}
+	if c.Size() > 200 {
+		t.Errorf("three runs and three dictionary entries came to %d bytes", c.Size())
+	}
+	for i, want := range map[int]string{0: "drive", 9_999: "drive", 10_000: "github", 29_999: "slack"} {
+		if got, ok := c.StringAt(i); !ok || got != want {
+			t.Errorf("row %d of the run encoded column is %q %v and should be %q", i, got, ok, want)
+		}
+	}
+}
+
+func TestAColumnOfOneValueStoresNoCodesAtAll(t *testing.T) {
+	b := column.NewBuilder(column.TypeInt)
+	for range 100_000 {
+		b.AppendInt(1755680000)
+	}
+	c := open(t, b)
+	if c.Bits() != 0 {
+		t.Errorf("a column with one distinct value packs at %d bits a row", c.Bits())
+	}
+	if c.Size() > 64 {
+		t.Errorf("a hundred thousand copies of one number came to %d bytes", c.Size())
+	}
+	rows := match(t, func() (*column.Bitmap, error) { return c.MatchInts(1755680000, 1755680000) })
+	if got := rows.Count(); got != 100_000 {
+		t.Errorf("%d of a hundred thousand identical rows matched their own value", got)
+	}
+	rows = match(t, func() (*column.Bitmap, error) { return c.MatchInts(0, 5) })
+	if !rows.Empty() {
+		t.Errorf("%d rows matched a range that does not contain their value", rows.Count())
+	}
+}
+
+// TestAScanAgreesWithWalkingTheRows is the one that would catch a bit packing
+// mistake, an off by one in a run, or a range that is exclusive at one end. It
+// builds the same data under both encodings and compares every predicate
+// against the answer you get by looking at each value in turn.
+func TestAScanAgreesWithWalkingTheRows(t *testing.T) {
+	const rows = 5000
+	r := rand.New(rand.NewPCG(2121, 3))
+	terms := []string{"", "a", "drive", "github", "github-enterprise", "slack", "zz"}
+
+	for _, sorted := range []bool{false, true} {
+		name := "shuffled"
+		if sorted {
+			name = "sorted"
+		}
+		t.Run(name, func(t *testing.T) {
+			values := make([]string, rows)
+			nulls := make([]bool, rows)
+			for i := range values {
+				values[i] = terms[r.IntN(len(terms))]
+				nulls[i] = r.IntN(10) == 0
+			}
+			if sorted {
+				slices.Sort(values)
+			}
+
+			b := column.NewBuilder(column.TypeString)
+			for i, v := range values {
+				if nulls[i] {
+					b.AppendNull()
+					continue
+				}
+				b.AppendString(v)
+			}
+			c := open(t, b)
+
+			check := func(what string, got *column.Bitmap, want func(string) bool) {
+				t.Helper()
+				expect := column.NewBitmap(rows)
+				for i, v := range values {
+					if !nulls[i] && want(v) {
+						expect.Set(i)
+					}
+				}
+				if !got.Equal(expect) {
+					t.Errorf("%s matched %d rows and walking them gives %d", what, got.Count(), expect.Count())
+				}
+			}
+
+			for _, v := range append(slices.Clone(terms), "nothing", "githu", "githubb") {
+				check("equals "+v, match(t, func() (*column.Bitmap, error) { return c.MatchStrings(v) }),
+					func(s string) bool { return s == v })
+				check("prefix "+v, match(t, func() (*column.Bitmap, error) { return c.MatchPrefix(v) }),
+					func(s string) bool { return strings.HasPrefix(s, v) })
+			}
+			set := []string{"drive", "slack", "nothing"}
+			check("one of", match(t, func() (*column.Bitmap, error) { return c.MatchStrings(set...) }),
+				func(s string) bool { return slices.Contains(set, s) })
+			check("no values at all", match(t, func() (*column.Bitmap, error) { return c.MatchStrings() }),
+				func(string) bool { return false })
+			check("every value", match(t, func() (*column.Bitmap, error) { return c.MatchPrefix("") }),
+				func(string) bool { return true })
+		})
+	}
+}
+
+func TestAnIntScanAgreesWithWalkingTheRows(t *testing.T) {
+	const rows = 5000
+	r := rand.New(rand.NewPCG(2121, 11))
+	values := make([]int64, rows)
+	for i := range values {
+		values[i] = int64(r.IntN(300)) - 100
+	}
+
+	b := column.NewBuilder(column.TypeInt)
+	for _, v := range values {
+		b.AppendInt(v)
+	}
+	c := open(t, b)
+
+	for _, span := range [][2]int64{
+		{-100, 199}, {0, 0}, {-1000, 1000}, {50, 40}, {-500, -200}, {200, 500}, {-100, -100}, {199, 199}, {math.MinInt64, math.MaxInt64},
+	} {
+		expect := column.NewBitmap(rows)
+		for i, v := range values {
+			if v >= span[0] && v <= span[1] {
+				expect.Set(i)
+			}
+		}
+		got := match(t, func() (*column.Bitmap, error) { return c.MatchInts(span[0], span[1]) })
+		if !got.Equal(expect) {
+			t.Errorf("[%d, %d] matched %d rows and walking them gives %d", span[0], span[1], got.Count(), expect.Count())
+		}
+	}
+}
+
+// TestAPermissionFilterIsAnIntersection is the issue's third box. The scan
+// hands back a bitmap and the ACL hands back a bitmap, and the answer is what
+// survives both without either side knowing about the other.
+func TestAPermissionFilterIsAnIntersection(t *testing.T) {
+	b := column.NewBuilder(column.TypeString)
+	for i := range 1000 {
+		b.AppendString([]string{"drive", "github", "slack"}[i%3])
+	}
+	c := open(t, b)
+
+	rows := match(t, func() (*column.Bitmap, error) { return c.MatchStrings("github") })
+	if got := rows.Count(); got != 333 {
+		t.Fatalf("the filter matched %d rows and there are 333 of them", got)
+	}
+
+	// Everything a principal may read. In the real thing this comes out of the
+	// ACL section of the segment.
+	allowed := column.NewBitmap(1000)
+	allowed.SetRange(0, 100)
+
+	rows.And(allowed)
+	for _, row := range rows.Rows() {
+		if row >= 100 {
+			t.Fatalf("row %d survived the intersection and is not allowed", row)
+		}
+		if v, _ := c.StringAt(row); v != "github" {
+			t.Fatalf("row %d survived the intersection and is %q", row, v)
+		}
+	}
+	if got := rows.Count(); got != 33 {
+		t.Errorf("%d rows are both github and allowed, and 33 of the first hundred are github", got)
+	}
+}
+
+func TestTheSameValuesProduceTheSameBytes(t *testing.T) {
+	build := func() []byte {
+		b := column.NewBuilder(column.TypeString)
+		// Appended out of order on purpose. The dictionary is sorted before it
+		// is written, so the order the values first arrived in must not survive
+		// into the bytes.
+		for _, s := range []string{"slack", "drive", "github", "drive", "slack"} {
+			b.AppendString(s)
+		}
+		out, err := b.Build()
+		if err != nil {
+			t.Fatalf("building: %v", err)
+		}
+		return out
+	}
+	if a, c := build(), build(); !bytes.Equal(a, c) {
+		t.Error("two builds of the same values produced different bytes")
+	}
+}
+
+func TestAppendingTheWrongTypeIsRefused(t *testing.T) {
+	b := column.NewBuilder(column.TypeString)
+	b.AppendString("drive")
+	b.AppendInt(3)
+	if _, err := b.Build(); !errors.Is(err, column.ErrType) {
+		t.Errorf("building a column with an integer appended to it gave %v", err)
+	}
+}
+
+func TestAnUnknownTypeIsRefusedAtTheBuilder(t *testing.T) {
+	if _, err := column.NewBuilder(column.Type(77)).Build(); !errors.Is(err, column.ErrType) {
+		t.Errorf("a builder for type 77 gave %v", err)
+	}
+}
+
+func TestOpenRefusesWhatItCannotRead(t *testing.T) {
+	good := populated(t)
+
+	cases := []struct {
+		name string
+		want error
+		edit func([]byte)
+	}{
+		{"a version from the future", column.ErrVersion, func(b []byte) { b[0] = 2 }},
+		{"a version from the past", column.ErrVersion, func(b []byte) { b[0] = 0 }},
+		{"a type nobody defined", column.ErrFormat, func(b []byte) { b[1] = 77 }},
+		{"an encoding nobody defined", column.ErrFormat, func(b []byte) { b[2] = 9 }},
+		{"a width that cannot be read back", column.ErrFormat, func(b []byte) { b[3] = 60 }},
+		{"a flag this version does not define", column.ErrFormat, func(b []byte) { b[12] = 0x80 }},
+		{"a reserved byte that is not zero", column.ErrFormat, func(b []byte) { b[13] = 1 }},
+		{"more rows than there are codes", column.ErrFormat, func(b []byte) { b[4] = 0xff }},
+		{"a dictionary larger than the bytes", column.ErrFormat, func(b []byte) { b[8] = 0xff }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := bytes.Clone(good)
+			tc.edit(b)
+			c, err := column.Open(b)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("opening gave %v (column %v) and should have given %v", err, c, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrailingBytesAreRefused(t *testing.T) {
+	b := append(populated(t), 0)
+	if _, err := column.Open(b); !errors.Is(err, column.ErrFormat) {
+		t.Errorf("a column with a byte stuck on the end opened with %v", err)
+	}
+}
+
+// TestTruncationIsAnErrorAndNeverAPanic cuts the bytes at every length. None of
+// them is a column and none of them may take the process down, because these
+// bytes come off a disk that may have been anything at all.
+func TestTruncationIsAnErrorAndNeverAPanic(t *testing.T) {
+	good := populated(t)
+	for n := range len(good) {
+		if _, err := column.Open(good[:n]); err == nil {
+			t.Fatalf("the first %d bytes of a %d byte column opened cleanly", n, len(good))
+		}
+	}
+}
+
+// TestEveryRowIsReachableUnderBothEncodings covers the random access path,
+// which for the run encoding is a search rather than a shift and is the one
+// place the two encodings do genuinely different work.
+func TestEveryRowIsReachableUnderBothEncodings(t *testing.T) {
+	r := rand.New(rand.NewPCG(2121, 5))
+	for _, sorted := range []bool{false, true} {
+		values := make([]int64, 2000)
+		for i := range values {
+			values[i] = int64(r.IntN(50))
+		}
+		if sorted {
+			slices.Sort(values)
+		}
+		b := column.NewBuilder(column.TypeInt)
+		for _, v := range values {
+			b.AppendInt(v)
+		}
+		c := open(t, b)
+		want := column.EncodingPlain
+		if sorted {
+			want = column.EncodingRuns
+		}
+		if c.Encoding() != want {
+			t.Fatalf("sorted=%v was encoded as %s and should have been %s", sorted, c.Encoding(), want)
+		}
+		for i, v := range values {
+			if got, ok := c.IntAt(i); !ok || got != v {
+				t.Fatalf("%s row %d is %d %v and should be %d", c.Encoding(), i, got, ok, v)
+			}
+		}
+		if _, ok := c.IntAt(-1); ok {
+			t.Error("row -1 has a value")
+		}
+		if _, ok := c.IntAt(len(values)); ok {
+			t.Error("the row after the last one has a value")
+		}
+	}
+}
+
+func TestAPredicateAgainstTheWrongTypeIsRefused(t *testing.T) {
+	str := open(t, appendAll(column.NewBuilder(column.TypeString), func(b *column.Builder) { b.AppendString("drive") }))
+	num := open(t, appendAll(column.NewBuilder(column.TypeInt), func(b *column.Builder) { b.AppendInt(1) }))
+
+	for _, call := range []struct {
+		what string
+		run  func() (*column.Bitmap, error)
+	}{
+		{"strings against an int column", func() (*column.Bitmap, error) { return num.MatchStrings("drive") }},
+		{"a prefix against an int column", func() (*column.Bitmap, error) { return num.MatchPrefix("d") }},
+		{"an int range against a string column", func() (*column.Bitmap, error) { return str.MatchInts(0, 1) }},
+		{"a time range against a string column", func() (*column.Bitmap, error) { return str.MatchTimes(time.Time{}, time.Now()) }},
+		{"a boolean against a string column", func() (*column.Bitmap, error) { return str.MatchBool(true) }},
+	} {
+		if _, err := call.run(); !errors.Is(err, column.ErrType) {
+			t.Errorf("%s gave %v", call.what, err)
+		}
+	}
+}
+
+// FuzzOpenSurvivesAnything is the same contract the segment format has. These
+// bytes come off a disk, and a reader that panics on a damaged file turns a
+// recoverable segment into an outage.
+func FuzzOpenSurvivesAnything(f *testing.F) {
+	if b, err := buildFuzzSeed(); err == nil {
+		f.Add(b)
+	}
+	f.Add([]byte{})
+	f.Add(make([]byte, 24))
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		c, err := column.Open(b)
+		if err != nil {
+			return
+		}
+		// It opened, so every accessor on it has to be safe for every row and
+		// for a few that are not rows.
+		for i := -2; i < c.Rows()+2; i++ {
+			c.StringAt(i)
+			c.IntAt(i)
+			c.TimeAt(i)
+			c.BoolAt(i)
+			c.CodeAt(i)
+		}
+		c.Dict()
+		c.Nulls()
+		c.Present()
+		_, _ = c.MatchStrings("", "a")
+		_, _ = c.MatchPrefix("a")
+		_, _ = c.MatchInts(math.MinInt64, math.MaxInt64)
+		_, _ = c.MatchTimes(time.Time{}, time.Now())
+		_, _ = c.MatchBool(true)
+	})
+}
+
+func buildFuzzSeed() ([]byte, error) {
+	b := column.NewBuilder(column.TypeString)
+	b.AppendString("drive")
+	b.AppendNull()
+	b.AppendString("github")
+	return b.Build()
+}
+
+// populated is a column with a dictionary, nulls and more than one row, so that
+// every section of the format is present in the bytes a test then damages.
+func populated(t testing.TB) []byte {
+	t.Helper()
+	b := column.NewBuilder(column.TypeString)
+	r := rand.New(rand.NewPCG(2121, 13))
+	for i := range 500 {
+		if i%17 == 0 {
+			b.AppendNull()
+			continue
+		}
+		b.AppendString(fmt.Sprintf("source-%02d", r.IntN(40)))
+	}
+	out, err := b.Build()
+	if err != nil {
+		t.Fatalf("building: %v", err)
+	}
+	return out
+}
+
+func open(t testing.TB, b *column.Builder) *column.Column {
+	t.Helper()
+	encoded, err := b.Build()
+	if err != nil {
+		t.Fatalf("building: %v", err)
+	}
+	c, err := column.Open(encoded)
+	if err != nil {
+		t.Fatalf("opening: %v", err)
+	}
+	return c
+}
+
+func appendAll(b *column.Builder, f func(*column.Builder)) *column.Builder {
+	f(b)
+	return b
+}
+
+func match(t testing.TB, f func() (*column.Bitmap, error)) *column.Bitmap {
+	t.Helper()
+	got, err := f()
+	if err != nil {
+		t.Fatalf("scanning: %v", err)
+	}
+	return got
+}

--- a/store/column/read.go
+++ b/store/column/read.go
@@ -1,0 +1,475 @@
+package column
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Column is an encoded column opened for reading.
+//
+// Open does not copy the bytes it is given, so a column over a mapped segment
+// costs a header parse and nothing else. The one exception is the presence
+// bitmap, which is a word per sixty four rows and is turned into a [Bitmap] so
+// that every scan can intersect with it directly.
+type Column struct {
+	typ      Type
+	encoding Encoding
+	bits     uint8
+	mask     uint64
+	rows     int
+	entries  int
+	base     int64
+	size     int
+
+	present *Bitmap // nil when nothing in the column is null
+
+	codes []byte // the packed encoding
+	runs  []run  // the run length encoding
+	ends  []int  // one past the last row of each run, for random access
+
+	offsets []byte // (entries+1) cumulative uint32 into blob
+	blob    []byte
+}
+
+// Open reads a column out of bytes that may be anything at all.
+//
+// The checks are ordered so that the most specific answer comes out first. A
+// version nobody knows is not a malformed column, it is a column written by
+// something newer, and an operator who is told the wrong one of those goes
+// looking in the wrong place.
+func Open(b []byte) (*Column, error) {
+	if len(b) < headerSize {
+		return nil, fmt.Errorf("%w: %d bytes is shorter than the %d byte header", ErrFormat, len(b), headerSize)
+	}
+	if v := b[offVersion]; v != Version {
+		return nil, fmt.Errorf("%w: %d, and this reads %d", ErrVersion, v, Version)
+	}
+
+	c := &Column{
+		typ:      Type(b[offType]),
+		encoding: Encoding(b[offEncoding]),
+		bits:     b[offBits],
+		rows:     int(le.Uint32(b[offRows:])),
+		entries:  int(le.Uint32(b[offEntries:])),
+		base:     int64(le.Uint64(b[offBase:])),
+		size:     len(b),
+	}
+	switch {
+	case !c.typ.known():
+		return nil, fmt.Errorf("%w: %s", ErrFormat, c.typ)
+	case c.encoding != EncodingPlain && c.encoding != EncodingRuns:
+		return nil, fmt.Errorf("%w: %s", ErrFormat, c.encoding)
+	case c.bits > maxPackedBits && c.bits != 64:
+		return nil, fmt.Errorf("%w: %d bits a code cannot be read back", ErrFormat, c.bits)
+	case b[offFlags]&^flagNulls != 0:
+		return nil, fmt.Errorf("%w: flags %#x has a bit this version does not define", ErrFormat, b[offFlags])
+	case b[offReserved] != 0 || b[offReserved+1] != 0 || b[offReserved+2] != 0:
+		return nil, fmt.Errorf("%w: the reserved bytes are not zero", ErrFormat)
+	case c.typ != TypeString && c.entries != 0:
+		return nil, fmt.Errorf("%w: a %s column has a dictionary of %d", ErrFormat, c.typ, c.entries)
+	}
+	if c.bits < 64 {
+		c.mask = 1<<c.bits - 1
+	} else {
+		c.mask = ^uint64(0)
+	}
+
+	rest := b[headerSize:]
+	if b[offFlags]&flagNulls != 0 {
+		words := (c.rows + 63) / 64
+		if len(rest) < words*8 {
+			return nil, fmt.Errorf("%w: the presence bitmap for %d rows does not fit", ErrFormat, c.rows)
+		}
+		c.present = NewBitmap(c.rows)
+		for i := range words {
+			c.present.words[i] = le.Uint64(rest[i*8:])
+		}
+		// A bit set past the last row would be a row that does not exist
+		// claiming to have a value, which nothing downstream would ever look
+		// at but which would make Count disagree with itself.
+		c.present.trim()
+		rest = rest[words*8:]
+	}
+
+	var err error
+	if rest, err = c.readCodes(rest); err != nil {
+		return nil, err
+	}
+	if rest, err = c.readDict(rest); err != nil {
+		return nil, err
+	}
+	if len(rest) != 0 {
+		return nil, fmt.Errorf("%w: %d bytes past the end of the column", ErrFormat, len(rest))
+	}
+	return c, nil
+}
+
+func (c *Column) readCodes(rest []byte) ([]byte, error) {
+	if c.encoding == EncodingPlain {
+		n := codeBytes(c.rows, c.bits)
+		if len(rest) < n {
+			return nil, fmt.Errorf("%w: %d rows at %d bits need %d bytes and there are %d", ErrFormat, c.rows, c.bits, n, len(rest))
+		}
+		c.codes = rest[:n:n]
+		return rest[n:], nil
+	}
+
+	if len(rest) < 4 {
+		return nil, fmt.Errorf("%w: no run count", ErrFormat)
+	}
+	count := int(le.Uint32(rest))
+	rest = rest[4:]
+	// The capacity comes from what is actually there rather than from the
+	// declared count, because the declared count is a number read out of bytes
+	// that may have been written by anything. Every run costs at least two
+	// bytes, so the shorter of the two is a bound the input cannot lie about.
+	c.runs = make([]run, 0, min(count, len(rest)/2))
+	total := 0
+	for range count {
+		code, n := binary.Uvarint(rest)
+		if n <= 0 {
+			return nil, fmt.Errorf("%w: run %d has no code", ErrFormat, len(c.runs))
+		}
+		rest = rest[n:]
+		length, n := binary.Uvarint(rest)
+		if n <= 0 {
+			return nil, fmt.Errorf("%w: run %d has no length", ErrFormat, len(c.runs))
+		}
+		rest = rest[n:]
+		if length == 0 || length > uint64(c.rows-total) {
+			return nil, fmt.Errorf("%w: run %d covers %d rows and %d are left", ErrFormat, len(c.runs), length, c.rows-total)
+		}
+		total += int(length)
+		c.runs = append(c.runs, run{code: code, length: int(length)})
+		c.ends = append(c.ends, total)
+	}
+	if total != c.rows {
+		return nil, fmt.Errorf("%w: the runs cover %d rows and the header says %d", ErrFormat, total, c.rows)
+	}
+	return rest, nil
+}
+
+func (c *Column) readDict(rest []byte) ([]byte, error) {
+	if c.typ != TypeString {
+		return rest, nil
+	}
+	n := 4 * (c.entries + 1)
+	if len(rest) < n {
+		return nil, fmt.Errorf("%w: a dictionary of %d needs %d bytes of offsets and there are %d", ErrFormat, c.entries, n, len(rest))
+	}
+	c.offsets = rest[:n:n]
+	rest = rest[n:]
+
+	blob := int(le.Uint32(c.offsets[n-4:]))
+	if len(rest) < blob {
+		return nil, fmt.Errorf("%w: the dictionary needs %d bytes of text and there are %d", ErrFormat, blob, len(rest))
+	}
+	c.blob = rest[:blob:blob]
+
+	// Offsets are cumulative, so they have to be in order. A reader that
+	// trusted them could be handed a pair that slices backwards, and the whole
+	// point of checking here is that the accessors below then never have to.
+	prev := uint32(0)
+	for i := 1; i <= c.entries; i++ {
+		at := le.Uint32(c.offsets[4*i:])
+		if at < prev {
+			return nil, fmt.Errorf("%w: dictionary offset %d goes backwards", ErrFormat, i)
+		}
+		prev = at
+	}
+	if c.entries > 0 && le.Uint32(c.offsets) != 0 {
+		return nil, fmt.Errorf("%w: the dictionary does not start at zero", ErrFormat)
+	}
+	return rest[blob:], nil
+}
+
+// Type is what the column holds.
+func (c *Column) Type() Type { return c.typ }
+
+// Encoding is how the codes are laid out. A benchmark and a size report want
+// this. A query does not.
+func (c *Column) Encoding() Encoding { return c.encoding }
+
+// Rows is how many rows the column has, nulls included.
+func (c *Column) Rows() int { return c.rows }
+
+// Size is the encoded size in bytes.
+func (c *Column) Size() int { return c.size }
+
+// Bits is the width of a packed code, and zero when every code is the same.
+func (c *Column) Bits() int { return int(c.bits) }
+
+// Dict returns the distinct values of a string column, sorted. It allocates all
+// of them, so it is for a facet listing or a test rather than for a scan.
+func (c *Column) Dict() []string {
+	out := make([]string, c.entries)
+	for i := range out {
+		out[i] = string(c.term(i))
+	}
+	return out
+}
+
+// term returns the dictionary entry as a window into the encoded bytes. The
+// bounds were checked by Open, which is why this does not check them.
+func (c *Column) term(i int) []byte {
+	lo := le.Uint32(c.offsets[4*i:])
+	hi := le.Uint32(c.offsets[4*(i+1):])
+	return c.blob[lo:hi]
+}
+
+// CodeAt returns the row's code and whether the row has a value at all. A code
+// is a dictionary rank on a string column and a value less the column's base on
+// the others, and it is exported so that a facet can tally rows without turning
+// each one back into a value first.
+func (c *Column) CodeAt(row int) (uint64, bool) {
+	if row < 0 || row >= c.rows {
+		return 0, false
+	}
+	if c.present != nil && !c.present.Get(row) {
+		return 0, false
+	}
+	return c.code(row), true
+}
+
+func (c *Column) code(row int) uint64 {
+	if c.encoding == EncodingRuns {
+		i := sort.Search(len(c.ends), func(i int) bool { return c.ends[i] > row })
+		if i == len(c.ends) {
+			return 0
+		}
+		return c.runs[i].code
+	}
+	if c.bits == 0 {
+		return 0
+	}
+	p := uint(row) * uint(c.bits)
+	return (le.Uint64(c.codes[p>>3:]) >> (p & 7)) & c.mask
+}
+
+// StringAt returns the value of a row of a string column, and false when the
+// row is null or the column is not one.
+func (c *Column) StringAt(row int) (string, bool) {
+	code, ok := c.CodeAt(row)
+	if !ok || c.typ != TypeString || code >= uint64(c.entries) {
+		return "", false
+	}
+	return string(c.term(int(code))), true
+}
+
+// IntAt returns the value of a row of an integer column.
+func (c *Column) IntAt(row int) (int64, bool) {
+	code, ok := c.CodeAt(row)
+	if !ok || c.typ != TypeInt {
+		return 0, false
+	}
+	return int64(code + uint64(c.base)), true
+}
+
+// TimeAt returns the value of a row of a time column, in UTC and to the
+// millisecond.
+func (c *Column) TimeAt(row int) (time.Time, bool) {
+	code, ok := c.CodeAt(row)
+	if !ok || c.typ != TypeTime {
+		return time.Time{}, false
+	}
+	return time.UnixMilli(int64(code + uint64(c.base))).UTC(), true
+}
+
+// BoolAt returns the value of a row of a boolean column.
+func (c *Column) BoolAt(row int) (value, ok bool) {
+	code, ok := c.CodeAt(row)
+	if !ok || c.typ != TypeBool {
+		return false, false
+	}
+	return code == 1, true
+}
+
+// Present returns the rows that have a value.
+func (c *Column) Present() *Bitmap {
+	if c.present == nil {
+		out := NewBitmap(c.rows)
+		out.SetRange(0, c.rows)
+		return out
+	}
+	return c.present.Clone()
+}
+
+// Nulls returns the rows that do not. It is the only way a null is ever
+// matched: no predicate returns one, because a missing value is not equal to
+// anything and is not inside any range.
+func (c *Column) Nulls() *Bitmap {
+	out := c.Present()
+	out.Not()
+	return out
+}
+
+// MatchStrings returns the rows whose value is one of these.
+//
+// The values are resolved against the dictionary first, which costs a binary
+// search each, and what the scan then compares is integers. A filter for six
+// sources over a million rows reads no text at all.
+func (c *Column) MatchStrings(vs ...string) (*Bitmap, error) {
+	if c.typ != TypeString {
+		return nil, fmt.Errorf("%w: strings against a %s column", ErrType, c.typ)
+	}
+	set := NewBitmap(c.entries)
+	for _, v := range vs {
+		if i, ok := c.rank([]byte(v)); ok {
+			set.Set(i)
+		}
+	}
+	return c.scan(filter{set: set, empty: set.Empty()}), nil
+}
+
+// MatchPrefix returns the rows whose value starts with the prefix. The
+// dictionary is sorted, so the entries that match are contiguous and the
+// predicate is a range on codes like every other one.
+func (c *Column) MatchPrefix(prefix string) (*Bitmap, error) {
+	if c.typ != TypeString {
+		return nil, fmt.Errorf("%w: a prefix against a %s column", ErrType, c.typ)
+	}
+	p := []byte(prefix)
+	lo := c.search(p)
+	hi := c.entries
+	if up := upper(p); up != nil {
+		hi = c.search(up)
+	}
+	if lo >= hi {
+		return c.scan(filter{empty: true}), nil
+	}
+	return c.scan(filter{lo: uint64(lo), hi: uint64(hi - 1)}), nil
+}
+
+// MatchInts returns the rows whose value is in [lo, hi].
+func (c *Column) MatchInts(lo, hi int64) (*Bitmap, error) {
+	if c.typ != TypeInt {
+		return nil, fmt.Errorf("%w: an integer range against a %s column", ErrType, c.typ)
+	}
+	return c.scan(c.rangeOf(lo, hi)), nil
+}
+
+// MatchTimes returns the rows whose value is in [lo, hi], to the millisecond
+// the column was built with. Both ends are inclusive, which for a date facet is
+// the answer people expect and for an open ended range is what the zero and the
+// far future are for.
+func (c *Column) MatchTimes(lo, hi time.Time) (*Bitmap, error) {
+	if c.typ != TypeTime {
+		return nil, fmt.Errorf("%w: a time range against a %s column", ErrType, c.typ)
+	}
+	return c.scan(c.rangeOf(lo.UnixMilli(), hi.UnixMilli())), nil
+}
+
+// MatchBool returns the rows with that value.
+func (c *Column) MatchBool(v bool) (*Bitmap, error) {
+	if c.typ != TypeBool {
+		return nil, fmt.Errorf("%w: a boolean against a %s column", ErrType, c.typ)
+	}
+	want := uint64(0)
+	if v {
+		want = 1
+	}
+	return c.scan(filter{lo: want, hi: want}), nil
+}
+
+// rangeOf turns a range of values into a range of codes. Every code is the
+// value less the column's base, so the arithmetic is unsigned and a range that
+// starts below the base or ends above the largest value simply clamps.
+func (c *Column) rangeOf(lo, hi int64) filter {
+	if hi < lo || hi < c.base {
+		return filter{empty: true}
+	}
+	f := filter{hi: uint64(hi) - uint64(c.base)}
+	if lo > c.base {
+		f.lo = uint64(lo) - uint64(c.base)
+	}
+	return f
+}
+
+// rank finds a value in the dictionary.
+func (c *Column) rank(v []byte) (int, bool) {
+	i := c.search(v)
+	if i < c.entries && bytes.Equal(c.term(i), v) {
+		return i, true
+	}
+	return 0, false
+}
+
+// search returns the first dictionary entry that is not less than v.
+func (c *Column) search(v []byte) int {
+	return sort.Search(c.entries, func(i int) bool { return bytes.Compare(c.term(i), v) >= 0 })
+}
+
+// upper returns the first byte string that is greater than everything starting
+// with p, or nil when there is none because p is all ones and every string that
+// starts with it sorts at the very end.
+func upper(p []byte) []byte {
+	out := bytes.Clone(p)
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i] != 0xff {
+			out[i]++
+			return out[:i+1]
+		}
+	}
+	return nil
+}
+
+// filter is a predicate reduced to codes: either a range, or a membership set
+// over the dictionary when the predicate names values that are not adjacent.
+type filter struct {
+	lo, hi uint64
+	set    *Bitmap
+	empty  bool
+}
+
+// scan is the one loop. Every predicate in this package comes down to it,
+// because every type is stored as codes in the same order as its values.
+func (c *Column) scan(f filter) *Bitmap {
+	out := NewBitmap(c.rows)
+	if f.empty {
+		return out
+	}
+	switch {
+	case c.encoding == EncodingRuns:
+		at := 0
+		for _, r := range c.runs {
+			if f.has(r.code) {
+				out.SetRange(at, at+r.length)
+			}
+			at += r.length
+		}
+	case c.bits == 0:
+		// Every row holds the same code, so the answer is all of them or none.
+		if f.has(0) {
+			out.SetRange(0, c.rows)
+		}
+	case f.set != nil:
+		n := uint64(f.set.Len())
+		for i := range c.rows {
+			if code := c.code(i); code < n && f.set.Get(int(code)) {
+				out.Set(i)
+			}
+		}
+	default:
+		for i := range c.rows {
+			if code := c.code(i); code >= f.lo && code <= f.hi {
+				out.Set(i)
+			}
+		}
+	}
+	// A null row carries a placeholder code, and a range that happens to
+	// contain it would otherwise match a row that has no value.
+	if c.present != nil {
+		out.And(c.present)
+	}
+	return out
+}
+
+func (f filter) has(code uint64) bool {
+	if f.set != nil {
+		return code < uint64(f.set.Len()) && f.set.Get(int(code))
+	}
+	return code >= f.lo && code <= f.hi
+}


### PR DESCRIPTION
Closes #3.

Second pull request of M1, on top of the segment format that just landed.
The segment says a section is a run of bytes with a kind on it, and this is what goes inside the ones that hold fields.

## What a scan returns

A bitmap of row numbers, and never the rows.

That is the whole design and everything else follows from it.
A filter that materialises a row before deciding whether to keep it has paid for every row it is about to throw away, and on a corpus where a source filter cuts a million rows to a thousand that is three orders of magnitude of decoding nobody asked for.
So a scan hands back which rows matched, the permission model hands back which rows a principal may read, and the answer is the intersection of the two.
Only what survives both is ever turned back into a document.

The bitmap is dense, a bit per row.
A compressed one would win on the selective filters and lose on the ones that match half the segment, and it would put a decoder in front of the single operation on this path that has to be as fast as an AND instruction.

## One physical representation

Every type is stored as a sequence of unsigned integer codes, and the codes are in the same order as the values they stand for.
A string column has a sorted dictionary and the code is a rank in it.
An integer or a time column subtracts the smallest value it saw, so a column of timestamps a week apart needs the bits to tell a week apart rather than the bits to hold a Unix epoch.
A boolean is one bit.

Two things fall out of that.

The first is that a range on values is a range on codes for every type, including strings, because the dictionary is sorted before it is written.
Equality, set membership, prefix, integer range, date range and boolean all come down to the same loop, and it compares integers.
A filter for six sources over a million rows resolves the six against the dictionary first, which costs a binary search each, and then reads no text at all.

The second is that there is one scan loop to make fast rather than six.

## Two encodings and no knob

Plain packs the codes at the narrowest width that fits, which for a thousand distinct sources is ten bits a row.
Runs stores each value once with the number of rows it covers, which is what the columns that arrive sorted want, and in a search index that is most of the interesting ones.

The builder measures both and keeps the smaller.
There is no option for it, because the builder has the data in front of it and the caller does not.
A column of a thousand rows in four runs wants run lengths, the same column shuffled wants packing, and nothing about the schema says which one arrived.

A column whose every value is the same stores no codes at all.
A hundred thousand copies of one timestamp comes to under sixty four bytes.

## Nulls

A null is absence rather than a value, so it does not get a code.
A column that has any carries a presence bitmap and every scan intersects with it.

That case is easy to get wrong quietly, so there is a test for exactly it.
A column holding 5, null, 7, null has a base of five, so the placeholder code of zero that sits under the nulls stands for the value five, and a range over every integer there is has to match two rows rather than four.

## The numbers

A million rows of a thousand distinct values, on an M4:

| Scan | rows a second |
| --- | --- |
| string equality, packed | 526 million |
| string set of four, packed | 537 million |
| string prefix, packed | 441 million |
| integer range, packed | 326 million |
| date range, packed | 195 million |
| boolean, packed | 298 million |
| any of them, run length encoded | above 60 billion |

The gap between the two halves of that table is the argument for measuring both encodings.
A run length scan does work per run rather than per row and fills whole words of the answer at a time, so a column that arrives sorted is read two to three hundred times faster than the same column shuffled.

The size box on the issue asks for an order of magnitude and gets 25.6 times.
Thirty three megabytes of strings encodes to 1.29 megabytes at ten bits a row, and the test fails if that ratio ever drops below ten.
It shuffles its input on purpose, because sorted input would be run length encoded and the number would be a hundred times better while proving nothing about the dictionary.

## Reading bytes that may be anything

Same contract as the segment format, for the same reason.
These bytes come off a disk and a reader that panics on a damaged file turns a recoverable segment into an outage.

`Open` checks the structure before it believes any of it: the declared sizes have to add up to exactly the bytes given with nothing left over, a run's length has to fit in the rows that are left, the runs together have to cover the rows the header claims, and dictionary offsets have to start at zero and never go backwards.
Nothing is allocated from the run count directly, since every run costs at least two bytes and the smaller of the count and half the remaining bytes is a bound the input cannot lie about.

A code that indexes past the end of the dictionary is possible in bytes that were tampered with, because a packed width can hold more values than the dictionary has.
Checking that at open would be a full scan of the column, so it is bounds checked where it is used instead: such a row reads back as having no value and it matches nothing.

`ErrVersion` and `ErrFormat` are separate on purpose.
An operator told "malformed" about a file that is merely from a newer build goes looking in the wrong place.

## How I convinced myself

- `gofmt -s`, `go vet ./...`, `go build ./...`, `go test -count=1 ./...` and `golangci-lint run` are clean.
- Every predicate is checked against the answer you get by walking the rows one at a time and looking at each value, under both encodings, with a tenth of the rows null.
  That is the test that would catch a bit packing mistake, an off by one in a run, or a range that turned out to be exclusive at one end.
- `SetRange` is checked against setting each row individually for every start position across five word boundaries, because it fills whole words and every boundary between them is a chance to be off by one.
- Truncation at every length is an error and never a panic.
- The fuzz target ran twenty million executions with no crash. It opens arbitrary bytes and, when they parse, calls every accessor for every row and a couple that are not rows.
- The benchmarks in the table above are checked in and are what produced it.

## What is deliberately not in here

Facet counts, which are a tally per code over a bitmap rather than a new encoding.
`Dict` and `CodeAt` are exported for that and #69 is where it belongs.

A common divisor for time columns.
A column whose values all sit on an hour boundary spends twenty two bits a row on zeros, which is why the date range is the slowest of the packed scans, and it is the obvious next thing.

Wiring this into the SQLite driver.
The format and its encodings come first and the segment writer is what joins them up, which is #9.

`docs/columns.md` has the layout, the error table and the reasoning.
