### PR TITLE
store/graph: entities and relationships over the same segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ func main() {
 | `store/segment` | the on disk segment container, [docs/segment.md](docs/segment.md) |
 | `store/column` | one field across every row of a segment, and the scans over it, [docs/columns.md](docs/columns.md) |
 | `store/vector` | the embedding section of a segment and the search over it, [docs/vectors.md](docs/vectors.md) |
+| `store/graph` | the entities and relationships of a segment and the walk over them, [docs/graph.md](docs/graph.md) |
 | `index` | query parsing, retrieval and ranking |
 | `connector` | the ingestion contract, cursors and checkpoints |
 | `connector/fssource` | the reference connector, a directory tree with OWNERS files |

--- a/arch_test.go
+++ b/arch_test.go
@@ -65,6 +65,21 @@ var allowed = map[string][]string{
 	// put the permission model in a second place again.
 	"store/vector": {"store/column"},
 
+	// graph is the entities and relationships of a segment, and it imports
+	// column for two reasons that are both the point. The entity keys and the
+	// edge kinds are columns, so looking an entity up by name is the same
+	// sorted dictionary search a source filter is. And the rows a principal may
+	// read arrive as the same bitmap the document scans use, which is what makes
+	// an entity's visibility derived from the documents that mention it rather
+	// than stored beside it. A second permission model here would be a second
+	// thing to keep in step with the first, and the failure when they drift is a
+	// name shown to somebody who was never meant to learn it.
+	//
+	// There is deliberately no edge to doc or connector. Extraction is a
+	// connector's job and this package has no opinion about how it is done, so
+	// it holds no extractor and defines no interface for one either.
+	"store/graph": {"store/column"},
+
 	// kura is the Go side of the Rust engine's C ABI and imports nothing of
 	// ours. It deals in document ids, bytes and vectors, and it is the one
 	// package in the repository that is not in the default build at all. An

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,0 +1,197 @@
+# Graph
+
+A segment holds documents.
+This section holds the people, teams, projects and customers those documents are about, the relationships between them, and the walk over both.
+
+Version 1.
+The implementation is `store/graph`, and the container it lives inside is [the segment format](segment.md).
+
+## An entity has no permissions of its own
+
+An entity is visible to a reader when that reader may read a document that mentions it.
+An edge is visible when they may read a document that says the relationship exists.
+That is the whole permission model, and there is not a second one anywhere in this package.
+
+The alternative is an access list per entity, and it is worse in a way that does not show up until it has been wrong for a while.
+Two permission models have to be kept in step, they drift, and the failure when they drift is a name shown to somebody who was never meant to learn it.
+Here there is nothing to keep in step.
+The bitmap that filters documents is the bitmap that filters entities, over the same row numbers, so an entity cannot outlive the reasons a reader had for knowing about it.
+
+It also gives the traversal a property worth stating plainly.
+A result is a walk over the subgraph the reader could have built for themselves by reading their own documents and writing down what they said.
+Nothing in it came from a document they cannot open.
+
+The rule is total rather than a rule with a hole in it.
+`Builder.Entity` refuses an entity with no mentions and `Builder.Edge` refuses an edge with no evidence, both with `ErrMention`, because a thing nobody can see through is invisible to every reader including the one allowed the whole segment.
+That is not a useful row, it is a bug in whatever produced it, and it should say so at the call that made it rather than turn into a traversal that quietly stops.
+In practice it costs nothing, because a document that evidences a relationship names both ends of it.
+
+## Extraction is the connector's problem
+
+There is no name recogniser here, no regular expression, no model, and no interface for one either.
+
+An interface the store defines is still the store having an opinion about extraction, and it is an opinion the store is in the worst position to hold.
+A connector knows what a person is in the system it reads, because that system has user ids.
+It says so by calling `Builder.Entity` and `Builder.Edge`, and this package's entire contribution is that whatever it is told survives a round trip and is never shown to somebody who may not see it.
+
+`arch_test.go` holds that: `store/graph` imports `store/column` and nothing else in the tree.
+There is no edge to `doc` and none to `connector`.
+
+The key is the connector's problem too.
+It has to be stable across segments and unique within one, because it is what a traversal starts from and what two segments agree on when the same person is in both.
+An email address, an account id, a URL.
+This package requires only that it is not empty and not repeated.
+
+## Entities are rows, in key order
+
+An entity is a row in three columns: its key, its type, and its list of mentions.
+
+The columns are `store/column`, the same ones the documents use, which is what makes the type of an entity a facet for free and the vocabulary of types a dictionary read rather than a scan.
+The mentions are a posting list, gap encoded as variable length integers, exactly the shape the term postings have.
+
+The rows are stored in key order rather than in the order a connector declared them, and that buys two things.
+Looking an entity up by key becomes a binary search over the rows instead of a scan of them, which matters because every traversal begins with one of those per seed.
+And the section stops depending on the order the ingest happened to walk the corpus in, so two ingests of the same documents produce the same bytes.
+
+The cost is that the number `Builder.Entity` hands back is a handle in that builder rather than a row in the finished section, since the order is only known once the last entity is in.
+`Builder.Edge` takes the handle, `Build` translates them, and a caller that wants the row asks the section with `Graph.Find`.
+
+## Edges are one contiguous run per entity
+
+The edges are sorted by source, then by kind, then by destination, and stored as an offset array of one `uint32` per entity plus a flat array of one `uint32` per edge.
+
+An entity's edges are therefore a slice, and an entity with no edges is a zero length slice rather than a special case.
+The kinds are a column, so the dictionary turns the kind names a traversal asks for into codes once before the walk and filtering by kind is an integer comparison per edge.
+The destinations are a plain array rather than a column, because they are read once per edge on the one hot loop of the walk and packing four bytes into three buys less than the unpacking costs.
+
+Direction is the caller's to define.
+An edge is stored as given and followed from source to destination, so a relationship worth walking both ways is two edges.
+That is cheaper than a flag every traversal has to reason about, and it lets the two directions carry different kinds, which "manages" and "reports to" usually should.
+
+## The header
+
+Fixed size, at the front, version first, the same shape the column and vector formats use.
+
+| Offset | Size | Field |
+| --- | --- | --- |
+| 0 | 1 | version |
+| 1 | 1 | flags, zero in this version |
+| 2 | 2 | reserved, zero |
+| 4 | 4 | entities |
+| 8 | 4 | edges |
+| 12 | 4 | document rows |
+
+Then a directory of seven parts, each an offset and a length of four bytes: entity keys, entity types, mentions, adjacency, edge kinds, edge targets, evidence.
+
+A posting part is a count, then that many offsets plus one, then the gaps.
+All integers are little endian, for the same reason they are in the segment format.
+
+The parts are required to be contiguous and in order and to end exactly at the end of the section.
+Requiring that rather than tolerating gaps is what makes one comparison at the end cover every byte between.
+
+## Reading bytes that may be anything
+
+These bytes come off a disk, so `Open` checks the structure before it believes any of it, and there is a fuzz target whose only contract is that nothing it is fed ever panics.
+
+| Error | What it means |
+| --- | --- |
+| `ErrVersion` | a section written by something newer, or a flag this build does not know |
+| `ErrFormat` | bytes that were damaged or were never a section |
+| `ErrEntity` | a key that is empty, repeated, or not in the section |
+| `ErrRow` | a document row outside the segment |
+| `ErrMention` | an entity or an edge nobody could ever see |
+| `ErrDepth` | more hops than `MaxDepth` |
+| `ErrLimit` | a negative limit |
+
+The checks that matter:
+
+- Nothing is allocated from a length read out of the bytes.
+  The entity and edge counts are bounded first, then turned into the sizes the parts would have to be, and those have to match the bytes actually on hand.
+- Every part is checked against the header about how many things it holds.
+  A section that paired one entity with another entity's mentions would answer questions wrongly rather than fail, and a wrong answer here is a name shown to the wrong person.
+- The adjacency is checked once at open: it has to ascend and to end at the edge count, which is what makes every entity's range a valid slice.
+  Every edge destination is bounds checked there too, which is why the walk can use one as an index without checking again.
+- A posting list's offsets have to ascend and the last one has to be the length of the data.
+- `TestOpenRefusesEveryDamagedByte` flips every byte of a real section two ways and requires that each one either opens or returns an error.
+
+## What a traversal costs
+
+`Traverse` takes seed keys, the kinds to follow, a depth, a limit and the permission bitmap.
+It is breadth first, and the bitmap is applied at every hop rather than at the end.
+An edge whose evidence the reader cannot read is not crossed, so nothing behind it is reached through it, and an entity with no readable mention is not returned even when an edge led to it.
+
+An entity is expanded at most once, because the walk keeps a bitmap of the ones it has reached, and expanding one reads its run of edges once.
+So however deep the traversal goes it reads each edge at most once and each entity at most once, and the worst case is one pass over the section rather than something that grows with depth.
+A cycle is not a special case, it is that bitmap doing its job.
+
+The visibility checks are the part that is not constant.
+Deciding something is visible stops at the first document the reader may see, so the usual cost is one variable length integer.
+Deciding it is not visible reads the whole list, because that is what it takes to be sure.
+A reader who may see very little is therefore the expensive case per entity rather than the cheap one, which is the right way round: their answer is the smallest, so paying more per entity still costs less overall.
+
+`Limit` stops the walk rather than trimming the answer, so it bounds the work and not just the output, and what it keeps is the entities nearest the seeds.
+`Result.Truncated` says the limit stopped it, and it is set only when there was more to find, not when the last thing there was to find happened to fill the page.
+
+Every part of the order is a property of the section rather than of the ingest or of the order the seeds were listed in, so the same question over the same segment gives the same answer in the same order.
+
+## What it costs
+
+On an Apple M4, one seed, depth 6, following every kind, with no permission filter, so the walk reaches everything it can:
+
+| Documents | Entities | Edges each | Section | Per traversal | Entities reached |
+| --- | --- | --- | --- | --- | --- |
+| 10 thousand | 2 thousand | 4 | 139 KB | 57 us | 1691 |
+| 100 thousand | 20 thousand | 4 | 1.5 MB | 165 us | 4616 |
+| 100 thousand | 20 thousand | 16 | 4.0 MB | 2.4 ms | 20000 |
+| 1 million | 200 thousand | 4 | 15.2 MB | 190 us | 5388 |
+
+That is 28 million entities a second in the first, second and fourth rows, which is the same number three times over corpora that differ by a hundred times in size.
+What a traversal costs is the component it walks, not the segment it walks it in.
+The dense row is the one that reaches the entire graph, and it is slower per entity because it also reads sixteen edges for each one.
+
+The same walk with a limit of 20, which is what a search result actually asks for:
+
+| Documents | Per traversal |
+| --- | --- |
+| 10 thousand | 1.9 us |
+| 100 thousand | 2.9 us |
+| 100 thousand dense | 2.5 us |
+| 1 million | 2.8 us |
+
+Flat, which is the number that says the graph can be on the request path.
+A bounded traversal is three microseconds whatever the segment holds, so a request that does one is spending its budget somewhere else.
+
+The 100 thousand document segment again, with a permission bitmap:
+
+| Rows the reader may see | Per traversal | Entities reached |
+| --- | --- | --- |
+| 100 percent | 233 us | 4616 |
+| 50 percent | 6.0 us | 102 |
+| 10 percent | 0.6 us | 2 |
+| 1 percent | 0.6 us | 1 |
+
+The answer collapses faster than the fraction does, and that is correct rather than a bug.
+Reaching an entity six hops out means every edge and every entity along the way was visible, so the odds multiply.
+A reader restricted to half the corpus does not get half the graph, they get the part of it their own documents actually support.
+
+Looking an entity up by key is 472 nanoseconds on the 20 thousand entity section, and encoding that section costs 8 milliseconds for 20 thousand entities and 80 thousand edges.
+The sort into key order is paid there, once, so that no reader pays for it.
+`go test -bench . ./store/graph/` is where those numbers come from.
+
+## What is deliberately not here yet
+
+Entity resolution.
+Two segments agree that two entities are the same when their keys are equal, and nothing here merges "Alice Smith" with "asmith@example.com".
+That is a decision with a confidence attached to it, which makes it a different kind of thing from anything in this package.
+
+Ranking.
+A traversal returns what is reachable, nearest first, and says nothing about which of those is worth showing.
+Scoring an entity by how much evidence it has and how close it is belongs to the layer that already scores documents.
+
+Merging graphs across segments.
+A traversal walks one segment, and a query that spans a corpus runs one per segment and joins on the keys.
+That join is the retrieval layer's, not the store's, and it needs entity resolution first to be worth more than concatenation.
+
+Edge properties.
+An edge is a kind, a direction and its evidence.
+A weight or a time range would go in a column beside the kinds, which is a version 2 with a flag, not a redesign.

--- a/store/graph/bench_test.go
+++ b/store/graph/bench_test.go
@@ -1,0 +1,200 @@
+package graph_test
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/tamnd/genba/store/column"
+	"github.com/tamnd/genba/store/graph"
+)
+
+// The shape of a real corpus, roughly. A segment of a hundred thousand
+// documents names some tens of thousands of distinct people, teams, projects
+// and customers, most of them a handful of times and a few of them everywhere,
+// and each one is in a few relationships.
+var shapes = []struct {
+	name           string
+	rows, entities int
+	degree         int
+}{
+	{"10k docs", 10_000, 2_000, 4},
+	{"100k docs", 100_000, 20_000, 4},
+	{"100k docs dense", 100_000, 20_000, 16},
+	{"1m docs", 1_000_000, 200_000, 4},
+}
+
+// BenchmarkTraverse is the worst case the documentation claims: a traversal to
+// the maximum depth over a graph large enough that the whole of it is reachable,
+// so the walk visits every entity it can and reads every edge out of them.
+//
+// The number to watch is entities a second rather than nanoseconds an
+// operation, because what a traversal costs is the size of the component it
+// walks and not the depth it was asked for.
+func BenchmarkTraverse(b *testing.B) {
+	for _, s := range shapes {
+		b.Run(s.name, func(b *testing.B) {
+			g, seeds := corpus(b, s.rows, s.entities, s.degree)
+			q := &graph.Traversal{From: seeds[:1], Depth: graph.MaxDepth}
+			reached := 0
+			b.ResetTimer()
+			for b.Loop() {
+				r, err := g.Traverse(q, nil)
+				if err != nil {
+					b.Fatalf("traversing: %v", err)
+				}
+				reached = len(r.Entities)
+			}
+			b.ReportMetric(float64(reached)*float64(b.N)/b.Elapsed().Seconds()/1e6, "Mentity/s")
+			b.ReportMetric(float64(reached), "reached")
+		})
+	}
+}
+
+// BenchmarkTraverseFiltered is the shape a real question has, where the reader
+// may see some fraction of the corpus.
+//
+// The interesting case is the last one. A reader who may see almost nothing is
+// the expensive case rather than the cheap one, because deciding an entity is
+// invisible means reading its whole mention list where deciding it is visible
+// stops at the first row. That is the trade the design makes on purpose, and it
+// is the right way round: the reader who is allowed the least is the one whose
+// answer is smallest, so paying more per entity still costs less overall.
+func BenchmarkTraverseFiltered(b *testing.B) {
+	const rows, entities, degree = 100_000, 20_000, 4
+	g, seeds := corpus(b, rows, entities, degree)
+
+	for _, percent := range []int{100, 50, 10, 1} {
+		b.Run(fmt.Sprintf("%d%%", percent), func(b *testing.B) {
+			rnd := rand.New(rand.NewPCG(2121, 51))
+			allow := column.NewBitmap(rows)
+			for row := range rows {
+				if rnd.IntN(100) < percent {
+					allow.Set(row)
+				}
+			}
+			// The seed's own documents are made readable whatever the fraction
+			// is, because a traversal from a seed the reader cannot see is over
+			// before it starts and measures nothing. What is being measured is
+			// the walk under a filter, not the odds that a reader picked at
+			// random may see the entity the question is about.
+			at, ok := g.Find(seeds[0])
+			if !ok {
+				b.Fatal("a key the corpus has was not found")
+			}
+			for _, row := range g.Mentions(at) {
+				allow.Set(row)
+			}
+			q := &graph.Traversal{From: seeds[:1], Depth: graph.MaxDepth}
+			reached := 0
+			b.ResetTimer()
+			for b.Loop() {
+				r, err := g.Traverse(q, allow)
+				if err != nil {
+					b.Fatalf("traversing: %v", err)
+				}
+				reached = len(r.Entities)
+			}
+			b.ReportMetric(float64(reached), "reached")
+		})
+	}
+}
+
+// BenchmarkTraverseLimited is what a search result actually asks for, which is
+// a page of related entities rather than a component. The limit stops the walk,
+// so this should be flat in the size of the graph, and it is the number that
+// says whether the graph can be on the request path.
+func BenchmarkTraverseLimited(b *testing.B) {
+	for _, s := range shapes {
+		b.Run(s.name, func(b *testing.B) {
+			g, seeds := corpus(b, s.rows, s.entities, s.degree)
+			q := &graph.Traversal{From: seeds[:1], Depth: graph.MaxDepth, Limit: 20}
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := g.Traverse(q, nil); err != nil {
+					b.Fatalf("traversing: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFind is looking an entity up by key, which every traversal starts
+// with and which is a binary search over the column's sorted dictionary.
+func BenchmarkFind(b *testing.B) {
+	const rows, entities, degree = 100_000, 20_000, 4
+	g, seeds := corpus(b, rows, entities, degree)
+	i := 0
+	for b.Loop() {
+		if _, ok := g.Find(seeds[i%len(seeds)]); !ok {
+			b.Fatal("a key the corpus has was not found")
+		}
+		i++
+	}
+}
+
+// BenchmarkBuild is what an ingestion pipeline pays to encode the section,
+// which includes sorting the entities into key order so that a reader does not
+// have to.
+func BenchmarkBuild(b *testing.B) {
+	const rows, entities, degree = 100_000, 20_000, 4
+	src := builder(b, rows, entities, degree)
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := src.Build(); err != nil {
+			b.Fatalf("building: %v", err)
+		}
+	}
+	b.ReportMetric(float64(entities)*float64(b.N)/b.Elapsed().Seconds()/1e3, "kentity/s")
+}
+
+// corpus builds a section once per case and keeps it, because what is being
+// measured is the walk and not the encoder.
+func corpus(tb testing.TB, rows, entities, degree int) (g *graph.Graph, seeds []string) {
+	tb.Helper()
+	raw, err := builder(tb, rows, entities, degree).Build()
+	if err != nil {
+		tb.Fatalf("building: %v", err)
+	}
+	g, err = graph.Open(raw)
+	if err != nil {
+		tb.Fatalf("opening: %v", err)
+	}
+	seeds = make([]string, 0, 16)
+	for i := range 16 {
+		seeds = append(seeds, key(i*entities/16))
+	}
+	tb.Logf("%d entities and %d edges over %d documents in %d bytes", g.Entities(), g.Edges(), g.Rows(), g.Size())
+	return g, seeds
+}
+
+func builder(tb testing.TB, rows, entities, degree int) *graph.Builder {
+	tb.Helper()
+	rnd := rand.New(rand.NewPCG(2121, 50))
+	b := graph.NewBuilder(rows)
+	for i := range entities {
+		// A few mentions each, spread over the corpus, which is what makes the
+		// visibility check a real one rather than a hit on the first row.
+		mentions := make([]int, 0, 4)
+		for range 4 {
+			mentions = append(mentions, rnd.IntN(rows))
+		}
+		if _, err := b.Entity(key(i), "person", mentions); err != nil {
+			tb.Fatalf("declaring entity %d: %v", i, err)
+		}
+	}
+	kinds := []string{"reports to", "owns", "member of", "worked on"}
+	for i := range entities {
+		for j := range degree {
+			if err := b.Edge(i, rnd.IntN(entities), kinds[j%len(kinds)], []int{rnd.IntN(rows)}); err != nil {
+				tb.Fatalf("declaring an edge from %d: %v", i, err)
+			}
+		}
+	}
+	return b
+}
+
+// key is the stable name of an entity in the generated corpus, padded so that
+// the dictionary order and the row order are the same, which keeps the
+// benchmark measuring the search rather than an accident of naming.
+func key(i int) string { return fmt.Sprintf("e%08d", i) }

--- a/store/graph/build.go
+++ b/store/graph/build.go
@@ -1,0 +1,271 @@
+package graph
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/tamnd/genba/store/column"
+)
+
+// Builder collects the entities and edges of a segment and encodes the section.
+//
+// Nothing here extracts anything. There is no name recogniser, no regular
+// expression and no model, and there is no interface for one either, because an
+// interface the store defines is still the store having an opinion about
+// extraction. A connector knows what a person is in the system it reads, and it
+// says so by calling [Builder.Entity] and [Builder.Edge]. This package's whole
+// contribution is that whatever it is told survives a round trip and is never
+// shown to somebody who may not see it.
+type Builder struct {
+	rows     int
+	keys     map[string]int
+	entities []entity
+	edges    []edge
+}
+
+type entity struct {
+	key      string
+	typ      string
+	mentions []int
+}
+
+type edge struct {
+	src, dst int
+	kind     string
+	evidence []int
+}
+
+// NewBuilder returns a builder for a segment with a given number of documents.
+//
+// The row count is here rather than inferred from the mentions because it is
+// what makes an out of range row an error at the call that made it. A builder
+// that grew to fit whatever it was told would encode a graph pointing at
+// documents the segment does not have, and that only becomes visible much
+// later, in a traversal that silently returns nothing.
+func NewBuilder(rows int) *Builder {
+	return &Builder{rows: rows, keys: make(map[string]int)}
+}
+
+// Rows is how many documents the segment holds.
+func (b *Builder) Rows() int { return b.rows }
+
+// Entities is how many entities have been declared.
+func (b *Builder) Entities() int { return len(b.entities) }
+
+// Edges is how many edges have been declared.
+func (b *Builder) Edges() int { return len(b.edges) }
+
+// Entity declares an entity and returns the handle to use for it.
+//
+// The handle is what [Builder.Edge] takes, and it is a number in this builder
+// rather than a row in the finished section, because [Builder.Build] stores the
+// entities in key order and only knows that order once the last one is in. A
+// caller that wants the row a section gave an entity asks the section, with
+// [Graph.Find].
+//
+// The key is what the entity is called from outside, and it has to be stable
+// across segments and unique within one, because it is what a traversal starts
+// from and what two segments agree on when the same person is in both. What
+// makes a good key is the connector's problem: an email address, an account id,
+// a URL. This package only requires that it is not empty and not repeated.
+//
+// mentions is the document rows that name this entity. An entity with none is
+// refused, because visibility here is derived from the documents and an entity
+// with nothing to be found through is invisible to every reader, including the
+// one who may see the whole segment. That is not a useful row, it is a bug in
+// whatever produced it, and it should say so here rather than turn into a
+// traversal that mysteriously stops.
+//
+// It is not a restriction in practice. A document that evidences an edge names
+// both of its ends, so an entity reachable at all is an entity with a mention.
+//
+// The rows are copied, sorted and deduplicated. A caller that found them by
+// scanning documents has them in the order it happened to scan, and sorting
+// them is a kindness that costs a builder nothing and a caller a mistake.
+func (b *Builder) Entity(key, typ string, mentions []int) (int, error) {
+	if key == "" {
+		return 0, fmt.Errorf("%w: an entity with no key", ErrEntity)
+	}
+	if at, ok := b.keys[key]; ok {
+		return 0, fmt.Errorf("%w: %q is already entity %d", ErrEntity, key, at)
+	}
+	rows, err := b.postings(mentions)
+	if err != nil {
+		return 0, fmt.Errorf("the mentions of %q: %w", key, err)
+	}
+	if len(rows) == 0 {
+		return 0, fmt.Errorf("%w: %q", ErrMention, key)
+	}
+
+	at := len(b.entities)
+	if at >= MaxEntities {
+		return 0, fmt.Errorf("%w: more than %d entities", ErrEntity, MaxEntities)
+	}
+	b.keys[key] = at
+	b.entities = append(b.entities, entity{key: key, typ: typ, mentions: rows})
+	return at, nil
+}
+
+// Lookup returns the handle of an entity already declared, which is what a
+// caller building edges out of a stream of documents needs when the same name
+// comes round again.
+func (b *Builder) Lookup(key string) (int, bool) {
+	at, ok := b.keys[key]
+	return at, ok
+}
+
+// Edge declares a typed relationship between two entities.
+//
+// evidence is the document rows that say the relationship exists, and it plays
+// the same part for an edge that mentions play for an entity: an edge nobody
+// can see evidence for is an edge nobody is told about. It is required for the
+// same reason, and refusing an edge with none is what makes the visibility rule
+// total rather than a rule with a hole in it that a caller can fall through by
+// omitting an argument.
+//
+// The direction is the caller's to define. This package stores an edge as
+// given and follows it from source to destination, so a relationship worth
+// walking both ways is two edges. Making that explicit is cheaper than a flag
+// that every traversal has to reason about, and it lets the two directions
+// carry different kinds, which "manages" and "reports to" usually should.
+func (b *Builder) Edge(src, dst int, kind string, evidence []int) error {
+	if src < 0 || src >= len(b.entities) {
+		return fmt.Errorf("%w: source %d", ErrEntity, src)
+	}
+	if dst < 0 || dst >= len(b.entities) {
+		return fmt.Errorf("%w: destination %d", ErrEntity, dst)
+	}
+	rows, err := b.postings(evidence)
+	if err != nil {
+		return fmt.Errorf("the evidence for %q: %w", kind, err)
+	}
+	if len(rows) == 0 {
+		return fmt.Errorf("%w: the %q edge from %q", ErrMention, kind, b.entities[src].key)
+	}
+	if len(b.edges) >= MaxEdges {
+		return fmt.Errorf("%w: more than %d edges", ErrEntity, MaxEdges)
+	}
+	b.edges = append(b.edges, edge{src: src, dst: dst, kind: kind, evidence: rows})
+	return nil
+}
+
+// postings validates and normalises a list of document rows.
+func (b *Builder) postings(rows []int) ([]int, error) {
+	out := slices.Clone(rows)
+	slices.Sort(out)
+	out = slices.Compact(out)
+	for _, row := range out {
+		if row < 0 || row >= b.rows {
+			return nil, fmt.Errorf("%w: row %d of %d", ErrRow, row, b.rows)
+		}
+	}
+	return out, nil
+}
+
+// Build returns the encoded section.
+func (b *Builder) Build() ([]byte, error) {
+	// The entities are stored in key order rather than in the order they were
+	// declared, which buys two things. Looking one up by key becomes a binary
+	// search over the rows instead of a scan of them, and every traversal starts
+	// with one of those. And the section stops depending on the order a
+	// connector happened to walk the documents in, so two ingests of the same
+	// corpus produce the same bytes.
+	order := make([]int, len(b.entities))
+	for i := range order {
+		order[i] = i
+	}
+	slices.SortFunc(order, func(x, y int) int {
+		return strings.Compare(b.entities[x].key, b.entities[y].key)
+	})
+	// row translates a declaration handle, which is what Entity returned and
+	// what the edges were declared against, into the row the section stores.
+	row := make([]int, len(b.entities))
+	for at, i := range order {
+		row[i] = at
+	}
+
+	// Sorted by source so that an entity's edges are one contiguous run, then
+	// by kind and destination so that the order a traversal returns them in is
+	// a property of the data rather than of the order they were declared in.
+	//
+	// Sorting by the kind string sorts by the kind code as well, because the
+	// column dictionary is sorted and a code is a rank in it.
+	edges := make([]edge, len(b.edges))
+	for i, e := range b.edges {
+		edges[i] = edge{src: row[e.src], dst: row[e.dst], kind: e.kind, evidence: e.evidence}
+	}
+	slices.SortStableFunc(edges, func(x, y edge) int {
+		if x.src != y.src {
+			return x.src - y.src
+		}
+		if c := strings.Compare(x.kind, y.kind); c != 0 {
+			return c
+		}
+		return x.dst - y.dst
+	})
+
+	keys := column.NewBuilder(column.TypeString)
+	types := column.NewBuilder(column.TypeString)
+	mentions := make([][]int, len(b.entities))
+	for at, i := range order {
+		e := b.entities[i]
+		keys.AppendString(e.key)
+		types.AppendString(e.typ)
+		mentions[at] = e.mentions
+	}
+
+	kinds := column.NewBuilder(column.TypeString)
+	targets := make([]byte, 4*len(edges))
+	evidence := make([][]int, len(edges))
+	adjacency := make([]byte, 4*(len(b.entities)+1))
+	at := 0
+	for i, e := range edges {
+		kinds.AppendString(e.kind)
+		le.PutUint32(targets[i*4:], uint32(e.dst))
+		evidence[i] = e.evidence
+		// Every entity between the last source and this one has no edges, and
+		// its slot is where this one's run begins, which is what makes an
+		// entity with no edges a zero length range rather than a special case.
+		for ; at <= e.src; at++ {
+			le.PutUint32(adjacency[at*4:], uint32(i))
+		}
+	}
+	for ; at <= len(b.entities); at++ {
+		le.PutUint32(adjacency[at*4:], uint32(len(edges)))
+	}
+
+	parts := make([][]byte, partCount)
+	var err error
+	if parts[partKeys], err = keys.Build(); err != nil {
+		return nil, fmt.Errorf("the entity keys: %w", err)
+	}
+	if parts[partTypes], err = types.Build(); err != nil {
+		return nil, fmt.Errorf("the entity types: %w", err)
+	}
+	if parts[partEdgeKinds], err = kinds.Build(); err != nil {
+		return nil, fmt.Errorf("the edge kinds: %w", err)
+	}
+	parts[partMentions] = encodePostings(mentions)
+	parts[partAdjacency] = adjacency
+	parts[partEdgeTargets] = targets
+	parts[partEvidence] = encodePostings(evidence)
+
+	size := headerSize + dirSize
+	for _, p := range parts {
+		size += len(p)
+	}
+	out := make([]byte, headerSize+dirSize, size)
+	out[offVersion] = Version
+	out[offFlags] = 0
+	le.PutUint16(out[offReserved:], 0)
+	le.PutUint32(out[offEntities:], uint32(len(b.entities)))
+	le.PutUint32(out[offEdges:], uint32(len(edges)))
+	le.PutUint32(out[offRows:], uint32(b.rows))
+	for i, p := range parts {
+		le.PutUint32(out[headerSize+i*entrySize:], uint32(len(out)))
+		le.PutUint32(out[headerSize+i*entrySize+4:], uint32(len(p)))
+		out = append(out, p...)
+	}
+	return out, nil
+}

--- a/store/graph/graph.go
+++ b/store/graph/graph.go
@@ -1,0 +1,179 @@
+// Package graph is the entity and relationship section of a segment, and the
+// traversal over it.
+//
+// Half of what people search for is a person, a team, a project or a customer,
+// and the useful answer is usually one hop away from the document that matched.
+// Who owns this service. Who else worked on that incident. Which customer the
+// contract belongs to. A search index that can only return documents makes
+// somebody answer those by reading the documents.
+//
+// # Visibility is derived, not stored
+//
+// An entity has no access control list of its own. It is visible to a reader
+// when the reader can see a document that mentions it, and an edge is visible
+// when the reader can see a document that says so.
+//
+// That is the whole reason the graph lives in the segment rather than beside
+// it. A second permission model is a second thing to keep in step with the
+// first, and the failure mode when they drift is a reader being shown a name
+// they were never supposed to learn. Here there is nothing to drift: the
+// permission bitmap that filters documents is the same bitmap that filters
+// entities, and an entity nobody may read has no visible mention to be found
+// through.
+//
+// It is deliberately conservative. A reader who can see that Alice reports to
+// Bob, and that Bob reports to Carol, can work out something about Carol
+// whether or not this package returns her. What the rule guarantees is the
+// direction that matters: nothing is returned that is not already stated in a
+// document the reader may read.
+//
+// # Columns and posting lists
+//
+// Entity keys and types are [column] sections, which is what makes looking an
+// entity up by name a binary search over a sorted dictionary and looking one up
+// by prefix a scan over codes rather than over text.
+//
+// Mentions and edge evidence are posting lists, ascending document rows as
+// variable length deltas, because they are read to answer one question, whether
+// any row in this list is visible, and that question is usually answered by the
+// first entry.
+//
+// Edges are a compressed adjacency: sorted by source, with an index that gives
+// each entity's run of them. Following an entity's edges is then a slice, which
+// is what bounds the traversal.
+//
+// # The shape
+//
+//	header      16 bytes, fixed
+//	directory   8 bytes per part, offset and length
+//	parts       the part bytes, in the same order
+//
+// Row numbers in the mention and evidence lists are the segment's document
+// rows, the same ones the columns and the vector section use, so a permission
+// bitmap built once serves all of them.
+package graph
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+// Version is the format this build writes and the only one it reads. Like the
+// segment around it, this is a refusal rather than a negotiation: a reader that
+// parses an unknown version hopefully is a reader that will one day return an
+// entity to somebody who should not have it.
+const Version uint8 = 1
+
+// The limits, which exist so that a header out of a damaged file is refused by
+// a comparison rather than by an allocator.
+const (
+	// MaxEntities is more entities than a segment of a few hundred thousand
+	// documents can plausibly name, by two orders of magnitude.
+	MaxEntities = 1 << 26
+
+	// MaxEdges is the same headroom on the relationships between them.
+	MaxEdges = 1 << 28
+
+	// MaxDepth bounds a traversal. Six hops is past the point where a result is
+	// about the thing that was asked for, and a caller that wants the whole
+	// component wants a different operation than this one.
+	MaxDepth = 6
+)
+
+// The errors a caller can act on differently.
+var (
+	// ErrVersion is a section written by something newer, so go and find that
+	// thing. It is separate from ErrFormat because an operator told
+	// "malformed" about a file that is merely from a newer build goes looking
+	// in the wrong place.
+	ErrVersion = errors.New("graph: unknown version")
+
+	// ErrFormat is bytes that were damaged or were never a graph section.
+	ErrFormat = errors.New("graph: malformed")
+
+	// ErrEntity is an entity row that does not exist, or a key that was
+	// declared twice.
+	ErrEntity = errors.New("graph: no such entity")
+
+	// ErrRow is a document row outside the segment, which means the caller and
+	// the segment disagree about how many documents there are.
+	ErrRow = errors.New("graph: document row is outside the segment")
+
+	// ErrMention is an entity with nothing to be found through. See
+	// [Builder.Entity].
+	ErrMention = errors.New("graph: an entity with no mention cannot be seen by anybody")
+
+	// ErrDepth is a traversal asking for more hops than [MaxDepth].
+	ErrDepth = errors.New("graph: depth is out of range")
+
+	// ErrLimit is a limit that is not a positive number of entities.
+	ErrLimit = errors.New("graph: limit is out of range")
+)
+
+// The header, byte for byte. Little endian throughout, for the same reason the
+// segment format is.
+//
+//	 0  1  version
+//	 1  1  flags, reserved and zero, so a future bit can be a refusal too
+//	 2  2  reserved, zero
+//	 4  4  entities
+//	 8  4  edges
+//	12  4  document rows the mention lists are numbered against
+const headerSize = 16
+
+const (
+	offVersion  = 0
+	offFlags    = 1
+	offReserved = 2
+	offEntities = 4
+	offEdges    = 8
+	offRows     = 12
+)
+
+// The parts, in the order they appear. The directory is a fixed length because
+// the set of parts is fixed: a part that is not needed is present and empty,
+// which costs eight bytes and removes the question of whether a missing part
+// means absent or means damaged.
+const (
+	// partKeys is a string column of one stable key per entity, in entity row
+	// order. The keys are what a caller names an entity by, and the column's
+	// sorted dictionary is what makes that a binary search.
+	partKeys = iota
+
+	// partTypes is a string column of one type per entity, person or team or
+	// project or whatever the extractor decided. This package does not know
+	// the set and does not want to.
+	partTypes
+
+	// partMentions is one posting list per entity, the document rows that
+	// mention it.
+	partMentions
+
+	// partAdjacency is entities+1 uint32 offsets into the edge arrays, so that
+	// the edges out of entity n are the half open range [n, n+1).
+	partAdjacency
+
+	// partEdgeKinds is a string column of one kind per edge, in edge order.
+	// The dictionary is what turns "follow only reports_to and owns" into two
+	// integer comparisons.
+	partEdgeKinds
+
+	// partEdgeTargets is one uint32 per edge, the destination entity row. It is
+	// a plain array rather than a column because it is read once per edge on
+	// the one loop in this package that has to be fast, and a packed code is a
+	// shift and a mask that buys nothing at four bytes.
+	partEdgeTargets
+
+	// partEvidence is one posting list per edge, the document rows that say the
+	// edge exists.
+	partEvidence
+
+	partCount
+)
+
+const entrySize = 8
+
+// dirSize is the whole directory, which is fixed because partCount is.
+const dirSize = partCount * entrySize
+
+var le = binary.LittleEndian

--- a/store/graph/graph_test.go
+++ b/store/graph/graph_test.go
@@ -1,0 +1,425 @@
+package graph_test
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/store/graph"
+)
+
+// The four boxes on the issue, in order: entities and edges survive a round
+// trip, a traversal never returns an entity the reader cannot see at any depth,
+// a bounded traversal on a large graph has a documented worst case, and
+// extraction is a connector concern.
+//
+// The last one is the absence of anything: there is no extractor in this
+// package, no interface for one, and no import of doc or connector, which
+// arch_test.go asserts.
+
+func TestEntitiesAndEdgesSurviveARoundTrip(t *testing.T) {
+	b := graph.NewBuilder(12)
+	alice := mustEntity(t, b, "person:alice", "person", []int{3, 0, 7, 3})
+	bob := mustEntity(t, b, "person:bob", "person", []int{0, 1})
+	pay := mustEntity(t, b, "service:payments", "service", []int{7, 9})
+
+	mustEdge(t, b, alice, bob, "reports to", []int{0})
+	mustEdge(t, b, alice, pay, "owns", []int{7})
+	mustEdge(t, b, bob, pay, "owns", []int{9})
+
+	g := open(t, b)
+
+	if got := g.Entities(); got != 3 {
+		t.Errorf("Entities returned %d, want 3", got)
+	}
+	if got := g.Edges(); got != 3 {
+		t.Errorf("Edges returned %d, want 3", got)
+	}
+	if got := g.Rows(); got != 12 {
+		t.Errorf("Rows returned %d, want 12", got)
+	}
+
+	for _, want := range []struct{ key, typ string }{
+		{"person:alice", "person"},
+		{"person:bob", "person"},
+		{"service:payments", "service"},
+	} {
+		at, ok := g.Find(want.key)
+		if !ok {
+			t.Fatalf("Find(%q) found nothing", want.key)
+		}
+		if got, _ := g.Key(at); got != want.key {
+			t.Errorf("entity %d has key %q, want %q", at, got, want.key)
+		}
+		if got, _ := g.Type(at); got != want.typ {
+			t.Errorf("entity %q has type %q, want %q", want.key, got, want.typ)
+		}
+	}
+
+	// Sorted and deduplicated, which is what the builder promises.
+	if got := g.Mentions(g.MustFind(t, "person:alice")); !slices.Equal(got, []int{0, 3, 7}) {
+		t.Errorf("the mentions of alice came back as %v, want [0 3 7]", got)
+	}
+
+	if got := g.Kinds(); !slices.Equal(got, []string{"owns", "reports to"}) {
+		t.Errorf("Kinds returned %v, want [owns, reports to]", got)
+	}
+	if got := g.Types(); !slices.Equal(got, []string{"person", "service"}) {
+		t.Errorf("Types returned %v, want [person, service]", got)
+	}
+
+	// Every edge, read back through the adjacency rather than by index, which
+	// is the path a traversal takes.
+	type stated struct{ from, kind, to string }
+	var got []stated
+	for e := range g.Entities() {
+		lo, hi := g.Out(e)
+		for i := lo; i < hi; i++ {
+			from, _ := g.Key(e)
+			kind, _ := g.Kind(i)
+			to, _ := g.Key(g.Target(i))
+			got = append(got, stated{from, kind, to})
+		}
+	}
+	want := []stated{
+		{"person:alice", "owns", "service:payments"},
+		{"person:alice", "reports to", "person:bob"},
+		{"person:bob", "owns", "service:payments"},
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("the edges came back as %v, want %v", got, want)
+	}
+
+	if got := g.Evidence(1); !slices.Equal(got, []int{0}) {
+		t.Errorf("the evidence for edge 1 is %v, want [0]", got)
+	}
+	t.Logf("%d entities and %d edges over %d documents in %d bytes", g.Entities(), g.Edges(), g.Rows(), g.Size())
+}
+
+// TestTheOrderOfTheSectionDoesNotDependOnTheOrderOfTheIngest is what makes two
+// ingests of the same corpus comparable, and it is why the entities are stored
+// in key order and the edges are sorted rather than kept as they arrived.
+func TestTheOrderOfTheSectionDoesNotDependOnTheOrderOfTheIngest(t *testing.T) {
+	keys := []string{"a", "c", "d"}
+	edges := []struct{ src, dst, kind string }{
+		{"a", "c", "knows"},
+		{"a", "d", "knows"},
+		{"c", "d", "manages"},
+		{"a", "d", "manages"},
+	}
+	build := func(people, order []int) []byte {
+		b := graph.NewBuilder(10)
+		at := make(map[string]int, len(keys))
+		for _, i := range people {
+			at[keys[i]] = mustEntity(t, b, keys[i], "person", []int{i})
+		}
+		for _, i := range order {
+			mustEdge(t, b, at[edges[i].src], at[edges[i].dst], edges[i].kind, []int{0})
+		}
+		raw, err := b.Build()
+		if err != nil {
+			t.Fatalf("building: %v", err)
+		}
+		return raw
+	}
+	first := build([]int{0, 1, 2}, []int{0, 1, 2, 3})
+	second := build([]int{2, 0, 1}, []int{3, 2, 1, 0})
+	if !slices.Equal(first, second) {
+		t.Error("the same corpus declared in a different order produced different bytes")
+	}
+}
+
+// TestTheEntitiesAreStoredInKeyOrder is the property [graph.Graph.Find] relies
+// on, and a section that stopped holding it would still answer most lookups,
+// which is exactly the kind of thing worth a test of its own.
+func TestTheEntitiesAreStoredInKeyOrder(t *testing.T) {
+	b := graph.NewBuilder(8)
+	for i, key := range []string{"zoe", "alice", "mallory", "bob"} {
+		mustEntity(t, b, key, "person", []int{i})
+	}
+	g := open(t, b)
+	want := []string{"alice", "bob", "mallory", "zoe"}
+	got := make([]string, g.Entities())
+	for i := range got {
+		got[i], _ = g.Key(i)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("the section holds %v, want %v", got, want)
+	}
+	for at, key := range want {
+		if got, ok := g.Find(key); !ok || got != at {
+			t.Errorf("Find(%q) = %d, %v, want %d, true", key, got, ok, at)
+		}
+	}
+	if _, ok := g.Find("nobody"); ok {
+		t.Error("a key the section does not have was found")
+	}
+}
+
+func TestAnEntityWithNoMentionIsRefused(t *testing.T) {
+	b := graph.NewBuilder(4)
+	if _, err := b.Entity("ghost", "person", nil); !errors.Is(err, graph.ErrMention) {
+		t.Errorf("an entity with no mention returned %v, want ErrMention", err)
+	}
+	if got := b.Entities(); got != 0 {
+		t.Errorf("the refused entity still added %d of them", got)
+	}
+
+	at := mustEntity(t, b, "real", "person", []int{0})
+	if err := b.Edge(at, at, "knows", nil); !errors.Is(err, graph.ErrMention) {
+		t.Errorf("an edge with no evidence returned %v, want ErrMention", err)
+	}
+	if got := b.Edges(); got != 0 {
+		t.Errorf("the refused edge still added %d of them", got)
+	}
+}
+
+func TestAKeyDeclaredTwiceIsRefused(t *testing.T) {
+	b := graph.NewBuilder(4)
+	mustEntity(t, b, "alice", "person", []int{0})
+	if _, err := b.Entity("alice", "person", []int{1}); !errors.Is(err, graph.ErrEntity) {
+		t.Errorf("a repeated key returned %v, want ErrEntity", err)
+	}
+	if _, err := b.Entity("", "person", []int{1}); !errors.Is(err, graph.ErrEntity) {
+		t.Errorf("an empty key returned %v, want ErrEntity", err)
+	}
+}
+
+// TestARowOutsideTheSegmentIsRefusedAtTheCallThatMadeIt is why the builder
+// takes a row count. A mention of a document the segment does not have is a
+// connector and a segment disagreeing about what was written, and the useful
+// place to say so is the call, not a traversal months later that quietly
+// returns nothing.
+func TestARowOutsideTheSegmentIsRefusedAtTheCallThatMadeIt(t *testing.T) {
+	b := graph.NewBuilder(5)
+	if _, err := b.Entity("alice", "person", []int{2, 5}); !errors.Is(err, graph.ErrRow) {
+		t.Errorf("a mention of row 5 in a segment of 5 rows returned %v, want ErrRow", err)
+	}
+	if _, err := b.Entity("bob", "person", []int{-1}); !errors.Is(err, graph.ErrRow) {
+		t.Errorf("a mention of row -1 returned %v, want ErrRow", err)
+	}
+
+	at := mustEntity(t, b, "carol", "person", []int{0})
+	if err := b.Edge(at, at, "knows", []int{9}); !errors.Is(err, graph.ErrRow) {
+		t.Errorf("evidence from row 9 returned %v, want ErrRow", err)
+	}
+	if err := b.Edge(at, 7, "knows", []int{0}); !errors.Is(err, graph.ErrEntity) {
+		t.Errorf("an edge to entity 7 of 1 returned %v, want ErrEntity", err)
+	}
+	if err := b.Edge(-1, at, "knows", []int{0}); !errors.Is(err, graph.ErrEntity) {
+		t.Errorf("an edge from entity -1 returned %v, want ErrEntity", err)
+	}
+}
+
+func TestAnEmptyGraphRoundTrips(t *testing.T) {
+	g := open(t, graph.NewBuilder(0))
+	if g.Entities() != 0 || g.Edges() != 0 {
+		t.Fatalf("an empty section holds %d entities and %d edges", g.Entities(), g.Edges())
+	}
+	if _, ok := g.Find("anything"); ok {
+		t.Error("Find found something in an empty section")
+	}
+	got, err := g.Traverse(&graph.Traversal{From: []string{"anything"}, Depth: 3}, nil)
+	if err != nil {
+		t.Fatalf("traversing an empty section: %v", err)
+	}
+	if len(got.Entities) != 0 {
+		t.Errorf("an empty section returned %d entities", len(got.Entities))
+	}
+}
+
+// TestOpenRefusesBytesThatAreNotASection covers the ways a section arrives
+// wrong. These bytes come off a disk, and a reader that trusts a length field
+// turns a bad sector into a dead process.
+func TestOpenRefusesBytesThatAreNotASection(t *testing.T) {
+	good := func() []byte {
+		b := graph.NewBuilder(8)
+		a := mustEntity(t, b, "a", "person", []int{0, 1})
+		c := mustEntity(t, b, "c", "team", []int{2})
+		mustEdge(t, b, a, c, "member of", []int{0})
+		raw, err := b.Build()
+		if err != nil {
+			t.Fatalf("building: %v", err)
+		}
+		return raw
+	}
+
+	cases := []struct {
+		name   string
+		damage func(b []byte) []byte
+		want   error
+	}{
+		{"empty", func([]byte) []byte { return nil }, graph.ErrFormat},
+		{"a header and nothing else", func(b []byte) []byte { return b[:16] }, graph.ErrFormat},
+		{"a version from the future", func(b []byte) []byte { b[0] = graph.Version + 1; return b }, graph.ErrVersion},
+		{"a flag this build does not know", func(b []byte) []byte { b[1] = 1; return b }, graph.ErrVersion},
+		{"reserved bytes that are not zero", func(b []byte) []byte { b[2] = 1; return b }, graph.ErrFormat},
+		{"more entities than the limit", func(b []byte) []byte { put32(b, 4, 1<<30); return b }, graph.ErrFormat},
+		{"more edges than the limit", func(b []byte) []byte { put32(b, 8, 1<<29); return b }, graph.ErrFormat},
+		{"an entity count the parts do not agree with", func(b []byte) []byte { put32(b, 4, 1); return b }, graph.ErrFormat},
+		{"an edge count the parts do not agree with", func(b []byte) []byte { put32(b, 8, 2); return b }, graph.ErrFormat},
+		{"a part that starts somewhere else", func(b []byte) []byte { put32(b, 16, 99); return b }, graph.ErrFormat},
+		{"a part that runs past the end", func(b []byte) []byte { put32(b, 20, 1<<20); return b }, graph.ErrFormat},
+		{"a truncated copy", func(b []byte) []byte { return b[:len(b)-1] }, graph.ErrFormat},
+		{"bytes after the end", func(b []byte) []byte { return append(b, 0) }, graph.ErrFormat},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := graph.Open(c.damage(good())); !errors.Is(err, c.want) {
+				t.Errorf("Open returned %v, want %v", err, c.want)
+			}
+		})
+	}
+}
+
+// TestOpenRefusesEveryDamagedByte is the blunt version of the table above. Every
+// byte of a section is flipped in turn, and whatever comes back has to be an
+// error or a section that answers questions without panicking. It is here
+// because a table of cases only covers the damage somebody thought of.
+func TestOpenRefusesEveryDamagedByte(t *testing.T) {
+	b := graph.NewBuilder(8)
+	a := mustEntity(t, b, "a", "person", []int{0, 1})
+	c := mustEntity(t, b, "c", "team", []int{2, 5})
+	mustEdge(t, b, a, c, "member of", []int{0})
+	mustEdge(t, b, c, a, "has member", []int{1})
+	raw, err := b.Build()
+	if err != nil {
+		t.Fatalf("building: %v", err)
+	}
+
+	opened := 0
+	for i := range raw {
+		for _, bit := range []byte{0x01, 0x80} {
+			damaged := slices.Clone(raw)
+			damaged[i] ^= bit
+			g, err := graph.Open(damaged)
+			if err != nil {
+				continue
+			}
+			opened++
+			// It parsed, so nothing it is asked may take the process down.
+			for e := range g.Entities() + 2 {
+				g.Key(e)
+				g.Type(e)
+				g.Mentions(e)
+				g.Visible(e, nil)
+				lo, hi := g.Out(e)
+				for x := lo; x < hi && x < g.Edges(); x++ {
+					g.Kind(x)
+					g.Target(x)
+					g.Evidence(x)
+				}
+			}
+			if _, err := g.Traverse(&graph.Traversal{From: []string{"a", "c"}, Depth: graph.MaxDepth}, nil); err != nil {
+				t.Fatalf("byte %d bit %#02x: traversing a section that opened: %v", i, bit, err)
+			}
+		}
+	}
+	t.Logf("%d of %d single bit flips still parsed, and none of them panicked", opened, len(raw)*2)
+}
+
+// FuzzOpen has one contract, which is that nothing it is fed ever panics.
+func FuzzOpen(f *testing.F) {
+	b := graph.NewBuilder(8)
+	a := mustEntity(f, b, "a", "person", []int{0, 1})
+	c := mustEntity(f, b, "c", "team", []int{2})
+	mustEdge(f, b, a, c, "member of", []int{0})
+	mustEdge(f, b, c, a, "has member", []int{1})
+	raw, err := b.Build()
+	if err != nil {
+		f.Fatalf("building: %v", err)
+	}
+	f.Add(raw)
+	f.Add([]byte{})
+	f.Add(make([]byte, 16+7*8))
+
+	f.Fuzz(func(t *testing.T, in []byte) {
+		g, err := graph.Open(in)
+		if err != nil {
+			return
+		}
+		for e := range g.Entities() + 2 {
+			g.Key(e)
+			g.Type(e)
+			g.Mentions(e)
+			g.Visible(e, nil)
+			g.Out(e)
+		}
+		for e := range g.Edges() + 2 {
+			g.Kind(e)
+			g.Evidence(e)
+			if e < g.Edges() {
+				g.Target(e)
+			}
+		}
+		if _, err := g.Traverse(&graph.Traversal{From: []string{"a", "c"}, Kinds: []string{"member of"}, Depth: graph.MaxDepth}, nil); err != nil {
+			t.Fatalf("traversing a section that opened: %v", err)
+		}
+	})
+}
+
+func put32(b []byte, at int, v uint32) {
+	b[at] = byte(v)
+	b[at+1] = byte(v >> 8)
+	b[at+2] = byte(v >> 16)
+	b[at+3] = byte(v >> 24)
+}
+
+func mustEntity(tb testing.TB, b *graph.Builder, key, typ string, mentions []int) int {
+	tb.Helper()
+	at, err := b.Entity(key, typ, mentions)
+	if err != nil {
+		tb.Fatalf("declaring %q: %v", key, err)
+	}
+	return at
+}
+
+func mustEdge(tb testing.TB, b *graph.Builder, src, dst int, kind string, evidence []int) {
+	tb.Helper()
+	if err := b.Edge(src, dst, kind, evidence); err != nil {
+		tb.Fatalf("declaring a %q edge: %v", kind, err)
+	}
+}
+
+// open builds and opens in one step, which is what every test that is not about
+// the encoding wants.
+func open(tb testing.TB, b *graph.Builder) *testGraph {
+	tb.Helper()
+	raw, err := b.Build()
+	if err != nil {
+		tb.Fatalf("building: %v", err)
+	}
+	g, err := graph.Open(raw)
+	if err != nil {
+		tb.Fatalf("opening: %v", err)
+	}
+	return &testGraph{Graph: g}
+}
+
+// testGraph is the section with the two lookups every test does spelled once.
+type testGraph struct{ *graph.Graph }
+
+func (g *testGraph) MustFind(tb testing.TB, key string) int {
+	tb.Helper()
+	at, ok := g.Find(key)
+	if !ok {
+		tb.Fatalf("the section has no entity %q", key)
+	}
+	return at
+}
+
+// keys turns a result into the entity keys it names, which is what the
+// traversal tests assert on: a row number says nothing about whether the answer
+// is right.
+func (g *testGraph) keys(r *graph.Result) []string {
+	out := make([]string, 0, len(r.Entities))
+	for _, e := range r.Entities {
+		key, ok := g.Key(e.Entity)
+		if !ok {
+			key = fmt.Sprintf("entity(%d)", e.Entity)
+		}
+		out = append(out, key)
+	}
+	return out
+}

--- a/store/graph/postings.go
+++ b/store/graph/postings.go
@@ -1,0 +1,171 @@
+package graph
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/tamnd/genba/store/column"
+)
+
+// A posting part holds one list of ascending document rows per entity or per
+// edge.
+//
+//	0  4  lists
+//	4  4*(lists+1)  byte offsets into the data, ascending, first zero
+//	   data, one list after another
+//
+// A list is its first row as a variable length integer followed by the gaps to
+// each row after it. The gaps are what make it small: an entity mentioned in a
+// run of consecutive documents costs a byte a document, and the alternative,
+// a dense bitmap per entity, costs the segment's row count in bits per entity
+// whether the entity is mentioned once or everywhere. Fifty thousand entities
+// over a hundred thousand documents is six hundred megabytes of mostly zeros
+// that way and a few megabytes this way.
+//
+// A list's length in ids is not stored. The offsets bound it, and decoding
+// stops when the bytes run out, so there is no count to disagree with the data.
+//
+// The offsets are what a reader validates, and they are the only thing it has
+// to: they must ascend and the last must be the length of the data. Every list
+// is then a subslice that cannot run past the part, so nothing below has to
+// check again.
+type postings struct {
+	offsets []byte
+	data    []byte
+	lists   int
+}
+
+// openPostings parses a posting part and checks its offsets.
+//
+// want is how many lists there should be, which the caller knows from the
+// header. Checking it here rather than trusting the part is what stops a
+// damaged file from pairing an entity with another entity's mentions, which
+// would be a wrong answer rather than an error.
+func openPostings(b []byte, want int, what string) (*postings, error) {
+	if len(b) < 4 {
+		return nil, fmt.Errorf("%w: the %s lists are %d bytes, shorter than a count", ErrFormat, what, len(b))
+	}
+	lists := int(le.Uint32(b))
+	if lists != want {
+		return nil, fmt.Errorf("%w: %d %s lists for %d of them", ErrFormat, lists, what, want)
+	}
+
+	// lists came from the header, which has already been bounded against the
+	// file, so this cannot overflow and cannot be a hostile allocation.
+	end := 4 + (lists+1)*4
+	if len(b) < end {
+		return nil, fmt.Errorf("%w: %d %s lists need %d bytes of offsets and the part holds %d", ErrFormat, lists, what, end, len(b))
+	}
+	p := &postings{offsets: b[4:end:end], data: b[end:], lists: lists}
+
+	last := uint32(0)
+	for i := range lists + 1 {
+		at := le.Uint32(p.offsets[i*4:])
+		if at < last {
+			return nil, fmt.Errorf("%w: the %s list offsets go backwards at %d", ErrFormat, what, i)
+		}
+		last = at
+	}
+	if int(last) != len(p.data) {
+		return nil, fmt.Errorf("%w: the %s lists end at %d and the part holds %d bytes", ErrFormat, what, last, len(p.data))
+	}
+	return p, nil
+}
+
+// at returns one list's bytes. A list outside the part is empty rather than a
+// panic, because the indexes reaching here come from a header that a damaged
+// file wrote.
+func (p *postings) at(i int) []byte {
+	if i < 0 || i >= p.lists {
+		return nil
+	}
+	lo, hi := le.Uint32(p.offsets[i*4:]), le.Uint32(p.offsets[(i+1)*4:])
+	return p.data[lo:hi:hi]
+}
+
+// visible reports whether any row in a list is one the reader may see.
+//
+// This is the one question the posting lists exist to answer and it is asked
+// once per entity and once per edge that a traversal considers, so it decodes
+// only as far as the first visible row. An entity mentioned in a thousand
+// documents the reader can see costs one gap, not a thousand.
+//
+// A nil allow means the reader may see everything, so a list is visible when it
+// has anything in it at all.
+func (p *postings) visible(i int, allow *column.Bitmap) bool {
+	b := p.at(i)
+	if allow == nil {
+		return len(b) > 0
+	}
+	row := uint64(0)
+	for len(b) > 0 {
+		gap, n := binary.Uvarint(b)
+		if n <= 0 {
+			return false
+		}
+		row += gap
+		if row > uint64(maxRow) {
+			return false
+		}
+		if allow.Get(int(row)) {
+			return true
+		}
+		b = b[n:]
+	}
+	return false
+}
+
+// rows decodes a whole list, which is what a caller wants when it is showing
+// why an entity came back rather than deciding whether it may.
+func (p *postings) rows(i int) []int {
+	b := p.at(i)
+	if len(b) == 0 {
+		return nil
+	}
+	// One byte is the smallest a row can cost, so this is an upper bound on the
+	// count that comes from the bytes on hand rather than from anything the
+	// file claims.
+	out := make([]int, 0, len(b))
+	row := uint64(0)
+	for len(b) > 0 {
+		gap, n := binary.Uvarint(b)
+		if n <= 0 || gap == 0 && len(out) > 0 {
+			return out
+		}
+		row += gap
+		if row > uint64(maxRow) {
+			return out
+		}
+		out = append(out, int(row))
+		b = b[n:]
+	}
+	return out
+}
+
+// maxRow is the largest document row a list can name, which is the largest a
+// segment can hold.
+const maxRow = 1<<32 - 1
+
+// encodePostings writes the part. The lists arrive already sorted, distinct and
+// in range, because [Builder.Entity] and [Builder.Edge] are where a caller's
+// mistake becomes an error with something useful in it, and by here it is too
+// late to say which call it came from.
+func encodePostings(lists [][]int) []byte {
+	// The gaps go straight after the header rather than into a second buffer
+	// that is copied on at the end. An offset lands at a fixed place in the
+	// header, so it can be written once the list before it is encoded, and one
+	// buffer that grows is one allocation instead of two and a copy.
+	header := 4 + (len(lists)+1)*4
+	out := make([]byte, header, header+4*len(lists))
+	le.PutUint32(out, uint32(len(lists)))
+	le.PutUint32(out[4:], 0)
+	for i, l := range lists {
+		last := 0
+		for _, row := range l {
+			out = binary.AppendUvarint(out, uint64(row-last))
+			last = row
+		}
+		le.PutUint32(out[4+(i+1)*4:], uint32(len(out)-header))
+	}
+	return out
+}

--- a/store/graph/read.go
+++ b/store/graph/read.go
@@ -1,0 +1,244 @@
+package graph
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/tamnd/genba/store/column"
+)
+
+// Graph is the entity and relationship section of a segment.
+//
+// It holds the bytes it was opened over and never copies them. Every part is a
+// window onto the section, so a memory mapped segment is traversed without
+// reading the parts a query never touches, and however many readers have the
+// same segment open there is one copy of it.
+type Graph struct {
+	b         []byte
+	rows      int
+	keys      *column.Column
+	types     *column.Column
+	kinds     *column.Column
+	mentions  *postings
+	evidence  *postings
+	adjacency []byte
+	targets   []byte
+	entities  int
+	edges     int
+}
+
+// Open parses a graph section.
+//
+// These bytes come off a disk, so nothing here is allocated from a length read
+// out of them, every part is checked against the bytes actually on hand, and a
+// part that does not agree with the header about how many things it holds is a
+// refusal rather than something to work around. A graph that pairs one entity
+// with another entity's mentions would answer questions wrongly rather than
+// fail, and a wrong answer here is a name shown to somebody who should not have
+// it.
+func Open(b []byte) (*Graph, error) {
+	if len(b) < headerSize+dirSize {
+		return nil, fmt.Errorf("%w: %d bytes is shorter than a header and a directory", ErrFormat, len(b))
+	}
+	if v := b[offVersion]; v != Version {
+		return nil, fmt.Errorf("%w: version %d, this build reads %d", ErrVersion, v, Version)
+	}
+	// A flag this build does not know changes the meaning of the bytes below it
+	// in a way it cannot guess, so it is the same refusal as an unknown version
+	// rather than something to skip politely.
+	if f := b[offFlags]; f != 0 {
+		return nil, fmt.Errorf("%w: flags %#02x are not known to this build", ErrVersion, f)
+	}
+	if r := le.Uint16(b[offReserved:]); r != 0 {
+		return nil, fmt.Errorf("%w: reserved header bytes are not zero", ErrFormat)
+	}
+
+	entities := uint64(le.Uint32(b[offEntities:]))
+	if entities > MaxEntities {
+		return nil, fmt.Errorf("%w: %d entities, the limit is %d", ErrFormat, entities, MaxEntities)
+	}
+	edges := uint64(le.Uint32(b[offEdges:]))
+	if edges > MaxEdges {
+		return nil, fmt.Errorf("%w: %d edges, the limit is %d", ErrFormat, edges, MaxEdges)
+	}
+
+	g := &Graph{b: b, rows: int(le.Uint32(b[offRows:])), entities: int(entities), edges: int(edges)}
+
+	parts := make([][]byte, partCount)
+	end := uint64(headerSize + dirSize)
+	for i := range parts {
+		at, length := uint64(le.Uint32(b[headerSize+i*entrySize:])), uint64(le.Uint32(b[headerSize+i*entrySize+4:]))
+		// The parts are contiguous and in order, so a directory that says
+		// anything else is damaged. Requiring it rather than tolerating it is
+		// what makes the last check below, that they end exactly at the end of
+		// the section, cover every byte between.
+		if at != end {
+			return nil, fmt.Errorf("%w: part %d starts at %d and the one before it ended at %d", ErrFormat, i, at, end)
+		}
+		if at+length > uint64(len(b)) {
+			return nil, fmt.Errorf("%w: part %d runs to %d and the section holds %d bytes", ErrFormat, i, at+length, len(b))
+		}
+		parts[i] = b[at : at+length : at+length]
+		end = at + length
+	}
+	if end != uint64(len(b)) {
+		return nil, fmt.Errorf("%w: the parts end at %d and the section holds %d bytes", ErrFormat, end, len(b))
+	}
+
+	var err error
+	if g.keys, err = g.column(parts[partKeys], g.entities, "entity keys"); err != nil {
+		return nil, err
+	}
+	if g.types, err = g.column(parts[partTypes], g.entities, "entity types"); err != nil {
+		return nil, err
+	}
+	if g.kinds, err = g.column(parts[partEdgeKinds], g.edges, "edge kinds"); err != nil {
+		return nil, err
+	}
+	if g.mentions, err = openPostings(parts[partMentions], g.entities, "mention"); err != nil {
+		return nil, err
+	}
+	if g.evidence, err = openPostings(parts[partEvidence], g.edges, "evidence"); err != nil {
+		return nil, err
+	}
+
+	// entities and edges have both been bounded above, so these cannot
+	// overflow and are safe to compute before comparing them to the file.
+	if want := (entities + 1) * 4; uint64(len(parts[partAdjacency])) != want {
+		return nil, fmt.Errorf("%w: %d entities need %d bytes of adjacency and the part holds %d", ErrFormat, entities, want, len(parts[partAdjacency]))
+	}
+	if want := edges * 4; uint64(len(parts[partEdgeTargets])) != want {
+		return nil, fmt.Errorf("%w: %d edges need %d bytes of targets and the part holds %d", ErrFormat, edges, want, len(parts[partEdgeTargets]))
+	}
+	g.adjacency, g.targets = parts[partAdjacency], parts[partEdgeTargets]
+
+	// The adjacency is read on the traversal loop, so it is checked once here
+	// rather than on every hop. It has to ascend, start at zero and end at the
+	// edge count, which is what makes every entity's range a valid slice.
+	last := uint32(0)
+	for i := range g.entities + 1 {
+		at := le.Uint32(g.adjacency[i*4:])
+		if at < last {
+			return nil, fmt.Errorf("%w: the adjacency goes backwards at entity %d", ErrFormat, i)
+		}
+		last = at
+	}
+	if uint64(last) != edges {
+		return nil, fmt.Errorf("%w: the adjacency ends at %d and the section holds %d edges", ErrFormat, last, edges)
+	}
+
+	// A target is read once per edge on the traversal loop and is used to index
+	// the adjacency, so it is bounds checked here rather than there.
+	for i := range g.edges {
+		if dst := le.Uint32(g.targets[i*4:]); uint64(dst) >= entities {
+			return nil, fmt.Errorf("%w: edge %d points at entity %d and the section holds %d", ErrFormat, i, dst, entities)
+		}
+	}
+	return g, nil
+}
+
+// column opens one of the three column parts and checks it covers the rows the
+// header claims.
+func (g *Graph) column(b []byte, want int, what string) (*column.Column, error) {
+	c, err := column.Open(b)
+	if err != nil {
+		return nil, fmt.Errorf("the %s: %w", what, err)
+	}
+	if c.Rows() != want {
+		return nil, fmt.Errorf("%w: the %s cover %d rows and the section holds %d", ErrFormat, what, c.Rows(), want)
+	}
+	return c, nil
+}
+
+// Rows is how many documents the segment holds, which is what the mention and
+// evidence lists are numbered against.
+func (g *Graph) Rows() int { return g.rows }
+
+// Entities is how many entities the section names.
+func (g *Graph) Entities() int { return g.entities }
+
+// Edges is how many relationships it holds.
+func (g *Graph) Edges() int { return g.edges }
+
+// Size is the length of the section in bytes.
+func (g *Graph) Size() int { return len(g.b) }
+
+// Key is an entity's stable key.
+func (g *Graph) Key(entity int) (string, bool) { return g.keys.StringAt(entity) }
+
+// Type is an entity's type, whatever the connector called it.
+func (g *Graph) Type(entity int) (string, bool) { return g.types.StringAt(entity) }
+
+// Kind is an edge's kind.
+func (g *Graph) Kind(edge int) (string, bool) { return g.kinds.StringAt(edge) }
+
+// Kinds is every edge kind in the section, sorted. It is the vocabulary the
+// segment actually uses, which is what a caller offering somebody a choice of
+// relationships to follow needs, and it is the column's dictionary rather than
+// a scan.
+func (g *Graph) Kinds() []string { return g.kinds.Dict() }
+
+// Types is every entity type in the section, sorted, for the same reason.
+func (g *Graph) Types() []string { return g.types.Dict() }
+
+// Find returns the row of the entity with a key, if the section has one.
+//
+// The entities are stored in key order, so this is a binary search over the
+// rows and costs a handful of comparisons on a segment with a hundred thousand
+// entities in it. That matters because every traversal starts with one of these
+// per seed, and a scan there would cost more than the walk.
+func (g *Graph) Find(key string) (int, bool) {
+	at := sort.Search(g.entities, func(i int) bool {
+		k, _ := g.keys.StringAt(i)
+		return k >= key
+	})
+	if at == g.entities {
+		return 0, false
+	}
+	if k, ok := g.keys.StringAt(at); !ok || k != key {
+		return 0, false
+	}
+	return at, true
+}
+
+// Mentions is the document rows that name an entity, unfiltered.
+//
+// It is the evidence for why an entity was returned rather than part of
+// deciding whether it should be, so a caller showing it to somebody has to
+// intersect it with what that reader may see. [Graph.Visible] is the question
+// the traversal asks, and it is the one to ask when the answer matters.
+func (g *Graph) Mentions(entity int) []int { return g.mentions.rows(entity) }
+
+// Evidence is the document rows that say an edge exists, unfiltered, with the
+// same caveat as [Graph.Mentions].
+func (g *Graph) Evidence(edge int) []int { return g.evidence.rows(edge) }
+
+// Visible reports whether a reader may know an entity exists, which is true
+// when they may read a document that mentions it.
+//
+// A nil allow means every document, which is what a caller with no principal to
+// apply passes.
+func (g *Graph) Visible(entity int, allow *column.Bitmap) bool {
+	return g.mentions.visible(entity, allow)
+}
+
+// EdgeVisible reports whether a reader may know a relationship exists, which is
+// true when they may read a document that says so.
+func (g *Graph) EdgeVisible(edge int, allow *column.Bitmap) bool {
+	return g.evidence.visible(edge, allow)
+}
+
+// Out is the range of edges leaving an entity, as a half open pair of edge
+// indexes. An entity with no edges is an empty range rather than a special
+// case.
+func (g *Graph) Out(entity int) (lo, hi int) {
+	if entity < 0 || entity >= g.entities {
+		return 0, 0
+	}
+	return int(le.Uint32(g.adjacency[entity*4:])), int(le.Uint32(g.adjacency[(entity+1)*4:]))
+}
+
+// Target is the entity an edge points at. Open has already checked every one of
+// these against the entity count, which is why the traversal can use it as an
+// index without checking again.
+func (g *Graph) Target(edge int) int { return int(le.Uint32(g.targets[edge*4:])) }

