### PR TITLE
Make a recording run actually clear the sample override

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,8 +55,14 @@ jobs:
           # shape. A round of two hundred and fifty has a steadier median than a
           # round of forty, so a baseline recorded that way is a baseline every
           # pull request is measured against with a ruler it was not drawn with.
-          GENBA_GATE_SAMPLES: ${{ inputs.record && '' || '2000' }}
-          GENBA_GATE_TOLERANCE: ${{ inputs.record && '' || '1.10' }}
+          #
+          # Zero rather than empty, because an expression whose true branch is
+          # an empty string falls through to the false branch: an empty string
+          # is falsy, so ${{ inputs.record && '' || '2000' }} is 2000 either
+          # way. The gate reads a zero as unset and there is a test that refuses
+          # to record with an override in place.
+          GENBA_GATE_SAMPLES: ${{ inputs.record && '0' || '2000' }}
+          GENBA_GATE_TOLERANCE: ${{ inputs.record && '0' || '1.10' }}
           GENBA_GATE_RECORD: ${{ inputs.record && '1' || '' }}
         run: |
           set -o pipefail

--- a/api/latency_test.go
+++ b/api/latency_test.go
@@ -185,6 +185,19 @@ func TestSearchLatencyGate(t *testing.T) {
 	if os.Getenv("GENBA_GATE") == "" {
 		t.Skip("the latency gate builds the benchmark corpus and measures it, so it is opt in: make bench-gate")
 	}
+	// A recording run has to use the sample count the code derives, because the
+	// figure being written down is the one every pull request will be compared
+	// against and the two have to be the same shape. A round of two hundred and
+	// fifty has a steadier median than a round of forty.
+	//
+	// This is a refusal rather than a note in a comment because it has already
+	// gone wrong once quietly, in a workflow expression that looked like it
+	// cleared the override and did not, and the only sign was a number in a
+	// JSON file that nobody had a reason to read.
+	if os.Getenv("GENBA_GATE_RECORD") != "" && gateEnvInt("GENBA_GATE_SAMPLES") > 0 {
+		t.Fatalf("GENBA_GATE_SAMPLES is %s and this is a recording run, so the baseline would be drawn with a ruler no pull request uses",
+			os.Getenv("GENBA_GATE_SAMPLES"))
+	}
 
 	st, spec := benchcorpus.Fixture(t)
 	// A fixed clock, because the recency prior is part of the score, and a


### PR DESCRIPTION
The nightly baseline recorded on 19 August says `"samples": 2000` for every class.
It should say between three hundred and a thousand, which is what a pull request derives from each class's budget.

#75 was meant to fix exactly this and does not, because of how GitHub Actions evaluates an expression.

```
GENBA_GATE_SAMPLES: ${{ inputs.record && '' || '2000' }}
```

An empty string is falsy in an Actions expression, so `true && ''` is `''`, and `'' || '2000'` is `'2000'`.
The false branch is taken either way and the override is never cleared.
It is the ternary that does not survive a falsy true branch, and the only sign it had gone wrong was a number in a JSON file nobody had a reason to read.

So it sets zero instead, which the gate already reads as unset for both the sample count and the tolerance.

The second half is a refusal in the gate, because a comment saying "do not record with an override" has now failed once.
Recording with `GENBA_GATE_SAMPLES` set is a hard failure, and it fires before the corpus is built, so a mis-set run fails in a second rather than after forty minutes.

```
--- FAIL: TestSearchLatencyGate (0.00s)
    latency_test.go:198: GENBA_GATE_SAMPLES is 2000 and this is a recording run, so the baseline would be drawn with a ruler no pull request uses
```

The nightly needs redispatching with `record=true` after this merges, and the baseline it produces is the one worth committing.
Until then the pull request gate reports and does not fail, which is what it already does.
