### PR TITLE
Storage: crash safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ func main() {
 | `store/column` | one field across every row of a segment, and the scans over it, [docs/columns.md](docs/columns.md) |
 | `store/vector` | the embedding section of a segment and the search over it, [docs/vectors.md](docs/vectors.md) |
 | `store/graph` | the entities and relationships of a segment and the walk over them, [docs/graph.md](docs/graph.md) |
+| `store/segdir` | the directory of segments, the manifest and the crash recovery, [docs/durability.md](docs/durability.md) |
 | `index` | query parsing, retrieval and ranking |
 | `connector` | the ingestion contract, cursors and checkpoints |
 | `connector/fssource` | the reference connector, a directory tree with OWNERS files |

--- a/arch_test.go
+++ b/arch_test.go
@@ -80,6 +80,14 @@ var allowed = map[string][]string{
 	// it holds no extractor and defines no interface for one either.
 	"store/graph": {"store/column"},
 
+	// segdir owns which segments are on disk and which of them a reader can
+	// see, so it needs the segment container to read a sequence number out of a
+	// header and to check that a published file parses. It needs nothing else.
+	// It does not know what a document is, it does not know what a query is,
+	// and a directory of segments is the same problem whatever the segments
+	// turn out to hold.
+	"store/segdir": {"store/segment"},
+
 	// kura is the Go side of the Rust engine's C ABI and imports nothing of
 	// ours. It deals in document ids, bytes and vectors, and it is the one
 	// package in the repository that is not in the default build at all. An

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -1,0 +1,151 @@
+# Durability
+
+A segment is immutable once it is written, so the only mutable thing in an index is the answer to the question "which segments are there".
+This is how that answer is stored, how it is changed, and what happens to it when the process dies in the middle of changing it.
+
+Version 1.
+The implementation is `store/segdir`, and the files it manages are [the segment format](segment.md).
+
+## A crash is a correctness problem, not a durability one
+
+Losing the last hour of a crawl to a power cut is annoying, and the fix is to crawl again.
+Coming back with half a segment is a different kind of problem, because half a segment is half an access list.
+
+A document whose permissions were written and whose content was not is a document with no readers.
+That is merely wrong, and somebody notices when their own file stops turning up.
+A document whose content was written and whose permissions were not is a document with every reader.
+Nobody notices that one, and it is the thing this package exists to make impossible.
+
+So the rule is not that writes are durable.
+The rule is that a segment is either wholly visible or wholly invisible, at every instant, to every reader, including the reader that opens the directory after the machine came back.
+
+## One rename is the whole design
+
+A publish writes the segment to a temporary name, makes it durable, renames it into place, and only then rewrites the manifest, also through a temporary name and a rename.
+A rename over an existing file is atomic on every filesystem worth running on, so the manifest is at every instant either exactly the old set or exactly the new one.
+There is no third state, however the write was interrupted.
+
+The manifest is written whole rather than appended to, and that is the decision worth defending.
+A log of changes is the usual answer and it is cheaper to append to, but it has a torn tail after a crash.
+A torn tail means a reader has to decide how much of the tail to believe, and that decision is where the bug lives.
+A file replaced by a rename has no torn state to have an opinion about: the old one is complete, the new one is complete, and there is nothing else to write code for.
+
+What it costs is rewriting sixteen bytes per live segment on every publish.
+On a ten thousand segment index that is a 160 KB write next to a segment that is measured in megabytes, and the benchmark below says it does not show up until the index is very large indeed.
+
+## Recovery is not a mode
+
+There is no clean shutdown flag, and there is no fast path that skips the checks when the last run exited politely.
+Every open sweeps the directory and verifies the live set, whether the last process was killed or not.
+
+A path taken only after a crash is a path exercised only after a crash, which is to say a path that is broken and nobody knows.
+Making the ordinary start take the recovery path means the recovery path runs thousands of times a day in development and in tests, and the first crash in production is the ten thousandth time it has run rather than the first.
+
+Recovery is the publish rule read backwards.
+Whatever the manifest names is what exists.
+Everything else in the directory is deleted, because every temporary file is a publish that was interrupted and every unnamed segment is either the same thing one step further on or a segment removed before the manifest could be rewritten.
+Nothing has ever been able to read either of them, so both are safe to delete, and deleting them is what keeps a directory that has crashed a thousand times the same size as one that never has.
+
+A manifest that names a segment which is not there is an error, not a smaller index.
+Quietly serving the segments that did survive is how a crash turns into a silent partial index, and a search that returns fewer answers looks exactly like a search that had fewer answers to give.
+That is the failure that takes a month to notice, so it is refused loudly instead.
+
+## The fsync policy
+
+Three settings, and the zero value is the safe one.
+A caller who has not thought about this gets the one that survives a power cut, and the weaker two have to be spelled out by somebody who has read what they give up.
+
+| Policy | Flushes | Survives a kill | Survives a power cut |
+| --- | --- | --- | --- |
+| `SyncFull` | the segment, the manifest and the directory | yes | yes |
+| `SyncManifest` | the manifest and the directory | yes | no |
+| `SyncNone` | nothing | yes | no |
+
+`SyncManifest` is the interesting one.
+The segment's pages belong to the operating system by the time the process dies, so a kill cannot lose them, and a power cut can.
+When it does, the manifest reaches the platter naming a segment whose bytes did not, which shows up at the next open as a segment that fails its size check or its verification.
+That is an error rather than a smaller index, so the failure is loud, and it is a reasonable setting for an index that can be rebuilt from its sources and a bad one for anything else.
+
+`Options.Verify` is separate from the sync policy.
+Off, an open stats every live segment and compares the length to what the manifest recorded, which catches the two things a crash produces: a file that is missing and a file that is short.
+On, it reads every segment, parses it and checks that the header holds the sequence the file name claims.
+It is worth turning on when the hardware is suspect, because a bad sector produces a file of exactly the right length full of something else, and nothing but reading it finds that.
+
+## The test kills a real process
+
+`TestKillingTheProcessAtEveryWritePointRecovers` runs a child at every instant a publish can be interrupted at, kills it there, and then opens what it left behind.
+Publish has six such instants and remove has three, and the test does not have those numbers written down anywhere: it keeps raising the crash point until the child survives, so adding a write to either path adds a case without anybody remembering to update a constant.
+
+It is a subprocess rather than a simulation because the thing under test is what the operating system does with writes that were in flight.
+A fake that decided which of them survived would be a test of the fake.
+The child dies with `os.Exit`, which runs no deferred function and flushes nothing, which is what a kill or a panic in another goroutine does.
+
+After each kill the directory has to satisfy all of this: it opens with verification on, everything published before the interrupted operation is still there and reads back as itself, the interrupted operation either wholly happened or wholly did not, the file count is exactly the live set plus the manifest, and a further publish and reopen work.
+That last one matters as much as the rest.
+A crash should leave something to carry on from rather than something to rebuild.
+
+The test was checked by breaking the code on purpose.
+Reordering a publish so the manifest is written before the segment rename makes it fail at two of the six crash points with "a published segment is missing or damaged", which is the ordering bug it exists to catch.
+
+What it cannot test is a power cut.
+The pages the child wrote and did not flush are the operating system's by the time it dies, so they arrive on disk afterwards, and only pulling the plug tells you whether an fsync was really called.
+That gap is the reason `SyncFull` is the default rather than something to reach for.
+The test proves the ordering is right, and fsync is what makes the ordering mean anything on a machine that loses power.
+
+## What recovery costs
+
+On an Apple M4, opening a directory with no crash to clean up, which is also what a clean start pays:
+
+| Segments | Open | Open with `Verify` |
+| --- | --- | --- |
+| 100 | 325 us | 2.0 ms |
+| 1 thousand | 3.5 ms | 20.8 ms |
+| 10 thousand | 36.5 ms | 237 ms |
+
+Linear in the number of segments and independent of what they hold, because a plain open reads the manifest, lists the directory and stats each live file.
+Ten thousand segments is a large index, and it is back in under forty milliseconds.
+Verification is six times that, which is the cost of reading the whole index rather than looking at it.
+
+The same open on a directory left in a mess, with five hundred interrupted publishes to sweep:
+
+| Segments | Open after a crash |
+| --- | --- |
+| 100 | 24.7 ms |
+| 1 thousand | 29.0 ms |
+| 10 thousand | 55.0 ms |
+
+The extra is the unlinking, and it is charged once because the rubbish is gone afterwards.
+A machine that has crashed repeatedly does not accumulate a recovery bill.
+
+The write side, with the flushes turned off, because with them on this measures the disk rather than the design:
+
+| Live segments | Per publish |
+| --- | --- |
+| 10 | 291 us |
+| 100 | 282 us |
+| 1 thousand | 298 us |
+| 10 thousand | 499 us |
+
+Flat until ten thousand, where rewriting the manifest whole finally starts to show, and even there it is half a millisecond.
+That is the number the whole design trades for, and it says the trade was cheap.
+`go test -bench . ./store/segdir/` is where these come from.
+
+## What is deliberately not here
+
+A write ahead log.
+A publish is durable when it returns and not before, and a crawl interrupted halfway through a batch redoes the batch.
+That is the right trade for a search index, where the source of truth is somebody else's system and everything here can be rebuilt from it.
+A log would buy back the last few seconds of an operation that is already idempotent, in exchange for the torn tail this design does not have.
+
+A lock.
+One writer at a time is assumed and not enforced.
+Two processes publishing into the same directory will produce a manifest that names segments one of them has never heard of, and the fix is not to do that.
+A lock file is a small thing to add when there is a second writer to protect against, and inventing one before then would be guessing at what it should do when the lock holder dies.
+
+Compaction.
+`Publish` and `Remove` are enough to express a merge, and deciding which segments to merge and when is a policy that needs to see the query load.
+That belongs above this package, which only has to make the swap safe.
+
+Multiple directories.
+An index is one directory here.
+Spreading segments across volumes is a thing to want eventually, and it changes the manifest from a list of sequences to a list of locations, which is a version 2 with a flag rather than a redesign.

--- a/store/segdir/bench_test.go
+++ b/store/segdir/bench_test.go
@@ -1,0 +1,108 @@
+package segdir_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tamnd/genba/store/segdir"
+)
+
+// The sizes a real index reaches. A segment is a flush of a memtable, so a
+// corpus of a few million documents is thousands of them before compaction
+// catches up, and ten thousand is the number worth being able to open quickly.
+var sizes = []int{100, 1_000, 10_000}
+
+// BenchmarkOpen is recovery, which is what an operator waits for after a crash.
+//
+// It is the same path a clean start takes, on purpose, because a path only
+// taken after a crash is a path only exercised after a crash. What it costs is
+// a read of the manifest, a listing of the directory and one stat per segment,
+// so it is linear in the number of segments and independent of their size.
+func BenchmarkOpen(b *testing.B) {
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("%d segments", n), func(b *testing.B) {
+			dir := corpus(b, n)
+			b.ResetTimer()
+			for b.Loop() {
+				open(b, dir, segdir.Options{})
+			}
+			b.ReportMetric(float64(n)*float64(b.N)/b.Elapsed().Seconds()/1e3, "ksegment/s")
+		})
+	}
+}
+
+// BenchmarkOpenVerified is what the paranoid option costs, which is a read of
+// the whole index rather than a stat of it.
+func BenchmarkOpenVerified(b *testing.B) {
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("%d segments", n), func(b *testing.B) {
+			dir := corpus(b, n)
+			b.ResetTimer()
+			for b.Loop() {
+				open(b, dir, segdir.Options{Verify: true})
+			}
+			b.ReportMetric(float64(n)*float64(b.N)/b.Elapsed().Seconds()/1e3, "ksegment/s")
+		})
+	}
+}
+
+// BenchmarkOpenAfterACrash is the same thing with rubbish to sweep, which is
+// what a directory that was interrupted a few hundred times looks like. The
+// number to compare it against is BenchmarkOpen at the same size.
+func BenchmarkOpenAfterACrash(b *testing.B) {
+	const litter = 500
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("%d segments", n), func(b *testing.B) {
+			dir := corpus(b, n)
+			b.ResetTimer()
+			for b.Loop() {
+				b.StopTimer()
+				for i := range litter {
+					file := filepath.Join(dir, fmt.Sprintf("%016d.seg.tmp", n+i+1))
+					if err := os.WriteFile(file, []byte("a publish that was interrupted"), 0o644); err != nil {
+						b.Fatalf("planting rubbish: %v", err)
+					}
+				}
+				b.StartTimer()
+				open(b, dir, segdir.Options{})
+			}
+		})
+	}
+}
+
+// BenchmarkPublish is the write side, and the number it exposes is the one the
+// design trades away: the manifest is rewritten whole every time, so a publish
+// costs a write proportional to the number of live segments rather than to the
+// one being added.
+//
+// It is measured with the flushes turned off, because with them on this is a
+// benchmark of the disk. The point is the shape of the curve.
+func BenchmarkPublish(b *testing.B) {
+	for _, n := range []int{10, 100, 1_000, 10_000} {
+		b.Run(fmt.Sprintf("%d live", n), func(b *testing.B) {
+			dir := corpus(b, n)
+			d := open(b, dir, segdir.Options{Sync: segdir.SyncNone})
+			b.ResetTimer()
+			for b.Loop() {
+				publish(b, d, d.Next(), "another")
+			}
+		})
+	}
+}
+
+// corpus is a directory with n segments in it, written without flushes because
+// what is being measured is the reading.
+func corpus(tb testing.TB, n int) string {
+	tb.Helper()
+	dir := filepath.Join(tb.TempDir(), "index")
+	d := open(tb, dir, segdir.Options{Sync: segdir.SyncNone})
+	for i := range n {
+		publish(tb, d, uint64(i+1), fmt.Sprintf("segment %d", i+1))
+	}
+	if err := d.Close(); err != nil {
+		tb.Fatalf("closing: %v", err)
+	}
+	return dir
+}

