### PR TITLE
Connectors: incremental sync with cursors and change feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ The mode bits describe the account the crawler runs as, not the people in the co
 `OwnersPolicy` reads the OWNERS files that Kubernetes and a number of other large repositories keep, taking the nearest one going up the tree, which is a real access control list maintained by real people over a corpus anybody can check out.
 A source built with no policy at all quarantines everything, so having not thought about permissions yet is a visible state in the stats rather than an invisible one in the index.
 
+Everything after the first sync is incremental.
+A second run over an unchanged tree reads no files at all, an OWNERS edit costs one write per document rather than a recrawl of the subtree, and a reconciliation sweep after every sync catches what a change feed cannot report, starting with the file somebody deleted.
+[docs/ingestion.md](docs/ingestion.md) has the details, including the optional capabilities a connector implements to get each of those and the rule that stops a timed out enumeration from emptying a working index.
+
 ## Storage
 
 The interface in `store` is deliberately narrow, and a driver passes or fails one conformance suite.

--- a/arch_test.go
+++ b/arch_test.go
@@ -113,7 +113,11 @@ var allowed = map[string][]string{
 	// document without going through the checks the pipeline applies.
 	"connector":          {"acl", "doc"},
 	"connector/fssource": {"acl", "connector", "doc"},
-	"ingest":             {"", "connector", "doc", "store"},
+	// ingest names acl because a permission change that arrives without the
+	// document is a map of access control lists and nothing else, and there is
+	// no way to carry one without saying what it is. It is the one type from
+	// that package the pipeline handles directly.
+	"ingest": {"", "acl", "connector", "doc", "store"},
 
 	// The benchmark corpus sits above everything, like storetest does, because
 	// it exists to be measured against rather than to be built on. It is the one

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -143,6 +143,8 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 			"heap_mb", megabytes(int64(after.HeapAlloc)),
 			"allocated_mb", megabytes(int64(after.TotalAlloc-before.TotalAlloc)),
 		)
+
+		reconcile(ctx, pipeline, src, tenant, log)
 	}
 
 	sync(ctx)
@@ -169,6 +171,53 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 		<-done
 		_ = src.Close()
 	}, nil
+}
+
+// reconcile sweeps the index against the tree and repairs what the sync could
+// not have seen.
+//
+// It runs after every sync rather than on a schedule of its own, and the reason
+// is that a directory tree has no change feed. A sync walks the tree and emits
+// what is newer than the cursor, which means a file somebody deleted produces
+// no event at all: there is nothing left to walk past. Without this the deleted
+// document stays in the index and keeps being served, and the only thing that
+// would ever remove it is a restart.
+//
+// The cost is a second walk of the same tree, stat only, plus a two column scan
+// of the index. On a corpus where the sync itself is already a stat per file
+// that is roughly double the cheap half of the work and none of the expensive
+// half, which is the right trade for the alternative being an index that serves
+// documents that no longer exist.
+func reconcile(ctx context.Context, pipeline *ingest.Pipeline, src connector.Connector, tenant string, log *slog.Logger) {
+	rec, err := pipeline.Reconcile(ctx, genba.TenantID(tenant), src)
+	if err != nil {
+		// Not fatal, and not even unusual. A store that cannot list what it holds
+		// or a connector that cannot enumerate simply has no sweep, and the sync
+		// that just finished is still good.
+		log.Warn("corpus reconciliation skipped", "source", src.Source(), "error", err)
+		return
+	}
+	if rec.Drift() == 0 {
+		return
+	}
+	// Logged at warning level because drift is the interesting event. An index
+	// that agrees with its source produces nothing here, so a line in the log
+	// means the incremental path missed something and is worth going to look at.
+	log.Warn("corpus reconciled",
+		"source", rec.Source,
+		"source_items", rec.SourceItems,
+		"index_items", rec.IndexItems,
+		"missing", rec.Missing.Count,
+		"stale", rec.Stale.Count,
+		"extra", rec.Extra.Count,
+		"repaired", rec.Repaired,
+		"deleted", rec.Deleted,
+		"sample_missing", rec.Missing.IDs,
+		"sample_stale", rec.Stale.IDs,
+		"sample_extra", rec.Extra.IDs,
+		"requests", rec.Requests.Requests(),
+		"duration", rec.Duration.Round(time.Millisecond),
+	)
 }
 
 // megabytes converts a byte count for the log.

--- a/cmd/genbad/corpus_test.go
+++ b/cmd/genbad/corpus_test.go
@@ -186,6 +186,63 @@ func TestOwnersDecideWhatAQueryReturns(t *testing.T) {
 	}
 }
 
+// A file somebody deleted has to stop coming back, and a walk of the tree can
+// never see one: there is nothing left to walk past. This is the sweep doing
+// the job the incremental path cannot do at all.
+func TestADeletedFileStopsComingBack(t *testing.T) {
+	root := corpusTree(t)
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, []string{
+			"-addr", addr,
+			"-tenant", "acme",
+			"-corpus", root,
+			"-corpus-name", "handbook",
+			"-corpus-refresh", "100ms",
+			"-log-level", "error",
+		}, env(nil), &out, &errOut)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("the server did not shut down")
+		}
+	}()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	if got := searchAs(t, addr, "alice", "deploying"); got.Total == 0 {
+		t.Fatal("the file was not indexed in the first place")
+	}
+	if err := os.Remove(filepath.Join(root, "guides", "deploy.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if got := searchAs(t, addr, "alice", "deploying"); got.Total == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("a file deleted from the tree is still in the results")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// And the rest of the corpus is still there, which is the part worth
+	// checking twice. A sweep that deletes too much looks the same in this test
+	// as one that works, right up until nothing can be found.
+	if got := searchAs(t, addr, "alice", "handbook"); got.Total == 0 {
+		t.Error("the sweep removed documents the tree still holds")
+	}
+}
+
 type hit struct {
 	ID    string `json:"id"`
 	Title string `json:"title"`

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -27,10 +27,27 @@
 // that change was durably stored, so a run that is killed picks up where it
 // stopped rather than starting again. What goes in a cursor is entirely the
 // connector's business, and nothing above it may parse it.
+//
+// # The incremental path is not enough on its own
+//
+// [Connector] is the whole of the required interface. Everything else here is
+// optional, and every one of the optional pieces exists because an index built
+// only out of a change feed drifts away from its source and nothing in the feed
+// ever says so. Events get dropped, a bulk edit at the source raises none, a
+// permission change raises one that carries no content, and a process killed
+// between a store and a checkpoint replays or skips.
+//
+// So a connector that can do better says so by implementing more:
+// [Enumerator] to list what the source holds, [Fetcher] to fetch one document
+// by id, [Counted] to report what it spent, and [Change.PermissionsOnly] to
+// report an access control change without the content that did not change.
+// A connector that implements none of them still works, and what it gives up
+// is the ability to be checked.
 package connector
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/tamnd/genba/acl"
@@ -79,9 +96,147 @@ type Change struct {
 	// from the index rather than stored.
 	Deleted bool
 
+	// PermissionsOnly says the only thing that changed is who may read the
+	// document, and that the rest of Document is not filled in.
+	//
+	// This is the difference between a permission change costing a write and
+	// costing a recrawl. Access control at a real source does not live on the
+	// document: it lives on the folder, the space, the group or the OWNERS file
+	// above it, and one edit there governs thousands of documents whose content
+	// nobody touched. A connector that noticed such an edit knows the new access
+	// control list without fetching anything, and this is how it says so.
+	//
+	// Only ID and Permissions are read. Everything else in Document is ignored,
+	// so a connector must not use this to sneak a content update through: the
+	// content will not be stored.
+	PermissionsOnly bool
+
 	// Cursor is the point to resume from once this change has been durably
 	// stored. It is opaque above the connector that produced it.
 	Cursor Cursor
+}
+
+// Item is one document as an enumeration sees it: a name and a version, and
+// deliberately nothing else.
+//
+// Listing a source is a different operation from reading it, and at most
+// sources it is a different price. This type is what makes that difference
+// usable: a walk that returns ids and revisions can compare a whole corpus
+// against the index without fetching a single document.
+type Item struct {
+	// ID is the document id, the same one [Change] would carry.
+	ID string
+
+	// Version is the source's own idea of a revision, which lands in
+	// [doc.Document.SourceUpdate] when the document is stored. It is opaque
+	// above the connector: the only thing done with it is comparing it to the
+	// version already stored, and a difference means the index is behind.
+	//
+	// An empty version means the source does not have one. That is allowed and
+	// it costs something: a document with no version can be found to be missing
+	// or extra, but never stale.
+	Version string
+}
+
+// Enumerator is the optional capability of a connector that can list what its
+// source holds without reading it.
+//
+// It is what reconciliation is built on. An incremental sync is a stream of
+// changes and it is only ever as good as the change feed underneath it: feeds
+// drop events, sources forget to raise them for a bulk edit, and a process
+// killed at the wrong moment resumes past something. None of those are visible
+// from inside the incremental path, which is exactly why the sweep that catches
+// them cannot be built out of it.
+//
+// A connector that cannot enumerate cheaply should not implement this. A sweep
+// that costs a full recrawl is a full recrawl, and an operator is better served
+// by being told the source has no enumeration than by a maintenance job that
+// quietly reads the corpus every night.
+type Enumerator interface {
+	Connector
+
+	// Enumerate calls fn for every document the source currently holds, and
+	// stops early if fn returns false. The order is unspecified.
+	//
+	// It must be complete or it must fail. A walk that silently returns part of
+	// the corpus reads, to everything above it, as a corpus that lost the rest,
+	// and the repair for that is deletion.
+	Enumerate(ctx context.Context, fn func(Item) bool) error
+}
+
+// Fetcher is the optional capability of a connector that can read one document
+// by id, out of the order a sync would have found it in.
+//
+// Reconciliation needs it to repair what it finds. Without it a sweep can still
+// report that the index is missing a document and can still delete one the
+// source no longer has, but it cannot fill the hole, and the only way to get
+// the document back is a full sync.
+type Fetcher interface {
+	Connector
+
+	// Fetch returns one document by id, with its permissions resolved the same
+	// way a sync would resolve them.
+	//
+	// It returns [ErrGone] if the source no longer has the document, which is
+	// not an error condition: it is the answer, and it is how a repair learns
+	// that what it was about to refetch should be deleted instead.
+	Fetch(ctx context.Context, id string) (doc.Document, error)
+}
+
+// ErrGone is returned by [Fetcher.Fetch] for a document the source no longer
+// has.
+var ErrGone = errors.New("connector: the source no longer has this document")
+
+// Counters is what a connector spent talking to its source.
+//
+// They exist because the claim that an incremental sync is cheap is not
+// checkable from the outside. A second run over an unchanged corpus takes
+// milliseconds either way on a local disk, and the same connector against a
+// real API with the same bug costs a hundred thousand requests and a rate
+// limit. Time measures the machine. These measure the work.
+//
+// The split is by price rather than by protocol, because that is what a
+// connector's caller is deciding about.
+type Counters struct {
+	// Lists is enumerations: a directory read, a page of a change feed, a
+	// search that returns identifiers.
+	Lists int64
+
+	// Metadata is per document lookups that do not return content, which is
+	// what an incremental sync spends on documents it decides to skip.
+	Metadata int64
+
+	// Fetches is full reads of a document. This is the expensive one and the
+	// one a second run over an unchanged corpus should leave at zero.
+	Fetches int64
+
+	// Bytes is how much content came back.
+	Bytes int64
+}
+
+// Requests is the total number of calls made to the source.
+func (c Counters) Requests() int64 { return c.Lists + c.Metadata + c.Fetches }
+
+// Since returns what has been spent since an earlier reading.
+//
+// A connector counts for its own lifetime rather than per run, because it does
+// not know where a run begins. A caller that wants one run takes a reading
+// before and subtracts it.
+func (c Counters) Since(earlier Counters) Counters {
+	return Counters{
+		Lists:    c.Lists - earlier.Lists,
+		Metadata: c.Metadata - earlier.Metadata,
+		Fetches:  c.Fetches - earlier.Fetches,
+		Bytes:    c.Bytes - earlier.Bytes,
+	}
+}
+
+// Counted is the optional capability of a connector that reports what it spent.
+type Counted interface {
+	// Counters returns the running totals for the life of the connector. It is
+	// safe to call from another goroutine while a sync is running, which is the
+	// point: a long sync is exactly when somebody wants to know.
+	Counters() Counters
 }
 
 // Cursor is a source's own idea of where a sync got to.

--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -43,6 +43,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -95,6 +96,46 @@ func PublicToTenant(source string) Policy {
 	})
 }
 
+// Versioned is the optional capability of a [Policy] that can say when its
+// answer for a path last changed.
+//
+// It is what turns a permission change into a write instead of a recrawl. A
+// sync that only compares modification times cannot see one at all: the file
+// did not change, the rule above it did. A policy that implements this is asked
+// about every file the walk decided to skip, and the ones whose rule moved get
+// a permissions only change.
+//
+// The answer has to be cheap. It is asked once per unchanged file, which on a
+// large tree is once per file, so anything that costs a read has to be cached
+// for the length of the walk.
+type Versioned interface {
+	// ChangedAt returns when the rule governing relPath last changed. A zero
+	// time means the policy has no rule for it, or has no idea, and nothing is
+	// refreshed on the strength of it.
+	ChangedAt(ctx context.Context, relPath string) (time.Time, error)
+}
+
+// Reloader is the optional capability of a [Policy] that caches.
+//
+// A source calls it once at the start of every walk. That is the contract the
+// caching in a policy is allowed to assume: answers may be held for the length
+// of one sync and must not be held across two, because the thing a later sync
+// exists to notice is exactly the edit that would invalidate them.
+type Reloader interface {
+	Reload()
+}
+
+// counters is what a source spent on the filesystem.
+//
+// The fields are atomic because [connector.Counted] promises a reading can be
+// taken while a sync is running, which is when an operator most wants one.
+type counters struct {
+	lists    atomic.Int64
+	metadata atomic.Int64
+	fetches  atomic.Int64
+	bytes    atomic.Int64
+}
+
 // Source reads documents out of a directory tree.
 type Source struct {
 	root   string
@@ -106,6 +147,8 @@ type Source struct {
 	skipDir   func(name string) bool
 	includeIf func(name string) bool
 	skipped   func(path string, reason error)
+
+	counters counters
 }
 
 // Option configures a source.
@@ -232,39 +275,17 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 		return connector.Cursor{}, err
 	}
 
