### PR TITLE
store/vector: the embedding section and the scan over it

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ func main() {
 | `store/memstore` | the reference in memory driver |
 | `store/sqlitestore` | the SQLite driver, pure Go, FTS5 and the permission check in one query |
 | `store/pgstore` | the PostgreSQL 18 driver, migrations as SQL files and the permission check in one query |
+| `store/segment` | the on disk segment container, [docs/segment.md](docs/segment.md) |
+| `store/column` | one field across every row of a segment, and the scans over it, [docs/columns.md](docs/columns.md) |
+| `store/vector` | the embedding section of a segment and the search over it, [docs/vectors.md](docs/vectors.md) |
 | `index` | query parsing, retrieval and ranking |
 | `connector` | the ingestion contract, cursors and checkpoints |
 | `connector/fssource` | the reference connector, a directory tree with OWNERS files |

--- a/arch_test.go
+++ b/arch_test.go
@@ -56,6 +56,15 @@ var allowed = map[string][]string{
 	// package least equipped to hold one.
 	"store/column": nil,
 
+	// vector is the embedding section and the scan over it, and the one thing it
+	// imports of ours is column, for the bitmap. That edge is the point rather
+	// than a convenience: the rows a principal may read arrive as a bitmap and
+	// the scan walks it, so a vector search cannot score a document it was not
+	// handed. Giving this package its own set type would mean converting between
+	// two of them on the hot path, and giving it any knowledge of an ACL would
+	// put the permission model in a second place again.
+	"store/vector": {"store/column"},
+
 	// kura is the Go side of the Rust engine's C ABI and imports nothing of
 	// ours. It deals in document ids, bytes and vectors, and it is the one
 	// package in the repository that is not in the default build at all. An

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -1,0 +1,174 @@
+# Vectors
+
+A segment's sections hold columns for filtering and one section for embeddings.
+This is that section, and the search over it.
+
+Version 1.
+The implementation is `store/vector`, and the container it lives inside is [the segment format](segment.md).
+
+## The flat scan comes first
+
+Every vector in the segment is scored against the query, and the best k are kept.
+
+That is not a placeholder for a graph index.
+It is the thing a graph index has to beat, and there is no way to know whether it does without the number it has to beat.
+A flat scan has no candidate list, no entry point and no beam width, so its recall is one by construction rather than by tuning, and every accuracy question about this package reduces to the quantisation and nothing else.
+
+It also stays useful after there is a second index.
+A segment of ten thousand documents is scanned in under a millisecond, and a graph built over ten thousand vectors costs more to build than the scan it replaces costs to run.
+
+## The permission filter is the loop
+
+`Search` takes a bitmap of the rows the reader may see, and it walks that bitmap.
+It does not walk the rows and ask the bitmap.
+
+The difference is the whole point.
+A scan that scores everything and filters afterwards has already read a document the caller is not allowed to see, and the only thing between that read and a leak is the code that comes next.
+Here an unreadable document is never touched, so there is no result to drop, no count to correct and no score to accidentally surface in an aggregate.
+
+It is also faster, and the benchmark below shows it: a reader who may see a hundredth of the corpus pays a hundredth of the scan.
+A scan that filtered afterwards would cost the same at every selectivity.
+
+A nil bitmap means every row, which is what a caller with no principal to apply passes.
+That is the only way to reach rows nobody vouched for, and it is deliberately the shape that has to be written out rather than the default that happens by omission.
+
+## Quantisation
+
+A vector is normalised, then each component is stored as one signed byte.
+
+The scale is the largest component of the normalised vector divided by 127, kept as a float32 beside the row.
+A component becomes a code by dividing by that scale and rounding.
+A query is quantised by the same rule, so the inner loop is an integer multiply and add over two byte arrays and the cosine is the integer dot product times the two scales.
+
+Keeping the query at full precision would mean converting a byte to a float on every component of every candidate, which is the one operation on this path that runs a few hundred million times a query.
+
+Per row the section costs `4 + dim` bytes against the `4 * dim` a float32 array would.
+At 768 dimensions that is 772 bytes against 3072, so a million documents is 772 MB rather than 3 GB.
+
+The accuracy that buys:
+
+| Dimensions | Worst score off the exact cosine |
+| --- | --- |
+| 64 | 0.004076 |
+| 384 | 0.001402 |
+| 768 | 0.001514 |
+
+Those are the worst row of five hundred, not the average, and they get better as the vectors get wider because the error per component is independent and the dot product averages over more of them.
+An embedding model does not distinguish two documents at four thousandths of a cosine, so this is well inside the noise of the thing being measured.
+
+The test that matters is not the size of the error though, it is whether the order survives it.
+`TestQuantisationDoesNotReorderClearResults` computes the exact float64 cosine for every row of a 1500 row corpus, then checks every pair in the returned order for an inversion.
+Two documents within the margin of each other may trade places, which is a swap nothing downstream can see.
+A pair separated by more than a hundredth of a cosine coming back the wrong way round fails.
+
+## Rows with no vector
+
+A document with no embedding still gets a row and still costs its bytes.
+
+The alternative is a section that skips it, which needs a second row numbering and a map between that and the segment's, and then every join between a vector result and a column filter goes through the map.
+Row numbers being the segment's is what lets a permission bitmap built from the columns be handed straight to the scan.
+
+A null row is a scale of zero, which is a value a real vector cannot have, because a vector with no largest component is a vector of all zeros.
+Those are refused at write with `ErrZero` rather than stored as a null.
+An embedder that returns zeros is broken, and a pipeline that quietly indexes that is a pipeline where a broken model looks like a corpus with no matches.
+
+The cost is real and worth stating: a segment where a tenth of the documents have embeddings still writes the full `4 + dim` bytes for all of them.
+That is the price of one row numbering, and it is the right trade until there is a corpus where it is not.
+
+## The header
+
+Fixed size, at the front, version first, the same shape the column format uses.
+
+| Offset | Size | Field |
+| --- | --- | --- |
+| 0 | 1 | version |
+| 1 | 1 | metric |
+| 2 | 1 | index kind |
+| 3 | 1 | flags, zero in this version |
+| 4 | 4 | dimensions |
+| 8 | 4 | rows |
+| 12 | 4 | reserved, zero |
+
+Then the scales, one float32 per row, then the codes, `dim` bytes per row.
+
+All integers are little endian, for the same reason they are in the segment format.
+
+## The index kind is a byte, not a branch
+
+Byte 2 says which index the section carries.
+`Open` reads it and returns an `Index`, and a caller holding one of those cannot tell an exact scan from an approximate index apart from asking it.
+
+On the write side `NewBuilder` takes a kind, and `KindAuto` leaves the choice to the builder.
+`Builder.resolve` is the single place that choice is made, and it is a method rather than a function because the size threshold a graph index would need is a row count and the builder has it.
+Today every size resolves to flat.
+
+That is what makes the second index a new file in this package rather than a change to everything that calls it.
+It is not yet an operator facing setting, because nothing writes segments yet: see the last section.
+
+## Reading bytes that may be anything
+
+These bytes come off a disk, so `Open` checks the structure before it believes any of it, and there is a fuzz target whose only contract is that nothing it is fed ever panics.
+
+| Error | What it means |
+| --- | --- |
+| `ErrVersion` | a section written by something newer, so go and find that thing |
+| `ErrFormat` | bytes that were damaged or were never a section |
+| `ErrKind` | an index this build cannot read |
+| `ErrDim` | a width that is impossible, or a query from a different segment |
+
+The checks that matter:
+
+- An unknown flag is refused like an unknown version rather than skipped politely, because a flag this build does not know changes the meaning of the bytes below it in a way it cannot guess.
+- Nothing is allocated from a length read out of the bytes.
+  The row count and the width are turned into the size the section would have to be, and that has to equal the bytes actually on hand exactly, with nothing left over.
+  A header claiming four billion rows fails that comparison rather than reserving memory for them.
+- A row outside the section reads back as having no vector rather than panicking, because the row numbers arriving at the scan come from a bitmap the caller built.
+  A bitmap from a longer segment stops the scan at the end of the section, which is correct and is also the cheap thing to do, since the bitmap walks ascending.
+
+## What it costs
+
+On an Apple M4, top 20, one query against the whole segment:
+
+| Rows | Dimensions | Per query | Rows a second |
+| --- | --- | --- | --- |
+| 100 thousand | 128 | 6.3 ms | 15.8 million |
+| 100 thousand | 768 | 42.5 ms | 2.4 million |
+| 1 million | 128 | 75.2 ms | 13.3 million |
+| 1 million | 384 | 201 ms | 5.0 million |
+
+Read that as bytes rather than rows and it is the same number four times: 1.7 to 2.0 GB a second, which is memory bandwidth.
+The scan is not compute bound and there is nothing clever left in the inner loop, so the next real gain is scanning fewer bytes rather than scanning them faster.
+
+The same corpus, 100 thousand rows at 768 dimensions, with a permission bitmap:
+
+| Rows the reader may see | Per query |
+| --- | --- |
+| 100 percent | 45.6 ms |
+| 50 percent | 25.6 ms |
+| 10 percent | 6.0 ms |
+| 1 percent | 0.47 ms |
+
+Walking the bitmap instead of the rows costs about seven percent when the reader may see everything, and it pays that back many times over at every other selectivity.
+
+Building costs 347 thousand vectors a second at 768 dimensions, single threaded, and a query is quantised in 2.7 microseconds.
+`go test -bench . ./store/vector/` is where those numbers come from.
+
+One measurement in that path is worth writing down because it went the other way.
+The rounding in `round` is `math.Round` rather than the obvious add a half and let the conversion truncate.
+The hand written version needs the sign of the value, which is a branch on data that is half negative, and it mispredicts every other component.
+Appending is three times faster with the library function, which is branchless bit manipulation.
+
+## What is deliberately not here yet
+
+A graph index, which is the reason `Index` and the kind byte exist.
+It becomes worth its build cost somewhere above the sizes in the table above, and the flat scan is the baseline that will say where.
+
+An operator facing setting for the kind.
+No storage driver writes segments yet, so there is nothing in the server to configure and a knob that reaches no code would be worse than none.
+The choice is a byte in the format and a single method on the builder, so it is a configuration decision the moment there is a configuration to hold it.
+
+SIMD in the inner loop.
+The dot product is an eight way unrolled scalar loop with the bounds checks removed, and it already runs at memory bandwidth, so wider instructions would speed up something that is not what is slow.
+
+Scoring several segments in parallel, which is a property of the layer above this one.
+A `Query` is quantised once and is safe to hand to every segment, which is why it is a value rather than an argument.

--- a/store/vector/bench_test.go
+++ b/store/vector/bench_test.go
@@ -1,0 +1,130 @@
+package vector_test
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/tamnd/genba/store/column"
+	"github.com/tamnd/genba/store/vector"
+)
+
+// The sizes the issue asks for, at the widths embedding models actually
+// produce. A million vectors at 384 dimensions is 384 MB of codes, which is the
+// largest thing in this repository's benchmarks and is the reason the wider
+// models are measured at a hundred thousand instead.
+var sizes = []struct{ rows, dim int }{
+	{100_000, 128},
+	{100_000, 768},
+	{1_000_000, 128},
+	{1_000_000, 384},
+}
+
+// k is a page of results, which is what a search actually asks for. The heap
+// only ever holds this many, so the size of the answer is not what the scan
+// costs.
+const k = 20
+
+func BenchmarkSearch(b *testing.B) {
+	for _, s := range sizes {
+		b.Run(fmt.Sprintf("%dk/%d", s.rows/1000, s.dim), func(b *testing.B) {
+			idx, q := corpus(b, s.rows, s.dim)
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := idx.Search(q, k, nil); err != nil {
+					b.Fatalf("searching: %v", err)
+				}
+			}
+			b.ReportMetric(float64(s.rows)*float64(b.N)/b.Elapsed().Seconds()/1e6, "Mrow/s")
+		})
+	}
+}
+
+// BenchmarkSearchFiltered is the shape a real query has, where the reader may
+// see some fraction of the corpus. The permission bitmap is the loop rather
+// than a check inside it, so these numbers should fall roughly with the
+// fraction, and a scan that filtered afterwards would show the same cost at
+// every one of them.
+func BenchmarkSearchFiltered(b *testing.B) {
+	const rows, dim = 100_000, 768
+	idx, q := corpus(b, rows, dim)
+
+	for _, percent := range []int{100, 50, 10, 1} {
+		b.Run(fmt.Sprintf("%d%%", percent), func(b *testing.B) {
+			rnd := rand.New(rand.NewPCG(2121, 41))
+			allow := column.NewBitmap(rows)
+			for row := range rows {
+				if rnd.IntN(100) < percent {
+					allow.Set(row)
+				}
+			}
+			visible := allow.Count()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := idx.Search(q, k, allow); err != nil {
+					b.Fatalf("searching: %v", err)
+				}
+			}
+			b.ReportMetric(float64(visible)*float64(b.N)/b.Elapsed().Seconds()/1e6, "Mrow/s")
+		})
+	}
+}
+
+func BenchmarkNewQuery(b *testing.B) {
+	rnd := rand.New(rand.NewPCG(2121, 42))
+	v := random(rnd, 768)
+	for b.Loop() {
+		if _, err := vector.NewQuery(v); err != nil {
+			b.Fatalf("building a query: %v", err)
+		}
+	}
+}
+
+// BenchmarkAppend is what an ingestion pipeline pays per document.
+//
+// It builds a whole small section per iteration rather than appending forever
+// into one builder. A builder that grows to a hundred megabytes inside the
+// timing loop measures the garbage collector reading a hundred megabyte slice,
+// which is around forty percent of the number and is not the encoder.
+func BenchmarkAppend(b *testing.B) {
+	rnd := rand.New(rand.NewPCG(2121, 43))
+	const dim, rows = 768, 4096
+	vs := make([][]float32, rows)
+	for i := range vs {
+		vs[i] = random(rnd, dim)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		bl := builder(b, dim, vector.KindFlat)
+		for _, v := range vs {
+			if err := bl.Append(v); err != nil {
+				b.Fatalf("appending: %v", err)
+			}
+		}
+	}
+	b.ReportMetric(float64(rows)*float64(b.N)/b.Elapsed().Seconds()/1e3, "kvec/s")
+}
+
+// corpus builds a section once per benchmark case and keeps it, because the
+// thing being measured is the scan and not the encoder. The vectors are drawn
+// from a normal distribution, which is the shape a real embedding has: the cost
+// of a scan does not depend on the values, but the shape of the heap traffic
+// does, and a corpus of identical vectors would make every candidate beat the
+// root and every candidate lose to it in turn.
+func corpus(tb testing.TB, rows, dim int) (vector.Index, *vector.Query) {
+	tb.Helper()
+	rnd := rand.New(rand.NewPCG(2121, 40))
+	b := builder(tb, dim, vector.KindFlat)
+	for range rows {
+		if err := b.Append(random(rnd, dim)); err != nil {
+			tb.Fatalf("appending: %v", err)
+		}
+	}
+	idx := open(tb, b)
+	q, err := vector.NewQuery(random(rnd, dim))
+	if err != nil {
+		tb.Fatalf("building a query: %v", err)
+	}
+	return idx, q
+}