--- a/store/segdir/crash_test.go
+++ b/store/segdir/crash_test.go
@@ -1,0 +1,240 @@
+package segdir
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/tamnd/genba/store/segment"
+)
+
+// The crash test kills a real process at every instant a publish can be
+// interrupted at, and then opens the directory and says what has to be true.
+//
+// It is a subprocess rather than a simulation because the thing being tested is
+// what the operating system does with writes that were in flight, and a fake
+// that decided which of them survived would be a test of the fake. The child is
+// this same test binary with an environment variable telling it which write
+// point to die at, and it dies with os.Exit, which runs no deferred function
+// and flushes nothing, exactly like a kill or a panic in another goroutine.
+//
+// What it cannot test is a power cut. The pages the child wrote and did not
+// flush are the operating system's by the time it dies, so they arrive on disk
+// afterwards, and only pulling the plug tells you whether an fsync was really
+// called. That gap is the reason SyncFull is the default rather than something
+// to reach for: the test proves the ordering is right, and fsync is what makes
+// the ordering mean anything on a machine that loses power.
+const (
+	crashEnvDir  = "GENBA_SEGDIR_CRASH_DIR"
+	crashEnvAt   = "GENBA_SEGDIR_CRASH_AT"
+	crashEnvWhat = "GENBA_SEGDIR_CRASH_WHAT"
+
+	// crashed is what the child exits with when it died where it was told to,
+	// so that the parent can tell that from a child that failed for some other
+	// reason and from one that ran out of write points.
+	crashed = 7
+)
+
+// TestKillingTheProcessAtEveryWritePointRecovers is the test issue #9 asks for.
+//
+// For each instant inside a publish, and then each instant inside a remove, a
+// child process is killed there and the directory it left behind has to satisfy
+// all of this: it opens, everything published before the interrupted operation
+// is still there and still readable, the interrupted operation either happened
+// or did not, nothing that no reader can see is left on disk, and the next
+// publish works.
+func TestKillingTheProcessAtEveryWritePointRecovers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this spawns a process per write point")
+	}
+	for _, what := range []string{"publish", "remove"} {
+		t.Run(what, func(t *testing.T) {
+			points := 0
+			// The number of write points is not written down anywhere, which is
+			// on purpose. The loop stops when the child survives, so adding one
+			// to the publish path adds a case here without anybody having to
+			// remember to update a constant.
+			for at := 1; at < 32; at++ {
+				dir := filepath.Join(t.TempDir(), "index")
+				if !crash(t, dir, what, at) {
+					points = at - 1
+					break
+				}
+				t.Run(fmt.Sprintf("at %d", at), func(t *testing.T) {
+					survivors(t, dir, what)
+				})
+			}
+			if points == 0 {
+				t.Fatal("the child never died, so nothing was tested")
+			}
+			t.Logf("%s has %d write points, and a crash at each of them recovers", what, points)
+		})
+	}
+}
+
+// crash runs a child that dies at the nth write point, and reports whether it
+// got that far.
+func crash(t *testing.T, dir, what string, at int) bool {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestCrashHelper", "-test.v")
+	cmd.Env = append(os.Environ(),
+		crashEnvDir+"="+dir,
+		crashEnvWhat+"="+what,
+		crashEnvAt+"="+strconv.Itoa(at),
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return false
+	}
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) || exit.ExitCode() != crashed {
+		t.Fatalf("the child failed for the wrong reason: %v\n%s", err, out)
+	}
+	return true
+}
+
+// TestCrashHelper is the child. It is skipped when it is nobody's child, which
+// is what makes it invisible in an ordinary test run.
+func TestCrashHelper(t *testing.T) {
+	dir := os.Getenv(crashEnvDir)
+	if dir == "" {
+		t.Skip("this test is only run as the child of the crash test")
+	}
+	at, err := strconv.Atoi(os.Getenv(crashEnvAt))
+	if err != nil {
+		t.Fatalf("the crash point: %v", err)
+	}
+
+	d, err := Open(dir, Options{})
+	if err != nil {
+		t.Fatalf("opening: %v", err)
+	}
+	// The state the parent expects to survive, published normally.
+	for i := range 3 {
+		if _, err := d.Publish(segmentOf(t, uint64(i+1))); err != nil {
+			t.Fatalf("publishing segment %d: %v", i+1, err)
+		}
+	}
+
+	// Armed only now, so the counting starts at the operation being tested.
+	seen := 0
+	crashPoint = func(string) {
+		seen++
+		if seen == at {
+			os.Exit(crashed)
+		}
+	}
+	switch what := os.Getenv(crashEnvWhat); what {
+	case "publish":
+		_, err = d.Publish(segmentOf(t, 4))
+	case "remove":
+		err = d.Remove(2)
+	default:
+		t.Fatalf("no such operation: %q", what)
+	}
+	if err != nil {
+		t.Fatalf("the operation failed rather than crashing: %v", err)
+	}
+	// A clean exit says the operation had fewer write points than the parent
+	// asked for, which is how the parent knows to stop.
+	os.Exit(0)
+}
+
+// survivors is everything that has to be true of a directory a killed process
+// left behind.
+func survivors(t *testing.T, dir, what string) {
+	t.Helper()
+
+	d, err := Open(dir, Options{Verify: true})
+	if err != nil {
+		t.Fatalf("the directory does not open: %v", err)
+	}
+	live := d.Segments()
+
+	// The three segments published before the interrupted operation are always
+	// there, and segment 2 is the one a remove was interrupted on.
+	want := []uint64{1, 2, 3}
+	if what == "remove" {
+		want = []uint64{1, 3}
+	}
+	for _, seq := range want {
+		if !slices.ContainsFunc(live, func(e Entry) bool { return e.Sequence == seq }) {
+			if what == "remove" || seq != 2 {
+				t.Errorf("segment %d is gone, and it was published before the crash", seq)
+			}
+		}
+	}
+	if what == "remove" && len(live) > 3 {
+		t.Errorf("the directory holds %d segments, want 2 or 3", len(live))
+	}
+	if what == "publish" && (len(live) < 3 || len(live) > 4) {
+		t.Errorf("the directory holds %d segments, want 3 or 4", len(live))
+	}
+
+	// Everything live reads back, and reads back as itself.
+	for _, e := range live {
+		b, err := d.Read(e.Sequence)
+		if err != nil {
+			t.Fatalf("reading segment %d: %v", e.Sequence, err)
+		}
+		s, err := segment.Open(b)
+		if err != nil {
+			t.Fatalf("segment %d does not parse: %v", e.Sequence, err)
+		}
+		if s.Sequence() != e.Sequence {
+			t.Errorf("the file for segment %d holds segment %d", e.Sequence, s.Sequence())
+		}
+	}
+
+	// Nothing a reader cannot see is left on disk, which is what stops a
+	// directory that has crashed a thousand times from filling a volume.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("listing: %v", err)
+	}
+	if got, want := len(entries), len(live)+1; got != want {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("the directory holds %d files and %d segments are live: %v", got, len(live), names)
+	}
+
+	// And the directory is not just readable, it is writable: a crash leaves
+	// something that can be carried on from rather than something that has to
+	// be rebuilt.
+	next := d.Next()
+	if _, err := d.Publish(segmentOf(t, next)); err != nil {
+		t.Fatalf("publishing after recovery: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+	again, err := Open(dir, Options{Verify: true})
+	if err != nil {
+		t.Fatalf("reopening after recovery: %v", err)
+	}
+	if got := again.Segments(); len(got) != len(live)+1 {
+		t.Errorf("after publishing again the directory holds %d segments, want %d", len(got), len(live)+1)
+	}
+}
+
+// segmentOf is a segment whose payload names its own sequence, so that a file
+// that holds the wrong segment is visible rather than plausible.
+func segmentOf(tb testing.TB, sequence uint64) []byte {
+	tb.Helper()
+	w := segment.NewWriter(sequence)
+	if err := w.Add(segment.KindFields, fmt.Appendf(nil, "segment %d", sequence)); err != nil {
+		tb.Fatalf("adding a section: %v", err)
+	}
+	b, err := w.Bytes()
+	if err != nil {
+		tb.Fatalf("building a segment: %v", err)
+	}
+	return b
+}

--- a/store/segdir/manifest.go
+++ b/store/segdir/manifest.go
@@ -1,0 +1,220 @@
+package segdir
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"os"
+	"path/filepath"
+
+	"github.com/tamnd/genba/store/segment"
+)
+
+// The manifest is the only mutable thing in an index, so it is small, it is
+// written whole, and it is checked before a byte of it is believed.
+//
+// Writing it whole rather than appending to it is the decision worth defending.
+// A log of changes is the usual answer and it is faster to append to, but it
+// has a torn tail after a crash, which means a reader has to decide how much of
+// the tail to believe, and that decision is the bug. A file that is replaced by
+// a rename has no torn state at all: the old one is complete and the new one is
+// complete, and there is no third possibility to write code for. The cost is
+// rewriting a few tens of bytes per live segment on every publish, which is
+// nothing next to writing the segment itself.
+const (
+	// manifestMagic is eight bytes for the same reason the segment's is: four
+	// bytes of anything turn up by accident in files that are not this.
+	manifestMagic = "genbaman"
+
+	// manifestVersion is a refusal rather than a negotiation, as it is
+	// everywhere else in the store.
+	manifestVersion uint16 = 1
+
+	manifestHeader = 32
+	manifestEntry  = 16
+)
+
+// Manifest layout, byte for byte, little endian throughout.
+//
+//	 0  8  magic
+//	 8  2  version
+//	10  2  flags, reserved and zero
+//	12  4  the number of entries
+//	16  8  the next sequence to hand out, so a name is never reused
+//	24  4  checksum, crc32 Castagnoli over every other byte of the file
+//	28  4  reserved, zero
+//
+// Then one entry per live segment, ascending by sequence:
+//
+//	0  8  sequence
+//	8  8  size in bytes
+const (
+	offMagic    = 0
+	offVersion  = 8
+	offFlags    = 10
+	offCount    = 12
+	offNext     = 16
+	offChecksum = 24
+	offReserved = 28
+)
+
+var (
+	le    = binary.LittleEndian
+	table = crc32.MakeTable(crc32.Castagnoli)
+)
+
+// encodeManifest returns the bytes of a manifest.
+func encodeManifest(live []Entry, next uint64) []byte {
+	out := make([]byte, manifestHeader+manifestEntry*len(live))
+	copy(out[offMagic:], manifestMagic)
+	le.PutUint16(out[offVersion:], manifestVersion)
+	le.PutUint16(out[offFlags:], 0)
+	le.PutUint32(out[offCount:], uint32(len(live)))
+	le.PutUint64(out[offNext:], next)
+	le.PutUint32(out[offReserved:], 0)
+	for i, e := range live {
+		at := manifestHeader + i*manifestEntry
+		le.PutUint64(out[at:], e.Sequence)
+		le.PutUint64(out[at+8:], uint64(e.Size))
+	}
+	le.PutUint32(out[offChecksum:], checksum(out))
+	return out
+}
+
+// checksum is the crc over every byte except the four the checksum itself
+// occupies, which is the same convention the segment header uses.
+func checksum(b []byte) uint32 {
+	h := crc32.New(table)
+	h.Write(b[:offChecksum])
+	h.Write(b[offReserved:])
+	return h.Sum32()
+}
+
+// decodeManifest parses one.
+//
+// These bytes come off a disk, so the count is not trusted to be the count.
+// Nothing is allocated from it: it is turned into the size the file would have
+// to be, and that has to be the size the file actually is, exactly, with
+// nothing left over. A manifest claiming four billion entries fails that
+// comparison rather than reserving memory for them.
+func decodeManifest(b []byte) ([]Entry, uint64, error) {
+	if len(b) < manifestHeader {
+		return nil, 0, fmt.Errorf("%w: %d bytes is shorter than a header", ErrFormat, len(b))
+	}
+	if string(b[offMagic:offMagic+len(manifestMagic)]) != manifestMagic {
+		return nil, 0, fmt.Errorf("%w: this is not a manifest", ErrFormat)
+	}
+	if v := le.Uint16(b[offVersion:]); v != manifestVersion {
+		return nil, 0, fmt.Errorf("%w: version %d, this build reads %d", ErrVersion, v, manifestVersion)
+	}
+	if f := le.Uint16(b[offFlags:]); f != 0 {
+		return nil, 0, fmt.Errorf("%w: flags %#04x are not known to this build", ErrVersion, f)
+	}
+	if r := le.Uint32(b[offReserved:]); r != 0 {
+		return nil, 0, fmt.Errorf("%w: reserved bytes are not zero", ErrFormat)
+	}
+	count := uint64(le.Uint32(b[offCount:]))
+	if want := uint64(manifestHeader) + count*manifestEntry; want != uint64(len(b)) {
+		return nil, 0, fmt.Errorf("%w: %d entries need %d bytes and the file holds %d", ErrFormat, count, want, len(b))
+	}
+	if got, want := checksum(b), le.Uint32(b[offChecksum:]); got != want {
+		return nil, 0, fmt.Errorf("%w: checksum %#08x, the file says %#08x", ErrFormat, got, want)
+	}
+
+	next := le.Uint64(b[offNext:])
+	out := make([]Entry, 0, count)
+	last := uint64(0)
+	for i := range int(count) {
+		at := manifestHeader + i*manifestEntry
+		e := Entry{Sequence: le.Uint64(b[at:]), Size: int64(le.Uint64(b[at+8:]))}
+		// Ascending and distinct, because a reader is entitled to treat the
+		// sequence as an identity and two entries sharing one would make the
+		// live set depend on which of them was looked at first.
+		if i > 0 && e.Sequence <= last {
+			return nil, 0, fmt.Errorf("%w: sequence %d follows %d", ErrFormat, e.Sequence, last)
+		}
+		if e.Size < 0 {
+			return nil, 0, fmt.Errorf("%w: segment %d has a size of %d", ErrFormat, e.Sequence, e.Size)
+		}
+		if e.Sequence > next {
+			return nil, 0, fmt.Errorf("%w: segment %d is ahead of the next sequence %d", ErrFormat, e.Sequence, next)
+		}
+		last = e.Sequence
+		out = append(out, e)
+	}
+	return out, next, nil
+}
+
+// readManifest loads the live set from disk.
+//
+// No manifest is an empty index rather than an error, which is what makes a
+// fresh directory and a directory whose first publish was interrupted the same
+// case. Both of them have never had a reader see anything, so there is nothing
+// to tell apart.
+func (d *Dir) readManifest() ([]Entry, uint64, error) {
+	b, err := os.ReadFile(filepath.Join(d.path, manifest))
+	if os.IsNotExist(err) {
+		return nil, 0, nil
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading the manifest: %w", err)
+	}
+	live, next, err := decodeManifest(b)
+	if err != nil {
+		return nil, 0, err
+	}
+	return live, next, nil
+}
+
+// writeManifest publishes a live set.
+//
+// This is the instant the index changes. Everything before it has been writing
+// files nobody can see, and everything after it is tidying up. The rename is
+// what makes it an instant rather than an interval.
+func (d *Dir) writeManifest(live []Entry, next uint64) error {
+	b := encodeManifest(live, next)
+	final := filepath.Join(d.path, manifest)
+	temp := final + tempExt
+
+	if err := writeFile(temp, b, d.opt.Sync != SyncNone); err != nil {
+		return fmt.Errorf("writing the manifest: %w", err)
+	}
+	crashPoint("manifest.write")
+
+	if err := os.Rename(temp, final); err != nil {
+		return fmt.Errorf("publishing the manifest: %w", err)
+	}
+	crashPoint("manifest.rename")
+
+	if d.opt.Sync != SyncNone {
+		if err := syncDir(d.path); err != nil {
+			return fmt.Errorf("flushing the directory: %w", err)
+		}
+	}
+	crashPoint("manifest.dir.sync")
+	return nil
+}
+
+// verify reads a published segment back and checks it parses and is the one the
+// manifest thinks it is.
+//
+// The sequence comparison is the part that is not obvious. A file with the
+// right name and the right length could still be a different segment, if a
+// crash happened between two publishes that reused a name, and the header says
+// which one it is. Names are never reused here, so this should be impossible,
+// and a check that holds an invariant nothing else enforces is worth the read
+// it costs.
+func verify(file string, want uint64) error {
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("%w: segment %d: %w", ErrMissing, want, err)
+	}
+	s, err := segment.Open(b)
+	if err != nil {
+		return fmt.Errorf("%w: segment %d: %w", ErrMissing, want, err)
+	}
+	if s.Sequence() != want {
+		return fmt.Errorf("%w: the file for segment %d holds segment %d", ErrMissing, want, s.Sequence())
+	}
+	return nil
+}

