### PR TITLE
Connectors: fetch and normalise access control lists per source

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,12 @@ The mode bits describe the account the crawler runs as, not the people in the co
 `OwnersPolicy` reads the OWNERS files that Kubernetes and a number of other large repositories keep, taking the nearest one going up the tree, which is a real access control list maintained by real people over a corpus anybody can check out.
 A source built with no policy at all quarantines everything, so having not thought about permissions yet is a visible state in the stats rather than an invisible one in the index.
 
+What a source said about who may read a document is turned into the model in one place, `connector/aclmap`, rather than once per connector.
+Every system names permissions differently, and the same idea is a `reader` in one, `READ` in another, `VIEW` in a third and `BROWSE_PROJECTS` in a fourth.
+Mapping each of those is easy on its own, and the collection of them is where a search engine leaks, because every connector would otherwise decide on its own what a grant to a partner's domain means and what to do with a statement it does not understand.
+So a refusal beats a grant everywhere, a link share is recorded rather than inferred from the absence of a restriction, and anything that cannot be represented faithfully is quarantined and counted by reason instead of approximated.
+[docs/permissions.md](docs/permissions.md) has the mapping table for each source and the reasoning behind the awkward cases.
+
 Everything after the first sync is incremental.
 A second run over an unchanged tree reads no files at all, an OWNERS edit costs one write per document rather than a recrawl of the subtree, and a reconciliation sweep after every sync catches what a change feed cannot report, starting with the file somebody deleted.
 [docs/ingestion.md](docs/ingestion.md) has the details, including the optional capabilities a connector implements to get each of those and the rule that stops a timed out enumeration from emptying a working index.

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -114,6 +114,56 @@ const (
 	ModeOwnerOnly
 )
 