--- a/store/graph/traverse.go
+++ b/store/graph/traverse.go
@@ -1,0 +1,241 @@
+package graph
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/tamnd/genba/store/column"
+)
+
+// Traversal is a question about the graph.
+type Traversal struct {
+	// From is the entity keys to start from. A key the section does not have is
+	// skipped rather than refused, because a caller asking the same question of
+	// every segment in a corpus is asking about entities that mostly are not in
+	// any one of them.
+	From []string
+
+	// Kinds is the edge kinds to follow, and empty means every kind. It is
+	// resolved against the section's dictionary once, before the walk, so
+	// filtering by kind costs an integer comparison per edge rather than a
+	// string one.
+	Kinds []string
+
+	// Depth is how many hops to take. Zero returns the seeds and nothing else,
+	// which is the cheap way to ask which of these entities this reader may
+	// know about at all. The limit is [MaxDepth].
+	Depth int
+
+	// Limit bounds the entities in the result, and zero means no bound. It
+	// stops the walk rather than trimming the answer, so it bounds the work as
+	// well, and what it keeps is the entities nearest the seeds because the
+	// walk is breadth first.
+	Limit int
+}
+
+// Reached is one entity a traversal found.
+type Reached struct {
+	// Entity is the entity row, which is what [Graph.Key] and [Graph.Type] take.
+	Entity int
+
+	// Depth is how many hops from the nearest seed it was found at, so a seed
+	// is zero.
+	Depth int
+}
+
+// Hop is one edge a traversal crossed. Together these are why the entities in a
+// result are there, which is what a caller needs to say "Alice, because she
+// owns the service the document is about" rather than just "Alice".
+type Hop struct {
+	// From and To are entity rows, and Edge is the edge index, which is what
+	// [Graph.Kind] and [Graph.Evidence] take.
+	From, Edge, To int
+}
+
+// Result is what a traversal found.
+type Result struct {
+	// Entities is what was reached, nearest first: by depth, then by the order
+	// the edges that led to them were crossed, which is the order the section
+	// stores those edges in. The seeds come first, sorted by entity row.
+	//
+	// Every part of that is a property of the section rather than of the ingest
+	// that wrote it or the order the caller listed the seeds in, so the same
+	// question over the same segment gives the same answer in the same order.
+	// It is what makes a limit mean something: what it keeps is the nearest
+	// entities, not an arbitrary subset.
+	Entities []Reached
+
+	// Edges is the hops that were crossed, in the order they were crossed.
+	Edges []Hop
+
+	// Truncated says the limit stopped the walk, so there was more to find.
+	Truncated bool
+}
+
+// Traverse walks the graph from a set of entities, following edges the reader
+// may see to entities the reader may see.
+//
+// allow is the same permission bitmap that filters documents, over the same
+// document rows, and it is applied at every hop rather than at the end. An edge
+// whose evidence the reader cannot read is not crossed, so nothing behind it is
+// reached through it, and an entity with no mention the reader can read is not
+// returned even when an edge led to it. A traversal is therefore a walk over
+// the subgraph the reader could have built by reading their own documents,
+// which is the strongest thing that can be said about it and the only thing
+// worth saying.
+//
+// A nil allow means every document, which is what a caller with no principal to
+// apply passes. It is the only way to reach entities nobody vouched for, and it
+// is deliberately the shape that has to be written out rather than the default
+// that happens by omission.
+//
+// # What it costs
+//
+// An entity is expanded at most once, because a traversal keeps a bitmap of
+// which ones it has reached, and expanding an entity walks its run of edges
+// once. So however deep the traversal goes, it reads each edge at most once and
+// each entity at most once, and the worst case is one pass over the section
+// rather than anything that grows with depth. A cycle is not a special case,
+// it is the same bitmap doing its job.
+//
+// The visibility checks are the part that is not constant. Deciding an edge or
+// an entity is visible stops at the first document the reader may see, so the
+// usual cost is one variable length integer. Deciding one is not visible reads
+// its whole list, because that is what it takes to be sure. A traversal by a
+// reader who may see nothing is therefore the expensive case rather than the
+// cheap one, and its worst case is the size of the mention and evidence lists
+// it touched.
+func (g *Graph) Traverse(t *Traversal, allow *column.Bitmap) (*Result, error) {
+	if t == nil {
+		return nil, fmt.Errorf("%w: no traversal", ErrFormat)
+	}
+	if t.Depth < 0 || t.Depth > MaxDepth {
+		return nil, fmt.Errorf("%w: %d hops, the limit is %d", ErrDepth, t.Depth, MaxDepth)
+	}
+	if t.Limit < 0 {
+		return nil, fmt.Errorf("%w: %d", ErrLimit, t.Limit)
+	}
+	kinds, err := g.follow(t.Kinds)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := t.Limit
+	if limit == 0 || limit > g.entities {
+		limit = g.entities
+	}
+	out := &Result{}
+	if limit == 0 {
+		return out, nil
+	}
+
+	seen := column.NewBitmap(g.entities)
+	frontier := make([]int, 0, len(t.From))
+	for _, key := range t.From {
+		at, ok := g.Find(key)
+		if !ok || seen.Get(at) || !g.Visible(at, allow) {
+			continue
+		}
+		seen.Set(at)
+		frontier = append(frontier, at)
+	}
+	// The seeds are sorted so that the result does not depend on the order the
+	// caller happened to list them, which is what makes two spellings of the
+	// same question the same question.
+	slices.Sort(frontier)
+	for _, at := range frontier {
+		// Checked before the entity is added rather than after, so that a limit
+		// reached exactly by the last thing there was to find is not reported as
+		// having cut anything off. Truncated means there was more.
+		if len(out.Entities) >= limit {
+			out.Truncated = true
+			return out, nil
+		}
+		out.Entities = append(out.Entities, Reached{Entity: at, Depth: 0})
+	}
+
+	next := make([]int, 0, len(frontier))
+	for depth := 1; depth <= t.Depth && len(frontier) > 0; depth++ {
+		next = next[:0]
+		for _, from := range frontier {
+			lo, hi := g.Out(from)
+			for e := lo; e < hi; e++ {
+				if !kinds.wanted(g, e) {
+					continue
+				}
+				to := g.Target(e)
+				if seen.Get(to) {
+					continue
+				}
+				// The edge first, because it is the cheaper of the two
+				// questions on a graph where entities are mentioned far more
+				// often than any one relationship is stated.
+				if !g.EdgeVisible(e, allow) || !g.Visible(to, allow) {
+					continue
+				}
+				if len(out.Entities) >= limit {
+					out.Truncated = true
+					return out, nil
+				}
+				seen.Set(to)
+				out.Edges = append(out.Edges, Hop{From: from, Edge: e, To: to})
+				out.Entities = append(out.Entities, Reached{Entity: to, Depth: depth})
+				next = append(next, to)
+			}
+		}
+		// Ascending, so the next level is expanded in section order whatever
+		// order this one discovered it in.
+		slices.Sort(next)
+		frontier = append(frontier[:0], next...)
+	}
+	return out, nil
+}
+
+// kindFilter is the set of edge kinds a traversal follows, resolved to codes.
+type kindFilter struct {
+	codes []uint64
+	all   bool
+}
+
+// wanted reports whether an edge is one of the kinds being followed.
+func (f kindFilter) wanted(g *Graph, edge int) bool {
+	if f.all {
+		return true
+	}
+	code, ok := g.kinds.CodeAt(edge)
+	if !ok {
+		return false
+	}
+	// The set is small enough that a scan beats a map: following one or two
+	// kinds is the ordinary case, and a map lookup on the inner loop of a
+	// traversal costs more than two comparisons.
+	return slices.Contains(f.codes, code)
+}
+
+// follow resolves the kinds a traversal asked for against the section's
+// dictionary.
+//
+// A kind the section does not use resolves to nothing and is dropped, and if
+// none of them resolve the filter matches no edge, which is what makes asking
+// for a relationship this segment has never seen return the seeds rather than
+// everything.
+func (g *Graph) follow(kinds []string) (kindFilter, error) {
+	if len(kinds) == 0 {
+		return kindFilter{all: true}, nil
+	}
+	m, err := g.kinds.MatchStrings(kinds...)
+	if err != nil {
+		return kindFilter{}, fmt.Errorf("the edge kinds: %w", err)
+	}
+	// MatchStrings answers in edge rows, and what is wanted is the codes. One
+	// matching edge per kind is enough to learn the code, and the set is at most
+	// the number of kinds asked for.
+	out := kindFilter{codes: make([]uint64, 0, len(kinds))}
+	m.Each(func(edge int) bool {
+		if code, ok := g.kinds.CodeAt(edge); ok && !slices.Contains(out.codes, code) {
+			out.codes = append(out.codes, code)
+		}
+		return len(out.codes) < len(kinds)
+	})
+	return out, nil
+}