--- a/store/segdir/publish.go
+++ b/store/segdir/publish.go
@@ -1,0 +1,196 @@
+package segdir
+
+import (
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/tamnd/genba/store/segment"
+)
+
+// Publish makes a segment visible, or does not.
+//
+// The bytes are parsed before anything is written, so a segment that is not a
+// segment is refused here rather than becoming a file that the next open has to
+// have an opinion about. The sequence comes out of the header, which is what
+// makes the file name and the segment's own identity one thing instead of two
+// that can disagree.
+//
+// The order is the whole of the crash safety, and it is worth reading as a
+// sequence of instants rather than as a list of steps:
+//
+//  1. The segment is written to a temporary name. Nothing can see it, and if
+//     the process dies here the next open deletes it.
+//  2. It is flushed, so the bytes are on the platter and not only in a cache.
+//  3. It is renamed into its real name. It is now readable by anything that
+//     looks, and still invisible, because nothing looks at anything the
+//     manifest does not name.
+//  4. The manifest is rewritten, flushed and renamed. This is the instant the
+//     segment becomes visible, and it is a single rename, so there is no
+//     instant at which it is half visible.
+//
+// A crash between any two of those leaves either the old index or the new one.
+// There is no third state to recover from, which is why recovery is a sweep and
+// a check rather than a repair.
+func (d *Dir) Publish(b []byte) (Entry, error) {
+	s, err := segment.Open(b)
+	if err != nil {
+		return Entry{}, fmt.Errorf("publishing: %w", err)
+	}
+	e := Entry{Sequence: s.Sequence(), Size: int64(len(b))}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return Entry{}, ErrClosed
+	}
+	at, found := slices.BinarySearchFunc(d.live, e, bySequence)
+	if found {
+		return Entry{}, fmt.Errorf("%w: %d", ErrSequence, e.Sequence)
+	}
+
+	file := d.File(e.Sequence)
+	temp := file + tempExt
+	if err := writeFile(temp, b, d.opt.Sync == SyncFull); err != nil {
+		return Entry{}, fmt.Errorf("writing segment %d: %w", e.Sequence, err)
+	}
+	crashPoint("segment.write")
+
+	if err := os.Rename(temp, file); err != nil {
+		return Entry{}, fmt.Errorf("moving segment %d into place: %w", e.Sequence, err)
+	}
+	crashPoint("segment.rename")
+
+	// The directory entry for the segment is flushed before the manifest is
+	// written rather than after. Otherwise a crash could leave a manifest that
+	// is durable naming a file whose name is not, which is the one ordering
+	// that produces an index that will not open.
+	if d.opt.Sync == SyncFull {
+		if err := syncDir(d.path); err != nil {
+			return Entry{}, fmt.Errorf("flushing the directory: %w", err)
+		}
+	}
+	crashPoint("segment.dir.sync")
+
+	next := max(d.next, e.Sequence)
+	live := slices.Insert(slices.Clone(d.live), at, e)
+	if err := d.writeManifest(live, next); err != nil {
+		// The segment file is left where it is. Removing it here would be a
+		// second thing that can fail while handling the first, and the next
+		// open deletes it anyway because the manifest does not name it.
+		return Entry{}, err
+	}
+	d.live, d.next = live, next
+	return e, nil
+}
+
+// Remove unpublishes segments and then deletes them.
+//
+// The manifest is rewritten first, so the files are already invisible by the
+// time they are unlinked, and a crash in between leaves files nothing names,
+// which the next open sweeps. Doing it the other way round would leave a window
+// where the manifest names a file that is gone, and that window is an index
+// that will not open.
+//
+// A sequence that is not published is not an error, because a compaction that
+// has to be safe to run twice should be able to run twice.
+func (d *Dir) Remove(sequences ...uint64) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return ErrClosed
+	}
+
+	live := slices.Clone(d.live)
+	gone := make([]uint64, 0, len(sequences))
+	for _, seq := range sequences {
+		at, found := slices.BinarySearchFunc(live, Entry{Sequence: seq}, bySequence)
+		if !found {
+			continue
+		}
+		live = slices.Delete(live, at, at+1)
+		gone = append(gone, seq)
+	}
+	if len(gone) == 0 {
+		return nil
+	}
+	if err := d.writeManifest(live, d.next); err != nil {
+		return err
+	}
+	d.live = live
+
+	for _, seq := range gone {
+		if err := os.Remove(d.File(seq)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing segment %d: %w", seq, err)
+		}
+	}
+	return nil
+}
+
+// Read returns the bytes of a published segment.
+//
+// It reads the file rather than mapping it, which is the simple thing and not
+// the fast one. Mapping belongs with the layer that caches segments across
+// queries, because the decision that matters there is when to unmap, and that
+// is a question about a cache rather than about a directory.
+func (d *Dir) Read(sequence uint64) ([]byte, error) {
+	d.mu.RLock()
+	closed := d.closed
+	_, found := slices.BinarySearchFunc(d.live, Entry{Sequence: sequence}, bySequence)
+	d.mu.RUnlock()
+	if closed {
+		return nil, ErrClosed
+	}
+	if !found {
+		return nil, fmt.Errorf("%w: %d is not published", ErrMissing, sequence)
+	}
+	b, err := os.ReadFile(d.File(sequence))
+	if err != nil {
+		return nil, fmt.Errorf("%w: segment %d: %w", ErrMissing, sequence, err)
+	}
+	return b, nil
+}
+
+// bySequence orders the live set, which is kept sorted so that a lookup is a
+// binary search and a publish is an insert rather than a resort.
+func bySequence(a, b Entry) int {
+	switch {
+	case a.Sequence < b.Sequence:
+		return -1
+	case a.Sequence > b.Sequence:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// writeFile writes a whole file and optionally flushes it.
+//
+// The flush is inside the same function as the write because the two belong
+// together: a caller that can write without flushing is a caller that will one
+// day forget, and the argument makes the choice visible at every call site.
+func writeFile(path string, b []byte, sync bool) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(b); err != nil {
+		f.Close()
+		return err
+	}
+	if sync {
+		if err := f.Sync(); err != nil {
+			f.Close()
+			return err
+		}
+	}
+	return f.Close()
+}
+
+// crashPoint is where the crash tests kill the process.
+//
+// It is a variable in the package rather than a test helper because the points
+// worth killing at are between two system calls, and there is nowhere else to
+// stand. It costs an indirect call through a no op on a path that already did a
+// write and an fsync, which is not a cost worth avoiding.
+var crashPoint = func(string) {}

--- a/store/segdir/publish.go
+++ b/store/segdir/publish.go
@@ -1,6 +1,7 @@
 package segdir
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -169,22 +170,29 @@ func bySequence(a, b Entry) int {
 // The flush is inside the same function as the write because the two belong
 // together: a caller that can write without flushing is a caller that will one
 // day forget, and the argument makes the choice visible at every call site.
-func writeFile(path string, b []byte, sync bool) error {
+//
+// The close is joined onto whatever else went wrong rather than dropped. A
+// close of a handle that was written to can fail on its own, and on a network
+// filesystem it is where a failed write is reported, so throwing that error
+// away is throwing away the news that the bytes are not there. Everything this
+// function writes goes on to be renamed into place, and renaming a file whose
+// close failed is exactly the half written segment the package exists to
+// prevent.
+func writeFile(path string, b []byte, sync bool) (err error) {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		err = errors.Join(err, f.Close())
+	}()
 	if _, err := f.Write(b); err != nil {
-		f.Close()
 		return err
 	}
 	if sync {
-		if err := f.Sync(); err != nil {
-			f.Close()
-			return err
-		}
+		return f.Sync()
 	}
-	return f.Close()
+	return nil
 }
 
 // crashPoint is where the crash tests kill the process.

--- a/store/segdir/segdir.go
+++ b/store/segdir/segdir.go
@@ -1,0 +1,354 @@
+// Package segdir is a directory of segments and the manifest that decides
+// which of them a reader can see.
+//
+// A segment is immutable once written, so the only mutable thing in an index is
+// the answer to "which segments are there". This package owns that answer. It
+// keeps it in one file, it changes it with one rename, and it treats everything
+// on disk that the manifest does not name as rubbish left by a crash.
+//
+// # Why a crash is a correctness problem and not a durability one
+//
+// Losing the last hour of a crawl to a power cut is annoying and it is fixable
+// by crawling again. Coming back with half a segment is not, because half a
+// segment is half an access list. A document whose permissions were written and
+// whose content was not is a document with no readers, which is merely wrong. A
+// document whose content was written and whose permissions were not is a
+// document with every reader, which is the thing this package exists to make
+// impossible.
+//
+// So the rule is not "writes are durable". The rule is that a segment is either
+// wholly visible or wholly invisible, at every instant, to every reader,
+// including the reader that opens the directory after the machine came back.
+//
+// # How
+//
+// A publish writes the segment to a temporary name, makes it durable, renames
+// it into place, and only then rewrites the manifest, also through a temporary
+// name and a rename. A rename over an existing file is atomic, so the manifest
+// is at every instant either exactly the old set or exactly the new one, and it
+// is never a mixture of them however the write was interrupted.
+//
+// Recovery is the same rule read backwards. Whatever the manifest names is what
+// exists, everything else in the directory is deleted, and a manifest that names
+// something that is not there is an error rather than a smaller index. That last
+// part matters: quietly serving the segments that did survive is how a crash
+// turns into a silent partial index that nobody notices for a month.
+//
+// # What this package is not
+//
+// It is not a write ahead log. A publish is durable when it returns and not
+// before, and a crawl that was halfway through a batch redoes the batch. That
+// is the right trade for a search index, where the source of truth is somebody
+// else's system and everything here can be rebuilt from it. A log would buy
+// back the last few seconds of an operation that is already idempotent.
+//
+// It is not a lock either. One process at a time is assumed and not enforced,
+// which is written down again in the docs rather than hidden here.
+package segdir
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Sync is how much durability a publish pays for.
+//
+// The zero value is the safe one, which is deliberate. A caller who has not
+// thought about this gets the setting that survives a power cut, and the two
+// weaker ones have to be spelled out by somebody who has read what they cost.
+type Sync uint8
+
+const (
+	// SyncFull flushes the segment, the manifest and the directory before a
+	// publish returns. An index written this way survives the machine losing
+	// power at any instant.
+	SyncFull Sync = iota
+
+	// SyncManifest flushes the manifest and the directory but not the bytes of
+	// the segment.
+	//
+	// It survives the process being killed, because the pages are the operating
+	// system's by then, and it does not survive the machine losing power: the
+	// manifest can reach the platter naming a segment whose bytes did not. That
+	// shows up at the next open as a segment that fails to verify, which is an
+	// error rather than a smaller index, so the failure is loud. It is a
+	// reasonable setting for an index that can be rebuilt from its sources and
+	// a bad one for anything else.
+	SyncManifest
+
+	// SyncNone flushes nothing. It survives the process being killed and
+	// nothing worse, and it is here for tests and for an index that is thrown
+	// away at the end of the run.
+	SyncNone
+)
+
+// String names the policy, so that a log line about durability says which one
+// was in force.
+func (s Sync) String() string {
+	switch s {
+	case SyncFull:
+		return "full"
+	case SyncManifest:
+		return "manifest"
+	case SyncNone:
+		return "none"
+	default:
+		return "sync(" + strconv.FormatUint(uint64(s), 10) + ")"
+	}
+}
+
+// Options are the settings a directory is opened with. The zero value is the
+// safe one.
+type Options struct {
+	// Sync is the durability policy. The zero value is [SyncFull].
+	Sync Sync
+
+	// Verify reads and checksums every published segment at open rather than
+	// only checking that it is there and is the size the manifest says.
+	//
+	// It is off by default because it turns opening an index into reading all
+	// of it, which is seconds on a large one, and because the cheap check
+	// already catches the failures a crash produces: a missing file and a
+	// truncated one. It is worth turning on when the hardware is suspect, since
+	// a bad sector produces a file of exactly the right length full of
+	// something else, and nothing but a checksum finds that.
+	Verify bool
+}
+
+// Entry is one published segment.
+type Entry struct {
+	// Sequence is the segment's own sequence number, taken from its header
+	// rather than assigned here, and it names the file. One number for both
+	// means there is no mapping to keep in step, and it means a tombstone that
+	// has to beat the document it deletes is a comparison a reader can make
+	// from the file name.
+	Sequence uint64
+
+	// Size is the length of the file in bytes, which is what the cheap check at
+	// open compares against.
+	Size int64
+}
+
+// Dir is a directory of segments.
+//
+// The live set is replaced wholesale rather than edited, so a reader that took
+// it and a writer that is publishing never touch the same slice. Publishes are
+// serialised: one writer, which is what the format assumes anyway.
+type Dir struct {
+	path   string
+	opt    Options
+	mu     sync.RWMutex
+	live   []Entry
+	next   uint64
+	closed bool
+}
+
+const (
+	segmentExt = ".seg"
+	tempExt    = ".tmp"
+	manifest   = "manifest"
+)
+
+var (
+	// ErrClosed is a use of a directory after Close.
+	ErrClosed = errors.New("segdir: the directory is closed")
+
+	// ErrFormat is a manifest that was damaged or was never a manifest.
+	ErrFormat = errors.New("segdir: the manifest is malformed")
+
+	// ErrVersion is a manifest written by a newer build.
+	ErrVersion = errors.New("segdir: unknown manifest version")
+
+	// ErrSequence is a publish of a sequence that is already there.
+	ErrSequence = errors.New("segdir: that sequence is already published")
+
+	// ErrMissing is a manifest that names a segment the directory does not
+	// hold, or holds at the wrong size. It is the loud version of a silently
+	// smaller index.
+	ErrMissing = errors.New("segdir: a published segment is missing or damaged")
+)
+
+// Open reads a directory, recovers it and returns the live set.
+//
+// Recovery is not a separate mode. There is no clean shutdown flag to check and
+// no fast path that skips it, because a path taken only after a crash is a path
+// that is only ever exercised after a crash. Every open deletes the temporary
+// files and the unpublished segments, and every open verifies that what the
+// manifest names is there.
+//
+// A directory that does not exist is created. A directory with no manifest is
+// an empty index, which is the same thing a fresh one is, so a caller does not
+// have to tell the two apart.
+func Open(path string, opt Options) (*Dir, error) {
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return nil, fmt.Errorf("the segment directory: %w", err)
+	}
+	d := &Dir{path: path, opt: opt}
+
+	live, next, err := d.readManifest()
+	if err != nil {
+		return nil, err
+	}
+	d.live, d.next = live, next
+
+	if err := d.sweep(); err != nil {
+		return nil, err
+	}
+	if err := d.check(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// Path is the directory this was opened on.
+func (d *Dir) Path() string { return d.path }
+
+// File is where a segment lives, which is what a caller that wants to map it
+// rather than read it needs.
+func (d *Dir) File(sequence uint64) string {
+	return filepath.Join(d.path, name(sequence))
+}
+
+// Segments is the live set, nearest to oldest by sequence.
+//
+// The slice is a copy, because the alternative is a caller holding the set
+// while a publish replaces it, and a reader that holds a stale set is fine
+// while a reader that holds a mutating one is not.
+func (d *Dir) Segments() []Entry {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return slices.Clone(d.live)
+}
+
+// Next is the sequence to give the next segment, and it is handed out once.
+//
+// The counter only ever goes up, including across a deletion, so a file name is
+// never reused. Reusing one would mean a reader that cached bytes by name could
+// be handed a different segment under a name it already knows.
+func (d *Dir) Next() uint64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.next++
+	return d.next
+}
+
+// Sequence is the highest sequence handed out so far.
+func (d *Dir) Sequence() uint64 {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.next
+}
+
+// Close releases the directory. There is nothing held open between publishes,
+// so this only makes later calls fail rather than flushing anything.
+func (d *Dir) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.closed = true
+	d.live = nil
+	return nil
+}
+
+// name is the file a sequence lives in. Zero padded so that the directory
+// listing and the sequence order are the same, which makes the listing readable
+// by a person and sortable by a machine without either of them parsing it.
+func name(sequence uint64) string {
+	return fmt.Sprintf("%016d%s", sequence, segmentExt)
+}
+
+// sequence reads a file name back, and reports false for anything that is not
+// one of ours. A directory can hold a README, an editor's swap file or somebody's
+// notes, and none of those are a segment that failed to get published.
+func sequence(file string) (uint64, bool) {
+	if !strings.HasSuffix(file, segmentExt) {
+		return 0, false
+	}
+	digits := strings.TrimSuffix(file, segmentExt)
+	if len(digits) != 16 {
+		return 0, false
+	}
+	var out uint64
+	for i := range len(digits) {
+		c := digits[i]
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		out = out*10 + uint64(c-'0')
+	}
+	return out, true
+}
+
+// sweep deletes what the manifest does not name.
+//
+// Every temporary file is a publish that was interrupted, and every segment
+// that is not live is either the same thing one step further on or a segment
+// that was removed before the manifest naming it could be rewritten. Both are
+// rubbish, both are safe to delete because nothing has ever been able to read
+// them, and deleting them here is what keeps a directory that has crashed a
+// thousand times the same size as one that never has.
+func (d *Dir) sweep() error {
+	entries, err := os.ReadDir(d.path)
+	if err != nil {
+		return fmt.Errorf("listing the segment directory: %w", err)
+	}
+	live := make(map[uint64]struct{}, len(d.live))
+	for _, e := range d.live {
+		live[e.Sequence] = struct{}{}
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		file := e.Name()
+		switch {
+		case strings.HasSuffix(file, tempExt):
+		case file == manifest:
+			continue
+		default:
+			seq, ok := sequence(file)
+			if !ok {
+				continue
+			}
+			if _, ok := live[seq]; ok {
+				continue
+			}
+		}
+		if err := os.Remove(filepath.Join(d.path, file)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing %s: %w", file, err)
+		}
+	}
+	return nil
+}
+
+// check is the other half of recovery: everything the manifest names has to be
+// there, at the size it was published at.
+//
+// A published segment that is missing is refused rather than dropped. An index
+// that quietly comes back smaller is a search that quietly returns fewer
+// answers, and the difference between those and no answers is what makes it
+// take a month to notice.
+func (d *Dir) check() error {
+	for _, e := range d.live {
+		file := d.File(e.Sequence)
+		info, err := os.Stat(file)
+		if err != nil {
+			return fmt.Errorf("%w: segment %d: %w", ErrMissing, e.Sequence, err)
+		}
+		if info.Size() != e.Size {
+			return fmt.Errorf("%w: segment %d is %d bytes and the manifest says %d", ErrMissing, e.Sequence, info.Size(), e.Size)
+		}
+		if !d.opt.Verify {
+			continue
+		}
+		if err := verify(file, e.Sequence); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/store/segdir/segdir_test.go
+++ b/store/segdir/segdir_test.go
@@ -1,0 +1,425 @@
+package segdir_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/store/segdir"
+	"github.com/tamnd/genba/store/segment"
+)
+
+func TestAPublishedSegmentSurvivesAReopen(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	for i := range 3 {
+		publish(t, d, d.Next(), fmt.Sprintf("document %d", i))
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+
+	again := open(t, dir, segdir.Options{Verify: true})
+	live := again.Segments()
+	if len(live) != 3 {
+		t.Fatalf("the reopened directory holds %d segments, want 3", len(live))
+	}
+	for i, e := range live {
+		if e.Sequence != uint64(i+1) {
+			t.Errorf("segment %d has sequence %d", i, e.Sequence)
+		}
+		b, err := again.Read(e.Sequence)
+		if err != nil {
+			t.Fatalf("reading segment %d: %v", e.Sequence, err)
+		}
+		if got := payload(t, b); got != fmt.Sprintf("document %d", i) {
+			t.Errorf("segment %d holds %q", e.Sequence, got)
+		}
+	}
+}
+
+// TestASegmentTheManifestDoesNotNameIsInvisible is the property the whole
+// package exists for, tested at the layer below the crash test: whatever put a
+// segment file there, a reader only ever sees what the manifest names.
+func TestASegmentTheManifestDoesNotNameIsInvisible(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	publish(t, d, d.Next(), "real")
+
+	// A publish that got as far as the rename and no further.
+	orphan := filepath.Join(dir, "0000000000000002.seg")
+	if err := os.WriteFile(orphan, build(t, 2, "never published"), 0o644); err != nil {
+		t.Fatalf("planting a segment: %v", err)
+	}
+	// A publish that did not get that far.
+	half := filepath.Join(dir, "0000000000000003.seg.tmp")
+	if err := os.WriteFile(half, []byte("half a segment"), 0o644); err != nil {
+		t.Fatalf("planting a partial write: %v", err)
+	}
+
+	again := open(t, dir, segdir.Options{Verify: true})
+	if got := again.Segments(); len(got) != 1 || got[0].Sequence != 1 {
+		t.Errorf("the reopened directory holds %v, want only segment 1", got)
+	}
+	if _, err := again.Read(2); !errors.Is(err, segdir.ErrMissing) {
+		t.Errorf("reading an unpublished segment returned %v, want ErrMissing", err)
+	}
+	for _, file := range []string{orphan, half} {
+		if _, err := os.Stat(file); !os.IsNotExist(err) {
+			t.Errorf("%s survived recovery", filepath.Base(file))
+		}
+	}
+}
+
+// TestRecoveryLeavesNothingBehind is why a directory that has crashed a
+// thousand times is the same size as one that never has.
+func TestRecoveryLeavesNothingBehind(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	publish(t, d, d.Next(), "one")
+	publish(t, d, d.Next(), "two")
+	for i := range 20 {
+		file := filepath.Join(dir, fmt.Sprintf("%016d.seg.tmp", i+3))
+		if err := os.WriteFile(file, []byte("rubbish"), 0o644); err != nil {
+			t.Fatalf("planting rubbish: %v", err)
+		}
+	}
+
+	open(t, dir, segdir.Options{})
+	if got, want := listing(t, dir), []string{"0000000000000001.seg", "0000000000000002.seg", "manifest"}; !slices.Equal(got, want) {
+		t.Errorf("after recovery the directory holds %v, want %v", got, want)
+	}
+}
+
+// TestAManifestThatNamesAMissingSegmentIsRefused is the loud failure. An index
+// that quietly came back smaller would be a search that quietly returns fewer
+// answers, and that takes a month to notice.
+func TestAManifestThatNamesAMissingSegmentIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	publish(t, d, d.Next(), "one")
+	publish(t, d, d.Next(), "two")
+
+	if err := os.Remove(filepath.Join(dir, "0000000000000002.seg")); err != nil {
+		t.Fatalf("removing a segment behind the manifest's back: %v", err)
+	}
+	if _, err := segdir.Open(dir, segdir.Options{}); !errors.Is(err, segdir.ErrMissing) {
+		t.Errorf("opening returned %v, want ErrMissing", err)
+	}
+}
+
+func TestASegmentTruncatedBehindTheManifestIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	publish(t, d, d.Next(), "one")
+
+	file := filepath.Join(dir, "0000000000000001.seg")
+	b, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("reading the segment: %v", err)
+	}
+	if err := os.WriteFile(file, b[:len(b)-8], 0o644); err != nil {
+		t.Fatalf("truncating the segment: %v", err)
+	}
+	if _, err := segdir.Open(dir, segdir.Options{}); !errors.Is(err, segdir.ErrMissing) {
+		t.Errorf("opening returned %v, want ErrMissing", err)
+	}
+}
+
+// TestVerifyIsWhatCatchesTheRightSizeAndTheWrongBytes says what the option
+// buys, which is the failure a crash does not produce and a bad sector does.
+func TestVerifyIsWhatCatchesTheRightSizeAndTheWrongBytes(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	publish(t, d, d.Next(), "one")
+
+	file := filepath.Join(dir, "0000000000000001.seg")
+	b, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("reading the segment: %v", err)
+	}
+	b[len(b)-1] ^= 0x40
+	if err := os.WriteFile(file, b, 0o644); err != nil {
+		t.Fatalf("damaging the segment: %v", err)
+	}
+
+	if _, err := segdir.Open(dir, segdir.Options{}); err != nil {
+		t.Errorf("the cheap check refused a file of the right length: %v", err)
+	}
+	if _, err := segdir.Open(dir, segdir.Options{Verify: true}); !errors.Is(err, segdir.ErrMissing) {
+		t.Errorf("verifying returned %v, want ErrMissing", err)
+	}
+}
+
+func TestASequencePublishedTwiceIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	publish(t, d, 1, "one")
+	if _, err := d.Publish(build(t, 1, "one again")); !errors.Is(err, segdir.ErrSequence) {
+		t.Errorf("publishing a sequence twice returned %v, want ErrSequence", err)
+	}
+}
+
+func TestBytesThatAreNotASegmentAreNeverWritten(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	if _, err := d.Publish([]byte("not a segment")); err == nil {
+		t.Fatal("publishing rubbish was accepted")
+	}
+	if got := listing(t, dir); len(got) != 0 {
+		t.Errorf("the refused publish left %v behind", got)
+	}
+}
+
+// TestASequenceIsNeverReused matters because something above this caches
+// segments by name. A name that came back meaning a different segment would be
+// a cache that serves the wrong bytes and never notices.
+func TestASequenceIsNeverReused(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	for range 3 {
+		publish(t, d, d.Next(), "a segment")
+	}
+	if err := d.Remove(1, 2, 3); err != nil {
+		t.Fatalf("removing: %v", err)
+	}
+	if got := d.Segments(); len(got) != 0 {
+		t.Fatalf("the directory still holds %v", got)
+	}
+
+	reopened := open(t, dir, segdir.Options{})
+	if got := reopened.Next(); got != 4 {
+		t.Errorf("the next sequence after removing everything is %d, want 4", got)
+	}
+}
+
+func TestRemovingSomethingThatIsNotThereIsNotAnError(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	publish(t, d, d.Next(), "one")
+	if err := d.Remove(99); err != nil {
+		t.Errorf("removing an unpublished sequence returned %v", err)
+	}
+	if err := d.Remove(1); err != nil {
+		t.Fatalf("removing: %v", err)
+	}
+	if err := d.Remove(1); err != nil {
+		t.Errorf("removing twice returned %v", err)
+	}
+	if got := listing(t, dir); !slices.Equal(got, []string{"manifest"}) {
+		t.Errorf("after removing everything the directory holds %v", got)
+	}
+}
+
+// TestTheSyncPolicyDefaultsToSafe is a one line test for a decision that is
+// easy to reverse by accident: the zero value of the options has to be the one
+// that survives a power cut.
+func TestTheSyncPolicyDefaultsToSafe(t *testing.T) {
+	if got := (segdir.Options{}).Sync; got != segdir.SyncFull {
+		t.Errorf("the default sync policy is %v, want full", got)
+	}
+	for _, s := range []segdir.Sync{segdir.SyncFull, segdir.SyncManifest, segdir.SyncNone} {
+		if got := s.String(); strings.HasPrefix(got, "sync(") {
+			t.Errorf("policy %d has no name", uint8(s))
+		}
+	}
+}
+
+func TestEveryPolicyRoundTrips(t *testing.T) {
+	for _, s := range []segdir.Sync{segdir.SyncFull, segdir.SyncManifest, segdir.SyncNone} {
+		t.Run(s.String(), func(t *testing.T) {
+			dir := t.TempDir()
+			d := open(t, dir, segdir.Options{Sync: s})
+			publish(t, d, d.Next(), "one")
+			publish(t, d, d.Next(), "two")
+
+			again := open(t, dir, segdir.Options{Verify: true})
+			if got := again.Segments(); len(got) != 2 {
+				t.Errorf("the reopened directory holds %d segments, want 2", len(got))
+			}
+		})
+	}
+}
+
+func TestUsingAClosedDirectoryIsRefused(t *testing.T) {
+	d := open(t, t.TempDir(), segdir.Options{})
+	if err := d.Close(); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+	if _, err := d.Publish(build(t, 1, "one")); !errors.Is(err, segdir.ErrClosed) {
+		t.Errorf("publishing to a closed directory returned %v, want ErrClosed", err)
+	}
+	if err := d.Remove(1); !errors.Is(err, segdir.ErrClosed) {
+		t.Errorf("removing from a closed directory returned %v, want ErrClosed", err)
+	}
+	if _, err := d.Read(1); !errors.Is(err, segdir.ErrClosed) {
+		t.Errorf("reading from a closed directory returned %v, want ErrClosed", err)
+	}
+}
+
+// TestOpenRefusesADamagedManifest is the same hostility the segment format
+// applies to its own bytes. A manifest is the one file that says what a reader
+// may see, so it is the last place to be forgiving.
+func TestOpenRefusesADamagedManifest(t *testing.T) {
+	cases := []struct {
+		name   string
+		damage func(b []byte) []byte
+		want   error
+	}{
+		{"empty", func([]byte) []byte { return nil }, segdir.ErrFormat},
+		{"a header and nothing else", func(b []byte) []byte { return b[:16] }, segdir.ErrFormat},
+		{"not a manifest", func(b []byte) []byte { b[0] = 'x'; return b }, segdir.ErrFormat},
+		{"a version from the future", func(b []byte) []byte { b[8] = 2; return b }, segdir.ErrVersion},
+		{"a flag this build does not know", func(b []byte) []byte { b[10] = 1; return b }, segdir.ErrVersion},
+		{"reserved bytes that are not zero", func(b []byte) []byte { b[28] = 1; return b }, segdir.ErrFormat},
+		{"a count the file cannot hold", func(b []byte) []byte { b[12] = 99; return b }, segdir.ErrFormat},
+		{"a flipped byte in an entry", func(b []byte) []byte { b[33] ^= 0x01; return b }, segdir.ErrFormat},
+		{"a truncated entry", func(b []byte) []byte { return b[:len(b)-4] }, segdir.ErrFormat},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			d := open(t, dir, segdir.Options{})
+			publish(t, d, d.Next(), "one")
+			publish(t, d, d.Next(), "two")
+
+			file := filepath.Join(dir, "manifest")
+			b, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("reading the manifest: %v", err)
+			}
+			if err := os.WriteFile(file, c.damage(b), 0o644); err != nil {
+				t.Fatalf("damaging the manifest: %v", err)
+			}
+			if _, err := segdir.Open(dir, segdir.Options{}); !errors.Is(err, c.want) {
+				t.Errorf("opening returned %v, want %v", err, c.want)
+			}
+		})
+	}
+}
+
+// TestOpenRefusesEveryDamagedManifestByte is the same idea without a list of
+// the ways it can go wrong. Every byte is flipped two ways and the only
+// requirement is that each one either opens or says why not.
+func TestOpenRefusesEveryDamagedManifestByte(t *testing.T) {
+	dir := t.TempDir()
+	d := open(t, dir, segdir.Options{})
+	publish(t, d, d.Next(), "one")
+	publish(t, d, d.Next(), "two")
+	sound, err := os.ReadFile(filepath.Join(dir, "manifest"))
+	if err != nil {
+		t.Fatalf("reading the manifest: %v", err)
+	}
+
+	for i := range sound {
+		for _, bit := range []byte{0x01, 0x80} {
+			b := slices.Clone(sound)
+			b[i] ^= bit
+			at := t.TempDir()
+			if err := os.WriteFile(filepath.Join(at, "manifest"), b, 0o644); err != nil {
+				t.Fatalf("writing the manifest: %v", err)
+			}
+			// Nothing to assert beyond not panicking and not hanging. A
+			// manifest that survives a flipped byte is one whose entries still
+			// name segments, and those are not there, so it fails at the check
+			// instead.
+			if _, err := segdir.Open(at, segdir.Options{}); err == nil {
+				t.Errorf("byte %d flipped with %#02x opened and named segments that are not there", i, bit)
+			}
+		}
+	}
+}
+
+func FuzzOpen(f *testing.F) {
+	dir := f.TempDir()
+	d := open(f, dir, segdir.Options{})
+	publish(f, d, d.Next(), "one")
+	b, err := os.ReadFile(filepath.Join(dir, "manifest"))
+	if err != nil {
+		f.Fatalf("reading the manifest: %v", err)
+	}
+	f.Add(b)
+	f.Add([]byte("genbaman"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		at := t.TempDir()
+		if err := os.WriteFile(filepath.Join(at, "manifest"), b, 0o644); err != nil {
+			t.Skip()
+		}
+		// The only contract is that nothing panics. A manifest that parses
+		// names segments that are not there, which is an error, and one that
+		// does not parse is an error too.
+		if d, err := segdir.Open(at, segdir.Options{}); err == nil {
+			d.Segments()
+			d.Close()
+		}
+	})
+}
+
+// build returns a segment carrying a payload, so that a test can tell one
+// segment from another by reading it back.
+func build(tb testing.TB, sequence uint64, payload string) []byte {
+	tb.Helper()
+	w := segment.NewWriter(sequence)
+	if err := w.Add(segment.KindFields, []byte(payload)); err != nil {
+		tb.Fatalf("adding a section: %v", err)
+	}
+	b, err := w.Bytes()
+	if err != nil {
+		tb.Fatalf("building a segment: %v", err)
+	}
+	return b
+}
+
+// payload reads it back.
+func payload(tb testing.TB, b []byte) string {
+	tb.Helper()
+	s, err := segment.Open(b)
+	if err != nil {
+		tb.Fatalf("opening a segment: %v", err)
+	}
+	section, ok := s.Section(segment.KindFields)
+	if !ok {
+		tb.Fatal("the segment has no fields section")
+	}
+	return string(section)
+}
+
+func open(tb testing.TB, path string, opt segdir.Options) *segdir.Dir {
+	tb.Helper()
+	d, err := segdir.Open(path, opt)
+	if err != nil {
+		tb.Fatalf("opening %s: %v", path, err)
+	}
+	return d
+}
+
+func publish(tb testing.TB, d *segdir.Dir, sequence uint64, payload string) segdir.Entry {
+	tb.Helper()
+	e, err := d.Publish(build(tb, sequence, payload))
+	if err != nil {
+		tb.Fatalf("publishing segment %d: %v", sequence, err)
+	}
+	return e
+}
+
+// listing is the file names in a directory, sorted, which is what the recovery
+// tests assert on.
+func listing(tb testing.TB, path string) []string {
+	tb.Helper()
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		tb.Fatalf("listing %s: %v", path, err)
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	slices.Sort(out)
+	return out
+}