-	var highest time.Time
-	walkErr := filepath.WalkDir(s.root, func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			// A directory that disappeared under the walk, or one this process
-			// may not read, is a fact about the tree rather than a reason to
-			// abandon the sync.
-			if d != nil && d.IsDir() {
-				return fs.SkipDir
-			}
-			return nil
-		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if d.IsDir() {
-			if p != s.root && s.skipDir(d.Name()) {
-				return fs.SkipDir
-			}
-			return nil
-		}
-		if !d.Type().IsRegular() || !s.includeIf(d.Name()) {
-			return nil
-		}
+	// A policy that caches its answers is told the walk is starting, so that an
+	// OWNERS file edited since the last run is read again. Without this a long
+	// running process would keep serving the access control list the tree had
+	// when it started, which is the failure mode where a revocation appears to
+	// have been applied and has not.
+	if r, ok := s.policy.(Reloader); ok {
+		r.Reload()
+	}
 
-		info, err := d.Info()
-		if err != nil {
-			s.skipped(p, err)
-			return nil
-		}
-		if limit := s.limitFor(d.Name()); info.Size() > limit {
-			s.skipped(p, fmt.Errorf("%d bytes is over the limit of %d", info.Size(), limit))
-			return nil
-		}
+	var highest time.Time
+	walkErr := s.walk(ctx, func(rel string, info fs.FileInfo) error {
 		mod := info.ModTime()
 		if mod.After(highest) {
 			highest = mod
@@ -272,24 +293,22 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 		// Not After rather than Before, so a file written in the same
 		// nanosecond as the cursor is not emitted twice on every later run.
 		if !since.IsZero() && !mod.After(since) {
-			return nil
+			at, err := s.refresh(ctx, rel, since, emit)
+			if at.After(highest) {
+				highest = at
+			}
+			return err
 		}
 
-		rel, err := filepath.Rel(s.root, p)
+		full := filepath.Join(s.root, filepath.FromSlash(rel))
+		document, err := s.read(ctx, full, rel, info)
 		if err != nil {
-			s.skipped(p, err)
-			return nil
-		}
-		rel = filepath.ToSlash(rel)
-
-		document, err := s.read(ctx, p, rel, info)
-		if err != nil {
-			s.skipped(p, err)
+			s.skipped(full, err)
 			return nil
 		}
 		return emit(ctx, connector.Change{
 			Document: document,
-			Cursor:   connector.Cursor{Value: mod.UTC().Format(time.RFC3339Nano), Time: mod},
+			Cursor:   connector.Cursor{Value: version(mod), Time: mod},
 		})
 	})
 	if walkErr != nil {
@@ -299,7 +318,57 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 	if highest.IsZero() {
 		return from, nil
 	}
-	return connector.Cursor{Value: highest.UTC().Format(time.RFC3339Nano), Time: highest}, nil
+	return connector.Cursor{Value: version(highest), Time: highest}, nil
+}
+
+// refresh emits a permission change for a file whose content did not change but
+// whose access control list did, and returns when that rule last changed.
+//
+// This is the whole of "a permission change takes effect without a content
+// recrawl" on a filesystem. Access here does not live on the file, it lives in
+// the OWNERS file above it, and editing one of those changes who may read every
+// document in a subtree without touching a single one of them. A sync that only
+// looks at modification times sees nothing at all, and the index keeps serving
+// the old answer until somebody notices.
+//
+// What it costs is one policy lookup per unchanged file, which for the OWNERS
+// policy is a map read after the first file in each directory. What it saves is
+// reading the subtree.
+func (s *Source) refresh(ctx context.Context, rel string, since time.Time, emit func(context.Context, connector.Change) error) (time.Time, error) {
+	versioned, ok := s.policy.(Versioned)
+	if !ok {
+		return time.Time{}, nil
+	}
+	at, err := versioned.ChangedAt(ctx, rel)
+	if err != nil {
+		// A policy that cannot answer for one path is not a reason to abandon the
+		// tree, for the same reason a file that cannot be read is not. It is
+		// reported and the walk carries on, and the document keeps the access
+		// control list it already had until something can say otherwise.
+		s.skipped(rel, err)
+		return time.Time{}, nil
+	}
+	if at.IsZero() || !at.After(since) {
+		return at, nil
+	}
+
+	perms, err := s.policy.Permissions(ctx, rel)
+	if err != nil {
+		// The rule that used to govern this file stopped resolving. Quarantining
+		// is the only safe reading: a document nobody can currently say who may
+		// read is not a document to keep serving on last week's answer.
+		perms = connector.Unresolved(s.name)
+		s.skipped(rel, err)
+	}
+	return at, emit(ctx, connector.Change{
+		Document:        doc.Document{ID: s.id(rel), Permissions: perms},
+		PermissionsOnly: true,
+		// No cursor. The time this change is derived from belongs to a file
+		// somewhere else in the tree, quite possibly one the walk has not
+		// reached, so it is not a statement about how far this walk got. The end
+		// of walk cursor covers it, and a run interrupted before that repeats the
+		// refresh, which costs one write.
+	})
 }
 
 // limitFor is the size limit that applies to one file name. An image gets the
@@ -313,10 +382,12 @@ func (s *Source) limitFor(name string) int64 {
 
 // read turns one file into a document.
 func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (doc.Document, error) {
+	s.counters.fetches.Add(1)
 	raw, err := os.ReadFile(full)
 	if err != nil {
 		return doc.Document{}, err
 	}
+	s.counters.bytes.Add(int64(len(raw)))
 
 	picture := isImage(rel)
 	// A file that is not valid UTF-8 and is not an image we recognise is a
@@ -361,7 +432,7 @@ func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (
 		Container:    containerOf(rel),
 		ModifiedAt:   info.ModTime(),
 		CreatedAt:    info.ModTime(),
-		SourceUpdate: info.ModTime().UTC().Format(time.RFC3339Nano),
+		SourceUpdate: version(info.ModTime()),
 		Permissions:  perms,
 		Properties: map[string]string{
 			"path":        rel,

--- a/connector/fssource/maintain.go
+++ b/connector/fssource/maintain.go
@@ -1,0 +1,178 @@
+package fssource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/doc"
+)
+
+var (
+	_ connector.Enumerator = (*Source)(nil)
+	_ connector.Fetcher    = (*Source)(nil)
+	_ connector.Counted    = (*Source)(nil)
+)
+
+// Enumerate calls fn for every file the source would index, with its
+// modification time as the version.
+//
+// It is the same walk [Source.Sync] does and it reads nothing. That is the
+// whole difference in price on a filesystem: a hundred thousand stats against a
+// hundred thousand reads, which on a real corpus is a second against a minute.
+func (s *Source) Enumerate(ctx context.Context, fn func(connector.Item) bool) error {
+	err := s.walk(ctx, func(rel string, info fs.FileInfo) error {
+		if !fn(connector.Item{ID: s.id(rel), Version: version(info.ModTime())}) {
+			return fs.SkipAll
+		}
+		return nil
+	})
+	// A walk this one stopped on purpose is not a failed walk, and reporting it
+	// as one would make a reconciliation that used an early exit delete the
+	// entire index.
+	if errors.Is(err, fs.SkipAll) {
+		return nil
+	}
+	return err
+}
+
+// Fetch reads one file by document id.
+//
+// It returns [connector.ErrGone] for a file that is no longer there, which is
+// the normal answer on a tree people are working in rather than a failure.
+func (s *Source) Fetch(ctx context.Context, id string) (doc.Document, error) {
+	if err := ctx.Err(); err != nil {
+		return doc.Document{}, err
+	}
+	rel, ok := s.rel(id)
+	if !ok {
+		// An id this source did not mint names a file it does not have. Saying
+		// so is the same answer as a deleted file, and it is the safe one: the
+		// caller deletes it from the index rather than storing something read
+		// from a path an id was allowed to steer.
+		return doc.Document{}, connector.ErrGone
+	}
+
+	full := filepath.Join(s.root, filepath.FromSlash(rel))
+	s.counters.metadata.Add(1)
+	info, err := os.Stat(full)
+	switch {
+	case os.IsNotExist(err):
+		return doc.Document{}, connector.ErrGone
+	case err != nil:
+		return doc.Document{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return doc.Document{}, connector.ErrGone
+	}
+	if limit := s.limitFor(rel); info.Size() > limit {
+		return doc.Document{}, connector.ErrGone
+	}
+
+	d, err := s.read(ctx, full, rel, info)
+	if err != nil {
+		return doc.Document{}, err
+	}
+	return d, nil
+}
+
+// Counters returns what this source has spent on the filesystem.
+func (s *Source) Counters() connector.Counters {
+	return connector.Counters{
+		Lists:    s.counters.lists.Load(),
+		Metadata: s.counters.metadata.Load(),
+		Fetches:  s.counters.fetches.Load(),
+		Bytes:    s.counters.bytes.Load(),
+	}
+}
+
+// id is the document id for a path relative to the root.
+func (s *Source) id(rel string) string { return s.name + ":" + rel }
+
+// rel is the inverse of id, and is where a path that tried to leave the tree is
+// stopped.
+//
+// The cleaning is not tidiness. An id arrives from the index, the index was
+// written by a connector, and a connector is a lot of code to trust with a
+// string that turns into a file path. Making the path absolute first and then
+// stripping the leading separator means a "../../etc/passwd" collapses to
+// "etc/passwd" inside the root rather than escaping it, and the stat that
+// follows simply finds nothing.
+func (s *Source) rel(id string) (string, bool) {
+	rel, ok := strings.CutPrefix(id, s.name+":")
+	if !ok || rel == "" {
+		return "", false
+	}
+	rel = strings.TrimPrefix(path.Clean("/"+rel), "/")
+	if rel == "" || rel == "." {
+		return "", false
+	}
+	return rel, true
+}
+
+// version is the form a modification time takes in a cursor and in an item, so
+// that the two are comparable without either side parsing the other's.
+func version(t time.Time) string { return t.UTC().Format(time.RFC3339Nano) }
+
+// walk is the tree traversal both Sync and Enumerate are built on.
+//
+// It applies the skip rules, the size limits and the include rule, counts what
+// it spent, and calls fn with the path relative to the root. What it does not
+// do is decide anything about documents, which is what keeps the two callers
+// from drifting apart on which files are in the corpus.
+func (s *Source) walk(ctx context.Context, fn func(rel string, info fs.FileInfo) error) error {
+	return filepath.WalkDir(s.root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A directory that disappeared under the walk, or one this process
+			// may not read, is a fact about the tree rather than a reason to
+			// abandon the sync.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if p != s.root && s.skipDir(d.Name()) {
+				return fs.SkipDir
+			}
+			s.counters.lists.Add(1)
+			return nil
+		}
+		if !d.Type().IsRegular() || !s.includeIf(d.Name()) {
+			return nil
+		}
+
+		s.counters.metadata.Add(1)
+		info, err := d.Info()
+		if err != nil {
+			s.skipped(p, err)
+			return nil
+		}
+		if limit := s.limitFor(d.Name()); info.Size() > limit {
+			s.skipped(p, errTooBig(info.Size(), limit))
+			return nil
+		}
+
+		rel, err := filepath.Rel(s.root, p)
+		if err != nil {
+			s.skipped(p, err)
+			return nil
+		}
+		return fn(filepath.ToSlash(rel), info)
+	})
+}
+
+// errTooBig is the reason a file over the size limit was passed over.
+func errTooBig(size, limit int64) error {
+	return fmt.Errorf("%d bytes is over the limit of %d", size, limit)
+}

--- a/connector/fssource/maintain_test.go
+++ b/connector/fssource/maintain_test.go
@@ -1,0 +1,385 @@
+package fssource_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/fssource"
+	"github.com/tamnd/genba/doc"
+)
+
+// enumerate runs one enumeration and returns what it listed, sorted.
+func enumerate(t *testing.T, s *fssource.Source) []connector.Item {
+	t.Helper()
+	var got []connector.Item
+	if err := s.Enumerate(t.Context(), func(it connector.Item) bool {
+		got = append(got, it)
+		return true
+	}); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	slices.SortFunc(got, func(a, b connector.Item) int { return strings.Compare(a.ID, b.ID) })
+	return got
+}
+
+func itemIDs(items []connector.Item) []string {
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.ID)
+	}
+	return out
+}
+
+// TestEnumerateListsWhatTheSyncIndexes is the property reconciliation depends
+// on. If the two walks disagreed about which files are in the corpus, a sweep
+// would report drift that is not there and then delete real documents to fix
+// it.
+func TestEnumerateListsWhatTheSyncIndexes(t *testing.T) {
+	root := tree(t, map[string]string{
+		"README.md":           "# The project\n",
+		"docs/install.md":     "# Installing\n",
+		"docs/deep/nested.md": "a line\n",
+		"cmd/main.go":         "package main\n",
+		".hidden/secret.md":   "# not in the corpus\n",
+		"node_modules/dep.js": "module.exports = 1",
+		"notes.unknownxt":     "not an extension we read",
+	})
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	indexed, _ := collect(t, s, connector.Cursor{})
+	listed := enumerate(t, s)
+
+	if !slices.Equal(itemIDs(listed), ids(indexed)) {
+		t.Fatalf("enumerate listed %v\nsync indexed %v", itemIDs(listed), ids(indexed))
+	}
+
+	// The version has to be the same string the document carries, because that
+	// is what an inventory compares against to decide a document is stale.
+	stored := map[string]string{}
+	for _, d := range indexed {
+		stored[d.ID] = d.SourceUpdate
+	}
+	for _, it := range listed {
+		if it.Version == "" {
+			t.Errorf("%s was listed without a version, so nothing can tell whether it moved on", it.ID)
+		}
+		if it.Version != stored[it.ID] {
+			t.Errorf("%s is listed at version %q and stored at %q", it.ID, it.Version, stored[it.ID])
+		}
+	}
+}
+
+func TestEnumerateStopsWhenTheCallerSaysSo(t *testing.T) {
+	root := tree(t, map[string]string{"a.md": "1", "b.md": "2", "c.md": "3", "d.md": "4"})
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seen := 0
+	err = s.Enumerate(t.Context(), func(connector.Item) bool {
+		seen++
+		return seen < 2
+	})
+	// Stopping on purpose is not a failed walk. A reconciliation that read it as
+	// one would take a short list for a source that lost its documents.
+	if err != nil {
+		t.Fatalf("an early stop was reported as an error: %v", err)
+	}
+	if seen != 2 {
+		t.Errorf("the walk listed %d items after being told to stop at 2", seen)
+	}
+}
+
+// TestEnumerateReadsNothing is the reason a sweep is affordable. Listing a tree
+// costs a stat per file, and the whole point of doing it on a schedule is that
+// it does not cost a read per file.
+func TestEnumerateReadsNothing(t *testing.T) {
+	root := tree(t, map[string]string{
+		"a.md": "# a\n", "b.md": "# b\n", "docs/c.md": "# c\n",
+	})
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before := s.Counters()
+	if listed := enumerate(t, s); len(listed) != 3 {
+		t.Fatalf("listed %d files, want 3", len(listed))
+	}
+	spent := s.Counters().Since(before)
+
+	if spent.Fetches != 0 || spent.Bytes != 0 {
+		t.Errorf("an enumeration read %d files and %d bytes, want none", spent.Fetches, spent.Bytes)
+	}
+	if spent.Metadata != 3 {
+		t.Errorf("an enumeration statted %d files, want 3", spent.Metadata)
+	}
+}
+
+func TestFetchReturnsTheDocumentForAnID(t *testing.T) {
+	root := tree(t, map[string]string{
+		"docs/install.md": "# Installing\n\nRun the thing.\n",
+	})
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	indexed, _ := collect(t, s, connector.Cursor{})
+	if len(indexed) != 1 {
+		t.Fatalf("indexed %d documents, want 1", len(indexed))
+	}
+
+	got, err := s.Fetch(t.Context(), "repo:docs/install.md")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	// A repaired document has to be the same document a sync would have
+	// produced, or the two ways into the index disagree and which one a
+	// document came through becomes something a reader can tell.
+	if got.ID != indexed[0].ID || got.Title != indexed[0].Title || got.Body != indexed[0].Body {
+		t.Errorf("fetch returned %+v\nsync produced %+v", got, indexed[0])
+	}
+	if got.Kind != doc.KindPage || got.SourceUpdate == "" {
+		t.Errorf("fetch returned kind %q and version %q", got.Kind, got.SourceUpdate)
+	}
+}
+
+// TestFetchSaysGoneRatherThanFailing covers every way an id can fail to name a
+// file this source will read. All of them are the same answer, because the
+// caller does the same thing with all of them: take the document out of the
+// index.
+func TestFetchSaysGoneRatherThanFailing(t *testing.T) {
+	root := tree(t, map[string]string{
+		"a.md":       "# a\n",
+		"docs/b.md":  "# b\n",
+		"huge.md":    string(make([]byte, 4096)),
+		"secret.txt": "not part of this source\n",
+	})
+	// A file outside the tree, which a traversal would reach if the id were
+	// used as a path without cleaning it.
+	outside := filepath.Join(filepath.Dir(root), "outside.md")
+	if err := os.WriteFile(outside, []byte("# outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(outside)
+
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"), fssource.WithMaxFileSize(1024))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		id   string
+	}{
+		{"a file that is not there", "repo:gone.md"},
+		{"an id another source minted", "other:a.md"},
+		{"an id with no path in it", "repo:"},
+		{"a directory", "repo:docs"},
+		{"a file over the size limit", "repo:huge.md"},
+		{"a path that tries to leave the tree", "repo:../" + filepath.Base(outside)},
+		{"a path that tries harder", "repo:docs/../../../../etc/passwd"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := s.Fetch(t.Context(), tc.id)
+			if !errors.Is(err, connector.ErrGone) {
+				t.Fatalf("fetch %q returned (%q, %v), want ErrGone", tc.id, got.ID, err)
+			}
+		})
+	}
+}
+
+// TestASecondSyncOverAnUnchangedTreeReadsNothing is the first box of the
+// incremental work, measured the way the box asks for it. The walk is
+// unavoidable on a filesystem, which has no change feed, but the reads are not,
+// and the reads are the whole cost.
+func TestASecondSyncOverAnUnchangedTreeReadsNothing(t *testing.T) {
+	files := map[string]string{}
+	for _, name := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		files["docs/"+name+".md"] = "# " + name + "\n\nsome body text\n"
+	}
+	root := tree(t, files)
+
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, cursor := collect(t, s, connector.Cursor{})
+	if len(first) != len(files) {
+		t.Fatalf("the first sync read %d files, want %d", len(first), len(files))
+	}
+	after := s.Counters()
+	if after.Fetches != int64(len(files)) {
+		t.Fatalf("the first sync read %d files, want %d", after.Fetches, len(files))
+	}
+
+	second, _ := collect(t, s, cursor)
+	if len(second) != 0 {
+		t.Fatalf("an unchanged tree produced %v", ids(second))
+	}
+
+	spent := s.Counters().Since(after)
+	if spent.Fetches != 0 || spent.Bytes != 0 {
+		t.Errorf("a second sync read %d files and %d bytes, want none", spent.Fetches, spent.Bytes)
+	}
+	// What it does spend is one stat per file and one listing per directory,
+	// which is the floor for a source without a change feed.
+	if spent.Metadata != int64(len(files)) {
+		t.Errorf("a second sync statted %d files, want %d", spent.Metadata, len(files))
+	}
+	if spent.Requests() >= after.Requests() {
+		t.Errorf("a second sync cost %d requests against the first sync's %d, so it saved nothing",
+			spent.Requests(), after.Requests())
+	}
+}
+
+// TestAnOwnersEditIsAPermissionChangeAndNotARecrawl is the third box, end to
+// end and on a real permission model. Editing one OWNERS file changes who may
+// read every document below it without touching a single one of them, and the
+// sync has to notice that without reading any of them again.
+func TestAnOwnersEditIsAPermissionChangeAndNotARecrawl(t *testing.T) {
+	root := tree(t, map[string]string{
+		"OWNERS":         "approvers:\n  - alice\n",
+		"docs/a.md":      "# a\n",
+		"docs/b.md":      "# b\n",
+		"other/OWNERS":   "approvers:\n  - carol\n",
+		"other/notes.md": "# notes\n",
+	})
+	policy, err := fssource.NewOwnersPolicy(root, "repo", "github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The OWNERS files themselves are left out of the corpus, so that what the
+	// counters show is what happened to the documents they govern.
+	s, err := fssource.New(root, "repo", policy,
+		fssource.WithInclude(func(name string) bool { return strings.HasSuffix(name, ".md") }))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, cursor := collect(t, s, connector.Cursor{})
+	if len(first) != 3 {
+		t.Fatalf("the first sync read %v, want three documents", ids(first))
+	}
+	for _, d := range first {
+		if len(d.Permissions.AllowUsers) != 1 {
+			t.Fatalf("%s starts with %d allowed users, want 1", d.ID, len(d.Permissions.AllowUsers))
+		}
+	}
+	after := s.Counters()
+
+	// One edit at the root, well into the future so the change is unambiguous
+	// on a filesystem with a coarse timestamp.
+	owners := filepath.Join(root, fssource.OwnersFile)
+	if err := os.WriteFile(owners, []byte("approvers:\n  - alice\n  - bob\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	later := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(owners, later, later); err != nil {
+		t.Fatal(err)
+	}
+
+	var changes []connector.Change
+	next, err := s.Sync(t.Context(), cursor, func(_ context.Context, ch connector.Change) error {
+		changes = append(changes, ch)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	// Only the two documents the edited file governs. The third lives under an
+	// OWNERS file nobody touched.
+	got := make([]string, 0, len(changes))
+	for _, ch := range changes {
+		if !ch.PermissionsOnly {
+			t.Errorf("%s came back as a content change, so the file was read again", ch.Document.ID)
+		}
+		got = append(got, ch.Document.ID)
+	}
+	slices.Sort(got)
+	if want := []string{"repo:docs/a.md", "repo:docs/b.md"}; !slices.Equal(got, want) {
+		t.Fatalf("the edit produced changes for %v, want %v", got, want)
+	}
+	for _, ch := range changes {
+		if len(ch.Document.Permissions.AllowUsers) != 2 {
+			t.Errorf("%s now allows %d users, want the two in the edited file",
+				ch.Document.ID, len(ch.Document.Permissions.AllowUsers))
+		}
+	}
+
+	spent := s.Counters().Since(after)
+	if spent.Fetches != 0 || spent.Bytes != 0 {
+		t.Errorf("applying a permission change read %d files and %d bytes, so it was a recrawl",
+			spent.Fetches, spent.Bytes)
+	}
+
+	// And it happens once. A cursor that did not move past the edit would
+	// replay the same change on every sync from here on.
+	changes = nil
+	if _, err := s.Sync(t.Context(), next, func(_ context.Context, ch connector.Change) error {
+		changes = append(changes, ch)
+		return nil
+	}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("the permission change was reported again on the next sync: %d changes", len(changes))
+	}
+}
+
+// TestAPolicyThatCachesIsToldWhenAWalkStarts is the bug underneath the box. A
+// policy that held its parsed files for the life of the process would answer a
+// week old question forever, and the revocation above would apply to nothing.
+func TestAPolicyThatCachesIsToldWhenAWalkStarts(t *testing.T) {
+	root := tree(t, map[string]string{
+		"OWNERS": "approvers:\n  - alice\n",
+		"a.md":   "# a\n",
+	})
+	policy, err := fssource.NewOwnersPolicy(root, "repo", "github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := fssource.New(root, "repo", policy,
+		fssource.WithInclude(func(name string) bool { return strings.HasSuffix(name, ".md") }))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, cursor := collect(t, s, connector.Cursor{}); cursor.IsZero() {
+		t.Fatal("the first sync returned no cursor")
+	}
+
+	if err := os.WriteFile(filepath.Join(root, fssource.OwnersFile), []byte("approvers:\n  - bob\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The document itself is touched, so this is a plain content sync. What is
+	// being checked is the access control list that comes with it.
+	later := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(filepath.Join(root, "a.md"), later, later); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := collect(t, s, connector.Cursor{})
+	if len(got) != 1 {
+		t.Fatalf("read %d documents, want 1", len(got))
+	}
+	users := got[0].Permissions.AllowUsers
+	if len(users) != 1 || users[0].Value != "bob" {
+		t.Errorf("the document allows %v, want the edited file's single approver", users)
+	}
+}

--- a/connector/fssource/owners.go
+++ b/connector/fssource/owners.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/tamnd/genba/acl"
 )
@@ -50,6 +51,10 @@ type OwnersPolicy struct {
 type owners struct {
 	approvers []string
 	reviewers []string
+
+	// modTime is when the file was last written, which is the answer to
+	// [OwnersPolicy.ChangedAt] for everything the file governs.
+	modTime time.Time
 }
 
 // NewOwnersPolicy returns a policy reading OWNERS files under root.
@@ -84,7 +89,63 @@ func (o *OwnersPolicy) WithFallback(p acl.Permissions) *OwnersPolicy {
 	return o
 }
 
-var _ Policy = (*OwnersPolicy)(nil)
+var (
+	_ Policy    = (*OwnersPolicy)(nil)
+	_ Versioned = (*OwnersPolicy)(nil)
+	_ Reloader  = (*OwnersPolicy)(nil)
+)
+
+// Reload drops the cache so that the next lookup reads the tree again.
+//
+// A source calls this at the start of every walk. Without it a process that
+// stays up for a week answers with the OWNERS files as they were when it
+// started, and a revocation made on Tuesday is applied to nothing. Holding the
+// cache for the length of one walk is what keeps the cost at one read per
+// OWNERS file per sync instead of one per document.
+func (o *OwnersPolicy) Reload() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	clear(o.byDir)
+	clear(o.parsed)
+}
+
+// ChangedAt returns when the OWNERS file governing relPath was last written.
+//
+// A path no OWNERS file governs has no answer and returns the zero time, even
+// when a fallback is set, because a fallback is a constant and a constant never
+// changed.
+func (o *OwnersPolicy) ChangedAt(ctx context.Context, relPath string) (time.Time, error) {
+	if err := ctx.Err(); err != nil {
+		return time.Time{}, err
+	}
+	own, err := o.nearest(relPath)
+	if err != nil || own == nil {
+		return time.Time{}, err
+	}
+	return own.modTime, nil
+}
+
+// nearest walks up from a file's directory to the root and returns the first
+// OWNERS file it finds, or nil.
+//
+// Nearest wins, which is what the convention means and what makes a subtree
+// able to narrow what its parent allowed.
+func (o *OwnersPolicy) nearest(relPath string) (*owners, error) {
+	dir := path.Dir(relPath)
+	for {
+		own, err := o.at(dir)
+		if err != nil {
+			return nil, err
+		}
+		if own != nil {
+			return own, nil
+		}
+		if dir == "." || dir == "/" || dir == "" {
+			return nil, nil
+		}
+		dir = path.Dir(dir)
+	}
+}
 
 // Permissions returns the access control list governing relPath.
 func (o *OwnersPolicy) Permissions(ctx context.Context, relPath string) (acl.Permissions, error) {
@@ -92,22 +153,12 @@ func (o *OwnersPolicy) Permissions(ctx context.Context, relPath string) (acl.Per
 		return acl.Permissions{}, err
 	}
 
-	// Walk up from the file's directory to the root, taking the first OWNERS
-	// file found. Nearest wins, which is what the convention means and what
-	// makes a subtree able to narrow what its parent allowed.
-	dir := path.Dir(relPath)
-	for {
-		own, err := o.at(dir)
-		if err != nil {
-			return acl.Permissions{}, err
-		}
-		if own != nil {
-			return o.permissionsFrom(own), nil
-		}
-		if dir == "." || dir == "/" || dir == "" {
-			break
-		}
-		dir = path.Dir(dir)
+	own, err := o.nearest(relPath)
+	if err != nil {
+		return acl.Permissions{}, err
+	}
+	if own != nil {
+		return o.permissionsFrom(own), nil
 	}
 
 	if o.hasFall {
@@ -152,6 +203,14 @@ func (o *OwnersPolicy) at(dir string) (*owners, error) {
 		return nil, fmt.Errorf("fssource: read %s: %w", full, err)
 	default:
 		own = parseOwners(string(b))
+		// The stat is separate from the read on purpose. Reading first and then
+		// asking how old it is means the time belongs to the bytes that were
+		// parsed, where the other order can record a time for content that was
+		// replaced in between and leave the change invisible until the file is
+		// touched again.
+		if info, err := os.Stat(full); err == nil {
+			own.modTime = info.ModTime()
+		}
 	}
 
 	o.mu.Lock()

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -1,0 +1,162 @@
+# Keeping an index in step with its source
+
+The first sync is the easy half.
+Read everything, store everything, and the index matches the source because it was just built from it.
+
+Everything after that is the hard half, and it is the half a search engine spends its whole life in.
+A corpus of a hundred thousand documents changes by a few dozen a day, so a sync that reads all of it to find them costs several thousand times what the change is worth.
+Reading only what changed is the whole game, and it has three parts that fail in different ways.
+
+## What changed: cursors
+
+A `Sync` is given a cursor and returns one.
+The cursor is opaque to everything except the connector that wrote it, because what it means is entirely a property of the source: a modification time for a directory tree, a change token for a document API, a log sequence number for a database.
+
+```go
+type Cursor struct {
+	Value string
+	Time  time.Time
+}
+```
+
+The pipeline stores a batch and then saves the cursor for it, never the other way round.
+A crash between the two replays documents, which is harmless because storing the same document twice is the same as storing it once.
+The other order loses documents and nothing downstream ever notices they are missing.
+
+For `fssource` the cursor is the highest modification time the last walk saw, and the saving is the read rather than the walk.
+A filesystem has no change feed, so there is no way to avoid statting every file, but there is every way to avoid opening them.
+That is what the counters measure.
+
+```go
+before := src.Counters()
+stats, err := pipeline.Run(ctx, "acme", src)
+spent := src.Counters().Since(before)
+```
+
+`Counters` is optional, and a connector that implements it reports four numbers: listings, metadata lookups, fetches and bytes.
+A second sync over an unchanged tree of eight files spends eight metadata lookups, zero fetches and zero bytes.
+That is the floor for a source without a change feed, and the test that says so is `TestASecondSyncOverAnUnchangedTreeReadsNothing`.
+
+## Who may read it: permissions without a recrawl
+
+A permission change is not a content change, and a sync built only on modification times cannot see one at all.
+Somebody edits an OWNERS file at the root of a repository, and who may read every document below it changes without a single one of those documents being touched.
+
+The connector reports this as a change with no document in it.
+
+```go
+type Change struct {
+	Document        doc.Document
+	Deleted         bool
+	PermissionsOnly bool
+	Cursor          Cursor
+}
+```
+
+Only `ID` and `Permissions` are read from a `PermissionsOnly` change.
+The rest is ignored, so a connector cannot use it to sneak a content update past the pipeline: the content will not be stored.
+
+The pipeline batches these the same way it batches documents and applies them with one call:
+
+```go
+type Maintenance interface {
+	Inventory(ctx context.Context, tenant, source string, fn func(Item) bool) error
+	SetPermissions(ctx context.Context, tenant string, perms map[string]acl.Permissions) (int, error)
+}
+```
+
+`SetPermissions` is a store capability rather than a store method, because not every driver can do it and a driver that cannot should say so rather than pretend.
+A pipeline over a store without it refuses a permission change instead of quietly dropping it.
+That is deliberate: a sync that reported success while a revocation went nowhere is worse than one that failed, because the failure is visible and the revocation is not.
+
+The subtle case inside a driver is the quarantine line.
+A document whose permissions do not resolve is held out of the full text index, the posting lists, the term statistics and the corpus counts, so a permission change that crosses that line has to retire or reindex the document, while a change from one resolved access control list to another must not touch any of it.
+The conformance suite in `store/storetest` checks both, on every driver.
+
+On the connector side this needs a policy that can say when its answer changed.
+
+```go
+type Versioned interface {
+	ChangedAt(ctx context.Context, relPath string) (time.Time, error)
+}
+
+type Reloader interface {
+	Reload()
+}
+```
+
+Every file the walk skips as unchanged is asked about, so the answer has to be cheap.
+For `OwnersPolicy` it is a map read after the first file in each directory.
+`Reload` is called once at the start of every walk, and it is what stops a process that has been up for a week from answering with the OWNERS files as they were when it started.
+The cache lives for exactly one walk: long enough to cost one read per OWNERS file per sync instead of one per document, short enough that the next sync notices the edit.
+
+## What the sync could not have seen: reconciliation
+
+An index built only out of a change feed drifts away from its source, and nothing in the feed ever says so.
+
+A feed drops an event.
+A bulk edit at the source raises none.
+A process is killed between the store and the checkpoint.
+A file is deleted, and a walk of a directory tree can never see that, because there is nothing left to walk past.
+
+None of those produce an error.
+They produce an index that is quietly wrong, and the only way to find out is to count both sides.
+
+```go
+rec, err := pipeline.Reconcile(ctx, "acme", src)
+```
+
+The sweep enumerates the source, walks the index, and sorts the difference into three piles.
+
+| Pile | What it means | What is done about it |
+| --- | --- | --- |
+| Missing | the source holds it and the index does not | refetched and stored |
+| Stale | both hold it, at different versions | refetched and stored |
+| Extra | the index holds it and the source no longer does | deleted |
+
+It needs two optional capabilities: a `store.Maintenance` store to list what is indexed, and a `connector.Enumerator` to list what the source holds.
+Repairing what is missing also needs a `connector.Fetcher`, and without one the sweep still reports and still deletes, and says once in the log that the rest is waiting for a full sync.
+
+```go
+type Enumerator interface {
+	Connector
+	Enumerate(ctx context.Context, fn func(Item) bool) error
+}
+```
+
+An enumeration reads nothing.
+On a filesystem it is a stat per file against a read per file, which on a real corpus is a second against a minute, and that price is the reason the sweep can run on the refresh interval rather than nightly.
+
+### Nothing is deleted on a partial enumeration
+
+If the walk of the source fails halfway, `Reconcile` returns the error and repairs nothing at all.
+It is the most important rule in the package.
+A list that stopped early is indistinguishable from a source that lost half its documents, and acting on the second reading would empty a working index because of a timeout.
+
+### The report
+
+The counts are exact and the ids are a sample of twenty per pile.
+The first sweep after a fresh index finds the whole corpus missing, and a report that named all of it would be a copy of the corpus in memory and a log line nobody reads.
+Twenty ids is what an operator actually uses, because it is enough to go and look at one and find out what is wrong.
+
+`genbad` runs a sweep after every sync and logs at warning level only when something drifted.
+An index that agrees with its source produces nothing in the log, so a line there means the incremental path missed something.
+
+### What it costs to hold
+
+The sweep keeps an id and a version per source document in memory for its duration, which is tens of megabytes for a corpus of a few million.
+The alternative is sorting both sides on disk and merging them, which is the right answer an order of magnitude further up and is not worth its complexity yet.
+
+## Writing a connector
+
+The required interface is still three methods, and a connector that implements only those works.
+Everything else is optional, and each piece buys one thing.
+
+| Capability | What it buys |
+| --- | --- |
+| `Enumerator` | reconciliation, so deletions and dropped events are found |
+| `Fetcher` | repair, so what reconciliation finds is fixed rather than only reported |
+| `Counted` | the numbers that say whether the incremental path is actually incremental |
+| `Change.PermissionsOnly` | a permission change costs a write instead of a recrawl |
+
+`connector/fssource` implements all four and is the one to read before writing another.

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/connector"
 	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/store"
@@ -53,6 +54,13 @@ type Pipeline struct {
 	batchSize   int
 	clock       func() time.Time
 	log         *slog.Logger
+
+	// maint is the same store when the driver can do the two things a
+	// maintenance job needs and a query path must never have: list what is
+	// stored, and rewrite an access control list without the document. It is
+	// nil for a driver without them, and the two operations that need it say so
+	// rather than silently doing nothing.
+	maint store.Maintenance
 }
 
 // Option configures a pipeline.
@@ -106,6 +114,7 @@ func New(s store.Store, cp connector.Checkpoints, opts ...Option) (*Pipeline, er
 	for _, opt := range opts {
 		opt(p)
 	}
+	p.maint, _ = s.(store.Maintenance)
 	return p, nil
 }
 
@@ -122,6 +131,14 @@ type Stats struct {
 
 	// Deleted is the number removed because the source no longer has them.
 	Deleted int
+
+	// Repermissioned is the number whose access control list was rewritten
+	// without their content being fetched.
+	//
+	// It is the number that says whether the cheap path for a permission change
+	// is working. A run that reindexed ten thousand documents because somebody
+	// edited one group looks fine in Indexed and is a recrawl.
+	Repermissioned int
 
 	// Skipped is the number rejected before the store, because they carried no
 	// id and there is nothing to file them under.
@@ -244,6 +261,9 @@ type run struct {
 
 	batch   []doc.Document
 	deletes []string
+	// perms holds the permission changes in the current batch, keyed by id so
+	// that two edits to the same document in one run cost one write.
+	perms map[string]acl.Permissions
 	// pending is the resume point of the last change in the current batch. It
 	// is saved only once that batch is stored.
 	pending connector.Cursor
@@ -280,6 +300,21 @@ func (r *run) emit(ctx context.Context, ch connector.Change) error {
 		return r.maybeFlush(ctx)
 	}
 
+	if ch.PermissionsOnly {
+		if p.maint == nil {
+			// Refusing is the only honest answer. The change carries no content,
+			// so there is nothing to put, and treating it as a no operation would
+			// leave a revoked document readable while the log said the sync
+			// succeeded.
+			return fmt.Errorf("ingest: %s reported a permission change for %s and this store cannot apply one without the document", r.source, d.ID)
+		}
+		if r.perms == nil {
+			r.perms = make(map[string]acl.Permissions, p.batchSize)
+		}
+		r.perms[d.ID] = d.Permissions
+		return r.maybeFlush(ctx)
+	}
+
 	d.IndexedAt = p.clock()
 	r.stats.Bytes += int64(len(d.Body))
 
@@ -301,7 +336,7 @@ func (r *run) emit(ctx context.Context, ch connector.Change) error {
 }
 
 func (r *run) maybeFlush(ctx context.Context) error {
-	if len(r.batch)+len(r.deletes) < r.pipeline.batchSize {
+	if len(r.batch)+len(r.deletes)+len(r.perms) < r.pipeline.batchSize {
 		return nil
 	}
 	return r.flush(ctx)
@@ -314,7 +349,7 @@ func (r *run) maybeFlush(ctx context.Context) error {
 // between them replays documents, which is harmless. The other order loses
 // them, which is not.
 func (r *run) flush(ctx context.Context) error {
-	if len(r.batch) == 0 && len(r.deletes) == 0 {
+	if len(r.batch) == 0 && len(r.deletes) == 0 && len(r.perms) == 0 {
 		return nil
 	}
 	p := r.pipeline
@@ -329,12 +364,28 @@ func (r *run) flush(ctx context.Context) error {
 			return fmt.Errorf("ingest: delete %d documents from %s: %w", len(r.deletes), r.source, err)
 		}
 	}
+	if len(r.perms) > 0 {
+		n, err := p.maint.SetPermissions(ctx, r.tenant, r.perms)
+		if err != nil {
+			return fmt.Errorf("ingest: set permissions on %d documents from %s: %w", len(r.perms), r.source, err)
+		}
+		r.stats.Repermissioned += n
+		// The difference is documents the source has an access control list for
+		// and the index does not hold. That is drift, and it is the kind the
+		// incremental path cannot fix on its own, so it is worth saying out loud
+		// rather than leaving as a gap between two counters.
+		if missing := len(r.perms) - n; missing > 0 {
+			p.log.Warn("permission change for documents that are not indexed",
+				"source", r.source, "tenant", r.tenant, "count", missing)
+		}
+	}
 	r.stats.Batches++
 
 	// Reuse the backing arrays. A long sync flushes thousands of times and
 	// there is no reason for each one to allocate a new batch.
 	r.batch = r.batch[:0]
 	r.deletes = r.deletes[:0]
+	clear(r.perms)
 
 	if err := p.saveCursor(ctx, r.tenant, r.source, r.pending); err != nil {
 		return err

--- a/ingest/permissions_test.go
+++ b/ingest/permissions_test.go
@@ -1,0 +1,165 @@
+package ingest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/ingest"
+	"github.com/tamnd/genba/store"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// engineering is an access control list nobody in these tests belongs to, which
+// is how a revocation is written.
+func engineering() acl.Permissions {
+	return acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "test",
+		AllowGroups: []acl.Ref{{Source: "test", Value: "engineering"}},
+		Version:     2,
+	}
+}
+
+// TestAPermissionChangeCostsAWriteNotARecrawl is the box. The connector reports
+// who may read a document and nothing else, and the document that comes back
+// afterwards is the one that went in.
+func TestAPermissionChangeCostsAWriteNotARecrawl(t *testing.T) {
+	st := memstore.New()
+	p, err := ingest.New(st, connector.NewMemoryCheckpoints())
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	run(t, p, &fakeSource{name: "test", changes: changes(4)})
+
+	// A second pipeline with no checkpoints, because these changes carry no
+	// cursor and a resumed run would filter them out before the pipeline ever
+	// saw one.
+	p, _ = ingest.New(st, nil)
+
+	// The body is deliberately empty. A pipeline that stored this change as a
+	// document would leave an indexed document with nothing in it, which is
+	// exactly the failure worth catching.
+	src := &fakeSource{name: "test", changes: []connector.Change{{
+		Document:        doc.Document{ID: "doc-0002", Permissions: engineering()},
+		PermissionsOnly: true,
+	}}}
+	stats := run(t, p, src)
+
+	if stats.Repermissioned != 1 {
+		t.Fatalf("the run repermissioned %d documents, want 1", stats.Repermissioned)
+	}
+	if stats.Indexed != 0 {
+		t.Fatalf("a permission change indexed %d documents, so it was a recrawl", stats.Indexed)
+	}
+
+	if _, err := st.Get(t.Context(), principal(), "doc-0002"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("a reader whose access was taken away can still read the document: %v", err)
+	}
+	member := &acl.Principal{
+		Tenant: tenant, Subject: "member", Kind: acl.KindUser,
+		Groups: acl.GroupSet{Version: 1, Members: []string{"test:engineering"}},
+	}
+	got, err := st.Get(t.Context(), member, "doc-0002")
+	if err != nil {
+		t.Fatalf("the reader who was granted access cannot read the document: %v", err)
+	}
+	if got.Title != "document number 2" || got.Body == "" {
+		t.Fatalf("a permission change rewrote the document: title %q, body of %d bytes", got.Title, len(got.Body))
+	}
+}
+
+// TestAPermissionChangeForAnUnknownDocumentIsNotAnError covers the disagreement
+// between a source and an index that reconciliation exists to settle. It must
+// not stop a sync.
+func TestAPermissionChangeForAnUnknownDocumentIsNotAnError(t *testing.T) {
+	st := memstore.New()
+	p, _ := ingest.New(st, connector.NewMemoryCheckpoints())
+
+	stats := run(t, p, &fakeSource{name: "test", changes: []connector.Change{
+		{Document: doc.Document{ID: "never-indexed", Permissions: engineering()}, PermissionsOnly: true},
+	}})
+
+	if stats.Repermissioned != 0 {
+		t.Fatalf("repermissioned %d documents that are not in the index", stats.Repermissioned)
+	}
+}
+
+// TestManyPermissionChangesAreOneWrite is why the change carries no content. An
+// edit to one group at the source governs a subtree, and the pipeline has to
+// turn that into a batch rather than a write per document.
+func TestManyPermissionChangesAreOneWrite(t *testing.T) {
+	st := &countingMaintenance{Store: memstore.New()}
+	p, err := ingest.New(st, connector.NewMemoryCheckpoints(), ingest.WithBatchSize(500))
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	run(t, p, &fakeSource{name: "test", changes: changes(200)})
+	p, _ = ingest.New(st, nil, ingest.WithBatchSize(500))
+
+	var perms []connector.Change
+	for _, ch := range changes(200) {
+		perms = append(perms, connector.Change{
+			Document:        doc.Document{ID: ch.Document.ID, Permissions: engineering()},
+			PermissionsOnly: true,
+		})
+	}
+	stats := run(t, p, &fakeSource{name: "test", changes: perms})
+
+	if stats.Repermissioned != 200 {
+		t.Fatalf("repermissioned %d documents, want 200", stats.Repermissioned)
+	}
+	if st.calls != 1 {
+		t.Fatalf("200 permission changes cost %d calls to the store, want 1", st.calls)
+	}
+}
+
+// TestAStoreThatCannotRepermissionSaysSo refuses rather than doing nothing. A
+// sync that reported success while a revocation went nowhere is worse than one
+// that failed.
+func TestAStoreThatCannotRepermissionSaysSo(t *testing.T) {
+	p, err := ingest.New(plainStore{memstore.New()}, connector.NewMemoryCheckpoints())
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	_, err = p.Run(t.Context(), tenant, &fakeSource{name: "test", changes: []connector.Change{
+		{Document: doc.Document{ID: "doc-0000", Permissions: engineering()}, PermissionsOnly: true},
+	}})
+	if err == nil {
+		t.Fatal("a permission change against a store that cannot apply one was reported as a success")
+	}
+}
+
+// countingMaintenance counts the calls that rewrite access control lists.
+type countingMaintenance struct {
+	*memstore.Store
+	calls int
+}
+
+func (c *countingMaintenance) SetPermissions(ctx context.Context, tenant string, perms map[string]acl.Permissions) (int, error) {
+	c.calls++
+	return c.Store.SetPermissions(ctx, tenant, perms)
+}
+
+// plainStore hides the optional capabilities of the driver underneath, so that
+// a test can see what the pipeline does with a store that only stores.
+type plainStore struct{ inner *memstore.Store }
+
+func (p plainStore) Put(ctx context.Context, docs ...doc.Document) error {
+	return p.inner.Put(ctx, docs...)
+}
+func (p plainStore) Delete(ctx context.Context, ids ...string) error {
+	return p.inner.Delete(ctx, ids...)
+}
+func (p plainStore) Get(ctx context.Context, pr *acl.Principal, id string) (doc.Document, error) {
+	return p.inner.Get(ctx, pr, id)
+}
+func (p plainStore) Scan(ctx context.Context, pr *acl.Principal, fn func(doc.Document) bool) error {
+	return p.inner.Scan(ctx, pr, fn)
+}
+func (p plainStore) Stats(ctx context.Context) (store.Stats, error) { return p.inner.Stats(ctx) }
+func (p plainStore) Close() error                                   { return p.inner.Close() }

--- a/ingest/reconcile.go
+++ b/ingest/reconcile.go
@@ -1,0 +1,288 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// SampleSize is how many ids a [Reconciliation] keeps per category.
+//
+// The counts are exact and the ids are a sample, because the first sweep after
+// a fresh index finds the whole corpus missing and a report that named all of
+// it would be a copy of the corpus in memory and a log line nobody reads. A
+// handful of ids is what an operator actually uses: it is enough to go and look
+// at one and find out what is wrong.
+const SampleSize = 20
+
+// Discrepancies is how many documents fell into one category and a sample of
+// which ones.
+type Discrepancies struct {
+	// Count is exact.
+	Count int
+
+	// IDs holds the first [SampleSize] of them, in the order they were found.
+	IDs []string
+}
+
+func (d *Discrepancies) add(id string) {
+	d.Count++
+	if len(d.IDs) < SampleSize {
+		d.IDs = append(d.IDs, id)
+	}
+}
+
+// Reconciliation is what one sweep found and what it did about it.
+type Reconciliation struct {
+	// Tenant and Source are what was compared.
+	Tenant string
+	Source string
+
+	// SourceItems and IndexItems are the two sides of the comparison, before
+	// anything was repaired.
+	SourceItems int
+	IndexItems  int
+
+	// Missing is what the source holds and the index does not. It is the drift
+	// a dropped change feed event leaves behind.
+	Missing Discrepancies
+
+	// Stale is what both hold, at different revisions. It is what a sync that
+	// was killed between the store and the checkpoint leaves behind, and what a
+	// source that changed a document without raising an event leaves behind.
+	Stale Discrepancies
+
+	// Extra is what the index holds and the source no longer does. It is the
+	// one an operator cares about most, because a document that was deleted at
+	// the source and is still in the index is still being served.
+	Extra Discrepancies
+
+	// Repaired is how many were refetched and stored.
+	Repaired int
+
+	// Deleted is how many were removed from the index.
+	Deleted int
+
+	// Requests is what the sweep spent at the source, for a connector that
+	// counts. A sweep over an index that is already correct should show one
+	// enumeration and no fetches.
+	Requests connector.Counters
+
+	// Duration is the wall clock time of the sweep.
+	Duration time.Duration
+}
+
+// Drift is how many documents disagreed, whether or not they were repaired.
+func (r Reconciliation) Drift() int {
+	return r.Missing.Count + r.Stale.Count + r.Extra.Count
+}
+
+// Reconcile compares what a source holds against what the index holds, repairs
+// the difference, and reports it.
+//
+// This is the part that catches what the incremental path missed, and it exists
+// because the incremental path cannot catch it by definition. A sync is a
+// stream of changes, and it is exactly as complete as the change feed under it:
+// a feed that drops an event, a source that does a bulk edit without raising
+// any, a permission model that grants through a group the connector cannot see,
+// a process killed at the wrong moment. None of those produce an error. They
+// produce an index that is quietly wrong, and the only way to find out is to
+// count both sides.
+//
+// It needs a [store.Maintenance] store and a [connector.Enumerator]. Refetching
+// what is missing or stale also needs a [connector.Fetcher]: without one the
+// sweep still reports and still deletes, and the missing documents wait for a
+// full sync.
+//
+// # Nothing is deleted on a partial enumeration
+//
+// If the walk of the source fails halfway, this returns the error and repairs
+// nothing at all. It is the most important rule here. A list that stopped early
+// is indistinguishable from a source that lost half its documents, and acting
+// on the second reading would delete a working index because of a timeout.
+func (p *Pipeline) Reconcile(ctx context.Context, tenant genba.TenantID, c connector.Connector) (Reconciliation, error) {
+	if c == nil {
+		return Reconciliation{}, errors.New("ingest: nil connector")
+	}
+	if tenant == "" {
+		return Reconciliation{}, errors.New("ingest: empty tenant")
+	}
+	source := c.Source()
+	rec := Reconciliation{Tenant: string(tenant), Source: source}
+
+	if p.maint == nil {
+		return rec, errors.New("ingest: this store cannot be reconciled, it does not implement store.Maintenance")
+	}
+	enum, ok := c.(connector.Enumerator)
+	if !ok {
+		return rec, fmt.Errorf("ingest: connector %s cannot be reconciled, it does not implement connector.Enumerator", source)
+	}
+
+	start := p.clock()
+	before := countersOf(c)
+
+	// One: what the source holds. This is held in memory for the length of the
+	// sweep, which is the real cost of reconciliation and is worth naming: an
+	// id and a version per document, so tens of megabytes for a corpus of a few
+	// million. The alternative is sorting both sides on disk and merging them,
+	// which is the right answer an order of magnitude further up and is not
+	// worth its complexity here.
+	held := make(map[string]string)
+	if err := enum.Enumerate(ctx, func(it connector.Item) bool {
+		if it.ID != "" {
+			held[it.ID] = it.Version
+		}
+		return true
+	}); err != nil {
+		return rec, fmt.Errorf("ingest: enumerate %s: %w", source, err)
+	}
+	rec.SourceItems = len(held)
+
+	// Two: what the index holds. Whatever is left in held afterwards is what
+	// the index has never seen.
+	var (
+		stale []string
+		extra []string
+	)
+	if err := p.maint.Inventory(ctx, string(tenant), source, func(it store.Item) bool {
+		rec.IndexItems++
+		version, ok := held[it.ID]
+		switch {
+		case !ok:
+			extra = append(extra, it.ID)
+		case version != "" && version != it.Version:
+			stale = append(stale, it.ID)
+		}
+		delete(held, it.ID)
+		return true
+	}); err != nil {
+		return rec, fmt.Errorf("ingest: inventory %s: %w", source, err)
+	}
+
+	missing := make([]string, 0, len(held))
+	for id := range held {
+		missing = append(missing, id)
+	}
+	// Sorted so that two sweeps over the same drift report the same sample, and
+	// so that the repair below touches documents in a stable order. Map order
+	// would make the sample a lottery and the log unreadable.
+	slices.Sort(missing)
+	slices.Sort(stale)
+	slices.Sort(extra)
+
+	for _, id := range missing {
+		rec.Missing.add(id)
+	}
+	for _, id := range stale {
+		rec.Stale.add(id)
+	}
+	for _, id := range extra {
+		rec.Extra.add(id)
+	}
+
+	if err := p.repair(ctx, string(tenant), c, &rec, missing, stale, extra); err != nil {
+		rec.Duration = p.clock().Sub(start)
+		rec.Requests = countersOf(c).Since(before)
+		return rec, err
+	}
+
+	rec.Duration = p.clock().Sub(start)
+	rec.Requests = countersOf(c).Since(before)
+
+	p.log.Info("reconciled",
+		"source", source,
+		"tenant", string(tenant),
+		"source_items", rec.SourceItems,
+		"index_items", rec.IndexItems,
+		"missing", rec.Missing.Count,
+		"stale", rec.Stale.Count,
+		"extra", rec.Extra.Count,
+		"repaired", rec.Repaired,
+		"deleted", rec.Deleted,
+		"requests", rec.Requests.Requests(),
+		"duration", rec.Duration,
+	)
+	return rec, nil
+}
+
+// repair puts back what is missing, rewrites what is stale and deletes what the
+// source no longer has.
+//
+// It reuses the run from a normal sync rather than writing to the store itself,
+// so that a repaired document goes through the same batching, the same tenant
+// and source stamping and the same quarantine rule as one that arrived from a
+// change feed. A document that is only correct when it comes in through one of
+// the two doors is a bug waiting for the other door.
+func (p *Pipeline) repair(ctx context.Context, tenant string, c connector.Connector, rec *Reconciliation, missing, stale, extra []string) error {
+	r := &run{pipeline: p, tenant: tenant, source: c.Source()}
+
+	for _, id := range extra {
+		if err := r.emit(ctx, connector.Change{Document: docWithID(id), Deleted: true}); err != nil {
+			return err
+		}
+	}
+
+	fetcher, ok := c.(connector.Fetcher)
+	if !ok {
+		if n := len(missing) + len(stale); n > 0 {
+			// Said once, loudly, rather than per document. A connector that
+			// cannot fetch by id is not broken, but an operator reading a report
+			// with a missing count in it needs to know why nothing happened
+			// about it.
+			p.log.Warn("documents are missing or stale and this connector cannot fetch by id, so they wait for a full sync",
+				"source", c.Source(), "tenant", tenant, "count", n)
+		}
+		if err := r.flush(ctx); err != nil {
+			return err
+		}
+		rec.Deleted = r.stats.Deleted
+		return nil
+	}
+
+	for _, id := range slices.Concat(missing, stale) {
+		d, err := fetcher.Fetch(ctx, id)
+		switch {
+		case errors.Is(err, connector.ErrGone):
+			// The source changed its mind between the enumeration and now,
+			// which is normal on a corpus people are working in. It is not
+			// missing, it is deleted, and it is treated as one.
+			if err := r.emit(ctx, connector.Change{Document: docWithID(id), Deleted: true}); err != nil {
+				return err
+			}
+			continue
+		case err != nil:
+			return fmt.Errorf("ingest: fetch %s from %s: %w", id, c.Source(), err)
+		}
+		d.ID = id
+		if err := r.emit(ctx, connector.Change{Document: d}); err != nil {
+			return err
+		}
+	}
+
+	if err := r.flush(ctx); err != nil {
+		return err
+	}
+	rec.Repaired = r.stats.Indexed + r.stats.Quarantined
+	rec.Deleted = r.stats.Deleted
+	return nil
+}
+
+// docWithID is the whole of a document for a deletion. There is nothing left to
+// index, so there is nothing else to fill in.
+func docWithID(id string) doc.Document { return doc.Document{ID: id} }
+
+// countersOf reads a connector's counters, or a zero reading from one that does
+// not count.
+func countersOf(c connector.Connector) connector.Counters {
+	if counted, ok := c.(connector.Counted); ok {
+		return counted.Counters()
+	}
+	return connector.Counters{}
+}

--- a/ingest/reconcile_test.go
+++ b/ingest/reconcile_test.go
@@ -1,0 +1,330 @@
+package ingest_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/ingest"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// listedSource is a source that can be listed and fetched, and counts what it
+// was asked for.
+//
+// It stands in for the thing the interfaces are really about: a system where
+// listing is cheap and fetching is not. Nothing here would be visible on a
+// local filesystem, where both are fast, and everything here is the difference
+// between a sync that finishes and one that gets rate limited.
+type listedSource struct {
+	name string
+
+	// held is the corpus, keyed by id, in the order a walk would find it.
+	held  map[string]doc.Document
+	order []string
+
+	// versions overrides what the enumeration reports, so that a test can make
+	// the source claim a revision the index does not have without changing the
+	// document behind it.
+	versions map[string]string
+
+	// enumErr fails the walk partway through, after emitting this many items.
+	enumErr   error
+	enumAfter int
+
+	counters connector.Counters
+	fetched  []string
+}
+
+func (s *listedSource) Source() string { return s.name }
+func (s *listedSource) Close() error   { return nil }
+
+// Sync emits nothing. These tests are about the sweep that runs beside the
+// incremental path, so the incremental path is left empty on purpose.
+func (s *listedSource) Sync(context.Context, connector.Cursor, func(context.Context, connector.Change) error) (connector.Cursor, error) {
+	return connector.Cursor{}, nil
+}
+
+func (s *listedSource) Enumerate(_ context.Context, fn func(connector.Item) bool) error {
+	s.counters.Lists++
+	for i, id := range s.order {
+		if s.enumErr != nil && i == s.enumAfter {
+			return s.enumErr
+		}
+		version := s.held[id].SourceUpdate
+		if v, ok := s.versions[id]; ok {
+			version = v
+		}
+		if !fn(connector.Item{ID: id, Version: version}) {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (s *listedSource) Fetch(_ context.Context, id string) (doc.Document, error) {
+	s.counters.Fetches++
+	s.fetched = append(s.fetched, id)
+	d, ok := s.held[id]
+	if !ok {
+		return doc.Document{}, connector.ErrGone
+	}
+	s.counters.Bytes += int64(len(d.Body))
+	return d, nil
+}
+
+func (s *listedSource) Counters() connector.Counters { return s.counters }
+
+func (s *listedSource) put(id, version, body string) {
+	if s.held == nil {
+		s.held = make(map[string]doc.Document)
+	}
+	if _, ok := s.held[id]; !ok {
+		s.order = append(s.order, id)
+	}
+	s.held[id] = doc.Document{
+		ID:           id,
+		Title:        "document " + id,
+		Body:         body,
+		SourceUpdate: version,
+		Permissions:  acl.Permissions{Mode: acl.ModePublicToTenant, Source: s.name},
+	}
+}
+
+func (s *listedSource) remove(id string) {
+	delete(s.held, id)
+	s.order = slices.DeleteFunc(s.order, func(x string) bool { return x == id })
+}
+
+// corpus builds a source holding n documents at revision one.
+func corpus(name string, n int) *listedSource {
+	s := &listedSource{name: name}
+	for i := range n {
+		s.put(fmt.Sprintf("doc-%04d", i), "v1", "the body of document "+strconv.Itoa(i))
+	}
+	return s
+}
+
+func reconcile(t *testing.T, p *ingest.Pipeline, src connector.Connector) ingest.Reconciliation {
+	t.Helper()
+	rec, err := p.Reconcile(t.Context(), tenant, src)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	return rec
+}
+
+// pipelineOver returns a pipeline over a fresh store, and the store.
+func pipelineOver(t *testing.T) (*ingest.Pipeline, *memstore.Store) {
+	t.Helper()
+	st := memstore.New()
+	p, err := ingest.New(st, connector.NewMemoryCheckpoints())
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	return p, st
+}
+
+// TestReconcileFillsAnEmptyIndex is the simplest reading of the comparison: an
+// index that has never seen the source is entirely missing, and the sweep is
+// what a first sync would have been.
+func TestReconcileFillsAnEmptyIndex(t *testing.T) {
+	p, st := pipelineOver(t)
+	src := corpus("test", 12)
+
+	rec := reconcile(t, p, src)
+
+	if rec.SourceItems != 12 || rec.IndexItems != 0 {
+		t.Fatalf("compared %d source items against %d index items, want 12 against 0", rec.SourceItems, rec.IndexItems)
+	}
+	if rec.Missing.Count != 12 || rec.Repaired != 12 {
+		t.Fatalf("found %d missing and repaired %d, want 12 and 12", rec.Missing.Count, rec.Repaired)
+	}
+	if rec.Extra.Count != 0 || rec.Stale.Count != 0 {
+		t.Fatalf("an empty index reported %d extra and %d stale", rec.Extra.Count, rec.Stale.Count)
+	}
+	if _, err := st.Get(t.Context(), principal(), "doc-0003"); err != nil {
+		t.Fatalf("a repaired document is not readable: %v", err)
+	}
+}
+
+// TestReconcileIsQuietWhenNothingDrifted is the case that has to be cheap,
+// because it is the case that happens every night for the life of a deployment.
+func TestReconcileIsQuietWhenNothingDrifted(t *testing.T) {
+	p, _ := pipelineOver(t)
+	src := corpus("test", 20)
+	reconcile(t, p, src)
+
+	before := src.Counters()
+	rec := reconcile(t, p, src)
+
+	if rec.Drift() != 0 {
+		t.Fatalf("a second sweep over an unchanged corpus found %d discrepancies", rec.Drift())
+	}
+	if rec.Repaired != 0 || rec.Deleted != 0 {
+		t.Fatalf("a sweep over an unchanged corpus repaired %d and deleted %d", rec.Repaired, rec.Deleted)
+	}
+	if fetches := src.Counters().Fetches - before.Fetches; fetches != 0 {
+		t.Fatalf("a sweep over an unchanged corpus fetched %d documents, want none", fetches)
+	}
+	if rec.Requests.Lists != 1 {
+		t.Fatalf("the sweep made %d enumerations, want 1", rec.Requests.Lists)
+	}
+}
+
+// TestReconcileRemovesWhatTheSourceDeleted is the box this was written for. A
+// document deleted at the source is still being served until something notices,
+// and nothing in a change feed has to say so.
+func TestReconcileRemovesWhatTheSourceDeleted(t *testing.T) {
+	p, st := pipelineOver(t)
+	src := corpus("test", 6)
+	reconcile(t, p, src)
+
+	src.remove("doc-0002")
+	rec := reconcile(t, p, src)
+
+	if rec.Extra.Count != 1 || !slices.Equal(rec.Extra.IDs, []string{"doc-0002"}) {
+		t.Fatalf("the sweep reported %d extra documents, ids %v, want doc-0002", rec.Extra.Count, rec.Extra.IDs)
+	}
+	if rec.Deleted != 1 {
+		t.Fatalf("the sweep deleted %d documents, want 1", rec.Deleted)
+	}
+	if _, err := st.Get(t.Context(), principal(), "doc-0002"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("a document deleted at the source is still readable: %v", err)
+	}
+
+	// And the sweep after that finds nothing, which is what says the repair was
+	// a repair and not a loop that deletes and refetches the same document
+	// every night.
+	if again := reconcile(t, p, src); again.Drift() != 0 {
+		t.Fatalf("the sweep after the repair found %d discrepancies", again.Drift())
+	}
+}
+
+// TestReconcileRefetchesWhatMovedOn covers the revision comparison, which is
+// the part that catches a source that changed a document without saying so.
+func TestReconcileRefetchesWhatMovedOn(t *testing.T) {
+	p, st := pipelineOver(t)
+	src := corpus("test", 5)
+	reconcile(t, p, src)
+
+	src.fetched = nil
+	src.put("doc-0001", "v2", "the body, rewritten")
+	rec := reconcile(t, p, src)
+
+	if rec.Stale.Count != 1 || !slices.Equal(rec.Stale.IDs, []string{"doc-0001"}) {
+		t.Fatalf("the sweep reported %d stale documents, ids %v, want doc-0001", rec.Stale.Count, rec.Stale.IDs)
+	}
+	if rec.Repaired != 1 {
+		t.Fatalf("the sweep repaired %d documents, want 1", rec.Repaired)
+	}
+	if !slices.Equal(src.fetched, []string{"doc-0001"}) {
+		t.Fatalf("the sweep fetched %v, want only the stale document", src.fetched)
+	}
+	got, err := st.Get(t.Context(), principal(), "doc-0001")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Body != "the body, rewritten" {
+		t.Fatalf("the repaired document still has the old body %q", got.Body)
+	}
+}
+
+// TestReconcileDeletesNothingOnAPartialEnumeration is the rule that matters
+// most in this file. A walk that failed halfway is not a statement about what
+// the source holds, and acting on it as though it were empties the index over a
+// timeout.
+func TestReconcileDeletesNothingOnAPartialEnumeration(t *testing.T) {
+	p, st := pipelineOver(t)
+	src := corpus("test", 10)
+	reconcile(t, p, src)
+
+	src.enumErr = errors.New("the source hung up")
+	src.enumAfter = 3
+
+	rec, err := p.Reconcile(t.Context(), tenant, src)
+	if err == nil {
+		t.Fatal("a failed enumeration was reported as a successful sweep")
+	}
+	if rec.Deleted != 0 {
+		t.Fatalf("a failed enumeration deleted %d documents", rec.Deleted)
+	}
+
+	var count int
+	if err := st.Scan(t.Context(), principal(), func(doc.Document) bool {
+		count++
+		return true
+	}); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if count != 10 {
+		t.Fatalf("the index holds %d documents after a failed sweep, want all 10", count)
+	}
+}
+
+// TestReconcileTreatsAVanishedFetchAsADeletion covers the race a corpus people
+// are working in produces every day: the document was there when the source was
+// listed and is gone by the time it is fetched.
+func TestReconcileTreatsAVanishedFetchAsADeletion(t *testing.T) {
+	p, st := pipelineOver(t)
+	src := corpus("test", 3)
+
+	// Listed but not held, which is exactly what a delete between the two
+	// calls looks like from here.
+	src.order = append(src.order, "doc-ghost")
+
+	rec := reconcile(t, p, src)
+
+	if rec.Missing.Count != 4 {
+		t.Fatalf("the sweep reported %d missing documents, want 4", rec.Missing.Count)
+	}
+	if rec.Repaired != 3 || rec.Deleted != 1 {
+		t.Fatalf("the sweep repaired %d and deleted %d, want 3 and 1", rec.Repaired, rec.Deleted)
+	}
+	if _, err := st.Get(t.Context(), principal(), "doc-ghost"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("a document that vanished between the list and the fetch is readable: %v", err)
+	}
+}
+
+// TestReconcileSamplesRatherThanListsEverything keeps the report a report. A
+// first sweep over a large corpus finds all of it missing, and a structure that
+// named every id would be a second copy of the corpus.
+func TestReconcileSamplesRatherThanListsEverything(t *testing.T) {
+	p, _ := pipelineOver(t)
+	src := corpus("test", ingest.SampleSize*3)
+
+	rec := reconcile(t, p, src)
+
+	if rec.Missing.Count != ingest.SampleSize*3 {
+		t.Fatalf("the count is %d, want the exact number missing", rec.Missing.Count)
+	}
+	if len(rec.Missing.IDs) != ingest.SampleSize {
+		t.Fatalf("the sample holds %d ids, want %d", len(rec.Missing.IDs), ingest.SampleSize)
+	}
+	if rec.Missing.IDs[0] != "doc-0000" {
+		t.Fatalf("the sample starts at %q, want the first id in sorted order", rec.Missing.IDs[0])
+	}
+}
+
+// TestReconcileNeedsAnEnumerator says no rather than doing something expensive
+// and calling it a sweep.
+func TestReconcileNeedsAnEnumerator(t *testing.T) {
+	p, _ := pipelineOver(t)
+	if _, err := p.Reconcile(t.Context(), tenant, &fakeSource{name: "test"}); err == nil {
+		t.Fatal("reconciling a connector that cannot enumerate was allowed")
+	}
+}
+
+func TestReconcileRefusesAnEmptyTenant(t *testing.T) {
+	p, _ := pipelineOver(t)
+	if _, err := p.Reconcile(t.Context(), "", corpus("test", 1)); err == nil {
+		t.Fatal("reconciling with no tenant was allowed")
+	}
+}

--- a/store/maintain.go
+++ b/store/maintain.go
@@ -1,0 +1,71 @@
+package store
+
+import (
+	"context"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// Item is one stored document as the ingestion pipeline sees it: a name and a
+// version, and deliberately nothing else.
+//
+// No title, no body, no permissions. A reconciliation compares two lists of
+// names and dates, and anything else in this struct would be content leaving
+// the store without a principal having asked for it.
+type Item struct {
+	// ID is the document id, the same one [Store.Delete] takes.
+	ID string
+
+	// Version is [doc.Document.SourceUpdate] as it was last stored, which is
+	// the source's own idea of a revision. It is opaque here: the pipeline only
+	// ever compares it to the version the connector reports now, and a
+	// difference means the stored copy is behind.
+	Version string
+}
+
+// Maintenance is the capability the ingestion pipeline needs and no query path
+// has.
+//
+// It is optional and separate from [Store] because it is the one part of the
+// interface that is not principal scoped, and that deserves to be looked at
+// squarely rather than folded in beside Get and Scan.
+//
+// The reason it cannot be principal scoped is that reconciliation asks "what
+// does this source hold that the index does not, and the other way round", and
+// a principal scoped answer would be one person's view of that. Deleting
+// everything a crawler's principal cannot see would empty the index on the
+// first run. The alternative is a principal that may see everything, which is a
+// superuser, and a superuser is a far worse thing to have in a permission model
+// than an interface that returns no content at all.
+//
+// So the bargain is written into the signatures. [Maintenance.Inventory] hands
+// back ids and versions, which is what a comparison needs and nothing a reader
+// could learn anything from. [Maintenance.SetPermissions] only writes.
+type Maintenance interface {
+	Store
+
+	// Inventory calls fn for every document held for one tenant and source, and
+	// stops early if fn returns false. The order is unspecified.
+	//
+	// Quarantined documents are included. A document whose permissions did not
+	// resolve is still a document the source may since have deleted, and
+	// leaving it out would make reconciliation the one path that cannot clean
+	// up the very documents an operator most wants gone.
+	Inventory(ctx context.Context, tenant, source string, fn func(Item) bool) error
+
+	// SetPermissions replaces the access control list of documents that are
+	// already stored, without touching anything else about them.
+	//
+	// This is what makes a permission change at the source cost a write per
+	// affected document rather than a recrawl of their content. An id the store
+	// does not hold is skipped rather than being an error, because the source
+	// and the index are allowed to disagree about what exists and that is what
+	// reconciliation is for. The return is how many were actually changed, so a
+	// caller can tell a run that did nothing from a run that did.
+	//
+	// A document whose new permissions do not resolve becomes quarantined by
+	// the same rule [Store.Put] applies, and one that resolves after being
+	// quarantined becomes queryable again. Revocation has to be as fast as
+	// granting, and it is the direction that matters.
+	SetPermissions(ctx context.Context, tenant string, perms map[string]acl.Permissions) (int, error)
+}

--- a/store/memstore/maintain.go
+++ b/store/memstore/maintain.go
@@ -1,0 +1,79 @@
+package memstore
+
+import (
+	"context"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Maintenance = (*Store)(nil)
+
+// Inventory calls fn for every document held for one tenant and source.
+//
+// The callback runs under the read lock, which is fine here and worth saying
+// out loud: it means a callback that writes back into this store deadlocks. The
+// pipeline collects ids and acts afterwards, and a driver over a database has
+// the same shape for the same reason, so the restriction is the interface's
+// rather than this driver's.
+func (s *Store) Inventory(ctx context.Context, tenant, source string, fn func(store.Item) bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return genba.ErrClosed
+	}
+	for _, d := range s.docs {
+		if d.Tenant != tenant || d.Source != source {
+			continue
+		}
+		if !fn(store.Item{ID: d.ID, Version: d.SourceUpdate}) {
+			return nil
+		}
+	}
+	return nil
+}
+
+// SetPermissions replaces the access control lists of stored documents.
+func (s *Store) SetPermissions(ctx context.Context, tenant string, perms map[string]acl.Permissions) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	changed, written, err := s.setPermissions(tenant, perms)
+	if err != nil {
+		return 0, err
+	}
+	// Reported as a write, because it is one. A cache that kept a result page
+	// for a document somebody has just been locked out of has to be told, and
+	// a revocation is the change it is least acceptable to miss.
+	s.Changes(written, false)
+	return changed, nil
+}
+
+// setPermissions does the work under the lock and reports how many documents it
+// rewrote and which ids to invalidate, per tenant.
+func (s *Store) setPermissions(tenant string, perms map[string]acl.Permissions) (changed int, written map[string][]string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, nil, genba.ErrClosed
+	}
+	written = make(map[string][]string)
+	for id, p := range perms {
+		d, ok := s.docs[id]
+		// A document of another tenant is not there as far as this call is
+		// concerned. The alternative is a caller able to rewrite the access
+		// control lists of a corpus it named by guessing at ids.
+		if !ok || d.Tenant != tenant {
+			continue
+		}
+		d.Permissions = p
+		s.docs[id] = d
+		written[d.Tenant] = append(written[d.Tenant], id)
+		changed++
+	}
+	return changed, written, nil
+}

--- a/store/memstore/memstore_test.go
+++ b/store/memstore/memstore_test.go
@@ -14,6 +14,10 @@ func TestConformance(t *testing.T) {
 	storetest.Run(t, newStore)
 }
 
+func TestMaintenanceConformance(t *testing.T) {
+	storetest.RunMaintenance(t, newStore)
+}
+
 // memstore implements store.Statistician and neither of the other two, so most
 // of this suite skips. The cases that do run are the ones that matter here: the
 // corpus statistics are what the ranking is normalised against, and they have

--- a/store/pgstore/maintain.go
+++ b/store/pgstore/maintain.go
@@ -1,0 +1,260 @@
+package pgstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Maintenance = (*Store)(nil)
+
+// Inventory calls fn for every document held for one tenant and source.
+//
+// It reads two columns of one table and nothing else. A reconciliation over a
+// corpus of a few million documents is a few million ids, and decoding the
+// stored JSON for each of them to reach a field the comparison does not use
+// would turn an index scan into a read of the corpus.
+func (s *Store) Inventory(ctx context.Context, tenant, source string, fn func(store.Item) bool) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, source_update FROM document WHERE tenant = $1 AND source = $2 ORDER BY id`, tenant, source)
+	if err != nil {
+		return fmt.Errorf("pgstore: inventory: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var item store.Item
+		if err := rows.Scan(&item.ID, &item.Version); err != nil {
+			return fmt.Errorf("pgstore: inventory: %w", err)
+		}
+		if !fn(item) {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("pgstore: inventory: %w", err)
+	}
+	return nil
+}
+
+// SetPermissions replaces the access control lists of stored documents.
+//
+// What it deliberately does not do is re-analyse the text. A permission change
+// touches the columns the visibility predicate reads, the reference rows it
+// joins against, and the stored copy of the document. Everything derived from
+// the words is left alone, because the words did not change, which is what
+// makes a company wide access control change cost a write per document rather
+// than a recrawl.
+//
+// The exception is a document that crosses the quarantine line in either
+// direction, since a quarantined document is not in the full text index or the
+// corpus statistics at all. That is the one path here that pays for the
+// analyzer, and it is the path that matters most: a revocation has to take
+// effect as fast as a grant.
+func (s *Store) SetPermissions(ctx context.Context, tenant string, perms map[string]acl.Permissions) (int, error) {
+	if err := s.ready(ctx); err != nil {
+		return 0, err
+	}
+	if len(perms) == 0 {
+		return 0, nil
+	}
+
+	var changed int
+	written := make(map[string][]string, 1)
+	err := s.retry(ctx, func(ctx context.Context) error {
+		changed = 0
+		clear(written)
+		return s.transact(ctx, func(tx pgx.Tx) error {
+			ids, err := setPermissions(ctx, tx, tenant, perms)
+			if err != nil {
+				return err
+			}
+			changed = len(ids)
+			if len(ids) > 0 {
+				written[tenant] = ids
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return 0, fmt.Errorf("pgstore: set permissions: %w", err)
+	}
+	s.Changes(written, false)
+	return changed, nil
+}
+
+// setPermissions does the work inside the transaction and returns the ids that
+// were actually there to change.
+func setPermissions(ctx context.Context, tx pgx.Tx, tenant string, perms map[string]acl.Permissions) ([]string, error) {
+	ids := make([]string, 0, len(perms))
+	for id := range perms {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	priors, err := readPriors(ctx, tx, ids)
+	if err != nil {
+		return nil, err
+	}
+	stored, err := readStored(ctx, tx, tenant, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	// Three groups, because the statistics only care about the line between
+	// quarantined and queryable. A document that changes from one access
+	// control list to another has not moved, and touching its postings would be
+	// deleting rows to write the same rows back.
+	var (
+		found   = make([]string, 0, len(ids))
+		flipped = make([]string, 0, len(ids))
+		back    = make([]doc.Document, 0, len(ids))
+	)
+	for _, id := range ids {
+		d, ok := stored[id]
+		if !ok {
+			continue
+		}
+		p := priors[id]
+		d.Permissions = perms[id]
+		stored[id] = d
+		found = append(found, id)
+		if p.queryable != d.Queryable() {
+			flipped = append(flipped, id)
+			if d.Queryable() {
+				back = append(back, d)
+			}
+		}
+	}
+	if len(found) == 0 {
+		return nil, nil
+	}
+
+	b := &pgx.Batch{}
+	retire(b, priors, flipped)
+	b.Queue(`DELETE FROM document_ref WHERE doc_id = ANY($1::text[])`, found)
+
+	rows := make([]posting, 0, len(back)*64)
+	var titleTokens, bodyTokens int64
+	for _, id := range found {
+		d := stored[id]
+		data, err := json.Marshal(d)
+		if err != nil {
+			return nil, fmt.Errorf("encode %s: %w", id, err)
+		}
+		var ownerKey string
+		if d.Permissions.Owner.Value != "" {
+			ownerKey = d.Permissions.Owner.UserKey()
+		}
+		b.Queue(`
+			UPDATE document SET mode = $2, owner_key = $3, queryable = $4
+			WHERE id = $1`, id, int16(d.Permissions.Mode), ownerKey, d.Queryable())
+		b.Queue(`UPDATE document_data SET data = $2 WHERE doc_id = $1`, id, string(data))
+
+		refs := refsOf(d.Permissions)
+		if len(refs) > 0 {
+			effects := make([]int16, len(refs))
+			scopes := make([]int16, len(refs))
+			keys := make([]string, len(refs))
+			for i, r := range refs {
+				effects[i], scopes[i], keys[i] = r.effect, r.scope, r.key
+			}
+			b.Queue(`
+				INSERT INTO document_ref (doc_id, effect, scope, key)
+				SELECT $1, e, s, k FROM unnest($2::smallint[], $3::smallint[], $4::text[]) AS t(e, s, k)`,
+				id, effects, scopes, keys)
+		}
+	}
+
+	// The full text column follows the quarantine line in both directions:
+	// emptied on the way out, rebuilt on the way in.
+	for _, id := range flipped {
+		d := stored[id]
+		terms := ""
+		if d.Queryable() {
+			a := d.Analyze()
+			terms = tsvector(a)
+			rows = appendPostings(rows, id, a)
+			titleTokens += int64(a.TitleTokens)
+			bodyTokens += int64(a.BodyTokens)
+		}
+		b.Queue(`UPDATE document SET terms = $2::tsvector WHERE id = $1`, id, terms)
+	}
+	if err := tx.SendBatch(ctx, b).Close(); err != nil {
+		return nil, err
+	}
+
+	if len(rows) > 0 {
+		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"posting"},
+			[]string{"doc_id", "term", "title_tf", "body_tf"},
+			pgx.CopyFromSlice(len(rows), func(i int) ([]any, error) {
+				r := rows[i]
+				return []any{r.docID, r.term, r.titleTF, r.bodyTF}, nil
+			})); err != nil {
+			return nil, fmt.Errorf("copy postings: %w", err)
+		}
+	}
+
+	if len(back) > 0 {
+		ids := make([]string, len(back))
+		for i, d := range back {
+			ids[i] = d.ID
+		}
+		b = &pgx.Batch{}
+		b.Queue(`
+			INSERT INTO term_stat (tenant, term, documents)
+			SELECT $1, term, count(*) FROM posting WHERE doc_id = ANY($2::text[]) GROUP BY term
+			ON CONFLICT (tenant, term) DO UPDATE SET documents = term_stat.documents + excluded.documents`,
+			tenant, ids)
+		b.Queue(`
+			INSERT INTO corpus (tenant, documents, title_tokens, body_tokens) VALUES ($1, $2, $3, $4)
+			ON CONFLICT (tenant) DO UPDATE SET
+				documents    = corpus.documents + excluded.documents,
+				title_tokens = corpus.title_tokens + excluded.title_tokens,
+				body_tokens  = corpus.body_tokens + excluded.body_tokens`,
+			tenant, int64(len(back)), titleTokens, bodyTokens)
+		if err := tx.SendBatch(ctx, b).Close(); err != nil {
+			return nil, err
+		}
+	}
+	return found, nil
+}
+
+// readStored reads the documents behind a set of ids, for one tenant.
+//
+// The tenant is in the predicate rather than checked afterwards, so a caller
+// that names an id belonging to somebody else changes nothing rather than
+// changing their access control list.
+func readStored(ctx context.Context, tx pgx.Tx, tenant string, ids []string) (map[string]doc.Document, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT x.data FROM document d JOIN document_data x ON x.doc_id = d.id
+		WHERE d.tenant = $1 AND d.id = ANY($2::text[])`, tenant, ids)
+	if err != nil {
+		return nil, fmt.Errorf("read the stored documents: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]doc.Document, len(ids))
+	for rows.Next() {
+		var data string
+		if err := rows.Scan(&data); err != nil {
+			return nil, fmt.Errorf("read the stored documents: %w", err)
+		}
+		var d doc.Document
+		if err := json.Unmarshal([]byte(data), &d); err != nil {
+			return nil, fmt.Errorf("decode a stored document: %w", err)
+		}
+		out[d.ID] = d
+	}
+	return out, rows.Err()
+}

--- a/store/pgstore/migrations/0002_source_update.down.sql
+++ b/store/pgstore/migrations/0002_source_update.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX document_tenant_source;
+ALTER TABLE document DROP COLUMN source_update;

--- a/store/pgstore/migrations/0002_source_update.up.sql
+++ b/store/pgstore/migrations/0002_source_update.up.sql
@@ -1,0 +1,21 @@
+-- source_update is the source's own revision for a document, which is what a
+-- reconciliation compares against the revision the source reports now.
+--
+-- It is a column rather than a field read out of the stored JSON because a
+-- reconciliation walks every document of a source, and decoding a four kilobyte
+-- document to reach a forty byte string would turn a scan of an index into a
+-- read of the whole corpus. That is the same argument document_data was split
+-- out on.
+ALTER TABLE document ADD COLUMN source_update text NOT NULL DEFAULT '';
+
+-- The cast is because data is stored as text rather than as jsonb, which is
+-- the choice document_data made on purpose: the column is handed back to Get
+-- byte for byte and nothing queries inside it. This backfill is the one place
+-- that has to look, and it runs once.
+UPDATE document d SET source_update = COALESCE(x.data::jsonb ->> 'SourceUpdate', '')
+FROM document_data x WHERE x.doc_id = d.id;
+
+-- The reconciliation predicate. document_source already exists and covers the
+-- source alone, which is the wrong way round for a walk that is always scoped
+-- to one tenant first.
+CREATE INDEX document_tenant_source ON document (tenant, source);

--- a/store/pgstore/pgstore_test.go
+++ b/store/pgstore/pgstore_test.go
@@ -115,6 +115,10 @@ func TestConformance(t *testing.T) {
 	storetest.Run(t, newStore)
 }
 
+func TestMaintenanceConformance(t *testing.T) {
+	storetest.RunMaintenance(t, newStore)
+}
+
 func TestRetrieverConformance(t *testing.T) {
 	storetest.RunRetriever(t, newStore)
 }

--- a/store/pgstore/write.go
+++ b/store/pgstore/write.go
@@ -278,9 +278,9 @@ func replace(b *pgx.Batch, d doc.Document, a doc.Analysis) error {
 	b.Queue(`
 		INSERT INTO document (
 			id, tenant, source, kind, container_fold, author_keys, owner_keys,
-			modified_at, mode, owner_key, queryable,
+			modified_at, mode, owner_key, queryable, source_update,
 			title_tokens, body_tokens, container, author_name, terms
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16::tsvector)
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17::tsvector)
 		ON CONFLICT (id) DO UPDATE SET
 			tenant         = excluded.tenant,
 			source         = excluded.source,
@@ -292,6 +292,7 @@ func replace(b *pgx.Batch, d doc.Document, a doc.Analysis) error {
 			mode           = excluded.mode,
 			owner_key      = excluded.owner_key,
 			queryable      = excluded.queryable,
+			source_update  = excluded.source_update,
 			title_tokens   = excluded.title_tokens,
 			body_tokens    = excluded.body_tokens,
 			container      = excluded.container,
@@ -299,7 +300,7 @@ func replace(b *pgx.Batch, d doc.Document, a doc.Analysis) error {
 			terms          = excluded.terms`,
 		d.ID, d.Tenant, d.Source, string(d.Kind),
 		store.Fold(d.Container), nonEmpty(store.PersonKeys(d.Author)), nonEmpty(store.PersonKeys(d.Owner)),
-		nullableNanos(d.ModifiedAt), int16(d.Permissions.Mode), ownerKey, d.Queryable(),
+		nullableNanos(d.ModifiedAt), int16(d.Permissions.Mode), ownerKey, d.Queryable(), d.SourceUpdate,
 		a.TitleTokens, a.BodyTokens, d.Container, d.Author.Display(), terms)
 
 	b.Queue(`

--- a/store/sqlitestore/maintain.go
+++ b/store/sqlitestore/maintain.go
@@ -1,0 +1,186 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Maintenance = (*Store)(nil)
+
+// Inventory calls fn for every document held for one tenant and source.
+//
+// It reads two columns of one table and nothing else. A reconciliation over a
+// corpus of a few million documents is a few million ids, and decoding the
+// stored JSON for each of them to reach a field the comparison does not use
+// would turn a scan of an index into a read of the whole corpus.
+func (s *Store) Inventory(ctx context.Context, tenant, source string, fn func(store.Item) bool) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, source_update FROM document WHERE tenant = ? AND source = ?`, tenant, source)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: inventory: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var (
+			id      string
+			version sql.NullString
+		)
+		if err := rows.Scan(&id, &version); err != nil {
+			return fmt.Errorf("sqlitestore: inventory: %w", err)
+		}
+		if !fn(store.Item{ID: id, Version: version.String}) {
+			return nil
+		}
+	}
+	return rows.Err()
+}
+
+// SetPermissions replaces the access control lists of stored documents.
+//
+// The work it deliberately does not do is re-analyse the text. A permission
+// change touches the columns the visibility predicate reads, the reference
+// rows it joins against, and the copy of the document in the data table.
+// Everything derived from the words is untouched, because the words did not
+// change, which is what makes a company wide access control change cost a write
+// per document rather than a recrawl.
+//
+// The exception is a document that crosses the quarantine line in either
+// direction. A quarantined document is not in the full text index or the corpus
+// statistics at all, so one that becomes readable has to be put in and one that
+// stops being readable has to come out, and that is the one case where the
+// analyzer runs.
+func (s *Store) SetPermissions(ctx context.Context, tenant string, perms map[string]acl.Permissions) (int, error) {
+	if err := s.ready(ctx); err != nil {
+		return 0, err
+	}
+	if len(perms) == 0 {
+		return 0, nil
+	}
+
+	s.write.Lock()
+	defer s.write.Unlock()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("sqlitestore: set permissions: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	w, err := newWriter(ctx, tx)
+	if err != nil {
+		return 0, fmt.Errorf("sqlitestore: set permissions: %w", err)
+	}
+	defer w.close()
+
+	changed := 0
+	written := make(map[string][]string)
+	for id, p := range perms {
+		ok, err := setOne(ctx, tx, w, tenant, id, p)
+		if err != nil {
+			return 0, fmt.Errorf("sqlitestore: set permissions %s: %w", id, err)
+		}
+		if ok {
+			written[tenant] = append(written[tenant], id)
+			changed++
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("sqlitestore: set permissions: %w", err)
+	}
+	s.Changes(written, false)
+	return changed, nil
+}
+
+// setOne rewrites the permissions of one document and reports whether there was
+// one to rewrite.
+func setOne(ctx context.Context, tx *sql.Tx, w *writer, tenant, id string, p acl.Permissions) (bool, error) {
+	var (
+		rowid int64
+		was   int
+		data  string
+	)
+	// The tenant is part of the predicate rather than something checked
+	// afterwards, so a caller that names an id belonging to somebody else
+	// changes nothing rather than changing their access control list.
+	err := tx.QueryRowContext(ctx, `
+		SELECT d.rowid, d.queryable, dd.data
+		FROM document d JOIN document_data dd ON dd.doc_id = d.id
+		WHERE d.id = ? AND d.tenant = ?`, id, tenant).Scan(&rowid, &was, &data)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return false, nil
+	case err != nil:
+		return false, err
+	}
+
+	d, err := decode(data)
+	if err != nil {
+		return false, err
+	}
+	d.Permissions = p
+	now := boolInt(d.Queryable())
+
+	// Crossing the line out of the index. retire is what takes the postings and
+	// the corpus statistics back out, and it has to run while the row still
+	// says what it used to contribute.
+	if was != now {
+		if _, _, _, err := w.retire(ctx, id); err != nil {
+			return false, err
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM document_fts WHERE rowid = ?`, rowid); err != nil {
+			return false, err
+		}
+	}
+
+	var ownerKey string
+	if p.Owner.Value != "" {
+		ownerKey = p.Owner.UserKey()
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE document SET mode = ?, owner_key = ?, queryable = ? WHERE rowid = ?`,
+		int(p.Mode), ownerKey, now, rowid); err != nil {
+		return false, err
+	}
+
+	raw, err := json.Marshal(d)
+	if err != nil {
+		return false, fmt.Errorf("encode: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE document_data SET data = ? WHERE doc_id = ?`, string(raw), id); err != nil {
+		return false, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM document_ref WHERE doc_id = ?`, id); err != nil {
+		return false, err
+	}
+	for _, r := range refsOf(p) {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO document_ref (doc_id, effect, scope, key) VALUES (?, ?, ?, ?)`,
+			id, r.effect, r.scope, r.key); err != nil {
+			return false, err
+		}
+	}
+
+	// Crossing the line back into the index, which is the only path here that
+	// pays for the analyzer.
+	if was != now && now == 1 {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO document_fts (rowid, terms) VALUES (?, ?)`, rowid, d.Analyzed()); err != nil {
+			return false, err
+		}
+		if err := w.index(ctx, rowid, d, d.Analyze()); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}

--- a/store/sqlitestore/schema.go
+++ b/store/sqlitestore/schema.go
@@ -182,6 +182,18 @@ var migrations = []step{
 	) WITHOUT ROWID`),
 	ddl(`INSERT INTO document_data (doc_id, data) SELECT id, data FROM document`),
 	ddl(`ALTER TABLE document DROP COLUMN data`),
+
+	// source_update is the source's own revision for the document, which is
+	// what a reconciliation compares against the revision the source reports
+	// now. It is a column rather than a field read out of the stored JSON
+	// because a reconciliation walks every document of a source and decoding a
+	// four kilobyte document to reach a forty byte string would turn a scan of
+	// an index into a read of the corpus, which is the mistake the split above
+	// was made to avoid.
+	ddl(`ALTER TABLE document ADD COLUMN source_update TEXT NOT NULL DEFAULT ''`),
+	ddl(`UPDATE document SET source_update = COALESCE(
+		(SELECT json_extract(dd.data, '$.SourceUpdate') FROM document_data dd WHERE dd.doc_id = document.id), '')`),
+	ddl(`CREATE INDEX document_tenant_source ON document (tenant, source)`),
 }
 
 // backfill recomputes the ranking statistics for every document already stored.

--- a/store/sqlitestore/sqlitestore.go
+++ b/store/sqlitestore/sqlitestore.go
@@ -275,9 +275,9 @@ func putOne(ctx context.Context, tx *sql.Tx, w *writer, d doc.Document) error {
 	err = tx.QueryRowContext(ctx, `
 		INSERT INTO document (
 			id, tenant, source, kind, container_fold, author_keys, owner_keys,
-			modified_at, mode, owner_key, queryable,
+			modified_at, mode, owner_key, queryable, source_update,
 			title_tokens, body_tokens, container, author_name
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			tenant = excluded.tenant,
 			source = excluded.source,
@@ -289,6 +289,7 @@ func putOne(ctx context.Context, tx *sql.Tx, w *writer, d doc.Document) error {
 			mode = excluded.mode,
 			owner_key = excluded.owner_key,
 			queryable = excluded.queryable,
+			source_update = excluded.source_update,
 			title_tokens = excluded.title_tokens,
 			body_tokens = excluded.body_tokens,
 			container = excluded.container,
@@ -296,7 +297,7 @@ func putOne(ctx context.Context, tx *sql.Tx, w *writer, d doc.Document) error {
 		RETURNING rowid`,
 		d.ID, d.Tenant, d.Source, string(d.Kind),
 		store.Fold(d.Container), jsonKeys(store.PersonKeys(d.Author)), jsonKeys(store.PersonKeys(d.Owner)),
-		nullableTime(d.ModifiedAt), int(d.Permissions.Mode), ownerKey, boolInt(d.Queryable()),
+		nullableTime(d.ModifiedAt), int(d.Permissions.Mode), ownerKey, boolInt(d.Queryable()), d.SourceUpdate,
 		a.TitleTokens, a.BodyTokens, d.Container, d.Author.Display(),
 	).Scan(&rowid)
 	if err != nil {

--- a/store/sqlitestore/sqlitestore_test.go
+++ b/store/sqlitestore/sqlitestore_test.go
@@ -30,6 +30,10 @@ func TestConformance(t *testing.T) {
 	storetest.Run(t, newStore)
 }
 
+func TestMaintenanceConformance(t *testing.T) {
+	storetest.RunMaintenance(t, newStore)
+}
+
 func TestRetrieverConformance(t *testing.T) {
 	storetest.RunRetriever(t, newStore)
 }

--- a/store/storetest/maintain.go
+++ b/store/storetest/maintain.go
@@ -1,0 +1,320 @@
+package storetest
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// RunMaintenance checks a driver's [store.Maintenance] against what the
+// ingestion pipeline relies on.
+//
+// The suite is separate from [Run] because the capability is optional, and it
+// is worth having on its own because both halves of it are easy to implement in
+// a way that looks right and is not. An inventory that quietly leaves out the
+// quarantined documents makes reconciliation unable to clean up exactly the
+// documents an operator most wants gone, and a permission change that forgets
+// the index leaves a revoked document matching queries while Get says it is not
+// there.
+func RunMaintenance(t *testing.T, newStore Factory) {
+	t.Helper()
+	for _, c := range maintainCases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newStore(t)
+			t.Cleanup(func() { _ = s.Close() })
+
+			m, ok := s.(store.Maintenance)
+			if !ok {
+				t.Skip("this driver does not implement store.Maintenance")
+			}
+			c.run(t, s, m)
+		})
+	}
+}
+
+type maintainCase struct {
+	name string
+	run  func(t *testing.T, s store.Store, m store.Maintenance)
+}
+
+var maintainCases = []maintainCase{
+	{"inventory lists one source of one tenant", testInventoryScope},
+	{"inventory reports the stored version", testInventoryVersion},
+	{"inventory includes quarantined documents", testInventoryQuarantined},
+	{"inventory stops when the callback says so", testInventoryEarlyStop},
+	{"a permission change does not rewrite the document", testSetPermissionsKeepsContent},
+	{"a permission change ignores ids of another tenant", testSetPermissionsTenant},
+	{"a revocation into quarantine takes a document out of the index", testSetPermissionsQuarantine},
+	{"a permission change is reported as a write", testSetPermissionsNotifies},
+}
+
+// versioned is a document carrying the source's own revision, which is the
+// field an incremental sync compares against.
+func versioned(id, source, version string) doc.Document {
+	d := document(id, readable())
+	d.Source = source
+	d.SourceUpdate = version
+	return d
+}
+
+// inventory collects a whole source, sorted, so a driver is free to return its
+// documents in whatever order its storage puts them in.
+func inventory(t *testing.T, m store.Maintenance, tenant, source string) []store.Item {
+	t.Helper()
+	var items []store.Item
+	if err := m.Inventory(t.Context(), tenant, source, func(it store.Item) bool {
+		items = append(items, it)
+		return true
+	}); err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	slices.SortFunc(items, func(a, b store.Item) int { return strings.Compare(a.ID, b.ID) })
+	return items
+}
+
+func inventoryIDs(t *testing.T, m store.Maintenance, tenant, source string) []string {
+	t.Helper()
+	items := inventory(t, m, tenant, source)
+	ids := make([]string, len(items))
+	for i, it := range items {
+		ids[i] = it.ID
+	}
+	return ids
+}
+
+func testInventoryScope(t *testing.T, s store.Store, m store.Maintenance) {
+	other := versioned("d4", "gdrive", "v1")
+	other.Tenant = "globex"
+	mustPut(t, s,
+		versioned("d1", "gdrive", "v1"),
+		versioned("d2", "gdrive", "v1"),
+		versioned("d3", "slack", "v1"),
+		other,
+	)
+
+	if ids := inventoryIDs(t, m, "acme", "gdrive"); !slices.Equal(ids, []string{"d1", "d2"}) {
+		t.Fatalf("Inventory returned %v, want only the gdrive documents of acme", ids)
+	}
+	if ids := inventoryIDs(t, m, "acme", "slack"); !slices.Equal(ids, []string{"d3"}) {
+		t.Fatalf("Inventory of slack returned %v, want [d3]", ids)
+	}
+	if ids := inventoryIDs(t, m, "acme", "never-crawled"); len(ids) != 0 {
+		t.Fatalf("Inventory of a source with nothing in it returned %v", ids)
+	}
+}
+
+// testInventoryVersion is what makes a second sync cheap. A store that returns
+// an empty version for every document turns every incremental run into a full
+// recrawl, and nothing else in the suite would notice.
+func testInventoryVersion(t *testing.T, s store.Store, m store.Maintenance) {
+	mustPut(t, s, versioned("d1", "gdrive", "etag-1"))
+
+	items := inventory(t, m, "acme", "gdrive")
+	if len(items) != 1 || items[0].Version != "etag-1" {
+		t.Fatalf("Inventory returned %+v, want one item at version etag-1", items)
+	}
+
+	// A rewrite at a new revision has to be visible here, or the comparison
+	// would say the stored copy is current forever.
+	d := versioned("d1", "gdrive", "etag-2")
+	d.Title = "runbook d1, second edition"
+	mustPut(t, s, d)
+
+	items = inventory(t, m, "acme", "gdrive")
+	if len(items) != 1 || items[0].Version != "etag-2" {
+		t.Fatalf("after a rewrite Inventory returned %+v, want one item at version etag-2", items)
+	}
+}
+
+func testInventoryQuarantined(t *testing.T, s store.Store, m store.Maintenance) {
+	bad := versioned("d2", "gdrive", "v1")
+	bad.Permissions = acl.Permissions{Mode: acl.ModeUnknown, Source: "gdrive"}
+	mustPut(t, s, versioned("d1", "gdrive", "v1"), bad)
+
+	if ids := inventoryIDs(t, m, "acme", "gdrive"); !slices.Equal(ids, []string{"d1", "d2"}) {
+		t.Fatalf("Inventory returned %v, want the quarantined document too", ids)
+	}
+}
+
+func testInventoryEarlyStop(t *testing.T, s store.Store, m store.Maintenance) {
+	mustPut(t, s,
+		versioned("d1", "gdrive", "v1"),
+		versioned("d2", "gdrive", "v1"),
+		versioned("d3", "gdrive", "v1"),
+	)
+
+	seen := 0
+	if err := m.Inventory(t.Context(), "acme", "gdrive", func(store.Item) bool {
+		seen++
+		return false
+	}); err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if seen != 1 {
+		t.Fatalf("Inventory called the callback %d times after it returned false, want 1", seen)
+	}
+}
+
+// testSetPermissionsKeepsContent is the whole point of the call: a company wide
+// access control change costs a write per document and not a recrawl, so the
+// document that comes back afterwards has to be the one that went in.
+func testSetPermissionsKeepsContent(t *testing.T, s store.Store, m store.Maintenance) {
+	d := versioned("d1", "gdrive", "etag-1")
+	d.Title = "the payments failover runbook"
+	mustPut(t, s, d)
+
+	sales := acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "gdrive",
+		AllowGroups: []acl.Ref{{Source: "gdrive", Value: "sales@acme.com"}},
+		Version:     2,
+	}
+	n, err := m.SetPermissions(t.Context(), "acme", map[string]acl.Permissions{"d1": sales, "missing": sales})
+	if err != nil {
+		t.Fatalf("SetPermissions: %v", err)
+	}
+	// An id the store does not hold is skipped rather than counted, so a caller
+	// can tell a run that did something from one that did not.
+	if n != 1 {
+		t.Fatalf("SetPermissions changed %d documents, want 1", n)
+	}
+
+	if _, err := s.Get(t.Context(), reader(), "d1"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("a reader whose access was taken away could still read the document: %v", err)
+	}
+	got, err := s.Get(t.Context(), stranger(), "d1")
+	if err != nil {
+		t.Fatalf("the reader who was granted access could not read the document: %v", err)
+	}
+	if got.Title != "the payments failover runbook" || got.Body != d.Body {
+		t.Fatalf("a permission change rewrote the document: title %q, body %q", got.Title, got.Body)
+	}
+	if got.SourceUpdate != "etag-1" {
+		t.Fatalf("a permission change moved the stored version to %q, so the next sync would recrawl", got.SourceUpdate)
+	}
+	if items := inventory(t, m, "acme", "gdrive"); len(items) != 1 || items[0].Version != "etag-1" {
+		t.Fatalf("after a permission change Inventory returned %+v, want the version unchanged", items)
+	}
+}
+
+func testSetPermissionsTenant(t *testing.T, s store.Store, m store.Maintenance) {
+	other := document("d1", acl.Permissions{Mode: acl.ModePublicToTenant, Version: 1})
+	other.Tenant = "globex"
+	mustPut(t, s, other)
+
+	n, err := m.SetPermissions(t.Context(), "acme", map[string]acl.Permissions{"d1": readable()})
+	if err != nil {
+		t.Fatalf("SetPermissions: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("SetPermissions changed %d documents of another tenant, want 0", n)
+	}
+
+	// The document is still what globex put there. A caller able to rewrite the
+	// access control lists of a corpus it named by guessing at ids would be a
+	// hole no amount of filtering on the read path closes.
+	globex := &acl.Principal{Tenant: "globex", Subject: "u_pat"}
+	got, err := s.Get(t.Context(), globex, "d1")
+	if err != nil {
+		t.Fatalf("Get as the owning tenant: %v", err)
+	}
+	if got.Permissions.Mode != acl.ModePublicToTenant {
+		t.Fatalf("another tenant's permissions were rewritten to mode %v", got.Permissions.Mode)
+	}
+}
+
+// testSetPermissionsQuarantine is the case a driver gets wrong. A quarantined
+// document is absent from the full text index and the corpus statistics, so a
+// permission change that crosses that line has to take it out or put it back,
+// and a driver that only updates the columns the visibility predicate reads
+// leaves a document matching queries after it has been revoked.
+func testSetPermissionsQuarantine(t *testing.T, s store.Store, m store.Maintenance) {
+	mustPut(t, s, versioned("d1", "gdrive", "v1"), versioned("d2", "gdrive", "v1"))
+
+	unresolved := acl.Permissions{Mode: acl.ModeUnknown, Source: "gdrive"}
+	if _, err := m.SetPermissions(t.Context(), "acme", map[string]acl.Permissions{"d1": unresolved}); err != nil {
+		t.Fatalf("SetPermissions: %v", err)
+	}
+
+	if _, err := s.Get(t.Context(), reader(), "d1"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("a quarantined document was still readable: %v", err)
+	}
+	st, err := s.Stats(t.Context())
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if st.Documents != 1 || st.Quarantined != 1 {
+		t.Fatalf("Stats = %+v, want 1 served and 1 quarantined", st)
+	}
+	matches(t, s, m, []string{"d2"})
+
+	// And back, which is the direction that has to pay for the analyzer again.
+	if _, err := m.SetPermissions(t.Context(), "acme", map[string]acl.Permissions{"d1": readable()}); err != nil {
+		t.Fatalf("SetPermissions: %v", err)
+	}
+	if _, err := s.Get(t.Context(), reader(), "d1"); err != nil {
+		t.Fatalf("a document whose permissions resolved again was not readable: %v", err)
+	}
+	st, err = s.Stats(t.Context())
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if st.Documents != 2 || st.Quarantined != 0 {
+		t.Fatalf("Stats = %+v, want 2 served and none quarantined", st)
+	}
+	matches(t, s, m, []string{"d1", "d2"})
+}
+
+// matches asserts what a term query finds, for a driver that has an index. The
+// comparison is against the Go rule rather than against a literal, so it is the
+// same assertion the retrieval suite makes and it cannot drift from it.
+func matches(t *testing.T, s store.Store, m store.Maintenance, want []string) {
+	t.Helper()
+	rt, ok := m.(store.Retriever)
+	if !ok {
+		return
+	}
+	got := agree(t, s, rt, reader(), store.Request{Terms: []string{"runbook"}})
+	if !slices.Equal(got, want) {
+		t.Fatalf("a term query retrieved %v, want %v", got, want)
+	}
+}
+
+func testSetPermissionsNotifies(t *testing.T, s store.Store, m store.Maintenance) {
+	n, ok := s.(store.Notifier)
+	if !ok {
+		t.Skip("this driver does not report its writes")
+	}
+	mustPut(t, s, versioned("d1", "gdrive", "v1"))
+
+	var got notified
+	stop := n.OnChange(got.record)
+	defer stop()
+
+	// A cache holding a result page for a document somebody has just been locked
+	// out of has to be told, and a revocation is the change it is least
+	// acceptable to miss.
+	if _, err := m.SetPermissions(t.Context(), "acme", map[string]acl.Permissions{
+		"d1":      {Mode: acl.ModeUnknown, Source: "gdrive"},
+		"missing": readable(),
+	}); err != nil {
+		t.Fatalf("SetPermissions: %v", err)
+	}
+
+	changes := got.all()
+	if len(changes) != 1 {
+		t.Fatalf("a permission change reported %d changes, want 1", len(changes))
+	}
+	if changes[0].Tenant != "acme" || !slices.Equal(changes[0].IDs, []string{"d1"}) {
+		t.Fatalf("the change reported tenant %q and ids %v, want acme and [d1]", changes[0].Tenant, changes[0].IDs)
+	}
+	if changes[0].Deleted {
+		t.Error("a permission change reported itself as a delete, so a subscriber would drop the document entirely")
+	}
+}


### PR DESCRIPTION
Closes #11.

A first sync is the easy half. Everything after it is the half a search engine spends its whole life in, and it has three parts that fail in different ways. This does all three.

## A second sync reads nothing

`Counters` is a new optional connector capability reporting four numbers: listings, metadata lookups, fetches and bytes. It is what makes "incremental" a measurement rather than a claim.

A second sync of `fssource` over an unchanged tree of eight files spends eight metadata lookups, zero fetches and zero bytes. The walk itself is unavoidable on a filesystem, which has no change feed, but the reads are not, and the reads are the whole cost.

## A permission change costs a write, not a recrawl

Somebody edits an OWNERS file at the root of a repository and who may read every document below it changes without one of those documents being touched. A sync built on modification times cannot see that at all.

The connector now reports it as a `Change` with `PermissionsOnly` set, carrying an id and an access control list and nothing else. Only those two fields are read, so a connector cannot use it to sneak a content update past the pipeline.

Applying one needs a store that can rewrite an access control list without the document, which is the new optional `store.Maintenance`:

```go
type Maintenance interface {
	Inventory(ctx context.Context, tenant, source string, fn func(Item) bool) error
	SetPermissions(ctx context.Context, tenant string, perms map[string]acl.Permissions) (int, error)
}
```

memstore, sqlitestore and pgstore all implement it and all pass a new conformance suite in `store/storetest`. The subtle case is the quarantine line: a document whose permissions do not resolve is held out of the full text index, the posting lists, the term statistics and the corpus counts, so a change crossing that line has to retire or reindex the document, while a change from one resolved list to another must not touch any of it. Both directions are in the suite.

A pipeline over a store without the capability refuses a permission change rather than dropping it. A sync that reported success while a revocation went nowhere is worse than one that failed, because the failure is visible and the revocation is not.

On the connector side this needs a policy that can say when its answer changed, which is the new `Versioned` and `Reloader` pair. That also fixes a real bug: `OwnersPolicy` cached its parsed files for the life of the process, so a server that had been up for a week answered with the OWNERS files as they were at startup. The cache now lives for exactly one walk, which is long enough to cost one read per OWNERS file per sync instead of one per document.

## Reconciliation finds what the feed cannot report

An index built only out of a change feed drifts away from its source and nothing in the feed ever says so. A feed drops an event, a bulk edit raises none, a process is killed between the store and the checkpoint, a file is deleted and a walk of a tree can never see it because there is nothing left to walk past.

```go
rec, err := pipeline.Reconcile(ctx, "acme", src)
```

The sweep enumerates the source, walks the index and sorts the difference into missing, stale and extra. Missing and stale are refetched, extra is deleted, and all of it goes through the same batching, stamping and quarantine rules a change feed uses, so which door a document came through is not something a reader can tell.

It runs after every sync in `genbad` and logs at warning level only when something drifted, so a line in the log means the incremental path missed something.

Two rules are worth calling out.

Nothing is deleted on a partial enumeration. If the walk of the source fails halfway, `Reconcile` returns the error and repairs nothing at all. A list that stopped early is indistinguishable from a source that lost half its documents, and acting on the second reading would empty a working index because of a timeout.

The counts are exact and the ids are a sample of twenty per pile. The first sweep after a fresh index finds the whole corpus missing, and a report naming all of it would be a copy of the corpus in memory and a log line nobody reads.

## What a connector has to implement

Still three methods. Everything added here is optional and each piece buys one thing.

| Capability | What it buys |
| --- | --- |
| `Enumerator` | reconciliation, so deletions and dropped events are found |
| `Fetcher` | repair, so what reconciliation finds is fixed rather than only reported |
| `Counted` | the numbers that say whether the incremental path is actually incremental |
| `Change.PermissionsOnly` | a permission change costs a write instead of a recrawl |

`fssource` implements all four. `Fetch` maps an id back to a path, and that is where a path that tries to leave the tree is stopped: the id is cleaned as an absolute path and then stripped of its leading separator, so `../../etc/passwd` collapses to `etc/passwd` inside the root and the stat simply finds nothing.

## The four boxes

- A second run after no changes does close to no work, measured in requests. `TestASecondSyncOverAnUnchangedTreeReadsNothing` asserts zero fetches and zero bytes over an unchanged tree, and `TestReconcileIsQuietWhenNothingDrifted` asserts one enumeration and no fetches for a sweep over an index that agrees.
- A document deleted at the source disappears from results within one sync. `TestADeletedFileStopsComingBack` starts the server on a directory, deletes a file, and waits for the query to stop returning it.
- A permission change at the source takes effect without a content recrawl. `TestAnOwnersEditIsAPermissionChangeAndNotARecrawl` edits one OWNERS file and checks that the two documents it governs come back as permission changes, that the third under an untouched file does not, that no bytes were read, and that it happens once rather than on every sync from then on.
- Reconciliation reports what it found that the incremental path missed. `Reconciliation` carries exact counts, samples, what was repaired and deleted, what it spent at the source and how long it took.

`docs/ingestion.md` is the long form, and the README points at it.