+// Sharing records how far a source said a document travels, beyond the people
+// its lists name.
+//
+// It grants nothing. [Permissions.Allows] never reads it and no storage driver
+// filters on it, because by the time a descriptor is stored the effective grant
+// is already in the mode and the lists. What it is for is saying so out loud.
+//
+// A document that anybody can read because somebody turned on a link is a
+// different fact from a document that anybody can read because somebody named
+// them, and an index that records only the second cannot answer the question an
+// administrator actually asks, which is what did we share and with whom. The
+// absence of a restriction is not a record of a decision, so the decision is
+// recorded.
+type Sharing uint8
+
+// The sharing states.
+const (
+	// SharedNone is a document readable only through its lists. It is the
+	// default and it is what almost everything is.
+	SharedNone Sharing = iota
+
+	// SharedByLink is a document its source says anybody holding a link may
+	// read.
+	//
+	// Whether that counts as a grant in the index is a deployment's decision
+	// and not this package's, because the two readings are both defensible and
+	// they are not the same. Somebody who has the link was given it. Somebody
+	// searching was not, and turning a link share into a search result hands
+	// the document to everybody who never had one.
+	SharedByLink
+
+	// SharedPublic is a document its source says is readable outside the
+	// tenant entirely, such as one published on the internet.
+	SharedPublic
+)
+
+// String returns the name of the sharing state.
+func (s Sharing) String() string {
+	switch s {
+	case SharedNone:
+		return "none"
+	case SharedByLink:
+		return "link"
+	case SharedPublic:
+		return "public"
+	default:
+		return "unknown"
+	}
+}
+
 // Ref names a user or a group inside one source.
 type Ref struct {
 	Source string
@@ -129,6 +179,10 @@ type Permissions struct {
 	AllowGroups []Ref
 	DenyUsers   []Ref
 	DenyGroups  []Ref
+
+	// Sharing is how far the source said the document travels. It is a record
+	// rather than a rule, and the comment on [Sharing] says why.
+	Sharing Sharing
 
 	// Source is the connector the document came from.
 	Source string

--- a/arch_test.go
+++ b/arch_test.go
@@ -111,8 +111,16 @@ var allowed = map[string][]string{
 	// neither knows anything about ranking. In particular connector does not
 	// import store: a source that could reach the store directly could write a
 	// document without going through the checks the pipeline applies.
-	"connector":          {"acl", "doc"},
-	"connector/fssource": {"acl", "connector", "doc"},
+	"connector": {"acl", "doc"},
+
+	// aclmap is the one place a source's own permission vocabulary is turned
+	// into the model, and it sits beside the connectors rather than inside acl
+	// because it is about somebody else's product rather than about ours. It
+	// imports acl and nothing else of ours, and it must stay that way: a
+	// mapping layer that could reach a store or a document would be a second
+	// place for the permission rule to live.
+	"connector/aclmap":   {"acl"},
+	"connector/fssource": {"acl", "connector", "connector/aclmap", "doc"},
 	// ingest names acl because a permission change that arrives without the
 	// document is a map of access control lists and nothing else, and there is
 	// no way to carry one without saying what it is. It is the one type from
@@ -128,7 +136,7 @@ var allowed = map[string][]string{
 	"benchcorpus/gen": {"benchcorpus", "store/sqlitestore"},
 
 	"cmd/genba":  {""},
-	"cmd/genbad": {"", "api", "config", "connector", "connector/fssource", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
+	"cmd/genbad": {"", "api", "config", "connector", "connector/aclmap", "connector/fssource", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
 }
 
 func TestDependencyDirection(t *testing.T) {

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tamnd/genba"
 	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/aclmap"
 	"github.com/tamnd/genba/connector/fssource"
 	"github.com/tamnd/genba/ingest"
 	"github.com/tamnd/genba/store"
@@ -145,6 +146,7 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 		)
 
 		reconcile(ctx, pipeline, src, tenant, log)
+		reportMapping(policy, log)
 	}
 
 	sync(ctx)
@@ -171,6 +173,39 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 		<-done
 		_ = src.Close()
 	}, nil
+}
+
+// aclCounter is a permission policy that counts what it mapped.
+type aclCounter interface {
+	Counts() aclmap.Counts
+}
+
+// reportMapping says what the permission mapping could not represent.
+//
+// A document held back because its source said something the model cannot carry
+// is invisible from every other angle. It is not an error, the sync succeeded,
+// and the only symptom is somebody who cannot find a document they know exists.
+// So it is counted by reason, and the reasons want different actions: a foreign
+// domain is a decision about the tenant, an unmappable deny is usually a source
+// feature nobody has written the mapping for, and a malformed grant is a bug in
+// a connector.
+func reportMapping(policy fssource.Policy, log *slog.Logger) {
+	counter, ok := policy.(aclCounter)
+	if !ok {
+		return
+	}
+	c := counter.Counts()
+	if c.Quarantined() == 0 {
+		return
+	}
+	log.Warn("permissions that could not be mapped",
+		"mapped", c.Mapped,
+		"quarantined", c.Quarantined(),
+		"foreign_domain", c.ForeignDomain,
+		"unmappable_deny", c.UnmappableDeny,
+		"malformed", c.Malformed,
+		"ignored_roles", c.Ignored,
+	)
 }
 
 // reconcile sweeps the index against the tree and repairs what the sync could

--- a/connector/aclmap/aclmap.go
+++ b/connector/aclmap/aclmap.go
@@ -1,0 +1,526 @@
+// Package aclmap turns what a source said about who may read a document into
+// the model the index runs on.
+//
+// Every system models permissions differently. Some grant to people, some to
+// groups, some to a whole email domain, some to anybody holding a link, and
+// several of them let a refusal override a grant. None of them agree on what to
+// call any of it: the same idea is a "reader" in one, "READ" in another, "VIEW"
+// in a third and "BROWSE_PROJECTS" in a fourth.
+//
+// A connector could map its own system straight onto [acl.Permissions], and the
+// first two would look fine. The trouble starts at the edges, and the edges are
+// where a search engine leaks. Every connector would decide on its own what a
+// grant to a domain means, whether a link share is a grant, and what to do with
+// a statement it does not understand, and the decision that costs a company its
+// private documents is the last one, made once, quietly, by whoever was writing
+// a connector on a Friday.
+//
+// So the decisions are made here, once, and a connector's job shrinks to
+// translating its own vocabulary into [Grant] values.
+//
+// # The rules
+//
+// A refusal beats a grant. This package puts denies in the deny lists and
+// [acl.Permissions.Allows] applies them first, in every source that has the
+// concept.
+//
+// Anything that cannot be represented faithfully is quarantined and counted. A
+// grant to a domain that is not the tenant's, or a refusal aimed at something
+// the model has no deny list for, produces a descriptor in [acl.ModeUnknown],
+// which is held out of every query path, and an error saying which document and
+// why. Approximating instead would mean guessing, and half of the guesses are a
+// document shown to somebody it was refused to.
+//
+// Link sharing and public documents are recorded rather than inferred from the
+// absence of a restriction. See [acl.Sharing].
+//
+// # What a connector writes
+//
+//	n, err := aclmap.New(aclmap.Drive("drive", "google", "acme.com"))
+//	...
+//	perms, err := n.Normalize([]aclmap.Grant{
+//		{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+//		{Subject: aclmap.Group, ID: "eng@acme.com", Role: "writer"},
+//	})
+//
+// The returned descriptor is safe whether or not the error is nil. A connector
+// that ignores the error stores a quarantined document, which is the failure
+// mode this package is built to have.
+package aclmap
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// Subject is who a statement is about.
+type Subject uint8
+
+// The subjects a source can name.
+const (
+	// User is one person, named however the source names people.
+	User Subject = iota
+
+	// Group is a set of people the source maintains.
+	Group
+
+	// Domain is everybody whose account belongs to an email domain.
+	Domain
+
+	// Anyone is no subject at all: the statement is about everybody, which is
+	// what a public document and a link share both look like at the source.
+	Anyone
+)
+
+// String returns the name of the subject.
+func (s Subject) String() string {
+	switch s {
+	case User:
+		return "user"
+	case Group:
+		return "group"
+	case Domain:
+		return "domain"
+	case Anyone:
+		return "anyone"
+	default:
+		return "unknown"
+	}
+}
+
+// Effect is whether a statement grants or refuses.
+type Effect uint8
+
+// The effects.
+const (
+	// Allow grants.
+	Allow Effect = iota
+
+	// Deny refuses, and beats every grant.
+	Deny
+)
+
+// Grant is one statement a source makes about one document, in the source's own
+// vocabulary.
+//
+// A connector fills these in from whatever its API returned and does not
+// interpret them. Interpreting is what [Normalizer.Normalize] is for, and the
+// whole value of the split is that the interpretation is in one place.
+type Grant struct {
+	// Subject is who the statement is about.
+	Subject Subject
+
+	// ID is the person, group or domain the source named. It is empty for
+	// [Anyone] and required for everything else.
+	ID string
+
+	// Effect is whether this grants or refuses.
+	Effect Effect
+
+	// Role is the source's own word for what was granted, such as "reader",
+	// "READ" or "BROWSE_PROJECTS". It is matched case insensitively against the
+	// read roles of the source, and a role that does not confer read is
+	// ignored and counted.
+	//
+	// An empty role means the statement is about reading. Several systems have
+	// no role at all on a share, and a connector should not have to invent one.
+	Role string
+
+	// Link says the statement is only in force for somebody holding a link.
+	Link bool
+
+	// Owner says this subject owns the document. It is only meaningful on a
+	// [User] grant.
+	Owner bool
+}
+
+// LinkPolicy is what a deployment wants a link share to mean in search.
+type LinkPolicy uint8
+
+// The link policies.
+const (
+	// LinkGrantsNothing is the default and the safe reading. A link shared
+	// document is readable by whoever its lists name, the share is recorded as
+	// [acl.SharedByLink], and somebody who never had the link does not find it
+	// by searching.
+	LinkGrantsNothing LinkPolicy = iota
+
+	// LinkGrantsTenant treats a link share as readable by everybody in the
+	// deployment.
+	//
+	// It is the right setting for a company where turning on a link is how
+	// people publish to their colleagues, and it has to be asked for by name,
+	// because in a company where it is not, this is the setting that hands
+	// several years of link shared documents to everybody at once.
+	LinkGrantsTenant
+)
+
+// Rules is how one source's vocabulary maps onto the model.
+//
+// The presets in sources.go carry the vocabularies of the systems this project
+// indexes, and each of them is the source system's own list of names rather
+// than one invented here.
+type Rules struct {
+	// Source is the connector name, which every produced descriptor carries.
+	Source string
+
+	// Identity is the identity source that the ids in a [Grant] belong to, for
+	// example "google" or "slack". Getting it right is what lets somebody who
+	// authenticated through one system match a list written in terms of
+	// another.
+	Identity string
+
+	// ReadRoles are the source's names for the roles that confer reading. A
+	// role outside the list is ignored and counted, which is how a grant of a
+	// permission to change a label stops being a grant to read the document.
+	//
+	// An empty list means every role confers read, which is correct for a
+	// source whose shares carry no role at all.
+	ReadRoles []string
+
+	// Domains are the email domains that are this tenant. A grant to one of
+	// them is everybody in the deployment. A grant to any other domain is a
+	// set of people the index cannot name, so it quarantines.
+	Domains []string
+
+	// Link is what a link share means here.
+	Link LinkPolicy
+}
+
+// Reason is why a document could not be mapped.
+type Reason uint8
+
+// The reasons, and the counters they increment.
+const (
+	// ReasonNone is a document that mapped.
+	ReasonNone Reason = iota
+
+	// ReasonForeignDomain is a grant to an email domain that is not the
+	// tenant's. The people it names are real and the index cannot enumerate
+	// them, so it cannot honour the grant and will not approximate it.
+	ReasonForeignDomain
+
+	// ReasonUnmappableDeny is a refusal the model has no deny list for, such as
+	// one aimed at a domain or at everybody. Dropping it would turn a refusal
+	// into silence, which is the one direction that must never happen.
+	ReasonUnmappableDeny
+
+	// ReasonMalformed is a statement naming nobody, such as a user grant with
+	// an empty id.
+	ReasonMalformed
+)
+
+// String returns the name of the reason.
+func (r Reason) String() string {
+	switch r {
+	case ReasonNone:
+		return "none"
+	case ReasonForeignDomain:
+		return "foreign domain"
+	case ReasonUnmappableDeny:
+		return "unmappable deny"
+	case ReasonMalformed:
+		return "malformed grant"
+	default:
+		return "unknown"
+	}
+}
+
+// Error is what a document that could not be mapped failed on.
+type Error struct {
+	Reason Reason
+
+	// Detail names the statement that could not be mapped, so that somebody
+	// reading a log has something to go and look at rather than a count.
+	Detail string
+}
+
+// Error implements error.
+func (e *Error) Error() string {
+	return fmt.Sprintf("aclmap: %s: %s", e.Reason, e.Detail)
+}
+
+// Counts is what a normaliser has seen.
+//
+// Quarantined documents are counted by reason because the three reasons want
+// three different actions. A foreign domain is a decision somebody has to make
+// about the tenant, an unmappable deny is usually a source feature nobody has
+// written the mapping for yet, and a malformed grant is a bug in a connector.
+// One number for all three is a number nobody can act on.
+type Counts struct {
+	// Mapped is documents that produced a usable descriptor.
+	Mapped int64
+
+	// ForeignDomain, UnmappableDeny and Malformed are documents quarantined for
+	// each reason.
+	ForeignDomain  int64
+	UnmappableDeny int64
+	Malformed      int64
+
+	// Ignored is statements whose role does not confer read. It is not a
+	// failure and it is worth watching: a sudden climb usually means a source
+	// renamed a role and the mapping has not caught up, which shows up to
+	// somebody as documents they used to be able to find.
+	Ignored int64
+}
+
+// Quarantined is how many documents were held back.
+func (c Counts) Quarantined() int64 {
+	return c.ForeignDomain + c.UnmappableDeny + c.Malformed
+}
+
+// Normalizer maps one source's statements onto descriptors and counts what it
+// did.
+//
+// It is safe for concurrent use, because a connector that fetches access
+// control lists in parallel is the normal shape of one and having to lock
+// around this would be a reason not to.
+type Normalizer struct {
+	rules Rules
+	read  map[string]bool
+	domas map[string]bool
+
+	mapped  atomic.Int64
+	foreign atomic.Int64
+	denied  atomic.Int64
+	bad     atomic.Int64
+	ignored atomic.Int64
+}
+
+// New returns a normaliser for one source.
+func New(r Rules) (*Normalizer, error) {
+	if r.Source == "" {
+		return nil, errors.New("aclmap: empty source name")
+	}
+	if r.Identity == "" {
+		// Without it every user reference would be compared against the bare
+		// value, so a person called "alice" in one system would match a person
+		// called "alice" in another. That is a silent grant across two
+		// companies' worth of accounts.
+		return nil, errors.New("aclmap: empty identity source")
+	}
+	n := &Normalizer{rules: r, read: make(map[string]bool, len(r.ReadRoles)), domas: make(map[string]bool, len(r.Domains))}
+	for _, role := range r.ReadRoles {
+		n.read[strings.ToLower(role)] = true
+	}
+	for _, d := range r.Domains {
+		n.domas[strings.ToLower(strings.TrimPrefix(d, "@"))] = true
+	}
+	return n, nil
+}
+
+// Counts returns what this normaliser has seen so far.
+func (n *Normalizer) Counts() Counts {
+	return Counts{
+		Mapped:         n.mapped.Load(),
+		ForeignDomain:  n.foreign.Load(),
+		UnmappableDeny: n.denied.Load(),
+		Malformed:      n.bad.Load(),
+		Ignored:        n.ignored.Load(),
+	}
+}
+
+// Normalize turns one document's statements into a descriptor.
+//
+// The descriptor it returns is safe to store whatever the error is. On failure
+// it is [acl.ModeUnknown], which every query path holds back, so a connector
+// that logs the error and carries on has quarantined the document rather than
+// published it.
+//
+// An empty list of statements is not a failure. A document nobody has been
+// given is a document nobody may read, and that is represented exactly: an
+// empty access control list, which allows nobody.
+func (n *Normalizer) Normalize(grants []Grant) (acl.Permissions, error) {
+	perm := acl.Permissions{Mode: acl.ModeACL, Source: n.rules.Source}
+	var owners int
+
+	for _, g := range grants {
+		if err := n.apply(&perm, g, &owners); err != nil {
+			n.count(err)
+			return n.unresolved(), err
+		}
+	}
+
+	// A document whose only statement is its owner is owner only rather than an
+	// access control list with one name in it. The two behave the same today
+	// and they do not mean the same thing, and the mode is what a later feature
+	// such as "everything of mine" reads.
+	if owners == 1 && len(perm.AllowUsers) == 0 && len(perm.AllowGroups) == 0 && perm.Mode == acl.ModeACL {
+		perm.Mode = acl.ModeOwnerOnly
+	}
+
+	n.mapped.Add(1)
+	return perm, nil
+}
+
+// apply folds one statement into the descriptor being built.
+func (n *Normalizer) apply(perm *acl.Permissions, g Grant, owners *int) error {
+	if g.Subject != Anyone && g.ID == "" {
+		return &Error{Reason: ReasonMalformed, Detail: g.Subject.String() + " grant naming nobody"}
+	}
+	if !n.confers(g.Role) {
+		// A role outside the read set is not a failure and not a grant. Somebody
+		// who may change a label may not read the document, and a source that
+		// says so is being precise rather than obstructive.
+		n.ignored.Add(1)
+		return nil
+	}
+
+	if g.Effect == Deny {
+		return n.deny(perm, g)
+	}
+	return n.allow(perm, g, owners)
+}
+
+// deny puts a refusal in the right list, or refuses to map the document.
+func (n *Normalizer) deny(perm *acl.Permissions, g Grant) error {
+	switch g.Subject {
+	case User:
+		perm.DenyUsers = appendRef(perm.DenyUsers, acl.Ref{Source: n.rules.Identity, Value: g.ID})
+		return nil
+	case Group:
+		perm.DenyGroups = appendRef(perm.DenyGroups, acl.Ref{Source: n.rules.Identity, Value: g.ID})
+		return nil
+	case Domain, Anyone:
+		// There is no deny list for these, and there is no safe approximation
+		// either. Treating a refusal aimed at a domain as one aimed at nobody
+		// would keep the document readable by exactly the people it was taken
+		// away from.
+		return &Error{Reason: ReasonUnmappableDeny, Detail: "a deny aimed at " + n.subjectName(g)}
+	default:
+		return &Error{Reason: ReasonMalformed, Detail: "unknown subject"}
+	}
+}
+
+// allow puts a grant in the right list, or widens the mode.
+func (n *Normalizer) allow(perm *acl.Permissions, g Grant, owners *int) error {
+	switch g.Subject {
+	case User:
+		ref := acl.Ref{Source: n.rules.Identity, Value: g.ID}
+		// The first owner is the owner. A source that reports several, which
+		// several do, keeps the rest as ordinary readers, because one field
+		// cannot hold two of them and dropping the others would take away
+		// access somebody has.
+		if g.Owner {
+			*owners++
+			if perm.Owner.Value == "" {
+				perm.Owner = ref
+				return nil
+			}
+		}
+		perm.AllowUsers = appendRef(perm.AllowUsers, ref)
+		return nil
+
+	case Group:
+		perm.AllowGroups = appendRef(perm.AllowGroups, acl.Ref{Source: n.rules.Identity, Value: g.ID})
+		return nil
+
+	case Domain:
+		if !n.domas[strings.ToLower(strings.TrimPrefix(g.ID, "@"))] {
+			return &Error{Reason: ReasonForeignDomain, Detail: "a grant to " + g.ID}
+		}
+		n.widen(perm, acl.ModePublicToTenant)
+		return nil
+
+	case Anyone:
+		return n.anyone(perm, g)
+
+	default:
+		return &Error{Reason: ReasonMalformed, Detail: "unknown subject"}
+	}
+}
+
+// anyone handles the two statements that carry no subject: a public document
+// and a link share.
+func (n *Normalizer) anyone(perm *acl.Permissions, g Grant) error {
+	if g.Link {
+		perm.Sharing = maxSharing(perm.Sharing, acl.SharedByLink)
+		if n.rules.Link == LinkGrantsTenant {
+			n.widen(perm, acl.ModePublicToTenant)
+		}
+		return nil
+	}
+	// Not a link, so the source is saying the document is out in the open. It
+	// is readable by everybody in the deployment, and the fact that it reaches
+	// further than that is recorded rather than lost.
+	perm.Sharing = maxSharing(perm.Sharing, acl.SharedPublic)
+	n.widen(perm, acl.ModePublicToTenant)
+	return nil
+}
+
+// widen moves the mode outwards and never inwards, so that the order the
+// statements arrived in cannot change the answer.
+func (n *Normalizer) widen(perm *acl.Permissions, m acl.Mode) {
+	if perm.Mode != acl.ModePublicToTenant {
+		perm.Mode = m
+	}
+}
+
+// unresolved is the descriptor a quarantined document gets. It names its source
+// so that a report can say which connector the document came from, and says
+// nothing else, because nothing else was established.
+func (n *Normalizer) unresolved() acl.Permissions {
+	return acl.Permissions{Mode: acl.ModeUnknown, Source: n.rules.Source}
+}
+
+// confers reports whether a role grants reading.
+func (n *Normalizer) confers(role string) bool {
+	// No role at all is a statement about reading. Several systems attach no
+	// role to a share, and a connector should not have to invent one.
+	if role == "" || len(n.read) == 0 {
+		return true
+	}
+	return n.read[strings.ToLower(role)]
+}
+
+// subjectName is how a statement's subject reads in an error.
+func (n *Normalizer) subjectName(g Grant) string {
+	if g.Subject == Anyone {
+		return "everybody"
+	}
+	return g.Subject.String() + " " + g.ID
+}
+
+// count increments the counter for a failure.
+func (n *Normalizer) count(err error) {
+	var e *Error
+	if !errors.As(err, &e) {
+		return
+	}
+	switch e.Reason {
+	case ReasonForeignDomain:
+		n.foreign.Add(1)
+	case ReasonUnmappableDeny:
+		n.denied.Add(1)
+	case ReasonMalformed, ReasonNone:
+		n.bad.Add(1)
+	}
+}
+
+// appendRef adds a reference unless it is already there.
+//
+// Duplicates are common, because a source that reports a person twice under two
+// roles is reporting the truth, and they are worth removing here rather than in
+// every driver: the lists end up in a query, and a list with a name in it four
+// times is four terms in that query.
+func appendRef(refs []acl.Ref, r acl.Ref) []acl.Ref {
+	for _, have := range refs {
+		if have == r {
+			return refs
+		}
+	}
+	return append(refs, r)
+}
+
+// maxSharing keeps the widest sharing seen, so that a document both link shared
+// and public is recorded as public.
+func maxSharing(a, b acl.Sharing) acl.Sharing {
+	if b > a {
+		return b
+	}
+	return a
+}

--- a/connector/aclmap/aclmap_test.go
+++ b/connector/aclmap/aclmap_test.go
@@ -1,0 +1,420 @@
+package aclmap_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/aclmap"
+)
+
+// person builds a principal known to one identity source, in the groups named.
+func person(identity, id string, groups ...string) *acl.Principal {
+	members := make([]string, 0, len(groups))
+	for _, g := range groups {
+		members = append(members, identity+":"+g)
+	}
+	return &acl.Principal{
+		Tenant:     "acme",
+		Subject:    "u-" + id,
+		Kind:       acl.KindUser,
+		Identities: []acl.Identity{{Source: identity, Value: id}},
+		Groups:     acl.GroupSet{Version: 1, Members: members},
+	}
+}
+
+func mustNew(t *testing.T, r aclmap.Rules) *aclmap.Normalizer {
+	t.Helper()
+	n, err := aclmap.New(r)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	return n
+}
+
+func TestNewRefusesRulesItCannotUse(t *testing.T) {
+	if _, err := aclmap.New(aclmap.Rules{Identity: "google"}); err == nil {
+		t.Error("a mapping with no source name was accepted")
+	}
+	// Without an identity source every user reference is compared as a bare
+	// value, so alice at one company matches alice at another.
+	if _, err := aclmap.New(aclmap.Rules{Source: "drive"}); err == nil {
+		t.Error("a mapping with no identity source was accepted")
+	}
+}
+
+// TestADenyBeatsAnAllow is the rule the whole package is arranged around, and
+// it is checked through Allows rather than by reading the lists, because the
+// lists are only worth anything if the evaluation order is right.
+func TestADenyBeatsAnAllow(t *testing.T) {
+	n := mustNew(t, aclmap.Drive("drive", "google", "acme.com"))
+
+	tests := []struct {
+		name   string
+		grants []aclmap.Grant
+		who    *acl.Principal
+		want   bool
+	}{
+		{
+			name: "a person named in both lists is refused",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.User, ID: "alice@acme.com", Role: "reader"},
+				{Subject: aclmap.User, ID: "alice@acme.com", Role: "reader", Effect: aclmap.Deny},
+			},
+			who:  person("google", "alice@acme.com"),
+			want: false,
+		},
+		{
+			name: "the order the statements arrived in does not matter",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.User, ID: "alice@acme.com", Role: "reader", Effect: aclmap.Deny},
+				{Subject: aclmap.User, ID: "alice@acme.com", Role: "reader"},
+			},
+			who:  person("google", "alice@acme.com"),
+			want: false,
+		},
+		{
+			name: "a group deny beats a group allow",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Group, ID: "eng@acme.com", Role: "writer"},
+				{Subject: aclmap.Group, ID: "contractors@acme.com", Role: "reader", Effect: aclmap.Deny},
+			},
+			who:  person("google", "bob@acme.com", "eng@acme.com", "contractors@acme.com"),
+			want: false,
+		},
+		{
+			name: "a deny on one person does not refuse another",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Group, ID: "eng@acme.com", Role: "writer"},
+				{Subject: aclmap.User, ID: "alice@acme.com", Role: "reader", Effect: aclmap.Deny},
+			},
+			who:  person("google", "bob@acme.com", "eng@acme.com"),
+			want: true,
+		},
+		{
+			name: "a deny beats the whole domain",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Domain, ID: "acme.com", Role: "reader"},
+				{Subject: aclmap.User, ID: "alice@acme.com", Role: "reader", Effect: aclmap.Deny},
+			},
+			who:  person("google", "alice@acme.com"),
+			want: false,
+		},
+		{
+			name: "a deny beats being the owner",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+				{Subject: aclmap.User, ID: "alice@acme.com", Role: "reader", Effect: aclmap.Deny},
+			},
+			who:  person("google", "alice@acme.com"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			perm, err := n.Normalize(tt.grants)
+			if err != nil {
+				t.Fatalf("normalize: %v", err)
+			}
+			if got := perm.Allows(tt.who); got != tt.want {
+				t.Errorf("allows is %v, want %v, from %+v", got, tt.want, perm)
+			}
+		})
+	}
+}
+
+// TestWhatCannotBeMappedIsQuarantinedAndCounted is the other half of the same
+// rule. Approximating a statement is how a document reaches somebody it was
+// taken away from, so nothing is approximated.
+func TestWhatCannotBeMappedIsQuarantinedAndCounted(t *testing.T) {
+	tests := []struct {
+		name   string
+		grants []aclmap.Grant
+		reason aclmap.Reason
+		count  func(aclmap.Counts) int64
+	}{
+		{
+			name:   "a grant to somebody else's domain",
+			grants: []aclmap.Grant{{Subject: aclmap.Domain, ID: "partner.example", Role: "reader"}},
+			reason: aclmap.ReasonForeignDomain,
+			count:  func(c aclmap.Counts) int64 { return c.ForeignDomain },
+		},
+		{
+			name:   "a refusal aimed at a domain",
+			grants: []aclmap.Grant{{Subject: aclmap.Domain, ID: "acme.com", Role: "reader", Effect: aclmap.Deny}},
+			reason: aclmap.ReasonUnmappableDeny,
+			count:  func(c aclmap.Counts) int64 { return c.UnmappableDeny },
+		},
+		{
+			name:   "a refusal aimed at everybody",
+			grants: []aclmap.Grant{{Subject: aclmap.Anyone, Role: "reader", Effect: aclmap.Deny}},
+			reason: aclmap.ReasonUnmappableDeny,
+			count:  func(c aclmap.Counts) int64 { return c.UnmappableDeny },
+		},
+		{
+			name:   "a grant naming nobody",
+			grants: []aclmap.Grant{{Subject: aclmap.User, Role: "reader"}},
+			reason: aclmap.ReasonMalformed,
+			count:  func(c aclmap.Counts) int64 { return c.Malformed },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := mustNew(t, aclmap.Drive("drive", "google", "acme.com"))
+			perm, err := n.Normalize(tt.grants)
+
+			var mapErr *aclmap.Error
+			if !errors.As(err, &mapErr) {
+				t.Fatalf("normalize returned %v, want an aclmap.Error", err)
+			}
+			if mapErr.Reason != tt.reason {
+				t.Errorf("reason is %v, want %v", mapErr.Reason, tt.reason)
+			}
+			if mapErr.Detail == "" {
+				t.Error("the error names nothing, so there is nothing to go and look at")
+			}
+
+			// The descriptor is the thing that matters. A connector that logs
+			// the error and carries on has to end up with a document nobody can
+			// read, not one nobody restricted.
+			if perm.Mode != acl.ModeUnknown {
+				t.Errorf("mode is %v, want unknown", perm.Mode)
+			}
+			if perm.Allows(person("google", "alice@acme.com")) {
+				t.Error("a quarantined document is readable")
+			}
+
+			counts := n.Counts()
+			if tt.count(counts) != 1 {
+				t.Errorf("the reason was not counted: %+v", counts)
+			}
+			if counts.Quarantined() != 1 || counts.Mapped != 0 {
+				t.Errorf("counts are %+v, want one quarantined and nothing mapped", counts)
+			}
+		})
+	}
+}
+
+// TestLinkSharingIsRecordedRatherThanInferred is the case where the absence of
+// a restriction is not the same as a decision. A link shared document has been
+// shared, and an index that stores only its allow list cannot say so.
+func TestLinkSharingIsRecordedRatherThanInferred(t *testing.T) {
+	grants := []aclmap.Grant{
+		{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+		{Subject: aclmap.Anyone, Role: "reader", Link: true},
+	}
+	stranger := person("google", "mallory@acme.com")
+
+	t.Run("by default a link is not a search grant", func(t *testing.T) {
+		n := mustNew(t, aclmap.Drive("drive", "google", "acme.com"))
+		perm, err := n.Normalize(grants)
+		if err != nil {
+			t.Fatalf("normalize: %v", err)
+		}
+		if perm.Sharing != acl.SharedByLink {
+			t.Errorf("sharing is %v, want link", perm.Sharing)
+		}
+		// Somebody who has the link was given it. Somebody searching was not,
+		// and the difference is the whole reason this is a setting.
+		if perm.Allows(stranger) {
+			t.Error("a link share was turned into a search result for somebody who never had the link")
+		}
+		if !perm.Allows(person("google", "alice@acme.com")) {
+			t.Error("the owner lost access")
+		}
+	})
+
+	t.Run("a deployment can say a link means the company", func(t *testing.T) {
+		rules := aclmap.Drive("drive", "google", "acme.com")
+		rules.Link = aclmap.LinkGrantsTenant
+		n := mustNew(t, rules)
+
+		perm, err := n.Normalize(grants)
+		if err != nil {
+			t.Fatalf("normalize: %v", err)
+		}
+		if perm.Mode != acl.ModePublicToTenant {
+			t.Errorf("mode is %v, want public to tenant", perm.Mode)
+		}
+		// Still recorded, because how it became readable is a separate fact
+		// from whether it is.
+		if perm.Sharing != acl.SharedByLink {
+			t.Errorf("sharing is %v, want link", perm.Sharing)
+		}
+		if !perm.Allows(stranger) {
+			t.Error("the setting was asked for and did nothing")
+		}
+	})
+}
+
+func TestAPublicDocumentSaysSo(t *testing.T) {
+	n := mustNew(t, aclmap.Drive("drive", "google", "acme.com"))
+
+	perm, err := n.Normalize([]aclmap.Grant{
+		{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+		{Subject: aclmap.Anyone, Role: "reader"},
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if perm.Sharing != acl.SharedPublic {
+		t.Errorf("sharing is %v, want public", perm.Sharing)
+	}
+	if perm.Mode != acl.ModePublicToTenant {
+		t.Errorf("mode is %v, want public to tenant", perm.Mode)
+	}
+	if !perm.Allows(person("google", "anybody@acme.com")) {
+		t.Error("a document its source says is on the internet is not readable inside the company")
+	}
+}
+
+// A widening statement cannot be undone by one that arrived after it, because
+// the order an API returns permissions in is not a statement about anything.
+func TestTheOrderOfStatementsDoesNotChangeTheAnswer(t *testing.T) {
+	n := mustNew(t, aclmap.Drive("drive", "google", "acme.com"))
+
+	forward, err := n.Normalize([]aclmap.Grant{
+		{Subject: aclmap.Domain, ID: "acme.com", Role: "reader"},
+		{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	backward, err := n.Normalize([]aclmap.Grant{
+		{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+		{Subject: aclmap.Domain, ID: "acme.com", Role: "reader"},
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if forward.Mode != acl.ModePublicToTenant || backward.Mode != acl.ModePublicToTenant {
+		t.Errorf("modes are %v and %v, want both public to tenant", forward.Mode, backward.Mode)
+	}
+}
+
+func TestARoleThatDoesNotConferReadIsNotAGrant(t *testing.T) {
+	// Object storage is where this bites hardest. WRITE on a bucket is
+	// permission to put objects into it and says nothing about reading them.
+	n := mustNew(t, aclmap.ObjectStore("s3", "aws", "acme.com"))
+
+	perm, err := n.Normalize([]aclmap.Grant{
+		{Subject: aclmap.User, ID: "uploader", Role: "WRITE"},
+		{Subject: aclmap.User, ID: "reader", Role: "READ"},
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if perm.Allows(person("aws", "uploader")) {
+		t.Error("somebody who may upload to a bucket can read what is in it")
+	}
+	if !perm.Allows(person("aws", "reader")) {
+		t.Error("somebody granted READ cannot read")
+	}
+	// Counted, because a climb in this number usually means a source renamed a
+	// role and the mapping has not caught up.
+	if c := n.Counts(); c.Ignored != 1 {
+		t.Errorf("ignored %d statements, want 1: %+v", c.Ignored, c)
+	}
+}
+
+func TestADocumentWithOnlyAnOwnerIsOwnerOnly(t *testing.T) {
+	n := mustNew(t, aclmap.Drive("drive", "google", "acme.com"))
+
+	perm, err := n.Normalize([]aclmap.Grant{
+		{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if perm.Mode != acl.ModeOwnerOnly {
+		t.Errorf("mode is %v, want owner only", perm.Mode)
+	}
+	if !perm.Allows(person("google", "alice@acme.com")) {
+		t.Error("the owner cannot read their own document")
+	}
+	if perm.Allows(person("google", "bob@acme.com")) {
+		t.Error("somebody else can read a private document")
+	}
+}
+
+// A second owner keeps their access. One field cannot hold two of them, and
+// dropping the rest would take away access somebody has.
+func TestASecondOwnerStaysAReader(t *testing.T) {
+	n := mustNew(t, aclmap.Drive("drive", "google", "acme.com"))
+
+	perm, err := n.Normalize([]aclmap.Grant{
+		{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+		{Subject: aclmap.User, ID: "bob@acme.com", Role: "owner", Owner: true},
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if perm.Owner.Value != "alice@acme.com" {
+		t.Errorf("owner is %q, want the first one reported", perm.Owner.Value)
+	}
+	for _, who := range []string{"alice@acme.com", "bob@acme.com"} {
+		if !perm.Allows(person("google", who)) {
+			t.Errorf("%s cannot read a document they own", who)
+		}
+	}
+}
+
+// A document nobody has been given is readable by nobody, and that is a mapped
+// document rather than a failure. There is nothing wrong with it and nothing to
+// go and fix.
+func TestNoStatementsIsAnEmptyListRatherThanAFailure(t *testing.T) {
+	n := mustNew(t, aclmap.Drive("drive", "google", "acme.com"))
+
+	perm, err := n.Normalize(nil)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if perm.Mode != acl.ModeACL {
+		t.Errorf("mode is %v, want an access control list", perm.Mode)
+	}
+	if perm.Allows(person("google", "alice@acme.com")) {
+		t.Error("a document nobody was given is readable")
+	}
+	if c := n.Counts(); c.Mapped != 1 || c.Quarantined() != 0 {
+		t.Errorf("counts are %+v, want it counted as mapped", c)
+	}
+}
+
+// A source reporting the same person twice under two roles is reporting the
+// truth. The lists end up in a query, and a name in one four times is four
+// terms in that query.
+func TestRepeatedStatementsCollapse(t *testing.T) {
+	n := mustNew(t, aclmap.Drive("drive", "google", "acme.com"))
+
+	perm, err := n.Normalize([]aclmap.Grant{
+		{Subject: aclmap.User, ID: "alice@acme.com", Role: "writer"},
+		{Subject: aclmap.User, ID: "alice@acme.com", Role: "commenter"},
+		{Subject: aclmap.Group, ID: "eng@acme.com", Role: "reader"},
+		{Subject: aclmap.Group, ID: "eng@acme.com", Role: "writer"},
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if len(perm.AllowUsers) != 1 || len(perm.AllowGroups) != 1 {
+		t.Errorf("lists are %v and %v, want one entry each", perm.AllowUsers, perm.AllowGroups)
+	}
+}
+
+func TestTheDescriptorNamesItsSourceAndIdentity(t *testing.T) {
+	n := mustNew(t, aclmap.Drive("drive", "google", "acme.com"))
+
+	perm, err := n.Normalize([]aclmap.Grant{{Subject: aclmap.Group, ID: "eng@acme.com", Role: "reader"}})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if perm.Source != "drive" {
+		t.Errorf("source is %q, want the connector name", perm.Source)
+	}
+	// The identity source is what lets somebody who authenticated through one
+	// system match a list written in terms of another.
+	if perm.AllowGroups[0].Source != "google" {
+		t.Errorf("the group reference belongs to %q, want google", perm.AllowGroups[0].Source)
+	}
+}

--- a/connector/aclmap/sources.go
+++ b/connector/aclmap/sources.go
@@ -1,0 +1,140 @@
+package aclmap
+
+// The vocabularies of the systems this project indexes.
+//
+// Every list below is the source system's own set of names, taken from its
+// documentation rather than invented here, and that is the point of keeping
+// them in one file. A role name is a fact about somebody else's product. It
+// changes when they change it, it is the thing that goes stale, and when it
+// does the symptom is documents quietly disappearing from search for the people
+// who could read them yesterday. Having all of them in one place means the
+// staleness is in one place, next to the tests that pin it.
+//
+// Each preset takes the connector's name, the identity source its ids belong
+// to, and the email domains that are this tenant. What it does not take is a
+// link policy, because that is a decision about a company rather than about a
+// product, and the default is the safe one.
+
+// Files is the mapping for a file system connector.
+//
+// A tree has no permission model of its own worth reading, so the roles here
+// are the ones a policy over the tree invents. The OWNERS convention that
+// Kubernetes and a number of other large repositories keep names approvers and
+// reviewers, and both are people who can read the subtree.
+//
+// There is no deny in an OWNERS file, and no link sharing either. A subtree
+// narrows what its parent allowed by replacing the list rather than by refusing
+// anybody, which is why the file system connector never produces a deny and
+// nothing here has to map one.
+func Files(source, identity string, domains ...string) Rules {
+	return Rules{
+		Source:    source,
+		Identity:  identity,
+		ReadRoles: []string{"approver", "reviewer", "owner"},
+		Domains:   domains,
+	}
+}
+
+// ObjectStore is the mapping for S3 and the object stores that copy its access
+// control lists.
+//
+// The permissions are S3's five: READ, WRITE, READ_ACP, WRITE_ACP and
+// FULL_CONTROL. Only two of them let somebody read the object, and the
+// distinction matters more here than it looks: WRITE on a bucket is permission
+// to put objects into it, not to read them, and a mapping that treated every
+// permission as read would hand a company's private buckets to whoever can
+// upload to them.
+//
+// The two group grantees are the ones that reach outside a company.
+// AllUsers means the open internet and maps to a public document. Anybody
+// authenticated is every account holder at the provider, which is not this
+// tenant and is not enumerable, so it quarantines like any other foreign
+// domain. A connector reports that one as a [Domain] grant to
+// "authenticated-users".
+func ObjectStore(source, identity string, domains ...string) Rules {
+	return Rules{
+		Source:    source,
+		Identity:  identity,
+		ReadRoles: []string{"read", "full_control"},
+		Domains:   domains,
+	}
+}
+
+// Drive is the mapping for a document store of the Google Drive shape.
+//
+// The roles are Drive's own: owner, organizer, fileOrganizer, writer,
+// commenter and reader. All six can read the file, which is worth stating
+// because it is the case where the obvious mapping is right and somebody will
+// otherwise wonder whether commenter was left out by mistake.
+//
+// This is the source that has all four subjects. A permission can name a user,
+// a group, a domain or anyone, and anyone can be qualified with a link, which
+// is why [LinkPolicy] exists at all.
+func Drive(source, identity string, domains ...string) Rules {
+	return Rules{
+		Source:    source,
+		Identity:  identity,
+		ReadRoles: []string{"owner", "organizer", "fileorganizer", "writer", "commenter", "reader"},
+		Domains:   domains,
+	}
+}
+
+// Chat is the mapping for a chat system of the Slack shape.
+//
+// Chat has almost no vocabulary, because a message's access is the channel's
+// membership and nothing else. A connector reports a private channel as a group
+// grant naming the channel, a public one as a domain grant to the workspace's
+// domain, and a direct message as a user grant per participant.
+//
+// The role is empty on all of them, which is what an empty [Rules.ReadRoles]
+// list is for: a member of a channel reads the channel, and there is nothing
+// finer to say.
+func Chat(source, identity string, domains ...string) Rules {
+	return Rules{
+		Source:   source,
+		Identity: identity,
+		Domains:  domains,
+	}
+}
+
+// Wiki is the mapping for a wiki of the Confluence shape.
+//
+// Space permissions carry names such as VIEW and EDIT, and a page can then
+// carry restrictions that narrow the space. Confluence has two kinds of
+// restriction and only one of them is a refusal in the sense used here: a view
+// restriction listing people replaces the space's answer for that page, which a
+// connector reports as an allow list, while an explicit exclusion is a deny.
+//
+// A connector that reports the space permissions and then the page restrictions
+// gets the right answer from this package for free, because a deny is applied
+// before any allow whatever order the statements arrived in.
+func Wiki(source, identity string, domains ...string) Rules {
+	return Rules{
+		Source:    source,
+		Identity:  identity,
+		ReadRoles: []string{"view", "read", "edit", "admin"},
+		Domains:   domains,
+	}
+}
+
+// Tickets is the mapping for an issue tracker of the Jira shape.
+//
+// Reading an issue takes the BROWSE_PROJECTS permission on its project, which
+// a permission scheme grants to users, groups and project roles. A connector
+// reports a project role as a group, because that is what it is: a named set of
+// people maintained by the source.
+//
+// The part that catches people out is issue security. A project can carry
+// security levels that narrow an individual issue to a subset of the people who
+// can browse the project, and an issue with a security level set is not
+// readable by the project's list at all. A connector must report the security
+// level's members and nothing else for such an issue, because reporting both
+// would widen it back to the project.
+func Tickets(source, identity string, domains ...string) Rules {
+	return Rules{
+		Source:    source,
+		Identity:  identity,
+		ReadRoles: []string{"browse_projects", "administer_projects"},
+		Domains:   domains,
+	}
+}

--- a/connector/aclmap/sources_test.go
+++ b/connector/aclmap/sources_test.go
@@ -1,0 +1,331 @@
+package aclmap_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/aclmap"
+)
+
+// mapCase is one statement of what a source said and what the index should make
+// of it.
+//
+// The tables below are the documented mapping for each source, in the form that
+// fails the build when somebody changes it. docs/permissions.md is the same
+// tables in prose, and the two are meant to be read together.
+type mapCase struct {
+	name   string
+	grants []aclmap.Grant
+
+	// mode and sharing are what the descriptor should say. They are only
+	// checked when reason is ReasonNone.
+	mode    acl.Mode
+	sharing acl.Sharing
+
+	// reason is the failure expected, or ReasonNone for a document that maps.
+	reason aclmap.Reason
+
+	// can and cannot are the people the answer is really about.
+	can    []*acl.Principal
+	cannot []*acl.Principal
+}
+
+func runCases(t *testing.T, rules aclmap.Rules, cases []mapCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := mustNew(t, rules)
+			perm, err := n.Normalize(tc.grants)
+
+			if tc.reason != aclmap.ReasonNone {
+				var mapErr *aclmap.Error
+				if !errors.As(err, &mapErr) {
+					t.Fatalf("normalize returned %v, want an aclmap.Error", err)
+				}
+				if mapErr.Reason != tc.reason {
+					t.Fatalf("reason is %v, want %v", mapErr.Reason, tc.reason)
+				}
+				if perm.Mode != acl.ModeUnknown {
+					t.Fatalf("mode is %v, want unknown", perm.Mode)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("normalize: %v", err)
+				}
+				if perm.Mode != tc.mode {
+					t.Errorf("mode is %v, want %v", perm.Mode, tc.mode)
+				}
+				if perm.Sharing != tc.sharing {
+					t.Errorf("sharing is %v, want %v", perm.Sharing, tc.sharing)
+				}
+			}
+
+			for _, p := range tc.can {
+				if !perm.Allows(p) {
+					t.Errorf("%s cannot read it", p.Subject)
+				}
+			}
+			for _, p := range tc.cannot {
+				if perm.Allows(p) {
+					t.Errorf("%s can read it", p.Subject)
+				}
+			}
+		})
+	}
+}
+
+// A file system has no permission model of its own worth reading, so the roles
+// are the ones the OWNERS convention invents. There is no deny in an OWNERS
+// file: a subtree narrows what its parent allowed by replacing the list rather
+// than by refusing anybody.
+func TestFilesMapping(t *testing.T) {
+	rules := aclmap.Files("handbook", "github")
+	alice := person("github", "alice")
+	bob := person("github", "bob")
+	mallory := person("github", "mallory")
+
+	runCases(t, rules, []mapCase{
+		{
+			name: "approvers and reviewers both read",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.User, ID: "alice", Role: "approver"},
+				{Subject: aclmap.User, ID: "bob", Role: "reviewer"},
+			},
+			mode:   acl.ModeACL,
+			can:    []*acl.Principal{alice, bob},
+			cannot: []*acl.Principal{mallory},
+		},
+		{
+			name:   "a subtree with no OWNERS file above it grants nobody",
+			grants: nil,
+			mode:   acl.ModeACL,
+			cannot: []*acl.Principal{alice, bob, mallory},
+		},
+		{
+			name: "a file with one owner and nobody else is owner only",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.User, ID: "alice", Role: "owner", Owner: true},
+			},
+			mode:   acl.ModeOwnerOnly,
+			can:    []*acl.Principal{alice},
+			cannot: []*acl.Principal{bob},
+		},
+	})
+}
+
+// S3 and the object stores that copy its access control lists. The permissions
+// are S3's five and only two of them let anybody read the object.
+func TestObjectStoreMapping(t *testing.T) {
+	rules := aclmap.ObjectStore("archive", "aws", "acme.com")
+	reader := person("aws", "canonical-1")
+	uploader := person("aws", "canonical-2")
+
+	runCases(t, rules, []mapCase{
+		{
+			name: "READ and FULL_CONTROL read, the rest do not",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.User, ID: "canonical-1", Role: "READ"},
+				{Subject: aclmap.User, ID: "canonical-2", Role: "WRITE"},
+			},
+			mode:   acl.ModeACL,
+			can:    []*acl.Principal{reader},
+			cannot: []*acl.Principal{uploader},
+		},
+		{
+			name: "the AllUsers group is the open internet",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Anyone, Role: "READ"},
+			},
+			mode:    acl.ModePublicToTenant,
+			sharing: acl.SharedPublic,
+			can:     []*acl.Principal{reader, uploader},
+		},
+		{
+			// Every account holder at the provider is not this company and
+			// cannot be enumerated, so there is nothing faithful to store.
+			name: "the authenticated users group is not the tenant",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Domain, ID: "authenticated-users", Role: "READ"},
+			},
+			reason: aclmap.ReasonForeignDomain,
+			cannot: []*acl.Principal{reader},
+		},
+		{
+			name: "a bucket policy that denies one account",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Domain, ID: "acme.com", Role: "READ"},
+				{Subject: aclmap.User, ID: "canonical-2", Role: "READ", Effect: aclmap.Deny},
+			},
+			mode:   acl.ModePublicToTenant,
+			can:    []*acl.Principal{reader},
+			cannot: []*acl.Principal{uploader},
+		},
+	})
+}
+
+// A document store of the Google Drive shape is the source with all four
+// subjects, and the only one where a share can be qualified with a link.
+func TestDriveMapping(t *testing.T) {
+	rules := aclmap.Drive("drive", "google", "acme.com")
+	alice := person("google", "alice@acme.com")
+	eng := person("google", "bob@acme.com", "eng@acme.com")
+	anyone := person("google", "mallory@acme.com")
+
+	runCases(t, rules, []mapCase{
+		{
+			name: "every role from owner to commenter reads",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+				{Subject: aclmap.Group, ID: "eng@acme.com", Role: "commenter"},
+			},
+			mode:   acl.ModeACL,
+			can:    []*acl.Principal{alice, eng},
+			cannot: []*acl.Principal{anyone},
+		},
+		{
+			name: "a grant to the company domain is everybody in it",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Domain, ID: "acme.com", Role: "reader"},
+			},
+			mode: acl.ModePublicToTenant,
+			can:  []*acl.Principal{alice, eng, anyone},
+		},
+		{
+			name: "a grant to a partner's domain names people this index cannot",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Domain, ID: "partner.example", Role: "reader"},
+			},
+			reason: aclmap.ReasonForeignDomain,
+			cannot: []*acl.Principal{alice, eng, anyone},
+		},
+		{
+			name: "a link share is recorded and grants nothing by default",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+				{Subject: aclmap.Anyone, Role: "reader", Link: true},
+			},
+			mode:    acl.ModeOwnerOnly,
+			sharing: acl.SharedByLink,
+			can:     []*acl.Principal{alice},
+			cannot:  []*acl.Principal{eng, anyone},
+		},
+		{
+			name: "published to the internet is public and says so",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Anyone, Role: "reader"},
+			},
+			mode:    acl.ModePublicToTenant,
+			sharing: acl.SharedPublic,
+			can:     []*acl.Principal{alice, anyone},
+		},
+	})
+}
+
+// Chat has almost no vocabulary, because a message's access is the channel's
+// membership and nothing else.
+func TestChatMapping(t *testing.T) {
+	rules := aclmap.Chat("slack", "slack", "acme.com")
+	member := person("slack", "U04AB", "C-private")
+	other := person("slack", "U04CD")
+
+	runCases(t, rules, []mapCase{
+		{
+			name: "a private channel is its membership",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Group, ID: "C-private"},
+			},
+			mode:   acl.ModeACL,
+			can:    []*acl.Principal{member},
+			cannot: []*acl.Principal{other},
+		},
+		{
+			name: "a public channel is the workspace",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Domain, ID: "acme.com"},
+			},
+			mode: acl.ModePublicToTenant,
+			can:  []*acl.Principal{member, other},
+		},
+		{
+			name: "a direct message is its participants",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.User, ID: "U04AB"},
+				{Subject: aclmap.User, ID: "U04EF"},
+			},
+			mode:   acl.ModeACL,
+			can:    []*acl.Principal{member},
+			cannot: []*acl.Principal{other},
+		},
+	})
+}
+
+// A wiki of the Confluence shape has space permissions and then page
+// restrictions that narrow them, and an exclusion is a real refusal.
+func TestWikiMapping(t *testing.T) {
+	rules := aclmap.Wiki("wiki", "atlassian", "acme.com")
+	staff := person("atlassian", "alice", "staff")
+	contractor := person("atlassian", "dave", "staff", "contractors")
+
+	runCases(t, rules, []mapCase{
+		{
+			name: "a space grants VIEW to a group",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Group, ID: "staff", Role: "VIEW"},
+			},
+			mode: acl.ModeACL,
+			can:  []*acl.Principal{staff, contractor},
+		},
+		{
+			name: "a page restriction refuses inside a space that allows",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Group, ID: "staff", Role: "VIEW"},
+				{Subject: aclmap.Group, ID: "contractors", Role: "VIEW", Effect: aclmap.Deny},
+			},
+			mode:   acl.ModeACL,
+			can:    []*acl.Principal{staff},
+			cannot: []*acl.Principal{contractor},
+		},
+	})
+}
+
+// An issue tracker of the Jira shape grants reading through BROWSE_PROJECTS,
+// and issue security levels narrow individual issues below that.
+func TestTicketsMapping(t *testing.T) {
+	rules := aclmap.Tickets("jira", "atlassian", "acme.com")
+	developer := person("atlassian", "alice", "developers")
+	security := person("atlassian", "erin", "security-team")
+
+	runCases(t, rules, []mapCase{
+		{
+			name: "a project role can browse the project",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Group, ID: "developers", Role: "BROWSE_PROJECTS"},
+			},
+			mode:   acl.ModeACL,
+			can:    []*acl.Principal{developer},
+			cannot: []*acl.Principal{security},
+		},
+		{
+			// The connector reports the security level and nothing else for an
+			// issue that has one. Reporting the project's list as well would
+			// widen the issue straight back to the project, which is the whole
+			// thing the level exists to stop.
+			name: "an issue with a security level is only its level",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Group, ID: "security-team", Role: "BROWSE_PROJECTS"},
+			},
+			mode:   acl.ModeACL,
+			can:    []*acl.Principal{security},
+			cannot: []*acl.Principal{developer},
+		},
+		{
+			name: "a permission to administer a project also reads it",
+			grants: []aclmap.Grant{
+				{Subject: aclmap.Group, ID: "developers", Role: "ADMINISTER_PROJECTS"},
+			},
+			mode: acl.ModeACL,
+			can:  []*acl.Principal{developer},
+		},
+	})
+}