--- a/store/segdir/sync_unix.go
+++ b/store/segdir/sync_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package segdir
+
+import "os"
+
+// syncDir flushes a directory, which is what makes a rename durable.
+//
+// A rename that has not been flushed is a name that exists in the page cache
+// and not on the platter, so a power cut can leave the file with its old name
+// or with no name at all. Everything in this package that renames a file
+// therefore follows it with one of these, and the reason it is a separate
+// function is that Windows cannot do it at all: see the other half of this
+// pair.
+func syncDir(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/store/segdir/sync_windows.go
+++ b/store/segdir/sync_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package segdir
+
+// syncDir does nothing on Windows, because there is nothing to do.
+//
+// A directory handle cannot be opened for writing and cannot be flushed, so the
+// call that works everywhere else has no counterpart here. What Windows gives
+// instead is that MoveFileEx with the replace flag, which is what os.Rename
+// uses, is atomic with respect to the directory entry, so a reader sees the old
+// file or the new one and never a partial name.
+//
+// The gap that leaves is a power cut in the window between the rename and the
+// file system flushing its own metadata, which is bounded by the file system
+// rather than by this package. It is written down here rather than papered
+// over, because a durability claim that is not true on one of the platforms
+// this ships on is worse than one that says which platform it means.
+func syncDir(string) error { return nil }


### PR DESCRIPTION
Closes #9.

An index is a set of immutable segments, so the only mutable thing in it is the answer to which segments are there.
This adds `store/segdir`, which owns that answer.
It keeps it in one manifest file, it changes it with one rename, and it treats everything on disk the manifest does not name as rubbish left by a crash.

## Why this is a correctness problem

Losing the last hour of a crawl to a power cut is annoying and the fix is to crawl again.
Coming back with half a segment is different, because half a segment is half an access list.
A document whose permissions were written and whose content was not is a document with no readers, which is merely wrong and which somebody notices.
A document whose content was written and whose permissions were not is a document with every reader, and nobody notices that one.

So the rule is not that writes are durable.
The rule is that a segment is either wholly visible or wholly invisible, at every instant, to every reader, including the reader that opens the directory after the machine came back.

## The design

A publish writes the segment to a temporary name, makes it durable, renames it into place, and only then rewrites the manifest, also through a temporary name and a rename.
A rename over an existing file is atomic, so the manifest is at every instant either exactly the old set or exactly the new one.

The manifest is written whole rather than appended to, which is the decision worth defending.
A log is cheaper to append to but it has a torn tail after a crash, which means a reader has to decide how much of the tail to believe, and that decision is where the bug lives.
A file replaced by a rename has only two possible states.
The cost is sixteen bytes per live segment rewritten on every publish, and the benchmark says that does not show up until the index is very large.

Recovery is not a mode.
There is no clean shutdown flag and no fast path that skips the checks, because a path taken only after a crash is a path exercised only after a crash.
Every open sweeps the temporary files and the unpublished segments, and every open checks that what the manifest names is there at the size it was published at.
A manifest that names a missing segment is refused rather than served as a smaller index, because a search that quietly returns fewer answers is the failure that takes a month to notice.

## The test kills a real process

`TestKillingTheProcessAtEveryWritePointRecovers` runs a child at every instant a publish can be interrupted at, kills it there with `os.Exit`, and then opens what it left behind.
Publish has six such instants and remove has three, and neither number is written down anywhere: the test raises the crash point until the child survives, so adding a write to either path adds a case without anybody remembering to update a constant.

It is a subprocess rather than a simulation because the thing under test is what the operating system does with writes that were in flight, and a fake that decided which of them survived would be a test of the fake.

After each kill the directory has to open with verification on, hold everything published before the interrupted operation and read each of them back as itself, have either wholly done or wholly not done the interrupted operation, hold exactly the live set plus the manifest and nothing else, and accept a further publish and reopen.

I checked the test by breaking the code on purpose.
Reordering a publish so the manifest is written before the segment rename makes it fail at two of the six crash points with "a published segment is missing or damaged".

What it cannot test is a power cut, since the pages the child did not flush are the operating system's by the time it dies.
That gap is why the safe fsync policy is the default rather than something to reach for.

## The fsync policy

Three settings, and the zero value is the safe one.

| Policy | Flushes | Survives a kill | Survives a power cut |
| --- | --- | --- | --- |
| `SyncFull` | the segment, the manifest and the directory | yes | yes |
| `SyncManifest` | the manifest and the directory | yes | no |
| `SyncNone` | nothing | yes | no |

`Options.Verify` is separate.
Off, an open stats every live segment and compares its length to the manifest, which catches the two things a crash produces.
On, it reads and parses every segment, which is what catches a bad sector that produced a file of the right length full of something else.

## What it costs

On an Apple M4:

| Segments | Open | Open after 500 interrupted publishes | Open with `Verify` |
| --- | --- | --- | --- |
| 100 | 325 us | 24.7 ms | 2.0 ms |
| 1 thousand | 3.5 ms | 29.0 ms | 20.8 ms |
| 10 thousand | 36.5 ms | 55.0 ms | 237 ms |

Ten thousand segments is a large index and it is back in under forty milliseconds.
Publishing is flat at around 290 us until ten thousand live segments, where rewriting the manifest whole reaches 499 us, and that is the number the whole design trades for.

## Also here

`docs/durability.md` has the reasoning, the numbers and what is deliberately not here, which is a write ahead log, a lock, compaction policy and segments spread across volumes.
The README layout table gains the package and `arch_test.go` pins its one dependency, `store/segment`.