--- a/store/vector/build.go
+++ b/store/vector/build.go
@@ -1,0 +1,184 @@
+package vector
+
+import (
+	"fmt"
+	"math"
+)
+
+// Builder collects the vectors of a segment and encodes the section.
+//
+// Rows are appended in segment row order and every row gets one call, including
+// the documents that have no embedding, which get [Builder.AppendNull]. The
+// builder does not know what a document is and cannot tell a missing row from a
+// caller that forgot one, so the rule is one call per row and the caller keeps
+// it.
+type Builder struct {
+	dim    int
+	kind   Kind
+	scales []float32
+	codes  []byte
+}
+
+// NewBuilder returns a builder for vectors of a given width.
+//
+// The kind is the index to write, and [KindAuto] leaves the choice to the
+// builder, which is what a caller that has no opinion should pass. A caller
+// with an opinion is usually an operator who has one, so the value comes from
+// configuration rather than from a decision made here.
+func NewBuilder(dim int, kind Kind) (*Builder, error) {
+	if dim <= 0 || dim > MaxDim {
+		return nil, fmt.Errorf("%w: %d dimensions, the limit is %d", ErrDim, dim, MaxDim)
+	}
+	switch kind {
+	case KindAuto, KindFlat:
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrKind, kind)
+	}
+	return &Builder{dim: dim, kind: kind}, nil
+}
+
+// Dim is the width of the vectors this builder takes.
+func (b *Builder) Dim() int { return b.dim }
+
+// Rows is how many rows have been appended.
+func (b *Builder) Rows() int { return len(b.scales) }
+
+// Append quantises a vector and adds it as the next row.
+//
+// The vector is normalised first, so the caller does not have to and two
+// callers cannot disagree about whether it was done. A vector of all zeros is
+// refused rather than stored as a null: it means the embedder returned nothing,
+// and a pipeline that silently indexes that is a pipeline where a broken model
+// looks like a corpus with no matches.
+func (b *Builder) Append(v []float32) error {
+	if len(v) != b.dim {
+		return fmt.Errorf("%w: the vector has %d and the section has %d", ErrDim, len(v), b.dim)
+	}
+	scale, unit := quantiser(v)
+	if scale == 0 {
+		return ErrZero
+	}
+	b.scales = append(b.scales, float32(scale))
+
+	// The row is grown in one step and then written by index. Appending a byte
+	// at a time is a length check and a capacity check per component, and on a
+	// corpus that is a few hundred million of each.
+	at := len(b.codes)
+	b.codes = append(b.codes, make([]byte, b.dim)...)
+	row := b.codes[at:]
+	for i, x := range v {
+		row[i] = byte(round(float64(x) * unit))
+	}
+	return nil
+}
+
+// AppendNull adds a row with no vector.
+//
+// The row still exists and still costs its bytes, because row numbers are the
+// segment's and a section that skipped a document would need a second numbering
+// and a map between the two. A null row is never scored and never appears in a
+// result, whatever the query.
+func (b *Builder) AppendNull() {
+	b.scales = append(b.scales, 0)
+	b.codes = append(b.codes, make([]byte, b.dim)...)
+}
+
+// Build returns the encoded section.
+func (b *Builder) Build() ([]byte, error) {
+	kind, err := b.resolve()
+	if err != nil {
+		return nil, err
+	}
+	rows := b.Rows()
+	out := make([]byte, headerSize+rows*scaleSize+rows*b.dim)
+	out[offVersion] = Version
+	out[offMetric] = byte(MetricCosine)
+	out[offKind] = byte(kind)
+	out[offFlags] = 0
+	le.PutUint32(out[offDim:], uint32(b.dim))
+	le.PutUint32(out[offRows:], uint32(rows))
+	le.PutUint32(out[offReserved:], 0)
+
+	at := headerSize
+	for _, s := range b.scales {
+		le.PutUint32(out[at:], math.Float32bits(s))
+		at += scaleSize
+	}
+	copy(out[at:], b.codes)
+	return out, nil
+}
+
+// resolve turns the requested kind into the one that gets written.
+//
+// It is a method rather than a function because the size threshold for a graph
+// index belongs here, and the row count it would read is the builder's. That is
+// the whole of what changes when there is a second index: a section built by a
+// build that picks a different kind is read by a different implementation of
+// [Index], and no caller of [NewBuilder] or [Open] is touched. Today every size
+// resolves to flat, because a flat scan is the only index this build has and an
+// exact answer at any size beats an approximate one that does not exist.
+func (b *Builder) resolve() (Kind, error) {
+	switch b.kind {
+	case KindAuto, KindFlat:
+		return KindFlat, nil
+	}
+	return 0, fmt.Errorf("%w: %s", ErrKind, b.kind)
+}
+
+// quantiser works out how a vector is encoded.
+//
+// It returns the scale to store beside the vector and the factor a raw
+// component is multiplied by to become a code, which is one over the length
+// times one over the scale. Both are returned rather than the caller doing the
+// second division itself, because a division per component of every vector in a
+// corpus is a real cost and because the query and the stored vectors have to be
+// quantised by the same rule or the dot product between them means nothing.
+//
+// A zero scale means a vector of all zeros, which has no direction.
+//
+// The sums are in float64. A vector of a thousand small components loses
+// precision in float32 before the square root ever sees it.
+func quantiser(v []float32) (scale, unit float64) {
+	sum, largest := float64(0), float64(0)
+	for _, f := range v {
+		x := float64(f)
+		sum += x * x
+		if a := math.Abs(x); a > largest {
+			largest = a
+		}
+	}
+	if sum == 0 {
+		return 0, 0
+	}
+	// The scale is stated in terms of the normalised vector, since that is what
+	// is being encoded, and it is the largest component of it over the 127
+	// codes a signed byte has either side of zero.
+	inv := 1 / math.Sqrt(sum)
+	scale = largest * inv / 127
+	return scale, inv / scale
+}
+
+// round puts one scaled component on the byte range.
+//
+// The clamp is not reachable from the arithmetic in [quantiser], where the
+// scale is defined as the largest component over 127. It is here because that
+// arithmetic is floating point and the cost of being wrong about it is a
+// wrapped byte, which turns the largest component of a vector into the most
+// negative one and the best match in a segment into the worst.
+//
+// The rounding is math.Round rather than the obvious add a half and let the
+// conversion truncate, which needs the sign of the value and is therefore a
+// branch on data that is half negative. That branch mispredicts every other
+// component and costs three times what the library function does, which is
+// branchless bit manipulation. BenchmarkAppend is three times faster this way,
+// which is the opposite of what writing the arithmetic out by hand usually
+// does and is why it was measured rather than assumed.
+func round(c float64) int8 {
+	switch {
+	case c >= 127:
+		return 127
+	case c <= -127:
+		return -127
+	}
+	return int8(math.Round(c))
+}

