### PR TITLE
perf: record the CI latency baseline

### DIFF
--- a/benchcorpus/baseline-ci.json
+++ b/benchcorpus/baseline-ci.json
@@ -1,0 +1,63 @@
+{
+  "seed": 2121,
+  "documents": 20000,
+  "recorded": "2026-08-19",
+  "runner": "ubuntu-latest nightly",
+  "calibration_ms": 12.41,
+  "classes": {
+    "common": {
+      "samples": 744,
+      "rounds": 8,
+      "best_ms": 85.246,
+      "p50_ms": 86.5,
+      "p95_ms": 149.706,
+      "p99_ms": 164.204,
+      "budget_ms": 10
+    },
+    "filter": {
+      "samples": 936,
+      "rounds": 8,
+      "best_ms": 33.199,
+      "p50_ms": 34.476,
+      "p95_ms": 42.009,
+      "p99_ms": 43.245,
+      "budget_ms": 8
+    },
+    "multi": {
+      "samples": 744,
+      "rounds": 8,
+      "best_ms": 39.473,
+      "p50_ms": 40.668,
+      "p95_ms": 93.849,
+      "p99_ms": 121.429,
+      "budget_ms": 10
+    },
+    "pathological": {
+      "samples": 296,
+      "rounds": 8,
+      "best_ms": 247.504,
+      "p50_ms": 249.094,
+      "p95_ms": 252.664,
+      "p99_ms": 257.135,
+      "budget_ms": 25
+    },
+    "rare": {
+      "samples": 1000,
+      "rounds": 8,
+      "best_ms": 8.014,
+      "p50_ms": 8.194,
+      "p95_ms": 18.429,
+      "p99_ms": 23.391,
+      "budget_ms": 3
+    },
+    "term-filter": {
+      "samples": 744,
+      "rounds": 8,
+      "best_ms": 16.052,
+      "p50_ms": 16.851,
+      "p95_ms": 39.223,
+      "p99_ms": 75.345,
+      "budget_ms": 10
+    }
+  }
+}


### PR DESCRIPTION
This is the file the latency gate compares a pull request against.
It was recorded by the nightly workflow on [run 32289302640](https://github.com/tamnd/genba/actions/runs/32289302640) and it is committed on its own, because a commit that moves a baseline and the code together is a commit nobody can review.

Until now the perf job had no baseline on the runner, so `gateCompare` took the branch that records the numbers and enforces nothing.
With this in place the gate turns on: a class inside its budget is held to the budget, a class over its budget is held to the baseline until the budget is met, and a move past the tolerance fails the job.

The sample counts are the derived ones, between 296 and 1000 depending on the class, rather than the 2000 an override was pinning them to before #79.
That is the ruler every pull request uses and the baseline had to be drawn with the same one, which is what the recording run now refuses to do otherwise.

| Class | p50 | p95 | Budget | Samples |
| --- | --- | --- | --- | --- |
| rare | 8.2ms | 18.4ms | 3ms | 1000 |
| term-filter | 16.9ms | 39.2ms | 10ms | 744 |
| filter | 34.5ms | 42.0ms | 8ms | 936 |
| multi | 40.7ms | 93.8ms | 10ms | 744 |
| common | 86.5ms | 149.7ms | 10ms | 744 |
| pathological | 249.1ms | 252.7ms | 25ms | 296 |

Calibration was 12.41ms, from nine readings spread through the run with a spread of one millisecond, so the machine was steady while these were taken.

Every class is over its stated budget on this runner, which is the point of the exemption rather than a reason to wait.
The budgets are what the query path is aiming at, the baseline is what a shared GitHub runner does today, and the gap between them is the work #55 and the issues under it are for.
Holding each class to its own recorded number means a change that makes any of them worse fails now, and the exemption expires on its own the moment a baseline inside the budget is recorded.