--- a/connector/fssource/maintain_test.go
+++ b/connector/fssource/maintain_test.go
@@ -259,6 +259,19 @@ func TestAnOwnersEditIsAPermissionChangeAndNotARecrawl(t *testing.T) {
 		"other/OWNERS":   "approvers:\n  - carol\n",
 		"other/notes.md": "# notes\n",
 	})
+	// The OWNERS files are backdated because they are not part of the corpus and
+	// so never contribute to the cursor, which is the highest modification time
+	// the walk saw. Written in the same instant as the documents they govern,
+	// whether one of them lands a microsecond either side of that cursor is down
+	// to the order a map was ranged over, and the second sync would refresh a
+	// subtree nobody edited for reasons that have nothing to do with the test.
+	old := time.Now().Add(-time.Hour)
+	for _, rel := range []string{"OWNERS", "other/OWNERS"} {
+		if err := os.Chtimes(filepath.Join(root, filepath.FromSlash(rel)), old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	policy, err := fssource.NewOwnersPolicy(root, "repo", "github")
 	if err != nil {
 		t.Fatal(err)

--- a/connector/fssource/owners.go
+++ b/connector/fssource/owners.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/aclmap"
 )
 
 // OwnersFile is the name of the file an [OwnersPolicy] reads.
@@ -42,6 +43,10 @@ type OwnersPolicy struct {
 	fallback acl.Permissions
 	hasFall  bool
 
+	// acls is the one place the vocabulary of this source is turned into the
+	// model, shared with every other connector.
+	acls *aclmap.Normalizer
+
 	mu     sync.RWMutex
 	byDir  map[string]*owners
 	parsed map[string]bool
@@ -68,10 +73,15 @@ func NewOwnersPolicy(root, source, identity string) (*OwnersPolicy, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fssource: owners policy: %w", err)
 	}
+	acls, err := aclmap.New(aclmap.Files(source, identity))
+	if err != nil {
+		return nil, fmt.Errorf("fssource: owners policy: %w", err)
+	}
 	return &OwnersPolicy{
 		root:     abs,
 		source:   source,
 		identity: identity,
+		acls:     acls,
 		byDir:    make(map[string]*owners),
 		parsed:   make(map[string]bool),
 	}, nil
@@ -158,7 +168,7 @@ func (o *OwnersPolicy) Permissions(ctx context.Context, relPath string) (acl.Per
 		return acl.Permissions{}, err
 	}
 	if own != nil {
-		return o.permissionsFrom(own), nil
+		return o.permissionsFrom(own)
 	}
 
 	if o.hasFall {
@@ -168,19 +178,35 @@ func (o *OwnersPolicy) Permissions(ctx context.Context, relPath string) (acl.Per
 }
 
 // permissionsFrom maps a parsed file onto a descriptor.
-func (o *OwnersPolicy) permissionsFrom(own *owners) acl.Permissions {
-	p := acl.Permissions{Mode: acl.ModeACL, Source: o.source}
+//
+// The mapping goes through [aclmap] rather than building a descriptor here, and
+// that is worth the indirection for a file this simple. What an OWNERS file
+// means is a small decision, and so is what a Drive share means, and so is what
+// an S3 grantee means. Each of them is easy on its own and the collection of
+// them is where a search engine leaks, so all of them live in one package with
+// one set of tests instead of one per connector.
+func (o *OwnersPolicy) permissionsFrom(own *owners) (acl.Permissions, error) {
+	grants := make([]aclmap.Grant, 0, len(own.approvers)+len(own.reviewers)+1)
+	if len(own.approvers) > 0 {
+		// The first approver is named twice on purpose: once as the owner and
+		// once as an ordinary reader. Being the owner of a directory is not a
+		// narrowing here, and dropping the second statement would take the file
+		// out of its own approver's results the moment somebody adds a second
+		// name to the list.
+		grants = append(grants, aclmap.Grant{Subject: aclmap.User, ID: own.approvers[0], Role: "owner", Owner: true})
+	}
 	for _, name := range own.approvers {
-		p.AllowUsers = append(p.AllowUsers, acl.Ref{Source: o.identity, Value: name})
+		grants = append(grants, aclmap.Grant{Subject: aclmap.User, ID: name, Role: "approver"})
 	}
 	for _, name := range own.reviewers {
-		p.AllowUsers = append(p.AllowUsers, acl.Ref{Source: o.identity, Value: name})
+		grants = append(grants, aclmap.Grant{Subject: aclmap.User, ID: name, Role: "reviewer"})
 	}
-	if len(own.approvers) > 0 {
-		p.Owner = acl.Ref{Source: o.identity, Value: own.approvers[0]}
-	}
-	return p
+	return o.acls.Normalize(grants)
 }
+
+// Counts returns what the mapping has seen, so that a deployment can watch the
+// numbers rather than find out from somebody who cannot find a document.
+func (o *OwnersPolicy) Counts() aclmap.Counts { return o.acls.Counts() }
 
 // at returns the parsed OWNERS file for a directory, or nil if there is none.
 // Results are cached because a large tree asks about the same directory once

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,209 @@
+# Reading somebody else's access control list
+
+Every system this index reads from models permissions differently.
+Some grant to people, some to groups, some to a whole email domain, some to anybody holding a link, and several of them let a refusal override a grant.
+None of them agree on what to call any of it.
+The same idea is a `reader` in one, `READ` in another, `VIEW` in a third and `BROWSE_PROJECTS` in a fourth.
+
+A connector could map its own system straight onto `acl.Permissions`, and the first two connectors would look fine.
+The trouble starts at the edges, and the edges are where a search engine leaks.
+Every connector would decide on its own what a grant to a domain means, whether a link share is a grant, and what to do with a statement it does not understand.
+The decision that costs a company its private documents is the last one, made once, quietly, by whoever was writing a connector on a Friday afternoon.
+
+So the decisions are made in one package, `connector/aclmap`, and a connector's job shrinks to translating its own vocabulary into `Grant` values.
+
+```go
+n, err := aclmap.New(aclmap.Drive("drive", "google", "acme.com"))
+...
+perms, err := n.Normalize([]aclmap.Grant{
+	{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
+	{Subject: aclmap.Group, ID: "eng@acme.com", Role: "writer"},
+})
+```
+
+`aclmap` imports `acl` and nothing else of ours, which `arch_test.go` enforces.
+A mapping layer that could reach a store or a document would be a second place for the permission rule to live.
+
+## What a connector says
+
+A `Grant` is one statement, in the source's own words, with no interpretation applied.
+
+| Field | Meaning |
+| --- | --- |
+| `Subject` | `User`, `Group`, `Domain` or `Anyone` |
+| `ID` | who the source named, empty for `Anyone` and required otherwise |
+| `Effect` | `Allow` or `Deny` |
+| `Role` | the source's own word, matched case insensitively, empty means read |
+| `Link` | the statement only holds for somebody with a link |
+| `Owner` | this user owns the document |
+
+`Normalize` returns a descriptor that is safe to store whether or not the error is nil.
+On failure it is `acl.ModeUnknown`, which every query path holds back, so a connector that logs the error and carries on has quarantined the document rather than published it.
+
+An empty list of statements is not a failure.
+A document nobody has been given is a document nobody may read, and that is represented exactly: an empty access control list, which allows nobody.
+
+## A refusal beats a grant
+
+A deny in the source is a deny in the index, in every source that has the concept.
+Denies aimed at a user or a group go into `DenyUsers` and `DenyGroups`, and `acl.Permissions.Allows` applies them before it looks at anything else.
+The order the statements arrived in does not change the answer, which matters because a wiki connector naturally reports the space permissions first and the page restrictions second.
+
+There is no deny list for a domain or for everybody, and there is no safe approximation either.
+Treating a refusal aimed at a domain as one aimed at nobody would keep the document readable by exactly the people it was taken away from.
+So that statement quarantines the document instead.
+
+## What cannot be mapped is quarantined and counted
+
+Three things fail, and they are counted separately because they want three different actions.
+
+| Reason | What it is | Who fixes it |
+| --- | --- | --- |
+| `ReasonForeignDomain` | a grant to an email domain that is not this tenant's | somebody has to decide what that domain means here |
+| `ReasonUnmappableDeny` | a refusal aimed at a domain or at everybody | usually a source feature nobody has written the mapping for |
+| `ReasonMalformed` | a statement naming nobody, such as a user grant with an empty id | a bug in a connector |
+
+A fourth counter, `Ignored`, is not a failure.
+It counts statements whose role does not confer read, such as a permission to change a label.
+It is worth watching anyway: a sudden climb usually means a source renamed a role and the mapping has not caught up, which shows up to a person as documents they could find yesterday and cannot find today.
+
+A quarantined document is invisible from every other angle.
+The sync succeeded, no error was returned to anybody, and the only symptom is somebody who cannot find a document they know exists.
+That is why `genbad` logs the counts after every sync when the policy reports them:
+
+```
+level=WARN msg="permissions that could not be mapped" mapped=1841 quarantined=12 foreign_domain=12 unmappable_deny=0 malformed=0 ignored_roles=93
+```
+
+## Link sharing and public documents are recorded
+
+A document shared by link and a document with no restrictions look the same if all you store is a list of names.
+They are not the same thing, so `acl.Permissions` carries what the source said:
+
+| `acl.Sharing` | What the source said |
+| --- | --- |
+| `SharedNone` | the lists are the whole story |
+| `SharedByLink` | anybody holding a link can open it |
+| `SharedPublic` | it is out in the open |
+
+`Sharing` is a record and not a rule.
+`Allows` never reads it, no storage driver filters on it, and that is deliberate.
+The permission rule has exactly one implementation in Go and one in each driver's SQL, and a field that changed the answer would have to be added to both, in agreement, forever.
+
+What a link share means for search is a decision about a company rather than about a product, so it is a setting.
+The default, `LinkGrantsNothing`, keeps the document readable by whoever the lists name and records the share.
+`LinkGrantsTenant` treats a link share as readable by everybody in the deployment.
+It has to be asked for by name, because in a company where turning on a link is not how people publish, it is the setting that hands several years of link shared documents to everybody at once.
+
+## The mappings
+
+Each preset in `connector/aclmap/sources.go` carries one source system's own list of names, taken from its documentation.
+A role name is a fact about somebody else's product.
+It changes when they change it, and when it does the symptom is documents quietly disappearing from search.
+Keeping all of them in one file means the staleness is in one place, next to the table driven tests in `sources_test.go` that pin it.
+
+### Files
+
+A directory tree has no permission model of its own worth reading, so the roles are the ones a policy over the tree invents.
+
+| Role | Reads |
+| --- | --- |
+| `owner` | yes |
+| `approver` | yes |
+| `reviewer` | yes |
+
+The OWNERS convention that Kubernetes and a number of other large repositories keep names approvers and reviewers, and both are people who can read the subtree.
+There is no deny and no link sharing.
+A subtree narrows what its parent allowed by replacing the list rather than by refusing anybody.
+A path with no OWNERS file anywhere above it has no answer at all and is quarantined, which is the case worth getting right: the default for "no rule found" is not "no restriction".
+
+### Object storage
+
+S3's five permissions, and the object stores that copy them.
+
+| Permission | Reads |
+| --- | --- |
+| `READ` | yes |
+| `FULL_CONTROL` | yes |
+| `WRITE` | no |
+| `READ_ACP` | no |
+| `WRITE_ACP` | no |
+
+The distinction matters more than it looks.
+`WRITE` on a bucket is permission to put objects into it, not to read them, and a mapping that treated every permission as read would hand a company's private buckets to whoever can upload to them.
+
+The two group grantees are the ones that reach outside a company.
+`AllUsers` is the open internet and maps to a public document, reported as an `Anyone` grant.
+`AuthenticatedUsers` is every account holder at the provider, which is not this tenant and cannot be enumerated, so a connector reports it as a `Domain` grant to `authenticated-users` and it quarantines like any other foreign domain.
+
+### Drive
+
+The roles are Drive's own, and all six of them can read the file.
+
+| Role | Reads |
+| --- | --- |
+| `owner` | yes |
+| `organizer` | yes |
+| `fileOrganizer` | yes |
+| `writer` | yes |
+| `commenter` | yes |
+| `reader` | yes |
+
+That is worth stating because it is the case where the obvious mapping is right, and somebody will otherwise wonder whether `commenter` was left out by mistake.
+
+This is the source with all four subjects.
+A permission can name a user, a group, a domain or anyone, and anyone can be qualified with a link, which is why `LinkPolicy` exists at all.
+A grant to the company's own domain is `ModePublicToTenant`.
+A grant to a partner's domain names real people this index cannot enumerate, so it quarantines.
+
+### Chat
+
+Chat has almost no vocabulary, because a message's access is the channel's membership and nothing else.
+
+| What the source has | How a connector reports it |
+| --- | --- |
+| a private channel | a `Group` grant naming the channel |
+| a public channel | a `Domain` grant to the workspace's domain |
+| a direct message | one `User` grant per participant |
+
+The role is empty on all of them, which is what an empty `ReadRoles` list is for.
+A member of a channel reads the channel, and there is nothing finer to say.
+
+### Wiki
+
+Space permissions carry names such as `VIEW` and `EDIT`, and a page can then carry restrictions that narrow the space.
+
+| Permission | Reads |
+| --- | --- |
+| `VIEW` | yes |
+| `READ` | yes |
+| `EDIT` | yes |
+| `ADMIN` | yes |
+
+Confluence has two kinds of restriction and only one of them is a refusal in the sense used here.
+A view restriction listing people replaces the space's answer for that page, which a connector reports as an allow list.
+An explicit exclusion is a deny.
+A connector that reports the space permissions and then the page restrictions gets the right answer for free, because a deny is applied first whatever order the statements arrived in.
+
+### Tickets
+
+Reading an issue takes the `BROWSE_PROJECTS` permission on its project.
+
+| Permission | Reads |
+| --- | --- |
+| `BROWSE_PROJECTS` | yes |
+| `ADMINISTER_PROJECTS` | yes |
+
+A permission scheme grants those to users, groups and project roles.
+A connector reports a project role as a group, because that is what it is: a named set of people maintained by the source.
+
+The part that catches people out is issue security.
+A project can carry security levels that narrow an individual issue to a subset of the people who can browse the project, and an issue with a security level set is not readable by the project's list at all.
+A connector must report the security level's members and nothing else for such an issue, because reporting both would widen it straight back to the project.
+
+## Adding a source
+
+Write a preset in `sources.go` with the source's own role names and a comment saying where they came from.
+Write a table in `sources_test.go` with a row per interesting statement, including the ones that should quarantine.
+Add the section here.
+Then the connector fills in `Grant` values and never decides anything.


### PR DESCRIPTION
Closes #12.

Every source names permissions differently.
The same idea is a `reader` in one, `READ` in another, `VIEW` in a third and `BROWSE_PROJECTS` in a fourth.
Mapping any one of them is easy, and the collection of them is where a search engine leaks, because each connector would otherwise decide on its own what a grant to a partner's domain means, whether a link share is a grant, and what to do with a statement it does not understand.
The decision that costs a company its private documents is the last one, made once, quietly, by whoever was writing a connector on a Friday.

So the decisions move into one package.

## connector/aclmap

A connector fills in `Grant` values in its own vocabulary and interprets nothing:

```go
n, err := aclmap.New(aclmap.Drive("drive", "google", "acme.com"))
perms, err := n.Normalize([]aclmap.Grant{
	{Subject: aclmap.User, ID: "alice@acme.com", Role: "owner", Owner: true},
	{Subject: aclmap.Group, ID: "eng@acme.com", Role: "writer"},
})
```

The package imports `acl` and nothing else of ours, and `arch_test.go` now enforces that.
A mapping layer that could reach a store or a document would be a second place for the permission rule to live.

The descriptor is safe to store whether or not the error is nil.
On failure it is `ModeUnknown`, which every query path holds back, so a connector that logs and carries on has quarantined the document rather than published it.

## A deny is a deny

Denies aimed at a user or a group go into the deny lists, and `Allows` applies them before anything else.
The order the statements arrived in does not change the answer, which is what lets a wiki connector report the space permissions first and the page restrictions second and still get the right result.

There is no deny list for a domain or for everybody, and no safe approximation either.
Treating a refusal aimed at a domain as one aimed at nobody would keep the document readable by exactly the people it was taken away from, so it quarantines instead.

## Quarantined and counted

Three failures, counted separately because they want three different actions.

| Reason | What it is | Who fixes it |
| --- | --- | --- |
| foreign domain | a grant to an email domain that is not this tenant's | somebody decides what that domain means here |
| unmappable deny | a refusal aimed at a domain or at everybody | usually a source feature nobody has mapped yet |
| malformed | a statement naming nobody | a bug in a connector |

A fourth counter, `Ignored`, tracks statements whose role does not confer read.
That is not a failure, and a sudden climb usually means a source renamed a role and the mapping has not caught up, which shows up to a person as documents they could find yesterday.

`genbad` logs the counts after every sync when the policy reports them, because a quarantined document is invisible from every other angle:

```
level=WARN msg="permissions that could not be mapped" mapped=1841 quarantined=12 foreign_domain=12 unmappable_deny=0 malformed=0 ignored_roles=93
```

## Link sharing is recorded, not inferred

`acl.Permissions` gains `Sharing`, which is `none`, `link` or `public`.
A document shared by link and a document with no restrictions look identical if all you store is a list of names, and they are not the same thing.

`Sharing` is a record and not a rule.
`Allows` never reads it and no driver filters on it, so the permission rule still has exactly one implementation in Go and one in each driver's SQL, and no storage driver needed changing for this.

What a link share means for search is a decision about a company rather than about a product, so it is a setting.
The default keeps the document readable by whoever the lists name.
`LinkGrantsTenant` has to be asked for by name, because in a company where turning on a link is not how people publish, it is the setting that hands several years of link shared documents to everybody at once.

## The mappings

Six presets, each carrying one source system's own role names taken from its documentation: files, object storage, Drive, chat, wiki and tickets.
`sources_test.go` is a table per source including the statements that should quarantine, and `docs/permissions.md` is the same tables in prose with the reasoning for the awkward cases.

The one that catches people out is issue security in a tracker: an issue with a security level is not readable by the project's list at all, so a connector must report the level's members and nothing else, because reporting both widens the issue straight back to the project.

`OwnersPolicy` now goes through the mapping rather than building a descriptor itself, and exposes `Counts()`.

## Also

Fixes a flake in the OWNERS refresh test.
The OWNERS files are outside the corpus and never contribute to the cursor, so whether one landed either side of it came down to the order a map was ranged over.
The test now backdates them.

Full suite green including Postgres, `golangci-lint` clean, no storage driver changed.