--- a/store/vector/read.go
+++ b/store/vector/read.go
@@ -1,0 +1,185 @@
+package vector
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/tamnd/genba/store/column"
+)
+
+// Index is what a vector search runs against.
+//
+// It exists so that the choice of index is a property of the segment rather
+// than a branch in the query path. [Open] reads the kind byte and returns the
+// implementation that matches it, and a caller holding one of these has no way
+// to tell an exact scan from an approximate index apart from asking it. Today
+// there is one implementation, [Set], and the interface is here now because
+// adding the second one later should not be a change to everything that calls
+// it.
+type Index interface {
+	// Search returns the best k rows for a query, restricted to the rows a
+	// principal may read.
+	Search(q *Query, k int, allow *column.Bitmap) ([]Match, error)
+
+	// Kind is the index this segment carries.
+	Kind() Kind
+
+	// Metric is how scores were computed.
+	Metric() Metric
+
+	// Dim is the width of the vectors.
+	Dim() int
+
+	// Rows is how many rows the section covers, including the ones with no
+	// vector.
+	Rows() int
+
+	// Size is the length of the section in bytes.
+	Size() int
+
+	// Has reports whether a row carries a vector.
+	Has(row int) bool
+
+	// At returns a row's vector, dequantised.
+	At(row int) ([]float32, bool)
+}
+
+var _ Index = (*Set)(nil)
+
+// Set is the flat index: every vector of a segment, scanned.
+//
+// It holds the bytes it was opened over and never copies them. The scales and
+// the codes are windows onto the section, so a segment of seventy five
+// megabytes costs seventy five megabytes once however many readers have it
+// open, and a memory mapped segment is searched without reading the parts of it
+// the query never touches.
+type Set struct {
+	b      []byte
+	kind   Kind
+	metric Metric
+	dim    int
+	rows   int
+	scales []byte
+	codes  []byte
+}
+
+// Open parses a vector section and returns the index it holds.
+//
+// These bytes come off a disk, so nothing here is allocated from a length read
+// out of them and every window is checked against the bytes actually on hand. A
+// header claiming four billion rows fails a bounds check rather than reserving
+// memory for them.
+//
+// The order of the checks is the same one the segment format uses. Version
+// first, because a newer encoding could put anything at all in the bytes below
+// and nothing after that line is worth doing until the layout is known. Then
+// the fields that size the two arrays, then the arrays themselves.
+func Open(b []byte) (Index, error) {
+	if len(b) < headerSize {
+		return nil, fmt.Errorf("%w: %d bytes is shorter than a header", ErrFormat, len(b))
+	}
+	if v := b[offVersion]; v != Version {
+		return nil, fmt.Errorf("%w: version %d, this build reads %d", ErrVersion, v, Version)
+	}
+	// A flag this build does not know changes the meaning of the bytes below in
+	// a way it cannot guess, so it is the same refusal as an unknown version
+	// rather than something to skip politely.
+	if f := b[offFlags]; f != 0 {
+		return nil, fmt.Errorf("%w: flags %#02x are not known to this build", ErrVersion, f)
+	}
+	if r := le.Uint32(b[offReserved:]); r != 0 {
+		return nil, fmt.Errorf("%w: reserved header bytes are not zero", ErrFormat)
+	}
+
+	metric := Metric(b[offMetric])
+	if metric != MetricCosine {
+		return nil, fmt.Errorf("%w: metric %s", ErrFormat, metric)
+	}
+	kind := Kind(b[offKind])
+	if kind != KindFlat {
+		return nil, fmt.Errorf("%w: %s", ErrKind, kind)
+	}
+
+	dim := uint64(le.Uint32(b[offDim:]))
+	if dim == 0 || dim > MaxDim {
+		return nil, fmt.Errorf("%w: %d dimensions, the limit is %d", ErrDim, dim, MaxDim)
+	}
+	rows := uint64(le.Uint32(b[offRows:]))
+
+	// rows is a uint32 and dim has been bounded by MaxDim, so neither product
+	// can overflow a uint64, which is why they are safe to compute before they
+	// are compared against the file.
+	want := uint64(headerSize) + rows*scaleSize + rows*dim
+	if want != uint64(len(b)) {
+		return nil, fmt.Errorf("%w: %d rows of %d dimensions need %d bytes and the section holds %d", ErrFormat, rows, dim, want, len(b))
+	}
+
+	end := headerSize + rows*scaleSize
+	return &Set{
+		b:      b,
+		kind:   kind,
+		metric: metric,
+		dim:    int(dim),
+		rows:   int(rows),
+		scales: b[headerSize:end:end],
+		codes:  b[end:],
+	}, nil
+}
+
+// Kind is the index this section carries, which is always flat here and is on
+// the interface so that a caller can report which one it got.
+func (s *Set) Kind() Kind { return s.kind }
+
+// Metric is how scores were computed.
+func (s *Set) Metric() Metric { return s.metric }
+
+// Dim is the width of the vectors.
+func (s *Set) Dim() int { return s.dim }
+
+// Rows is how many rows the section covers, including the ones with no vector.
+func (s *Set) Rows() int { return s.rows }
+
+// Size is the length of the section in bytes.
+func (s *Set) Size() int { return len(s.b) }
+
+// Has reports whether a row carries a vector. A row that does not has a scale
+// of zero, which is a value a real vector cannot have, since a vector with no
+// largest component is a vector of all zeros and those are refused at write.
+func (s *Set) Has(row int) bool { return s.scaleAt(row) != 0 }
+
+// At returns a row's vector, dequantised, and whether there was one.
+//
+// It allocates, and it is here for a caller that wants to look at a stored
+// vector rather than search with it: a test, a diagnostic, or a re rank of a
+// page of results against the full precision query. A scan never calls it.
+func (s *Set) At(row int) ([]float32, bool) {
+	scale := s.scaleAt(row)
+	if scale == 0 {
+		return nil, false
+	}
+	codes := s.codesAt(row)
+	out := make([]float32, s.dim)
+	for i, c := range codes {
+		out[i] = scale * float32(int8(c))
+	}
+	return out, true
+}
+
+// scaleAt is a row's scale, and zero for a row outside the section. Out of
+// range reads back as absent rather than as a panic, because the row numbers
+// reaching here come from a bitmap the caller built and a search that is asked
+// about a row that does not exist should return nothing rather than take the
+// process down.
+func (s *Set) scaleAt(row int) float32 {
+	if row < 0 || row >= s.rows {
+		return 0
+	}
+	return math.Float32frombits(le.Uint32(s.scales[row*scaleSize:]))
+}
+
+// codesAt is a row's codes, as the bytes they are stored in. The caller reads
+// them as signed, which is a conversion rather than work.
+func (s *Set) codesAt(row int) []byte {
+	at := row * s.dim
+	return s.codes[at : at+s.dim : at+s.dim]
+}