--- a/store/graph/traverse_test.go
+++ b/store/graph/traverse_test.go
@@ -1,0 +1,406 @@
+package graph_test
+
+import (
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/store/column"
+	"github.com/tamnd/genba/store/graph"
+)
+
+// org is a small organisation, written out so that every assertion below can be
+// read against something concrete.
+//
+// The document rows are the point of the fixture. Every entity and every edge
+// names the documents it is evidenced by, and those are what a reader is or is
+// not allowed to see, so hiding a document is how a test hides a fact.
+//
+//	row  what it says
+//	  0  alice reports to bob
+//	  1  bob reports to carol
+//	  2  carol reports to dave
+//	  3  alice owns payments
+//	  4  bob owns billing
+//	  5  a page that names alice and nobody else
+//	  6  a page that names dave and nobody else
+//	  7  a page that names payments and nobody else
+//	  8  a page that names billing and nobody else
+//	  9  a page that names carol and nobody else
+//	 10  a page that names bob and nobody else
+func org(tb testing.TB) *testGraph {
+	tb.Helper()
+	b := graph.NewBuilder(11)
+	alice := mustEntity(tb, b, "alice", "person", []int{0, 3, 5})
+	bob := mustEntity(tb, b, "bob", "person", []int{0, 1, 4, 10})
+	carol := mustEntity(tb, b, "carol", "person", []int{1, 2, 9})
+	dave := mustEntity(tb, b, "dave", "person", []int{2, 6})
+	payments := mustEntity(tb, b, "payments", "service", []int{3, 7})
+	billing := mustEntity(tb, b, "billing", "service", []int{4, 8})
+
+	mustEdge(tb, b, alice, bob, "reports to", []int{0})
+	mustEdge(tb, b, bob, carol, "reports to", []int{1})
+	mustEdge(tb, b, carol, dave, "reports to", []int{2})
+	mustEdge(tb, b, alice, payments, "owns", []int{3})
+	mustEdge(tb, b, bob, billing, "owns", []int{4})
+	return open(tb, b)
+}
+
+// all is the bitmap of a reader who may see every document, which is not the
+// same thing as a nil bitmap: nil is "no principal to apply" and this is "a
+// principal who happens to be allowed everything". Both have to give the same
+// answer, and a few tests check that they do.
+func all(rows int) *column.Bitmap {
+	b := column.NewBitmap(rows)
+	b.SetRange(0, rows)
+	return b
+}
+
+// hiding is every document except the ones named, which is how a test says
+// "this reader may not read that".
+func hiding(rows int, hidden ...int) *column.Bitmap {
+	b := all(rows)
+	for _, row := range hidden {
+		b.Clear(row)
+	}
+	return b
+}
+
+func TestATraversalFollowsEdgesToTheDepthAsked(t *testing.T) {
+	g := org(t)
+	for depth, want := range map[int][]string{
+		0: {"alice"},
+		1: {"alice", "payments", "bob"},
+		2: {"alice", "payments", "bob", "billing", "carol"},
+		3: {"alice", "payments", "bob", "billing", "carol", "dave"},
+		4: {"alice", "payments", "bob", "billing", "carol", "dave"},
+	} {
+		got := traverse(t, g, &graph.Traversal{From: []string{"alice"}, Depth: depth}, nil)
+		if !slices.Equal(got, want) {
+			t.Errorf("depth %d returned %v, want %v", depth, got, want)
+		}
+	}
+}
+
+// TestTraversalNeverReturnsAnEntityTheReaderCannotSee is the box on the issue.
+//
+// It is checked three ways, because there are three ways to get it wrong: the
+// seed, the destination and the edge in between.
+func TestTraversalNeverReturnsAnEntityTheReaderCannotSee(t *testing.T) {
+	g := org(t)
+	const rows = 11
+
+	t.Run("a seed the reader cannot see is not a seed", func(t *testing.T) {
+		// Alice is named in rows 0, 3 and 5. Hide all three and she is not
+		// somebody this reader has ever heard of, so nothing is reachable
+		// through her even though every other document is readable.
+		got := traverse(t, g, &graph.Traversal{From: []string{"alice"}, Depth: 3}, hiding(rows, 0, 3, 5))
+		if len(got) != 0 {
+			t.Errorf("a reader who cannot see alice started from her anyway and got %v", got)
+		}
+	})
+
+	t.Run("an entity the reader cannot see is not returned", func(t *testing.T) {
+		// Billing is named in rows 4 and 8, and row 4 is also the document that
+		// says bob owns it. Hiding row 8 alone leaves it visible through row 4,
+		// so this first pins that the fixture works the way it is supposed to.
+		allow := hiding(rows, 8)
+		got := traverse(t, g, &graph.Traversal{From: []string{"alice"}, Depth: 3}, allow)
+		if !slices.Contains(got, "billing") {
+			t.Fatalf("billing is still visible through row 4 and did not come back: %v", got)
+		}
+
+		// Then hide row 4 as well. There is now no document this reader may
+		// read that names billing at all, so it is not somebody they have heard
+		// of, and the edge that led to it is gone with the same document.
+		got = traverse(t, g, &graph.Traversal{From: []string{"alice"}, Depth: 3}, hiding(rows, 4, 8))
+		if slices.Contains(got, "billing") {
+			t.Errorf("a reader who can see no document naming billing got it anyway: %v", got)
+		}
+		// The rest of the graph is untouched, so this is not passing by
+		// returning nothing.
+		if !slices.Contains(got, "dave") {
+			t.Errorf("hiding billing also lost dave, which is not what was asked: %v", got)
+		}
+	})
+
+	t.Run("an edge the reader cannot see is not crossed", func(t *testing.T) {
+		// Row 1 is the only document that says bob reports to carol. Hide it
+		// and the reader can still see bob and can still see carol, through
+		// rows 10 and 9 respectively, but must not learn that one reports to
+		// the other, and must not reach dave through her.
+		allow := hiding(rows, 1)
+		if !g.Visible(g.MustFind(t, "carol"), allow) {
+			t.Fatal("the fixture is wrong, carol should still be visible through row 9")
+		}
+		got := traverse(t, g, &graph.Traversal{From: []string{"alice"}, Depth: 4}, allow)
+		want := []string{"alice", "payments", "bob", "billing"}
+		if !slices.Equal(got, want) {
+			t.Errorf("a reader who cannot read row 1 got %v, want %v", got, want)
+		}
+	})
+}
+
+// TestVisibilityIsCheckedAtEveryHopRatherThanAtTheEnd is the same box from the
+// other side. A single hidden document in the middle of a chain has to stop
+// everything behind it, however deep, which is what says the check is in the
+// walk rather than a filter over the answer.
+func TestVisibilityIsCheckedAtEveryHopRatherThanAtTheEnd(t *testing.T) {
+	// A chain of forty entities, each linked to the next by an edge evidenced
+	// by one document and each mentioned by one other.
+	const n = 40
+	b := graph.NewBuilder(2 * n)
+	at := make([]int, n)
+	for i := range n {
+		at[i] = mustEntity(t, b, fmt.Sprintf("e%02d", i), "person", []int{n + i})
+	}
+	for i := range n - 1 {
+		mustEdge(t, b, at[i], at[i+1], "next", []int{i})
+	}
+	g := open(t, b)
+
+	for _, cut := range []int{0, 1, 17, n - 2} {
+		got := traverse(t, g, &graph.Traversal{From: []string{"e00"}, Depth: graph.MaxDepth}, hiding(2*n, cut))
+		want := min(cut+1, graph.MaxDepth+1)
+		if len(got) != want {
+			t.Errorf("hiding the document behind hop %d returned %d entities, want %d: %v", cut, len(got), want, got)
+		}
+	}
+}
+
+// TestAReaderWhoMaySeeNothingGetsNothing is the degenerate case, and it is
+// worth its own test because it is the one a permission bug most often turns
+// into everything.
+func TestAReaderWhoMaySeeNothingGetsNothing(t *testing.T) {
+	g := org(t)
+	got := traverse(t, g, &graph.Traversal{From: []string{"alice", "bob", "carol"}, Depth: graph.MaxDepth}, column.NewBitmap(11))
+	if len(got) != 0 {
+		t.Errorf("a reader who may see no document got %v", got)
+	}
+}
+
+// TestNoPrincipalAndAPrincipalWhoMaySeeEverythingAgree keeps the nil bitmap
+// from drifting into a different code path with a different answer.
+func TestNoPrincipalAndAPrincipalWhoMaySeeEverythingAgree(t *testing.T) {
+	g := org(t)
+	q := &graph.Traversal{From: []string{"alice"}, Depth: graph.MaxDepth}
+	if a, b := traverse(t, g, q, nil), traverse(t, g, q, all(11)); !slices.Equal(a, b) {
+		t.Errorf("no principal returned %v and a principal who may see everything returned %v", a, b)
+	}
+}
+
+func TestOnlyTheKindsAskedForAreFollowed(t *testing.T) {
+	g := org(t)
+	for _, c := range []struct {
+		kinds []string
+		want  []string
+	}{
+		{nil, []string{"alice", "payments", "bob", "billing", "carol", "dave"}},
+		{[]string{"reports to"}, []string{"alice", "bob", "carol", "dave"}},
+		{[]string{"owns"}, []string{"alice", "payments"}},
+		{[]string{"owns", "reports to"}, []string{"alice", "payments", "bob", "billing", "carol", "dave"}},
+		{[]string{"married to"}, []string{"alice"}},
+		{[]string{"married to", "owns"}, []string{"alice", "payments"}},
+	} {
+		got := traverse(t, g, &graph.Traversal{From: []string{"alice"}, Kinds: c.kinds, Depth: graph.MaxDepth}, nil)
+		if !slices.Equal(got, c.want) {
+			t.Errorf("following %v returned %v, want %v", c.kinds, got, c.want)
+		}
+	}
+}
+
+// TestTheLimitStopsTheWalkRatherThanTrimmingTheAnswer is what makes the limit a
+// bound on work as well as on the result. It also pins what is kept, which is
+// the entities nearest the seeds, because a limit that returned an arbitrary
+// subset would be a limit nobody could use.
+func TestTheLimitStopsTheWalkRatherThanTrimmingTheAnswer(t *testing.T) {
+	g := org(t)
+	full := traverse(t, g, &graph.Traversal{From: []string{"alice"}, Depth: graph.MaxDepth}, nil)
+	for limit := 1; limit <= len(full)+1; limit++ {
+		r, err := g.Traverse(&graph.Traversal{From: []string{"alice"}, Depth: graph.MaxDepth, Limit: limit}, nil)
+		if err != nil {
+			t.Fatalf("limit %d: %v", limit, err)
+		}
+		want := full[:min(limit, len(full))]
+		if got := g.keys(r); !slices.Equal(got, want) {
+			t.Errorf("limit %d returned %v, want %v", limit, got, want)
+		}
+		if truncated := limit < len(full); r.Truncated != truncated {
+			t.Errorf("limit %d reported Truncated as %v, want %v", limit, r.Truncated, truncated)
+		}
+	}
+}
+
+// TestACycleIsNotASpecialCase is what the seen bitmap is for. Without it this
+// test does not fail, it hangs.
+func TestACycleIsNotASpecialCase(t *testing.T) {
+	b := graph.NewBuilder(6)
+	a := mustEntity(t, b, "a", "person", []int{0})
+	c := mustEntity(t, b, "c", "person", []int{1})
+	d := mustEntity(t, b, "d", "person", []int{2})
+	mustEdge(t, b, a, c, "next", []int{3})
+	mustEdge(t, b, c, d, "next", []int{4})
+	mustEdge(t, b, d, a, "next", []int{5})
+	g := open(t, b)
+
+	got := traverse(t, g, &graph.Traversal{From: []string{"a"}, Depth: graph.MaxDepth}, nil)
+	if want := []string{"a", "c", "d"}; !slices.Equal(got, want) {
+		t.Errorf("a cycle returned %v, want %v", got, want)
+	}
+}
+
+// TestAnEntityIsReturnedAtItsShortestDepth matters because a caller usually
+// ranks by it. Breadth first is what makes it true, and a depth first walk
+// would pass every other test in this file and fail this one.
+func TestAnEntityIsReturnedAtItsShortestDepth(t *testing.T) {
+	b := graph.NewBuilder(8)
+	a := mustEntity(t, b, "a", "person", []int{0})
+	c := mustEntity(t, b, "c", "person", []int{1})
+	d := mustEntity(t, b, "d", "person", []int{2})
+	e := mustEntity(t, b, "e", "person", []int{3})
+	// a reaches e directly and also the long way round through c and d, and the
+	// long way is declared first so that a walk that took edges in the order
+	// they were given would find e at depth three.
+	mustEdge(t, b, a, c, "z long", []int{4})
+	mustEdge(t, b, c, d, "z long", []int{5})
+	mustEdge(t, b, d, e, "z long", []int{6})
+	mustEdge(t, b, a, e, "z long", []int{7})
+	g := open(t, b)
+
+	r, err := g.Traverse(&graph.Traversal{From: []string{"a"}, Depth: graph.MaxDepth}, nil)
+	if err != nil {
+		t.Fatalf("traversing: %v", err)
+	}
+	want := map[string]int{"a": 0, "c": 1, "e": 1, "d": 2}
+	for _, reached := range r.Entities {
+		key, _ := g.Key(reached.Entity)
+		if got := reached.Depth; got != want[key] {
+			t.Errorf("%s came back at depth %d, want %d", key, got, want[key])
+		}
+	}
+	if len(r.Entities) != len(want) {
+		t.Errorf("got %d entities, want %d", len(r.Entities), len(want))
+	}
+}
+
+// TestTheHopsSayWhyAnEntityIsInTheResult is what makes a result explainable. A
+// list of names with no edges behind them cannot be shown to anybody with a
+// reason attached.
+func TestTheHopsSayWhyAnEntityIsInTheResult(t *testing.T) {
+	g := org(t)
+	r, err := g.Traverse(&graph.Traversal{From: []string{"alice"}, Depth: 2}, nil)
+	if err != nil {
+		t.Fatalf("traversing: %v", err)
+	}
+	type stated struct{ from, kind, to string }
+	var got []stated
+	for _, h := range r.Edges {
+		from, _ := g.Key(h.From)
+		kind, _ := g.Kind(h.Edge)
+		to, _ := g.Key(h.To)
+		got = append(got, stated{from, kind, to})
+		if len(g.Evidence(h.Edge)) == 0 {
+			t.Errorf("the %s edge from %s has no evidence behind it", kind, from)
+		}
+	}
+	want := []stated{
+		{"alice", "owns", "payments"},
+		{"alice", "reports to", "bob"},
+		{"bob", "owns", "billing"},
+		{"bob", "reports to", "carol"},
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("the hops came back as %v, want %v", got, want)
+	}
+}
+
+// TestTheAnswerDoesNotDependOnTheOrderOfTheSeeds keeps two spellings of the
+// same question the same question.
+func TestTheAnswerDoesNotDependOnTheOrderOfTheSeeds(t *testing.T) {
+	g := org(t)
+	first := traverse(t, g, &graph.Traversal{From: []string{"alice", "carol", "payments"}, Depth: 2}, nil)
+	second := traverse(t, g, &graph.Traversal{From: []string{"payments", "alice", "carol", "alice"}, Depth: 2}, nil)
+	if !slices.Equal(first, second) {
+		t.Errorf("two orderings of the same seeds returned %v and %v", first, second)
+	}
+}
+
+func TestASeedTheSectionDoesNotHaveIsSkipped(t *testing.T) {
+	g := org(t)
+	got := traverse(t, g, &graph.Traversal{From: []string{"nobody", "alice", "also nobody"}, Depth: 1}, nil)
+	if want := []string{"alice", "payments", "bob"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestATraversalOutOfRangeIsRefused(t *testing.T) {
+	g := org(t)
+	if _, err := g.Traverse(&graph.Traversal{From: []string{"alice"}, Depth: graph.MaxDepth + 1}, nil); !errors.Is(err, graph.ErrDepth) {
+		t.Errorf("a traversal past MaxDepth returned %v, want ErrDepth", err)
+	}
+	if _, err := g.Traverse(&graph.Traversal{From: []string{"alice"}, Depth: -1}, nil); !errors.Is(err, graph.ErrDepth) {
+		t.Errorf("a negative depth returned %v, want ErrDepth", err)
+	}
+	if _, err := g.Traverse(&graph.Traversal{From: []string{"alice"}, Limit: -1}, nil); !errors.Is(err, graph.ErrLimit) {
+		t.Errorf("a negative limit returned %v, want ErrLimit", err)
+	}
+	if _, err := g.Traverse(nil, nil); err == nil {
+		t.Error("a nil traversal was accepted")
+	}
+}
+
+// TestAnEntityIsExpandedAtMostOnce is the documented worst case, checked
+// against a graph with enough overlap that a walk which expanded an entity per
+// path rather than per traversal would do far more work than one pass.
+//
+// It counts by hiding nothing and comparing the edges crossed against the edges
+// that exist: every hop in the result is a distinct edge, and there can never
+// be more of them than the section holds.
+func TestAnEntityIsExpandedAtMostOnce(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(2121, 30))
+	const entities, rows = 400, 2000
+	b := graph.NewBuilder(rows)
+	at := make([]int, entities)
+	for i := range entities {
+		at[i] = mustEntity(t, b, fmt.Sprintf("e%03d", i), "person", []int{i % rows})
+	}
+	edges := 0
+	for i := range entities {
+		for range 6 {
+			mustEdge(t, b, at[i], at[rnd.IntN(entities)], "next", []int{rnd.IntN(rows)})
+			edges++
+		}
+	}
+	g := open(t, b)
+
+	r, err := g.Traverse(&graph.Traversal{From: []string{"e000"}, Depth: graph.MaxDepth}, nil)
+	if err != nil {
+		t.Fatalf("traversing: %v", err)
+	}
+	if len(r.Entities) > g.Entities() {
+		t.Fatalf("a traversal returned %d entities and the section holds %d", len(r.Entities), g.Entities())
+	}
+	seen := make(map[int]bool, len(r.Edges))
+	for _, h := range r.Edges {
+		if seen[h.Edge] {
+			t.Fatalf("edge %d was crossed twice", h.Edge)
+		}
+		seen[h.Edge] = true
+	}
+	if len(r.Edges) > edges {
+		t.Fatalf("a traversal crossed %d edges and the section holds %d", len(r.Edges), edges)
+	}
+	t.Logf("%d entities and %d hops out of %d entities and %d edges", len(r.Entities), len(r.Edges), g.Entities(), edges)
+}
+
+// traverse is Traverse with the error handled and the rows turned into keys.
+func traverse(tb testing.TB, g *testGraph, q *graph.Traversal, allow *column.Bitmap) []string {
+	tb.Helper()
+	r, err := g.Traverse(q, allow)
+	if err != nil {
+		tb.Fatalf("traversing: %v", err)
+	}
+	return g.keys(r)
+}


### PR DESCRIPTION
Closes #8.

A segment holds documents. This adds the section that holds the people, teams, projects and customers those documents are about, the relationships between them, and the traversal over both. `docs/graph.md` has the reasoning and the numbers.

## An entity has no permissions of its own

This is the decision worth reviewing.

An entity is visible to a reader when that reader may read a document that mentions it, and an edge is visible when they may read a document that says the relationship exists. There is no access list on an entity and no second permission model anywhere in the package.

The alternative is worse in a way that does not show up until it has been wrong for a while. Two models have to be kept in step, they drift, and the failure when they drift is a name shown to somebody who was never meant to learn it. Here the bitmap that filters documents is the bitmap that filters entities, over the same row numbers, so an entity cannot outlive the reasons a reader had for knowing about it.

It also gives the traversal a property that can be stated plainly. A result is a walk over the subgraph the reader could have built for themselves by reading their own documents and writing down what they said. Nothing in it came from a document they cannot open.

The rule is total rather than a rule with a hole in it. `Builder.Entity` refuses an entity with no mentions and `Builder.Edge` refuses an edge with no evidence, both with `ErrMention`, because a thing nobody can see through is invisible to every reader including the one allowed the whole segment. That is not a useful row, it is a bug in whatever produced it, and it should say so at the call that made it. It costs nothing in practice, since a document that evidences a relationship names both ends of it.

`TestVisibilityIsCheckedAtEveryHopRatherThanAtTheEnd` is the one to read. It builds a chain of forty entities, hides the documents behind the third hop, and requires that the walk stops there rather than filtering at the end.

## Extraction is a connector concern

There is no name recogniser here, no regular expression, no model, and no interface for one either. An interface the store defines is still the store having an opinion about extraction, and the store is in the worst position to hold one. A connector knows what a person is in the system it reads, because that system has user ids.

`arch_test.go` holds it: `store/graph` imports `store/column` and nothing else in the tree, with no edge to `doc` and none to `connector`.

## The shape

Entities are rows in three columns, their key, their type and their mentions, and the columns are the same `store/column` the documents use. The rows are stored in key order rather than in declaration order, which makes a lookup a binary search instead of a scan and makes two ingests of the same corpus produce the same bytes. The cost is that the number `Builder.Entity` returns is a handle in that builder rather than a row in the section, since the order is only known once the last entity is in.

Edges are sorted by source, then kind, then destination, and stored as an offset array of one `uint32` per entity plus a flat target array. An entity's edges are a slice, and an entity with no edges is an empty slice rather than a special case. The kinds are a column, so the dictionary resolves the kind names a traversal asks for into codes once and filtering by kind is an integer comparison per edge.

## What a traversal costs

An entity is expanded at most once, because the walk keeps a bitmap of the ones it has reached, and expanding one reads its run of edges once. So the worst case is one pass over the section however deep the traversal goes, and a cycle is not a special case, it is that bitmap doing its job.

The visibility checks are the part that is not constant. Deciding something is visible stops at the first document the reader may see. Deciding it is not visible reads the whole list, because that is what it takes to be sure. A reader who may see very little is the expensive case per entity, which is the right way round: their answer is the smallest, so paying more per entity still costs less overall.

`Limit` stops the walk rather than trimming the answer, so it bounds the work and not just the output.

On an Apple M4, one seed, depth 6, every kind, no filter:

| Documents | Entities | Edges each | Per traversal | Reached |
| --- | --- | --- | --- | --- |
| 10 thousand | 2 thousand | 4 | 57 us | 1691 |
| 100 thousand | 20 thousand | 4 | 165 us | 4616 |
| 100 thousand | 20 thousand | 16 | 2.4 ms | 20000 |
| 1 million | 200 thousand | 4 | 190 us | 5388 |

That is 28 million entities a second in the first, second and fourth rows, the same number three times over corpora that differ by a hundred times in size. What a traversal costs is the component it walks, not the segment it walks it in.

The same walk with a limit of 20, which is what a search result actually asks for, is 1.9, 2.9, 2.5 and 2.8 microseconds. Flat, which is the number that says the graph can go on the request path.

With a permission bitmap on the 100 thousand document segment: 233 us at 100 percent, 6.0 us at 50 percent, 0.6 us at 10 percent. The answer collapses faster than the fraction does, and that is correct rather than a bug. Reaching an entity six hops out means every edge and every entity along the way was visible, so the odds multiply. A reader restricted to half the corpus gets the part of the graph their own documents actually support.

## Reading bytes that may be anything

Nothing is allocated from a length read out of the section, every part is checked against the header about how many things it holds, the adjacency is validated once at open so the walk can index it without checking again, and every edge destination is bounds checked there too.

`TestOpenRefusesEveryDamagedByte` flips every byte of a real section two ways and requires each one either opens or returns an error. `FuzzOpen` ran thirty seconds and ten million executions clean.

## Checks

`gofmt`, `go vet ./...`, `go test ./...` and `golangci-lint run ./...` are clean.
