### PR TITLE
ci: pin the Kura engine to a commit instead of tracking a branch

### DIFF
--- a/docs/kura.md
+++ b/docs/kura.md
@@ -39,6 +39,21 @@ A checked in binary is a binary nobody can review and a build nobody can reprodu
 
 `KURA_REPO`, `KURA_REF` and `KURA_SRC` override where it comes from, which is what you want when testing a change to the engine alongside a change here.
 
+## The engine version is pinned
+
+`REF` in `scripts/kura.sh` is a commit, not a branch.
+
+A build that tracks a branch is not reproducible: two machines a day apart get two different engines, and the tests that pass on one are not evidence about the other.
+It is also a way for a commit in the engine repository to turn CI red on whichever pull request here happens to be open, which points the blame at the wrong change and teaches people to ignore a check.
+That is not hypothetical, it is [#83](https://github.com/tamnd/genba/issues/83).
+
+Bumping the engine is a commit here like any other.
+Change the line, run `make kura && make kura-test`, and open a pull request, which is what makes the tests run against the new engine before it lands rather than after.
+The CI cache key hashes `scripts/kura.sh`, so a bump cannot be served a build of the previous engine.
+
+The ABI is stable but the encodings behind it are not yet, so a bump is sometimes a change to `store/kura` as well.
+That is the review the pin exists to force.
+
 ## What the ABI covers
 
 | Area | What is there |

--- a/scripts/kura.sh
+++ b/scripts/kura.sh
@@ -9,7 +9,12 @@
 set -eu
 
 REPO=${KURA_REPO:-https://github.com/tamnd/kura}
-REF=${KURA_REF:-main}
+# Pinned, because the engine is a separate repository and a build that tracks a
+# branch is not reproducible: two machines a day apart get two different
+# engines, and a commit over there turns CI red on whichever pull request here
+# happens to be open. Bumping this is a commit like any other, which is what
+# makes the tests run against the new engine before it lands rather than after.
+REF=${KURA_REF:-bab2997c0a373d04e48a16c89c68a30dc3039e6e}
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 SRC=${KURA_SRC:-$ROOT/third_party/kura-src}
 DEST=$ROOT/third_party/kura
@@ -20,13 +25,18 @@ if ! command -v cargo >/dev/null 2>&1; then
 	exit 1
 fi
 
-if [ -d "$SRC/.git" ]; then
-	git -C "$SRC" fetch --quiet origin "$REF"
-	git -C "$SRC" checkout --quiet FETCH_HEAD
-else
+# One path for both cases, because --branch takes a name and REF is a commit.
+# An empty clone followed by a fetch of the ref is what works for a commit, a
+# tag and a branch alike, so an override does not have to be any particular one
+# of those.
+if [ ! -d "$SRC/.git" ]; then
 	rm -rf "$SRC"
-	git clone --quiet --depth 1 --branch "$REF" "$REPO" "$SRC"
+	mkdir -p "$SRC"
+	git -C "$SRC" init --quiet
+	git -C "$SRC" remote add origin "$REPO"
 fi
+git -C "$SRC" fetch --quiet --depth 1 origin "$REF"
+git -C "$SRC" checkout --quiet --force FETCH_HEAD
 
 # On Windows, cargo defaults to the MSVC toolchain and cgo uses the mingw gcc
 # that comes with Go. A library from one does not link into the other, and the


### PR DESCRIPTION
Closes #83.

`scripts/kura.sh` built whatever was on the tip of `main` in the engine repository at the moment the job ran, so the version this repository tests against changed without a commit here.

## What went wrong

On #82 the engine landed a change to the posting block encoding, packing at a fixed width instead of varints, thirty one seconds before the `kura (windows-latest)` job started. The Go decoder still read varints:

```
--- FAIL: TestPostingsRoundTrip
    kura_test.go:191: decoding 128 ids: kura: input ended early
```

That pull request touched `store/vector`, `docs` and the README, and nothing that job compiles. Only Windows went red, because the other two runners restored a cache built from the older source, which makes the same problem look intermittent as well as misattributed.

Three things were wrong at once. A red check that is not the author's is a check people learn to ignore, and the next one that is real gets ignored with it. A build that tracks a branch is not reproducible, so the tests that pass on one machine are not evidence about another. And the cache could serve a build of a different engine than the one checked out.

## The change

`REF` is now the commit the Go side is known to work against, `bab2997c`, with the reason written next to it. Bumping it is a commit here like any other, which is what makes the tests run against the new engine before it lands rather than after.

The clone became an init and a fetch, because `git clone --depth 1 --branch` takes a name and this is now a commit. One path serves a commit, a tag and a branch alike, so `KURA_REF` can still be any of them when developing against both repositories at once, and a checkout left on some other ref is moved back rather than confusing the next build.

No workflow change was needed for the cache. The key is `kura-${{ runner.os }}-${{ hashFiles('scripts/kura.sh') }}` and the ref now lives in that file, so bumping the engine changes the key by construction.

`docs/kura.md` gains a section saying the version is pinned, why, and how to bump it.

## Checked

`make kura` from an empty directory fetches the pinned commit by sha and builds it, running it again on an existing checkout is a no op, and a checkout manually moved to the tip of `main` is pulled back to the pin on the next run. `make kura-test` passes against the result on this machine.

The engine tip has moved twice more since #82 merged, which is the argument for this in one line.