--- a/store/vector/search.go
+++ b/store/vector/search.go
@@ -1,0 +1,232 @@
+package vector
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+
+	"github.com/tamnd/genba/store/column"
+)
+
+// Query is a search vector, normalised and quantised once.
+//
+// It is a value rather than a parameter to [Set.Search] because a corpus is
+// many segments and the same question is asked of every one of them. Quantising
+// the query per segment would be a few hundred divisions repeated for no
+// reason, and worse, it would be a place where two segments could end up
+// comparing against slightly different numbers.
+type Query struct {
+	codes []int8
+	scale float32
+}
+
+// NewQuery quantises a search vector.
+//
+// It is quantised the same way the stored vectors are, rather than kept at full
+// precision, because the alternative is converting a byte to a float on every
+// component of every candidate. Both sides being bytes is what makes the inner
+// loop an integer multiply and add, and the accuracy it costs is well inside
+// the gap between a relevant document and an irrelevant one.
+func NewQuery(v []float32) (*Query, error) {
+	if len(v) == 0 || len(v) > MaxDim {
+		return nil, fmt.Errorf("%w: %d dimensions, the limit is %d", ErrDim, len(v), MaxDim)
+	}
+	scale, unit := quantiser(v)
+	if scale == 0 {
+		return nil, ErrZero
+	}
+	q := &Query{codes: make([]int8, len(v)), scale: float32(scale)}
+	for i, x := range v {
+		q.codes[i] = round(float64(x) * unit)
+	}
+	return q, nil
+}
+
+// Dim is the width of the query.
+func (q *Query) Dim() int { return len(q.codes) }
+
+// Match is one row and what it scored.
+type Match struct {
+	// Row is the segment row, which is the same row the columns of that segment
+	// use.
+	Row int
+
+	// Score is the cosine of the angle between the query and the stored vector,
+	// so it runs from minus one to one and larger is closer.
+	Score float32
+}
+
+// ErrQuery is a search with no query in it, which is a caller bug rather than
+// anything about the data.
+var ErrQuery = errors.New("vector: no query")
+
+// Search returns the best k rows for a query, restricted to the rows a
+// principal may read.
+//
+// allow is the permission filter and it is the loop, not a check inside one. A
+// nil allow means every row, which is what a caller with no principal to apply
+// passes, and it is the only way to search rows nobody vouched for. Any other
+// bitmap and the scan visits exactly the rows it holds, so a document the
+// reader may not see is never scored, cannot enter the heap and cannot be
+// counted anywhere downstream.
+//
+// Rows with no vector are skipped, whatever the filter says about them.
+//
+// The result is ordered by score, highest first, and by row within a tie, so
+// two runs of the same query over the same segment return the same list in the
+// same order.
+func (s *Set) Search(q *Query, k int, allow *column.Bitmap) ([]Match, error) {
+	if q == nil {
+		return nil, ErrQuery
+	}
+	if len(q.codes) != s.dim {
+		return nil, fmt.Errorf("%w: the query has %d and the section has %d", ErrDim, len(q.codes), s.dim)
+	}
+	if k <= 0 || s.rows == 0 {
+		return nil, nil
+	}
+	if k > s.rows {
+		k = s.rows
+	}
+
+	h := &top{k: k, m: make([]Match, 0, k)}
+	if allow == nil {
+		for row := range s.rows {
+			s.score(q, row, h)
+		}
+	} else {
+		// Each walks the set ascending, so a row past the end of this section
+		// means every row after it is too. That happens when the bitmap came
+		// from a longer segment than this one, and stopping is both correct and
+		// the cheap thing to do.
+		allow.Each(func(row int) bool {
+			if row >= s.rows {
+				return false
+			}
+			s.score(q, row, h)
+			return true
+		})
+	}
+	return h.sorted(), nil
+}
+
+// score computes one row and offers it to the heap.
+func (s *Set) score(q *Query, row int, h *top) {
+	scale := math.Float32frombits(le.Uint32(s.scales[row*scaleSize:]))
+	if scale == 0 {
+		return
+	}
+	at := row * s.dim
+	h.offer(Match{Row: row, Score: q.scale * scale * float32(dot(q.codes, s.codes[at:at+s.dim]))})
+}
+
+// dot is the inner product of a quantised query and a row of quantised codes.
+//
+// It accumulates in four independent sums so that the additions do not form one
+// dependency chain the processor has to walk a step at a time. The slices are
+// cut to the same length first, which is what lets the bounds check disappear
+// from the body.
+//
+// An int32 is enough by a wide margin: the largest term is 127 times 127, and
+// [MaxDim] of them is three orders of magnitude short of overflowing.
+func dot(q []int8, c []byte) int32 {
+	c = c[:len(q)]
+	var a0, a1, a2, a3 int32
+	for len(q) >= 8 {
+		x, y := q[:8:8], c[:8:8]
+		a0 += int32(x[0])*int32(int8(y[0])) + int32(x[4])*int32(int8(y[4]))
+		a1 += int32(x[1])*int32(int8(y[1])) + int32(x[5])*int32(int8(y[5]))
+		a2 += int32(x[2])*int32(int8(y[2])) + int32(x[6])*int32(int8(y[6]))
+		a3 += int32(x[3])*int32(int8(y[3])) + int32(x[7])*int32(int8(y[7]))
+		q, c = q[8:], c[8:]
+	}
+	for i := range q {
+		a0 += int32(q[i]) * int32(int8(c[i]))
+	}
+	return a0 + a1 + a2 + a3
+}
+
+// top keeps the best k matches seen.
+//
+// A heap rather than a sorted slice because the whole point of a scan is that
+// almost nothing it looks at is worth keeping: once the heap is full, a
+// candidate that does not beat the worst of it costs one comparison and
+// nothing else. Sorting everything and cutting would be the same amount of
+// scanning and a million element sort on top of it.
+//
+// It is a minimum heap, so the root is the worst thing being kept, which is the
+// only element a new candidate has to be compared against.
+type top struct {
+	k int
+	m []Match
+}
+
+// worse orders two matches. A lower score is worse, and on a tie a higher row
+// is worse, which is what makes the output stable: of two documents that score
+// identically, the one earlier in the segment is the one kept.
+func worse(a, b Match) bool {
+	if a.Score != b.Score {
+		return a.Score < b.Score
+	}
+	return a.Row > b.Row
+}
+
+func (t *top) offer(m Match) {
+	if len(t.m) < t.k {
+		t.m = append(t.m, m)
+		t.up(len(t.m) - 1)
+		return
+	}
+	if !worse(t.m[0], m) {
+		return
+	}
+	t.m[0] = m
+	t.down(0)
+}
+
+func (t *top) up(i int) {
+	for i > 0 {
+		parent := (i - 1) / 2
+		if !worse(t.m[i], t.m[parent]) {
+			return
+		}
+		t.m[i], t.m[parent] = t.m[parent], t.m[i]
+		i = parent
+	}
+}
+
+func (t *top) down(i int) {
+	for {
+		left, smallest := 2*i+1, i
+		if left < len(t.m) && worse(t.m[left], t.m[smallest]) {
+			smallest = left
+		}
+		if right := left + 1; right < len(t.m) && worse(t.m[right], t.m[smallest]) {
+			smallest = right
+		}
+		if smallest == i {
+			return
+		}
+		t.m[i], t.m[smallest] = t.m[smallest], t.m[i]
+		i = smallest
+	}
+}
+
+// sorted returns what the heap holds, best first. It is called once per search
+// over at most k elements, so the sort is not on any path that matters.
+func (t *top) sorted() []Match {
+	slices.SortFunc(t.m, func(a, b Match) int {
+		switch {
+		case worse(a, b):
+			return 1
+		case worse(b, a):
+			return -1
+		}
+		return 0
+	})
+	if len(t.m) == 0 {
+		return nil
+	}
+	return t.m
+}

--- a/store/vector/search_test.go
+++ b/store/vector/search_test.go
@@ -1,0 +1,340 @@
+package vector_test
+
+import (
+	"math"
+	"math/rand/v2"
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/store/column"
+	"github.com/tamnd/genba/store/vector"
+)
+
+// TestTheScanConsidersEveryRow is what "recall is exact by definition" means in
+// practice. A flat scan has no candidate list to get wrong, so asking for as
+// many results as there are rows returns every row that carries a vector, in
+// descending order, with nothing missing and nothing counted twice.
+func TestTheScanConsidersEveryRow(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 20))
+	const dim, rows = 96, 2000
+
+	b := builder(t, dim, vector.KindFlat)
+	for range rows {
+		if err := b.Append(random(rnd, dim)); err != nil {
+			t.Fatalf("appending: %v", err)
+		}
+	}
+	s := open(t, b)
+
+	got := search(t, s, random(rnd, dim), rows, nil)
+	if len(got) != rows {
+		t.Fatalf("asking for %d results over %d rows returned %d", rows, rows, len(got))
+	}
+	seen := make(map[int]bool, rows)
+	for i, m := range got {
+		if seen[m.Row] {
+			t.Fatalf("row %d came back twice", m.Row)
+		}
+		seen[m.Row] = true
+		if i > 0 && got[i-1].Score < m.Score {
+			t.Fatalf("result %d scored %f and the one before it scored %f, which is out of order", i, m.Score, got[i-1].Score)
+		}
+	}
+	for row := range rows {
+		if !seen[row] {
+			t.Fatalf("row %d was never scored", row)
+		}
+	}
+}
+
+// TestQuantisationDoesNotReorderClearResults is the box on the issue.
+//
+// Quantisation is lossy, so two documents that score within the noise of each
+// other can swap places, and that is fine: nothing downstream can tell them
+// apart either. What must not happen is a pair with a real gap between them
+// coming back the wrong way round, because that is a relevant document losing
+// to an irrelevant one.
+//
+// So this compares the whole returned order against the exact cosines and
+// fails on any inversion wider than the margin.
+func TestQuantisationDoesNotReorderClearResults(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 21))
+	const dim, rows = 768, 1500
+
+	// A tenth of a percent of the score range, which is a hundred times the
+	// error the quantisation actually produces at this width and still far
+	// finer than any difference a person could see in a result list.
+	const margin = 0.01
+
+	vs := make([][]float32, rows)
+	b := builder(t, dim, vector.KindFlat)
+	for i := range vs {
+		vs[i] = random(rnd, dim)
+		if err := b.Append(vs[i]); err != nil {
+			t.Fatalf("appending: %v", err)
+		}
+	}
+	s := open(t, b)
+
+	q := random(rnd, dim)
+	exact := make([]float64, rows)
+	for i, v := range vs {
+		exact[i] = cosine(q, v)
+	}
+
+	got := search(t, s, q, rows, nil)
+	if len(got) != rows {
+		t.Fatalf("got %d results over %d rows", len(got), rows)
+	}
+	inversions := 0
+	for i := range got {
+		for j := i + 1; j < len(got); j++ {
+			if exact[got[j].Row]-exact[got[i].Row] > margin {
+				inversions++
+				if inversions == 1 {
+					t.Errorf("row %d came back at position %d with an exact cosine of %.6f, ahead of row %d at position %d with %.6f",
+						got[i].Row, i, exact[got[i].Row], got[j].Row, j, exact[got[j].Row])
+				}
+			}
+		}
+	}
+	if inversions > 0 {
+		t.Errorf("%d pairs separated by more than %.3f came back in the wrong order", inversions, margin)
+	}
+}
+
+// TestScoresTrackTheCosine measures the thing the ordering above depends on. It
+// is a separate test because a number worth relying on is a number worth
+// printing: the log line is what says how much room the margin has.
+func TestScoresTrackTheCosine(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 22))
+	for _, dim := range []int{64, 384, 768} {
+		const rows = 500
+		vs := make([][]float32, rows)
+		b := builder(t, dim, vector.KindFlat)
+		for i := range vs {
+			vs[i] = random(rnd, dim)
+			if err := b.Append(vs[i]); err != nil {
+				t.Fatalf("appending: %v", err)
+			}
+		}
+		s := open(t, b)
+
+		q := random(rnd, dim)
+		got := search(t, s, q, rows, nil)
+
+		worst := 0.0
+		for _, m := range got {
+			if e := math.Abs(float64(m.Score) - cosine(q, vs[m.Row])); e > worst {
+				worst = e
+			}
+		}
+		t.Logf("%d dimensions: the worst score is off the exact cosine by %.6f", dim, worst)
+		if worst > 0.01 {
+			t.Errorf("%d dimensions: the worst score is off by %.6f, want under 0.01", dim, worst)
+		}
+	}
+}
+
+// TestTheScanNeverScoresARowTheReaderMayNotSee is the second box on the issue.
+//
+// The bitmap is deliberately the complement of the best matches, so a scan that
+// filtered afterwards rather than as it went would still pass a test that only
+// checked the rows it returned. This one checks the whole answer against the
+// top of the allowed rows computed separately, so a result that came from
+// anywhere else fails.
+func TestTheScanNeverScoresARowTheReaderMayNotSee(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 23))
+	const dim, rows, k = 128, 1200, 20
+
+	vs := make([][]float32, rows)
+	b := builder(t, dim, vector.KindFlat)
+	for i := range vs {
+		vs[i] = random(rnd, dim)
+		if err := b.Append(vs[i]); err != nil {
+			t.Fatalf("appending: %v", err)
+		}
+	}
+	s := open(t, b)
+
+	q := random(rnd, dim)
+	exact := make([]float64, rows)
+	order := make([]int, rows)
+	for i, v := range vs {
+		exact[i] = cosine(q, v)
+		order[i] = i
+	}
+	slices.SortFunc(order, func(a, c int) int {
+		switch {
+		case exact[a] > exact[c]:
+			return -1
+		case exact[a] < exact[c]:
+			return 1
+		}
+		return a - c
+	})
+
+	// Hide the fifty nearest documents, which is the case a filter applied
+	// after the scan gets wrong in the most visible way.
+	hidden := make(map[int]bool, 50)
+	for _, row := range order[:50] {
+		hidden[row] = true
+	}
+	allow := column.NewBitmap(rows)
+	var want []int
+	for _, row := range order {
+		if hidden[row] {
+			continue
+		}
+		allow.Set(row)
+		if len(want) < k {
+			want = append(want, row)
+		}
+	}
+
+	got := search(t, s, q, k, allow)
+	if len(got) != k {
+		t.Fatalf("got %d results, want %d", len(got), k)
+	}
+	for _, m := range got {
+		if hidden[m.Row] {
+			t.Fatalf("row %d was hidden from the reader and came back anyway", m.Row)
+		}
+	}
+
+	// The cut is where the twentieth allowed document sits, and the margin is
+	// the quantisation noise around it. Two documents either side of the cut
+	// and within the noise of each other can trade places, which is a swap
+	// nothing downstream can see. A document from outside that band cannot be
+	// there at all, and one from well inside it cannot be missing.
+	const margin = 0.005
+	cut := exact[want[k-1]]
+	in := make(map[int]bool, k)
+	for _, m := range got {
+		in[m.Row] = true
+		if exact[m.Row] < cut-margin {
+			t.Errorf("row %d came back at cosine %.6f, below the twentieth allowed document at %.6f", m.Row, exact[m.Row], cut)
+		}
+	}
+	for _, row := range want {
+		if !in[row] && exact[row] > cut+margin {
+			t.Errorf("row %d at cosine %.6f is clear of the cut at %.6f and did not come back", row, exact[row], cut)
+		}
+	}
+}
+
+func TestAReaderWhoMaySeeNothingGetsNothing(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 24))
+	const dim, rows = 32, 200
+
+	b := builder(t, dim, vector.KindFlat)
+	for range rows {
+		if err := b.Append(random(rnd, dim)); err != nil {
+			t.Fatalf("appending: %v", err)
+		}
+	}
+	s := open(t, b)
+
+	if got := search(t, s, random(rnd, dim), 10, column.NewBitmap(rows)); len(got) != 0 {
+		t.Errorf("an empty permission bitmap returned %d matches, want none", len(got))
+	}
+}
+
+// TestABitmapFromALongerSegmentStopsAtTheEnd covers the bitmap that was built
+// against a segment with more rows than this section has, which happens the
+// moment a section is written for a subset of a segment's documents.
+func TestABitmapFromALongerSegmentStopsAtTheEnd(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 25))
+	const dim, rows = 32, 50
+
+	b := builder(t, dim, vector.KindFlat)
+	for range rows {
+		if err := b.Append(random(rnd, dim)); err != nil {
+			t.Fatalf("appending: %v", err)
+		}
+	}
+	s := open(t, b)
+
+	allow := column.NewBitmap(rows * 4)
+	for row := range rows * 4 {
+		allow.Set(row)
+	}
+	got := search(t, s, random(rnd, dim), rows*4, allow)
+	if len(got) != rows {
+		t.Fatalf("got %d matches over %d rows, want %d", len(got), rows, rows)
+	}
+	for _, m := range got {
+		if m.Row >= rows {
+			t.Fatalf("row %d is past the end of a section with %d rows", m.Row, rows)
+		}
+	}
+}
+
+// TestATieIsBrokenByTheRow keeps the output stable. Two documents that are
+// genuinely the same distance from a query are common, and a result list that
+// reorders them between two identical requests is a result list that looks
+// broken to anybody paging through it.
+func TestATieIsBrokenByTheRow(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 26))
+	const dim = 64
+
+	same := random(rnd, dim)
+	b := builder(t, dim, vector.KindFlat)
+	for row := range 12 {
+		v := random(rnd, dim)
+		if row == 5 || row == 9 {
+			v = same
+		}
+		if err := b.Append(v); err != nil {
+			t.Fatalf("appending: %v", err)
+		}
+	}
+	s := open(t, b)
+
+	got := search(t, s, same, 2, nil)
+	if len(got) != 2 {
+		t.Fatalf("got %d matches, want 2", len(got))
+	}
+	if got[0].Score != got[1].Score {
+		t.Fatalf("the two copies scored %f and %f, which is not a tie", got[0].Score, got[1].Score)
+	}
+	if got[0].Row != 5 || got[1].Row != 9 {
+		t.Errorf("a tie came back as rows %d and %d, want 5 then 9", got[0].Row, got[1].Row)
+	}
+}
+
+func TestKBoundsTheResult(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 27))
+	const dim, rows = 32, 100
+
+	b := builder(t, dim, vector.KindFlat)
+	for range rows {
+		if err := b.Append(random(rnd, dim)); err != nil {
+			t.Fatalf("appending: %v", err)
+		}
+	}
+	s := open(t, b)
+	q := random(rnd, dim)
+
+	for _, k := range []int{-1, 0, 1, 7, rows, rows * 2} {
+		got := search(t, s, q, k, nil)
+		want := min(max(k, 0), rows)
+		if len(got) != want {
+			t.Errorf("k of %d returned %d matches, want %d", k, len(got), want)
+		}
+	}
+}
+
+// search is Search with the query built and the errors handled once.
+func search(tb testing.TB, s vector.Index, v []float32, k int, allow *column.Bitmap) []vector.Match {
+	tb.Helper()
+	q, err := vector.NewQuery(v)
+	if err != nil {
+		tb.Fatalf("building a query: %v", err)
+	}
+	got, err := s.Search(q, k, allow)
+	if err != nil {
+		tb.Fatalf("searching: %v", err)
+	}
+	return got
+}

--- a/store/vector/vector.go
+++ b/store/vector/vector.go
@@ -1,0 +1,169 @@
+// Package vector stores embeddings in a segment section and searches them.
+//
+// One section, two arrays and a scan. Every vector is normalised and quantised
+// to a byte a component with its own scale, the search vector is quantised the
+// same way, and a score is an integer dot product turned back into a cosine at
+// the end. A hundred thousand passages at 768 dimensions is seventy five
+// megabytes, and searching them is one sequential pass over those bytes.
+//
+// # Why the flat scan comes first
+//
+// It is exact. The top k a flat scan returns is the true top k under the
+// metric, so recall is not a number that has to be measured, it is one by
+// construction. Every approximate index trades that away for speed, and the
+// only honest way to decide whether a particular trade is worth making is to
+// have the exact answer to compare against. So this is the thing a graph index
+// has to beat to earn its complexity, and on a few hundred thousand vectors
+// there is not much to beat.
+//
+// # The permission filter is the scan
+//
+// [Set.Search] is given the rows the principal may read and walks those rows.
+// Not the whole segment with a filter afterwards, and not the whole segment
+// with a check inside the loop. The allowed rows are what the loop is over, so
+// a document the reader may not see is never scored, never reaches the heap and
+// cannot be counted. That also makes a filtered search cheaper than an
+// unfiltered one, which is the right way round: the more restricted the reader,
+// the less work the machine does.
+//
+// # Quantisation
+//
+// Cosine is the metric, so a vector is normalised to unit length before
+// anything else happens to it. Its components are then divided by its own
+// largest magnitude and rounded to a signed byte, and that largest magnitude
+// over 127 is the scale stored beside it.
+//
+// The scale is per vector rather than per section because how large the largest
+// component of a unit vector is depends on how peaked that vector is. A section
+// holding a sharply peaked embedding and a flat one would have to size its
+// codes for the peaked one, and every code of the flat one would then spend
+// most of its bits on leading zeros.
+//
+// The cost is a rounding error of at most half a scale per component, from each
+// of the two vectors in a dot product. On 768 dimensional unit vectors that is
+// a dot product error with a standard deviation near four ten thousandths,
+// against scores that spread over about 0.036 for unrelated text. So the error
+// is around one percent of the distance between two unrelated documents and
+// far below the distance between a relevant one and an irrelevant one, and
+// there is a test that fails if a clearly separated pair ever comes back in the
+// wrong order.
+//
+// # Rows are the segment's rows
+//
+// A row here is the same row as in the segment's columns, so row 4000 is the
+// same document in both and the intersection of a filter and a vector search is
+// an intersection of row numbers. A document with no embedding still occupies
+// its row, written as a null, because a section that skipped it would need a
+// second numbering and a map between the two.
+package vector
+
+import (
+	"encoding/binary"
+	"errors"
+	"strconv"
+)
+
+// Version is the encoding this package writes and the only one it reads. A
+// reader that meets a version it does not know refuses the bytes rather than
+// guessing at them, the same way the segment format and the column encoding do.
+const Version uint8 = 1
+
+// Metric is how two vectors are compared.
+type Metric uint8
+
+// The supported metrics. Cosine is the one embedding models are trained for,
+// and for the unit vectors this package stores it is the dot product.
+const (
+	MetricCosine Metric = 1
+)
+
+func (m Metric) String() string {
+	if m == MetricCosine {
+		return "cosine"
+	}
+	return "metric(" + strconv.Itoa(int(m)) + ")"
+}
+
+// Kind names the index a section carries.
+//
+// It is a byte in the header rather than a decision in the code, which is what
+// makes the choice of index a property of the data. A segment written with a
+// graph index is read by a different implementation of [Index], chosen by
+// [Open] from this byte, and nothing that calls [Open] knows the difference.
+type Kind uint8
+
+// The index kinds.
+const (
+	// KindAuto is not a kind a section can carry. It is what a builder is given
+	// when the caller would rather the builder decided, and it is resolved to a
+	// real kind before a byte is written.
+	KindAuto Kind = 0
+
+	// KindFlat is every vector, scanned. Exact, and the only kind this build
+	// writes or reads.
+	KindFlat Kind = 1
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindAuto:
+		return "auto"
+	case KindFlat:
+		return "flat"
+	}
+	return "kind(" + strconv.Itoa(int(k)) + ")"
+}
+
+// MaxDim is the widest vector this will store.
+//
+// It is above every embedding model in use and it is checked anyway, for two
+// reasons. A dimension read out of a damaged file is a number nothing should be
+// sized from, and the scan accumulates a dot product of two signed bytes in an
+// int32, which holds 127 times 127 times a hundred and thirty thousand
+// dimensions before it wraps. This is three orders of magnitude inside that.
+const MaxDim = 4096
+
+// The errors a caller can act on differently. They are separate values because
+// they send somebody looking in different places: a version is a section
+// written by a newer build, a format error is bytes that were damaged or were
+// never a section, a dimension error is a query that does not belong to this
+// segment, and a zero vector is an embedder that returned nothing.
+var (
+	ErrVersion = errors.New("vector: unknown version")
+	ErrFormat  = errors.New("vector: malformed")
+	ErrKind    = errors.New("vector: unknown index kind")
+	ErrDim     = errors.New("vector: wrong number of dimensions")
+	ErrZero    = errors.New("vector: a zero vector has no direction")
+)
+
+// The header. Fixed size, at the front, and the version is the first byte so a
+// reader can refuse an unknown one before it has interpreted anything else.
+//
+//	0  1  version
+//	1  1  metric
+//	2  1  index kind
+//	3  1  flags, reserved and zero, so a future bit can be a refusal too
+//	4  4  dimensions
+//	8  4  rows
+//	12 4  reserved, zero
+//
+// Then the scales, one float32 per row, and then the codes, dim signed bytes
+// per row. The scales come first so that the four byte values stay aligned
+// whatever the dimension is, and so that a scan reading a scale and then a row
+// of codes reads two runs that each go forwards.
+const headerSize = 16
+
+const (
+	offVersion  = 0
+	offMetric   = 1
+	offKind     = 2
+	offFlags    = 3
+	offDim      = 4
+	offRows     = 8
+	offReserved = 12
+)
+
+// scaleSize is the width of one stored scale.
+const scaleSize = 4
+
+var le = binary.LittleEndian

--- a/store/vector/vector_test.go
+++ b/store/vector/vector_test.go
@@ -1,0 +1,311 @@
+package vector_test
+
+import (
+	"errors"
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/tamnd/genba/store/vector"
+)
+
+// The four boxes on the issue, in order: the flat scan is exact by construction
+// and the quantisation does not reorder anything clear, the scan applies
+// visibility as it goes, the benchmarks cover a hundred thousand and a million
+// vectors in bench_test.go, and the index kind is a byte in the section rather
+// than a branch in the code.
+
+func TestASectionRoundTripsTheDirectionOfEveryVector(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 7))
+	const dim, rows = 128, 300
+
+	want := make([][]float32, rows)
+	b := builder(t, dim, vector.KindAuto)
+	for i := range want {
+		want[i] = random(rnd, dim)
+		if err := b.Append(want[i]); err != nil {
+			t.Fatalf("appending row %d: %v", i, err)
+		}
+	}
+	s := open(t, b)
+
+	if got := s.Rows(); got != rows {
+		t.Errorf("Rows returned %d, want %d", got, rows)
+	}
+	if got := s.Dim(); got != dim {
+		t.Errorf("Dim returned %d, want %d", got, dim)
+	}
+	if got := s.Kind(); got != vector.KindFlat {
+		t.Errorf("Kind returned %s, want %s", got, vector.KindFlat)
+	}
+	if got := s.Metric(); got != vector.MetricCosine {
+		t.Errorf("Metric returned %s, want %s", got, vector.MetricCosine)
+	}
+
+	// A quantised vector is not the vector that went in and is not supposed to
+	// be. What has to survive is the direction, because the direction is the
+	// only thing cosine reads.
+	worst := 1.0
+	for i, v := range want {
+		got, ok := s.At(i)
+		if !ok {
+			t.Fatalf("row %d has no vector", i)
+		}
+		if c := cosine(v, got); c < worst {
+			worst = c
+		}
+	}
+	if worst < 0.9999 {
+		t.Errorf("the worst row came back at cosine %.6f to what went in, want at least 0.9999", worst)
+	}
+	t.Logf("%d rows of %d dimensions in %d bytes, the worst at cosine %.6f to the original", rows, dim, s.Size(), worst)
+}
+
+func TestARowWithNoVectorIsNeverScored(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 8))
+	const dim = 64
+
+	b := builder(t, dim, vector.KindFlat)
+	q := random(rnd, dim)
+	// Row 0 is the query itself, so if a null row could ever be returned it
+	// would have to displace the best possible match to do it.
+	if err := b.Append(q); err != nil {
+		t.Fatalf("appending: %v", err)
+	}
+	for range 20 {
+		b.AppendNull()
+	}
+	s := open(t, b)
+
+	if s.Has(3) {
+		t.Error("Has says a null row carries a vector")
+	}
+	if _, ok := s.At(3); ok {
+		t.Error("At returned a vector for a null row")
+	}
+
+	got := search(t, s, q, 21, nil)
+	if len(got) != 1 {
+		t.Fatalf("a section with one vector and twenty nulls returned %d matches, want 1", len(got))
+	}
+	if got[0].Row != 0 {
+		t.Errorf("the one match is row %d, want 0", got[0].Row)
+	}
+}
+
+func TestAZeroVectorIsRefusedRatherThanStored(t *testing.T) {
+	b := builder(t, 8, vector.KindAuto)
+	if err := b.Append(make([]float32, 8)); !errors.Is(err, vector.ErrZero) {
+		t.Errorf("appending a zero vector returned %v, want ErrZero", err)
+	}
+	if _, err := vector.NewQuery(make([]float32, 8)); !errors.Is(err, vector.ErrZero) {
+		t.Errorf("a zero query returned %v, want ErrZero", err)
+	}
+	if got := b.Rows(); got != 0 {
+		t.Errorf("the refused vector still added %d rows", got)
+	}
+}
+
+func TestAVectorOfTheWrongWidthIsRefused(t *testing.T) {
+	b := builder(t, 8, vector.KindAuto)
+	if err := b.Append(make([]float32, 9)); !errors.Is(err, vector.ErrDim) {
+		t.Errorf("appending nine components to an eight wide section returned %v, want ErrDim", err)
+	}
+	if _, err := vector.NewBuilder(0, vector.KindAuto); !errors.Is(err, vector.ErrDim) {
+		t.Errorf("a section of no dimensions returned %v, want ErrDim", err)
+	}
+	if _, err := vector.NewBuilder(vector.MaxDim+1, vector.KindAuto); !errors.Is(err, vector.ErrDim) {
+		t.Errorf("a section wider than MaxDim returned %v, want ErrDim", err)
+	}
+}
+
+func TestAQueryFromAnotherSegmentIsRefused(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 9))
+	b := builder(t, 16, vector.KindAuto)
+	if err := b.Append(random(rnd, 16)); err != nil {
+		t.Fatalf("appending: %v", err)
+	}
+	s := open(t, b)
+
+	q, err := vector.NewQuery(random(rnd, 32))
+	if err != nil {
+		t.Fatalf("building a query: %v", err)
+	}
+	if _, err := s.Search(q, 10, nil); !errors.Is(err, vector.ErrDim) {
+		t.Errorf("a 32 wide query against a 16 wide section returned %v, want ErrDim", err)
+	}
+	if _, err := s.Search(nil, 10, nil); !errors.Is(err, vector.ErrQuery) {
+		t.Errorf("a search with no query returned %v, want ErrQuery", err)
+	}
+}
+
+// TestTheIndexKindIsAByteInTheSection is the box that says choosing an index is
+// a configuration decision rather than a code change. The kind is written into
+// the header, Open dispatches on it, and a caller holds an interface either way.
+func TestTheIndexKindIsAByteInTheSection(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 10))
+	for _, want := range []vector.Kind{vector.KindAuto, vector.KindFlat} {
+		b := builder(t, 8, want)
+		if err := b.Append(random(rnd, 8)); err != nil {
+			t.Fatalf("appending: %v", err)
+		}
+		raw, err := b.Build()
+		if err != nil {
+			t.Fatalf("building with kind %s: %v", want, err)
+		}
+		// Byte two of the header, which is where a reader looks before it
+		// decides which implementation to hand back.
+		if got := vector.Kind(raw[2]); got != vector.KindFlat {
+			t.Errorf("a section asked for %s carries kind %s, want %s", want, got, vector.KindFlat)
+		}
+		s, err := vector.Open(raw)
+		if err != nil {
+			t.Fatalf("opening: %v", err)
+		}
+		if got := s.Kind(); got != vector.KindFlat {
+			t.Errorf("the opened index reports %s, want %s", got, vector.KindFlat)
+		}
+	}
+
+	if _, err := vector.NewBuilder(8, vector.Kind(9)); !errors.Is(err, vector.ErrKind) {
+		t.Errorf("a builder for an unknown kind returned %v, want ErrKind", err)
+	}
+}
+
+// TestOpenRefusesBytesThatAreNotASection covers the ways a section arrives
+// wrong. These bytes come off a disk, and a reader that trusts a length field
+// turns a bad sector into a dead process.
+func TestOpenRefusesBytesThatAreNotASection(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 11))
+	good := func() []byte {
+		b := builder(t, 16, vector.KindFlat)
+		for range 4 {
+			if err := b.Append(random(rnd, 16)); err != nil {
+				t.Fatalf("appending: %v", err)
+			}
+		}
+		raw, err := b.Build()
+		if err != nil {
+			t.Fatalf("building: %v", err)
+		}
+		return raw
+	}
+
+	cases := []struct {
+		name   string
+		damage func(b []byte) []byte
+		want   error
+	}{
+		{"empty", func([]byte) []byte { return nil }, vector.ErrFormat},
+		{"a header and nothing else", func(b []byte) []byte { return b[:8] }, vector.ErrFormat},
+		{"a version from the future", func(b []byte) []byte { b[0] = vector.Version + 1; return b }, vector.ErrVersion},
+		{"a flag this build does not know", func(b []byte) []byte { b[3] = 1; return b }, vector.ErrVersion},
+		{"reserved bytes that are not zero", func(b []byte) []byte { b[12] = 1; return b }, vector.ErrFormat},
+		{"a metric this build does not have", func(b []byte) []byte { b[1] = 9; return b }, vector.ErrFormat},
+		{"an index kind this build cannot read", func(b []byte) []byte { b[2] = 9; return b }, vector.ErrKind},
+		{"no dimensions", func(b []byte) []byte { b[4] = 0; b[5] = 0; return b }, vector.ErrDim},
+		{"more dimensions than the limit", func(b []byte) []byte { b[4], b[5], b[6], b[7] = 0xff, 0xff, 0xff, 0xff; return b }, vector.ErrDim},
+		{"a row count the bytes cannot hold", func(b []byte) []byte { b[8], b[9], b[10], b[11] = 0xff, 0xff, 0xff, 0x0f; return b }, vector.ErrFormat},
+		{"a truncated copy", func(b []byte) []byte { return b[:len(b)-1] }, vector.ErrFormat},
+		{"bytes after the end", func(b []byte) []byte { return append(b, 0) }, vector.ErrFormat},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := vector.Open(c.damage(good())); !errors.Is(err, c.want) {
+				t.Errorf("Open returned %v, want %v", err, c.want)
+			}
+		})
+	}
+}
+
+// FuzzOpen has one contract, which is that nothing it is fed ever panics. A
+// reader that panics on a damaged file turns a recoverable segment into an
+// outage.
+func FuzzOpen(f *testing.F) {
+	rnd := rand.New(rand.NewPCG(2121, 12))
+	b := builder(f, 8, vector.KindFlat)
+	for range 3 {
+		if err := b.Append(random(rnd, 8)); err != nil {
+			f.Fatalf("appending: %v", err)
+		}
+	}
+	b.AppendNull()
+	raw, err := b.Build()
+	if err != nil {
+		f.Fatalf("building: %v", err)
+	}
+	f.Add(raw)
+	f.Add([]byte{})
+	f.Add(make([]byte, 16))
+
+	q, err := vector.NewQuery(random(rnd, 8))
+	if err != nil {
+		f.Fatalf("building a query: %v", err)
+	}
+	f.Fuzz(func(t *testing.T, in []byte) {
+		s, err := vector.Open(in)
+		if err != nil {
+			return
+		}
+		for row := range s.Rows() + 2 {
+			s.Has(row)
+			s.At(row)
+		}
+		if s.Dim() == q.Dim() {
+			if _, err := s.Search(q, 5, nil); err != nil {
+				t.Fatalf("searching a section that opened: %v", err)
+			}
+		}
+	})
+}
+
+// builder is NewBuilder with the error handled once.
+func builder(tb testing.TB, dim int, kind vector.Kind) *vector.Builder {
+	tb.Helper()
+	b, err := vector.NewBuilder(dim, kind)
+	if err != nil {
+		tb.Fatalf("a builder for %d dimensions: %v", dim, err)
+	}
+	return b
+}
+
+// open builds and opens in one step, which is what every test that is not about
+// the encoding wants.
+func open(tb testing.TB, b *vector.Builder) vector.Index {
+	tb.Helper()
+	raw, err := b.Build()
+	if err != nil {
+		tb.Fatalf("building: %v", err)
+	}
+	s, err := vector.Open(raw)
+	if err != nil {
+		tb.Fatalf("opening: %v", err)
+	}
+	return s
+}
+
+// random returns a vector from a normal distribution, which is the shape a real
+// embedding has: no component dominates and the length carries no meaning.
+func random(rnd *rand.Rand, dim int) []float32 {
+	v := make([]float32, dim)
+	for i := range v {
+		v[i] = float32(rnd.NormFloat64())
+	}
+	return v
+}
+
+// cosine is the exact answer, in float64, which is what everything here is
+// measured against.
+func cosine(a, b []float32) float64 {
+	var dot, na, nb float64
+	for i := range a {
+		x, y := float64(a[i]), float64(b[i])
+		dot += x * y
+		na += x * x
+		nb += y * y
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / math.Sqrt(na*nb)
+}


### PR DESCRIPTION
Closes #7.

A segment's vectors, quantised to a byte a component, and a flat scan that scores every one of them against a query.
`docs/vectors.md` has the format and the reasoning, and the README layout table now lists `store/segment` and `store/column` too, which it had been missing.

## Why a flat scan first

It is what an approximate index has to beat, and there is no way to know whether one does without the number it has to beat.
A flat scan has no candidate list, no entry point and no beam width, so its recall is one by construction rather than by tuning, and every accuracy question about this package reduces to the quantisation and nothing else.

It also stays useful after there is a second index.
A segment of ten thousand documents is scanned in under a millisecond, and a graph built over ten thousand vectors costs more to build than the scan it replaces costs to run.

## The permission bitmap is the loop

`Search` takes the rows the reader may see and walks that bitmap.
It does not walk the rows and ask the bitmap.

A scan that scores everything and filters afterwards has already read a document the caller is not allowed to see, and the only thing between that read and a leak is the code that comes next.
Here an unreadable document is never touched, so there is no result to drop, no count to correct and no score to accidentally surface in an aggregate.

It is faster as well, and the benchmark shows it. On the same hundred thousand row corpus at 768 dimensions:

| Rows the reader may see | Per query |
| --- | --- |
| 100 percent | 45.6 ms |
| 50 percent | 25.6 ms |
| 10 percent | 6.0 ms |
| 1 percent | 0.47 ms |

A scan that filtered afterwards would show the same cost at every one of those.
Walking the bitmap costs about seven percent when the reader may see everything, and it pays that back many times over everywhere else.

## Quantisation, and what it costs in accuracy

A vector is normalised, then each component is stored as one signed byte with a float32 scale beside the row.
The query is quantised by the same rule, so the inner loop is an integer multiply and add over two byte arrays.
Keeping the query at full precision would mean converting a byte to a float on every component of every candidate, which is the one operation here that runs a few hundred million times a query.

Per row that is `4 + dim` bytes against the `4 * dim` a float32 array would take, so a million documents at 768 dimensions is 772 MB rather than 3 GB.

| Dimensions | Worst score off the exact cosine |
| --- | --- |
| 64 | 0.004076 |
| 384 | 0.001402 |
| 768 | 0.001514 |

Those are the worst row of five hundred rather than the average, and they improve with width because the error per component is independent and the dot product averages over more of them.

The size of the error is not the interesting test though, the order is.
`TestQuantisationDoesNotReorderClearResults` computes the exact float64 cosine for every row of a 1500 row corpus and checks every pair in the returned order for an inversion.
Two documents within the margin of each other may trade places, which is a swap nothing downstream can see.
A pair separated by more than a hundredth of a cosine coming back the wrong way round fails.

## The index kind is a byte, not a branch

Byte 2 of the header says which index the section carries.
`Open` reads it and returns an `Index`, and a caller holding one cannot tell an exact scan from an approximate one apart from asking it.
On the write side `Builder.resolve` is the single place the choice is made, and it is a method rather than a function because the size threshold a graph index needs is a row count and the builder has it.

Worth being straight about the fourth box on the issue: this is satisfied at the format and API level, and it is not yet an operator facing setting.
No storage driver writes segments yet, so there is nothing in the server to configure and a knob that reached no code would be worse than none.

## What it costs

Apple M4, top 20, one query against the whole segment:

| Rows | Dimensions | Per query | Rows a second |
| --- | --- | --- | --- |
| 100 thousand | 128 | 6.3 ms | 15.8 million |
| 100 thousand | 768 | 42.5 ms | 2.4 million |
| 1 million | 128 | 75.2 ms | 13.3 million |
| 1 million | 384 | 201 ms | 5.0 million |

Read as bytes rather than rows and it is the same number four times, 1.7 to 2.0 GB a second, which is memory bandwidth.
The scan is not compute bound, so the next real gain is scanning fewer bytes rather than scanning them faster.
Building costs 347 thousand vectors a second at 768 dimensions and a query is quantised in 2.7 microseconds.

A million vectors at 768 would be 750 MB, which is why the grid is a hundred thousand at the wide models and a million at the narrow ones.

## Two things that were measured rather than assumed

The dot product started as a four way unroll indexed by `i`, which left a bounds check on every line under `-d=ssa/check_bce/debug=1`.
Rewriting it as an eight way slice advancing loop removed them and took a hundred thousand rows at 128 dimensions from 7.07 ms to 3.39 ms.

The rounding is `math.Round` rather than the obvious add a half and let the conversion truncate.
The hand written version needs the sign of the value, which is a branch on data that is half negative and mispredicts every other component.
Appending is three times faster with the library function. That is the opposite of what writing the arithmetic out by hand usually does, which is why it got an A/B rather than a guess.

## Rows with no vector

A document with no embedding still gets a row and still costs its bytes, because row numbers are the segment's and a section that skipped a document would need a second numbering and a map between the two.
That map is what lets a permission bitmap built from the columns be handed straight to the scan, so it is worth the space.
A null row is a scale of zero, and a zero vector at write time is `ErrZero` rather than a silent null, because an embedder returning zeros is broken and a pipeline that quietly indexes that is one where a broken model looks like a corpus with no matches.

## Checks

`gofmt`, `go vet` and `golangci-lint run ./store/vector/...` are clean, `go test ./store/vector/` passes, and `FuzzOpen` ran 5.6 million executions over thirty seconds with no crash.
`arch_test.go` gains one entry: `store/vector` imports `store/column` and nothing else of ours, which is the point rather than a convenience, since the rows a principal may read arrive as a bitmap and the scan walks it.