### PR TITLE
Connectors: file system permissions from the operating system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,24 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: go tool cover -func=coverage.out | tail -1
 
+  # The connectors on Windows, because one of them reads the security
+  # descriptor of every file it indexes and there is no way to be sure that
+  # code is right by cross compiling it. Nothing else in the tree asks the
+  # operating system a question it can get wrong, so this stays narrow rather
+  # than becoming a third row of the matrix above.
+  windows:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+      - name: test the connectors
+        run: go test -count=1 ./connector/...
+
   # The Postgres driver against a real PostgreSQL 18. There is no in process
   # Postgres, so its tests skip without a server, and a driver whose suite
   # skipped in CI would be a green tick over nothing. That is what the last step

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ By default every file in the corpus is readable by everybody in the tenant, whic
 If the tree has OWNERS files in it, `-corpus-acl owners` reads them instead, and a query then returns different results depending on who is asking.
 Paths that no OWNERS file governs are quarantined rather than published, and the count of them is on the sync log line.
 
+If the tree is the file server, `-corpus-acl os` reads the permissions the operating system already keeps on it: the owner, the group and the mode bits on Unix, the POSIX access control list where a file carries one, and the security descriptor on Windows.
+It needs `-corpus-identity` to say which identity source the account names belong to, so that somebody who signed in through the company directory matches a list that came out of a password file.
+A world readable file grants nothing until `-corpus-domain` names the domain the accounts on the host belong to, because a host's accounts are not a tenant.
+Point this at a copy of a file server rather than the file server and you get the permissions the copy has, which are the ones the crawler runs as, so do not.
+A `chmod` reaches the index on the next sync without the file being read again.
+
 ## Configuration
 
 Every setting has a flag and an environment variable.
@@ -152,7 +158,9 @@ The corpus flags have no environment variables, because a directory to index is 
 | --- | --- | --- |
 | `-corpus` | empty | directory to index at startup |
 | `-corpus-name` | `files` | source name the documents carry, and what `-source` filters on |
-| `-corpus-acl` | `tenant` | who may read it: `tenant` for everybody in the tenant, `owners` to read OWNERS files |
+| `-corpus-acl` | `tenant` | who may read it: `tenant` for everybody in the tenant, `owners` to read OWNERS files, `os` to read the file system's own permissions |
+| `-corpus-identity` | `unix` | identity source the account names in the tree belong to, for `-corpus-acl os` |
+| `-corpus-domain` | empty | domain the accounts on this host belong to, for `-corpus-acl os`, empty to grant nothing on the world bit |
 | `-corpus-refresh` | `0` | how often to sync again, zero for once at startup |
 
 ## Metrics

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -29,8 +29,19 @@ type corpusOptions struct {
 	// Name is the source name the documents carry, and what a query filters on.
 	Name string
 
-	// ACL selects how permissions are decided, either "tenant" or "owners".
+	// ACL selects how permissions are decided: "tenant", "owners" or "os".
 	ACL string
+
+	// Identity names the identity source the account names in the tree belong
+	// to, and is what the "os" policy writes its references under. Getting it
+	// right is what lets somebody who signed in through the company directory
+	// match a list that came out of a password file.
+	Identity string
+
+	// Domain is the domain the accounts on this host belong to, and is what
+	// the "os" policy needs before a world readable file means anything. Empty
+	// leaves the world bit granting nothing, which is the safe reading.
+	Domain string
 
 	// Refresh is how often to sync again. Zero syncs once at startup.
 	Refresh time.Duration
@@ -40,6 +51,7 @@ type corpusOptions struct {
 const (
 	aclTenant = "tenant"
 	aclOwners = "owners"
+	aclOS     = "os"
 )
 
 func (o corpusOptions) validate() error {
@@ -51,8 +63,16 @@ func (o corpusOptions) validate() error {
 	}
 	switch o.ACL {
 	case aclTenant, aclOwners:
+	case aclOS:
+		if o.Identity == "" {
+			// Every reference the policy writes carries this name, and without
+			// one they would all be compared against the bare account name. A
+			// person called "alice" here would then match a person called
+			// "alice" at another company.
+			return fmt.Errorf("corpus acl %q needs an identity source", aclOS)
+		}
 	default:
-		return fmt.Errorf("unknown corpus acl %q, want %q or %q", o.ACL, aclTenant, aclOwners)
+		return fmt.Errorf("unknown corpus acl %q, want %q, %q or %q", o.ACL, aclTenant, aclOwners, aclOS)
 	}
 	if o.Refresh < 0 {
 		return errors.New("corpus refresh is negative")
@@ -67,12 +87,27 @@ func (o corpusOptions) validate() error {
 // quarantines it, which shows up in the log and in the stats. Giving it a
 // fallback here would turn "nobody has said" into "everybody may", which is the
 // one substitution this system is built to avoid.
+//
+// The os policy has the opposite thing worth saying about it. It is right for a
+// tree that is the file server and wrong for a copy of one, because a tree that
+// was rsynced here carries the permissions the copy has, which are this
+// process's own.
 func policyFor(o corpusOptions) (fssource.Policy, error) {
 	switch o.ACL {
 	case aclTenant:
 		return fssource.PublicToTenant(o.Name), nil
 	case aclOwners:
 		p, err := fssource.NewOwnersPolicy(o.Dir, o.Name, "github")
+		if err != nil {
+			return nil, err
+		}
+		return p, nil
+	case aclOS:
+		var domains []string
+		if o.Domain != "" {
+			domains = append(domains, o.Domain)
+		}
+		p, err := fssource.NewOSPolicy(o.Dir, o.Name, o.Identity, domains...)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/genbad/corpus_os_test.go
+++ b/cmd/genbad/corpus_os_test.go
@@ -1,0 +1,114 @@
+//go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// account is the name the operating system policy will resolve this process to,
+// which is the name a request has to arrive under for any of it to match.
+func account(t *testing.T) string {
+	t.Helper()
+	u, err := user.LookupId(strconv.Itoa(os.Getuid()))
+	if err != nil {
+		t.Skipf("this machine cannot name the account it is running as: %v", err)
+	}
+	return u.Username
+}
+
+// TestTheFileSystemDecidesWhatAQueryReturns is the operating system policy
+// through the front door. The tree is the file server, the mode bits are the
+// access control system, and a query gets back what the person asking can open
+// with a shell on the same machine.
+func TestTheFileSystemDecidesWhatAQueryReturns(t *testing.T) {
+	root := corpusTree(t)
+	me := account(t)
+
+	// Nobody but the owner, which under this policy is a document with one
+	// name on it rather than a list.
+	if err := os.Chmod(filepath.Join(root, "guides", "legacy.md"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	addr := freeAddr(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, []string{
+			"-addr", addr,
+			"-tenant", "acme",
+			"-corpus", root,
+			"-corpus-name", "handbook",
+			"-corpus-acl", aclOS,
+			// The identity source has to be the one the front door issues
+			// identifiers under, or the names on the files and the names on the
+			// request are two different vocabularies that happen to look alike.
+			"-corpus-identity", "github",
+			"-log-level", "error",
+		}, env(nil), &out, &errOut)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("the server did not shut down")
+		}
+	}()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	if got := searchAs(t, addr, me, "legacy"); got.Total == 0 {
+		t.Error("the owner of a file cannot find it")
+	}
+	if got := searchAs(t, addr, "mallory", "legacy"); got.Total != 0 {
+		t.Errorf("somebody with no account on this machine was shown %v", got.Hits)
+	}
+	if got := searchAs(t, addr, "mallory", "deploying"); got.Total != 0 {
+		t.Errorf("a file readable by one host's accounts was shown to a stranger: %v", got.Hits)
+	}
+}
+
+func TestTheOperatingSystemPolicyIsBuiltFromTheFlags(t *testing.T) {
+	root := corpusTree(t)
+	opts := corpusOptions{Dir: root, Name: "handbook", ACL: aclOS, Identity: "unix"}
+	if err := opts.validate(); err != nil {
+		t.Fatalf("a usable set was rejected: %v", err)
+	}
+
+	policy, err := policyFor(opts)
+	if err != nil {
+		t.Fatalf("building the policy: %v", err)
+	}
+	perm, err := policy.Permissions(t.Context(), "README.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	if perm.Owner.Source != "unix" {
+		t.Errorf("the owner is written under %q, want the identity source the flag named", perm.Owner.Source)
+	}
+
+	// And the domain flag reaches the policy, which for a world readable file
+	// is the difference between a list of two names and the whole tenant.
+	opts.Domain = "acme.example"
+	told, err := policyFor(opts)
+	if err != nil {
+		t.Fatalf("building the policy: %v", err)
+	}
+	widened, err := told.Permissions(t.Context(), "README.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	if widened.Mode == perm.Mode {
+		t.Errorf("naming the domain left a world readable file at %v", perm.Mode)
+	}
+}

--- a/cmd/genbad/corpus_test.go
+++ b/cmd/genbad/corpus_test.go
@@ -50,6 +50,8 @@ func TestCorpusFlagsAreChecked(t *testing.T) {
 		{"an unknown acl", corpusOptions{Dir: "/tmp", Name: "files", ACL: "everyone"}, "everyone"},
 		{"a negative refresh", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclTenant, Refresh: -time.Second}, "negative"},
 		{"a usable set", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOwners}, ""},
+		{"the os policy with nobody to name accounts", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOS}, "identity source"},
+		{"the os policy told where the names come from", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOS, Identity: "unix"}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -72,7 +72,9 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	var corpus corpusOptions
 	fs.StringVar(&corpus.Dir, "corpus", "", "directory to index at startup")
 	fs.StringVar(&corpus.Name, "corpus-name", "files", "source name the indexed directory carries")
-	fs.StringVar(&corpus.ACL, "corpus-acl", aclTenant, "who may read the corpus: tenant or owners")
+	fs.StringVar(&corpus.ACL, "corpus-acl", aclTenant, "who may read the corpus: tenant, owners or os")
+	fs.StringVar(&corpus.Identity, "corpus-identity", "unix", "identity source the account names in the tree belong to, for -corpus-acl os")
+	fs.StringVar(&corpus.Domain, "corpus-domain", "", "domain the accounts on this host belong to, for -corpus-acl os, empty for none")
 	fs.DurationVar(&corpus.Refresh, "corpus-refresh", 0, "how often to reindex the directory, zero for once")
 
 	showVersion := fs.Bool("version", false, "print the version and exit")

--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -126,6 +126,23 @@ type Versioned interface {
 	ChangedAt(ctx context.Context, relPath string) (time.Time, error)
 }
 
+// statPolicy and statVersioned are the same two questions asked with the file
+// information the walk is already holding.
+//
+// They are unexported on purpose, so they are not a second interface anybody
+// outside has to implement. What they are is a way for a policy that reads the
+// file system itself to avoid a second stat of every file in the tree, which on
+// a corpus of a million files is a million system calls a sync spends finding
+// out something it was told a moment ago.
+type (
+	statPolicy interface {
+		permissionsFor(ctx context.Context, relPath string, info fs.FileInfo) (acl.Permissions, error)
+	}
+	statVersioned interface {
+		changedAtFor(ctx context.Context, relPath string, info fs.FileInfo) (time.Time, error)
+	}
+)
+
 // Reloader is the optional capability of a [Policy] that caches.
 //
 // A source calls it once at the start of every walk. That is the contract the
@@ -316,11 +333,22 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 		// Not After rather than Before, so a file written in the same
 		// nanosecond as the cursor is not emitted twice on every later run.
 		if !since.IsZero() && !mod.After(since) {
-			at, err := s.refresh(ctx, rel, since, emit)
+			at, err := s.refresh(ctx, rel, info, since, emit)
 			if at.After(highest) {
 				highest = at
 			}
 			return err
+		}
+
+		// The cursor has to cover when the permissions last changed as well as
+		// when the content did, because the next run compares both against it. A
+		// file whose mode was last written after it was last edited would
+		// otherwise come back as a permission change on the very next sync,
+		// stating the same access control list it was just given, for every such
+		// file in the tree. An error here is the policy's problem and read below
+		// reports it.
+		if at, err := s.changedAt(ctx, rel, info); err == nil && at.After(highest) {
+			highest = at
 		}
 
 		full := filepath.Join(s.root, filepath.FromSlash(rel))
@@ -357,12 +385,8 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 // What it costs is one policy lookup per unchanged file, which for the OWNERS
 // policy is a map read after the first file in each directory. What it saves is
 // reading the subtree.
-func (s *Source) refresh(ctx context.Context, rel string, since time.Time, emit func(context.Context, connector.Change) error) (time.Time, error) {
-	versioned, ok := s.policy.(Versioned)
-	if !ok {
-		return time.Time{}, nil
-	}
-	at, err := versioned.ChangedAt(ctx, rel)
+func (s *Source) refresh(ctx context.Context, rel string, info fs.FileInfo, since time.Time, emit func(context.Context, connector.Change) error) (time.Time, error) {
+	at, err := s.changedAt(ctx, rel, info)
 	if err != nil {
 		// A policy that cannot answer for one path is not a reason to abandon the
 		// tree, for the same reason a file that cannot be read is not. It is
@@ -375,7 +399,7 @@ func (s *Source) refresh(ctx context.Context, rel string, since time.Time, emit 
 		return at, nil
 	}
 
-	perms, err := s.policy.Permissions(ctx, rel)
+	perms, err := s.permissions(ctx, rel, info)
 	if err != nil {
 		// The rule that used to govern this file stopped resolving. Quarantining
 		// is the only safe reading: a document nobody can currently say who may
@@ -392,6 +416,34 @@ func (s *Source) refresh(ctx context.Context, rel string, since time.Time, emit 
 		// of walk cursor covers it, and a run interrupted before that repeats the
 		// refresh, which costs one write.
 	})
+}
+
+// permissions asks the policy who may read a file, handing over the file
+// information where the policy is one that wants it.
+//
+// A nil policy is not an oversight and not an error. It is the state a source
+// built without one is in, and the answer is that nothing resolved, which
+// quarantines every document rather than publishing the tree.
+func (s *Source) permissions(ctx context.Context, rel string, info fs.FileInfo) (acl.Permissions, error) {
+	if s.policy == nil {
+		return connector.Unresolved(s.name), nil
+	}
+	if p, ok := s.policy.(statPolicy); ok {
+		return p.permissionsFor(ctx, rel, info)
+	}
+	return s.policy.Permissions(ctx, rel)
+}
+
+// changedAt asks the policy when the rule governing a file last changed, and
+// returns the zero time for a policy that cannot say.
+func (s *Source) changedAt(ctx context.Context, rel string, info fs.FileInfo) (time.Time, error) {
+	if p, ok := s.policy.(statVersioned); ok {
+		return p.changedAtFor(ctx, rel, info)
+	}
+	if p, ok := s.policy.(Versioned); ok {
+		return p.ChangedAt(ctx, rel)
+	}
+	return time.Time{}, nil
 }
 
 // limitFor is the size limit that applies to one file name. An image gets the
@@ -426,15 +478,12 @@ func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (
 		return doc.Document{}, errors.New("not text")
 	}
 
-	perms := connector.Unresolved(s.name)
-	if s.policy != nil {
-		got, err := s.policy.Permissions(ctx, rel)
-		if err == nil {
-			perms = got
-		}
-		// On an error the document keeps the unresolved descriptor and is
-		// quarantined by the pipeline. Failing to answer is not permission to
-		// publish.
+	perms, err := s.permissions(ctx, rel, info)
+	if err != nil {
+		// The document keeps the unresolved descriptor and is quarantined by the
+		// pipeline. Failing to answer is not permission to publish.
+		perms = connector.Unresolved(s.name)
+		s.skipped(full, err)
 	}
 
 	var (

--- a/connector/fssource/osperm.go
+++ b/connector/fssource/osperm.go
@@ -1,0 +1,343 @@
+package fssource
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/aclmap"
+)
+
+// OSPolicy derives permissions from what the operating system keeps on the
+// files themselves: the owner, the group and the mode bits on Unix, and the
+// discretionary access control list on Windows.
+//
+// It is the policy for a tree that is the file server, because there the
+// operating system is the access control system and there is nothing better
+// above it. It is the wrong policy for a copy of one. A tree that was rsynced
+// to the crawler carries the permissions the copy has, which are the crawler's
+// own, and indexing those would hand the lot to whoever the crawler runs as.
+//
+// # Unix
+//
+// The owner and the group become a user and a group reference under the
+// identity source given to [NewOSPolicy], and each one is a grant only where
+// its read bit is set. An owner who took away their own read bit could put it
+// back, so there is an argument for granting to them regardless, and the
+// literal reading is used instead: being wrong this way costs somebody a file
+// of their own they cannot find, and being wrong the other way costs a file
+// shown to somebody who was refused it.
+//
+// The world bit is the one that cannot be mapped without being told something
+// first. It says every account on this host may read the file, and a host's
+// accounts are not a tenant: on a laptop they are one person, on a login server
+// they are the company, and on a machine with a guest account they are more
+// than the company. So it grants nothing at all unless [NewOSPolicy] was given
+// the domain those accounts belong to.
+//
+// Where a file carries a POSIX access control list, that list is read in place
+// of the mode bits, because the two disagree in the direction that leaks. The
+// group bits of such a file are the mask rather than the group's own
+// permission, so a group the mask has taken read away from still reads as
+// allowed, and a mapping built on the mode alone offers the file to people who
+// cannot open it.
+//
+// The extended access control lists macOS and the BSDs keep are a different
+// format in a different place, reachable only through the C library, and they
+// are not read. A file carrying one gets the answer its mode bits give, which
+// is narrower than the truth where the list grants and wider than it where the
+// list refuses. That is the one gap in this policy that goes the wrong way, and
+// it is stated here rather than left to be found: on those systems this is a
+// good answer for an ordinary tree and not a safe one for a tree somebody has
+// been managing with the access control list editor.
+//
+// # Windows
+//
+// The owner comes from the security descriptor and the grants come from the
+// discretionary access control list, which is the one platform here with
+// refusals in it. A refusal becomes a deny and beats every grant, which is what
+// Windows does too.
+//
+// Entries that exist only to be inherited by files created later are skipped,
+// because they say nothing about this file. Entries naming Everyone or
+// Authenticated Users go through the same door as the Unix world bit and grant
+// nothing until a domain names them.
+//
+// # Names
+//
+// Every identifier is resolved to an account name through the password and
+// group databases, or through the account database on Windows, and a file whose
+// owner does not resolve is quarantined rather than indexed under a number. A
+// numeric user id is not an identity: it means one person on one host and
+// somebody else on the next, so a grant written in terms of one would either
+// match nobody or match the wrong person.
+type OSPolicy struct {
+	root     string
+	source   string
+	identity string
+	domain   string
+
+	acls *aclmap.Normalizer
+
+	mu    sync.Mutex
+	named map[string]string
+}
+
+// NewOSPolicy returns a policy reading the permissions the operating system
+// keeps on the files under root.
+//
+// source names the connector. identity names the identity source the account
+// names belong to, for example "unix" for a machine's own accounts or the name
+// of the directory the host is joined to. Getting that one right is what lets
+// somebody who authenticated through the company directory match a list that
+// came out of a password file.
+//
+// worldDomain is optional and is the domain the accounts on this host belong
+// to. Give it and a world readable file is readable by everybody in the tenant.
+// Leave it out and the world bit grants nothing, which is the safe reading and
+// the reason it is not the caller's job to remember to pass a flag.
+func NewOSPolicy(root, source, identity string, worldDomain ...string) (*OSPolicy, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("fssource: os policy: %w", err)
+	}
+	var domain string
+	if len(worldDomain) > 0 {
+		domain = worldDomain[0]
+	}
+	acls, err := aclmap.New(aclmap.Files(source, identity, worldDomain...))
+	if err != nil {
+		return nil, fmt.Errorf("fssource: os policy: %w", err)
+	}
+	return &OSPolicy{
+		root:     abs,
+		source:   source,
+		identity: identity,
+		domain:   domain,
+		acls:     acls,
+		named:    make(map[string]string),
+	}, nil
+}
+
+var (
+	_ Policy        = (*OSPolicy)(nil)
+	_ Versioned     = (*OSPolicy)(nil)
+	_ Reloader      = (*OSPolicy)(nil)
+	_ statPolicy    = (*OSPolicy)(nil)
+	_ statVersioned = (*OSPolicy)(nil)
+)
+
+// Counts returns what the mapping has seen, so that a deployment can watch the
+// quarantine numbers rather than hear about them from somebody who cannot find
+// a document.
+func (p *OSPolicy) Counts() aclmap.Counts { return p.acls.Counts() }
+
+// Reload drops the resolved account names.
+//
+// The names are the only thing cached here, because the permissions themselves
+// are read from the file every time and there is nothing to go stale about
+// them. A name can still go stale: an account renamed between two syncs would
+// otherwise keep the name it had when the process started, and a grant to a
+// name nobody has any more is a grant to nobody.
+func (p *OSPolicy) Reload() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	clear(p.named)
+}
+
+// Permissions returns the access control list the operating system holds for a
+// path.
+func (p *OSPolicy) Permissions(ctx context.Context, relPath string) (acl.Permissions, error) {
+	info, err := os.Stat(p.full(relPath))
+	if err != nil {
+		return acl.Permissions{}, err
+	}
+	return p.permissionsFor(ctx, relPath, info)
+}
+
+// permissionsFor is the same answer for a file the caller has already stated.
+//
+// A walk has the file information in its hand when it asks, and asking for it
+// again would double the number of system calls a sync makes on a tree of a
+// million files. The exported method is what everything else uses.
+func (p *OSPolicy) permissionsFor(ctx context.Context, relPath string, info fs.FileInfo) (acl.Permissions, error) {
+	if err := ctx.Err(); err != nil {
+		return acl.Permissions{}, err
+	}
+	rules, err := accessRules(p.full(relPath), info)
+	if err != nil {
+		return acl.Permissions{}, err
+	}
+
+	grants := make([]aclmap.Grant, 0, len(rules))
+	for _, r := range rules {
+		g, ok, err := p.grant(r)
+		if err != nil {
+			return acl.Permissions{}, err
+		}
+		if ok {
+			grants = append(grants, g)
+		}
+	}
+	return p.acls.Normalize(grants)
+}
+
+// ChangedAt returns when the permissions on a path last changed.
+func (p *OSPolicy) ChangedAt(ctx context.Context, relPath string) (time.Time, error) {
+	info, err := os.Stat(p.full(relPath))
+	if err != nil {
+		return time.Time{}, err
+	}
+	return p.changedAtFor(ctx, relPath, info)
+}
+
+// changedAtFor is what makes a chmod take effect without a recrawl.
+//
+// The answer is the inode change time, which moves when the mode, the owner or
+// the access control list is written and stays where it is when only the
+// content is. That is exactly the event a sync comparing modification times
+// cannot see, and the one that has to be seen: a revocation that takes effect
+// the next time somebody happens to edit the file is not a revocation.
+//
+// Windows has no equivalent that can be read without opening every file, so it
+// answers with the zero time and a permission change there waits for the file
+// to be touched. That is stated rather than worked around, because the way to
+// work around it is a stat that costs an open per file per sync.
+func (p *OSPolicy) changedAtFor(ctx context.Context, _ string, info fs.FileInfo) (time.Time, error) {
+	if err := ctx.Err(); err != nil {
+		return time.Time{}, err
+	}
+	return changeTime(info), nil
+}
+
+// full is the absolute path of a path relative to the root.
+func (p *OSPolicy) full(relPath string) string {
+	return filepath.Join(p.root, filepath.FromSlash(relPath))
+}
+
+// grant turns one operating system rule into a statement aclmap understands,
+// and reports whether there is a statement to make at all.
+func (p *OSPolicy) grant(r rule) (aclmap.Grant, bool, error) {
+	g := aclmap.Grant{Subject: r.subject, Owner: r.owner}
+	if r.deny {
+		g.Effect = aclmap.Deny
+	}
+
+	switch r.subject {
+	case aclmap.Domain:
+		if p.domain == "" {
+			if r.deny {
+				// A refusal aimed at everybody cannot be dropped for want of a
+				// domain to name them by. Reporting it as aimed at everybody is
+				// what it is, and aclmap has no deny list for that, so the
+				// document is quarantined instead of quietly widened.
+				return aclmap.Grant{Subject: aclmap.Anyone, Effect: aclmap.Deny}, true, nil
+			}
+			return aclmap.Grant{}, false, nil
+		}
+		g.ID = p.domain
+		return g, true, nil
+
+	case aclmap.User, aclmap.Group:
+		name, err := p.lookup(r)
+		if err != nil {
+			return aclmap.Grant{}, false, err
+		}
+		g.ID = name
+		return g, true, nil
+
+	case aclmap.Anyone:
+		return g, true, nil
+
+	default:
+		return aclmap.Grant{}, false, fmt.Errorf("fssource: unknown subject %v", r.subject)
+	}
+}
+
+// lookup resolves one identifier to an account name, caching the answer.
+//
+// A large tree asks about the same handful of owners once per file, and the
+// lookup goes to a password file or, on a joined host, to a directory server
+// over the network. Caching it is the difference between a sync that reads the
+// tree and a sync that interrogates the directory a million times.
+func (p *OSPolicy) lookup(r rule) (string, error) {
+	if r.name != "" {
+		// The platform resolved it on the way past, which is what Windows does:
+		// working out whether a security identifier names a person or a group is
+		// the same call that returns the name, so throwing the name away here
+		// would mean asking twice.
+		return r.name, nil
+	}
+
+	key := r.subject.String() + ":" + r.id
+	p.mu.Lock()
+	name, ok := p.named[key]
+	p.mu.Unlock()
+	if ok {
+		return name, nil
+	}
+
+	name, err := resolve(r)
+	if err != nil {
+		return "", err
+	}
+	p.mu.Lock()
+	p.named[key] = name
+	p.mu.Unlock()
+	return name, nil
+}
+
+// resolve asks the operating system what an identifier is called.
+func resolve(r rule) (string, error) {
+	switch r.subject {
+	case aclmap.Group:
+		g, err := user.LookupGroupId(r.id)
+		if err != nil {
+			return "", fmt.Errorf("fssource: group %s: %w", r.id, err)
+		}
+		return g.Name, nil
+	case aclmap.User, aclmap.Domain, aclmap.Anyone:
+		u, err := user.LookupId(r.id)
+		if err != nil {
+			return "", fmt.Errorf("fssource: user %s: %w", r.id, err)
+		}
+		return u.Username, nil
+	default:
+		return "", fmt.Errorf("fssource: unknown subject %v", r.subject)
+	}
+}
+
+// rule is one statement the operating system makes about one file, in the
+// vocabulary the platforms have in common.
+//
+// Producing these is the whole of what the platform specific code does, which
+// is what keeps the mode bits, the access control list entries and the Windows
+// access masks each inside the one file that knows what they mean. Everything
+// above works in users, groups and everybody.
+type rule struct {
+	// subject is who the statement is about. Domain means everybody with an
+	// account on this host, which is the Unix world bit and the Windows Everyone
+	// entry, and which grants nothing until a domain names them.
+	subject aclmap.Subject
+
+	// id is the operating system's own identifier: a numeric user or group id on
+	// Unix, a security identifier on Windows.
+	id string
+
+	// name is the account name where the platform already knows it, so that a
+	// second lookup is not needed to find out.
+	name string
+
+	// deny says the statement refuses rather than grants. Only Windows produces
+	// one.
+	deny bool
+
+	// owner says the subject owns the file.
+	owner bool
+}

--- a/connector/fssource/osperm_bsd.go
+++ b/connector/fssource/osperm_bsd.go
@@ -1,0 +1,20 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+
+package fssource
+
+import "syscall"
+
+// posixACL always reports that there is none.
+//
+// These systems keep extended access control lists of the NFSv4 shape, in a
+// place a program can only reach through the C library, and they are not read
+// here. A file carrying one gets the answer its mode bits give, which is
+// narrower than the truth where the list grants and wider than it where the
+// list refuses. That second case is the reason this is stated in the package
+// documentation rather than left to be discovered: on these systems the policy
+// is a good answer for an ordinary tree and not a safe one for a tree somebody
+// has been managing with the access control list editor.
+func posixACL(string) (raw []byte, ok bool, err error) { return nil, false, nil }
+
+// inodeChange is when the inode last changed.
+func inodeChange(st *syscall.Stat_t) (sec, nsec int64) { return st.Ctimespec.Unix() }

--- a/connector/fssource/osperm_linux.go
+++ b/connector/fssource/osperm_linux.go
@@ -1,0 +1,43 @@
+package fssource
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// The name Linux stores a POSIX access control list under, and a size that
+// holds a list with a few hundred names in it.
+//
+// Asking for the length first and then reading would be two system calls per
+// file over a tree where almost no file has a list at all, so the buffer is
+// sized to cover the ones that do and a list longer than it is reported rather
+// than truncated.
+const (
+	posixACLAttr = "system.posix_acl_access"
+	posixACLMax  = 4 << 10
+)
+
+// posixACL reads the access control list attached to a file, and reports false
+// where there is none, which is the ordinary case.
+func posixACL(full string) (raw []byte, ok bool, err error) {
+	buf := make([]byte, posixACLMax)
+	n, err := syscall.Getxattr(full, posixACLAttr, buf)
+	switch {
+	case errors.Is(err, syscall.ENODATA), errors.Is(err, syscall.ENOTSUP), errors.Is(err, syscall.EOPNOTSUPP):
+		// No list on this file, or a file system that does not keep them. Both
+		// mean the mode bits are the whole answer.
+		return nil, false, nil
+	case errors.Is(err, syscall.ERANGE):
+		// A list longer than the buffer. Reading the front of it would leave
+		// entries out, and an entry left out is either a grant nobody gets or a
+		// refusal nobody applies.
+		return nil, false, fmt.Errorf("fssource: %s: access control list over %d bytes", full, posixACLMax)
+	case err != nil:
+		return nil, false, fmt.Errorf("fssource: %s: %w", full, err)
+	}
+	return buf[:n], true, nil
+}
+
+// inodeChange is when the inode last changed.
+func inodeChange(st *syscall.Stat_t) (sec, nsec int64) { return st.Ctim.Unix() }

--- a/connector/fssource/osperm_linux_test.go
+++ b/connector/fssource/osperm_linux_test.go
@@ -1,0 +1,110 @@
+package fssource_test
+
+import (
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// setfacl edits a file's access control list, and skips the test where the tool
+// or the file system is missing.
+//
+// Driving the kernel rather than writing the bytes by hand is the point of
+// these tests. The decoder in this package reads a layout nothing here defines,
+// so the only way to find out it is being read correctly is to have somebody
+// else write it.
+func setfacl(t *testing.T, path string, spec ...string) {
+	t.Helper()
+	tool, err := exec.LookPath("setfacl")
+	if err != nil {
+		t.Skip("setfacl is not installed on this machine")
+	}
+	args := make([]string, 0, len(spec)*2+1)
+	for _, s := range spec {
+		args = append(args, "-m", s)
+	}
+	args = append(args, path)
+	out, err := exec.CommandContext(t.Context(), tool, args...).CombinedOutput()
+	if err != nil {
+		t.Skipf("this file system does not take access control lists: %v: %s", err, out)
+	}
+}
+
+// stranger is an account other than the one running the tests, which every
+// machine that has a password database at all has one of.
+func stranger(t *testing.T) *user.User {
+	t.Helper()
+	for _, name := range []string{"nobody", "daemon", "bin", "games"} {
+		u, err := user.Lookup(name)
+		if err == nil && u.Uid != strconv.Itoa(os.Getuid()) {
+			return u
+		}
+	}
+	t.Skip("this machine has no second account to grant anything to")
+	return nil
+}
+
+// TestAnAccessControlListOnDiskNamesSomebodyTheModeBitsCannot is the reader
+// against a list the kernel wrote. A file at 0600 with one extra name on it has
+// a second reader that no mode bit can express, and a policy that answered from
+// the mode alone would hide the file from them.
+func TestAnAccessControlListOnDiskNamesSomebodyTheModeBitsCannot(t *testing.T) {
+	p, root := osPolicy(t, "# a note\n")
+	note := filepath.Join(root, "note.md")
+	chmod(t, note, 0o600)
+	guest := stranger(t)
+	setfacl(t, note, "u:"+guest.Uid+":r")
+
+	perm, err := p.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	want := acl.Ref{Source: theIdentity, Value: guest.Username}
+	if !slices.Contains(perm.AllowUsers, want) {
+		t.Fatalf("the list allows %v, want it to contain %+v", perm.AllowUsers, want)
+	}
+	if !perm.Allows(named(guest.Username)) {
+		t.Errorf("%q was named on the list and refused", guest.Username)
+	}
+	if !perm.Allows(named(whoAmI(t))) {
+		t.Error("the owner lost their own file to an entry about somebody else")
+	}
+}
+
+// TestTheMaskTakesTheFileBackIsTheWholeReasonTheListIsRead is the case the mode
+// bits get wrong in the direction that hands somebody a document. After this
+// edit the file still shows a group read bit, and the person named on it can no
+// longer open it.
+func TestTheMaskTakesTheFileBackIsTheWholeReasonTheListIsRead(t *testing.T) {
+	p, root := osPolicy(t, "# a note\n")
+	note := filepath.Join(root, "note.md")
+	chmod(t, note, 0o600)
+	guest := stranger(t)
+	setfacl(t, note, "u:"+guest.Uid+":r")
+	setfacl(t, note, "m::-")
+
+	info, err := os.Stat(note)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o040 != 0 {
+		t.Logf("the mode now reads %04o, which is the mask and not a group grant", info.Mode().Perm())
+	}
+
+	perm, err := p.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	if perm.Allows(named(guest.Username)) {
+		t.Fatalf("%q was refused by the mask and allowed by %+v", guest.Username, perm)
+	}
+	if !perm.Allows(named(whoAmI(t))) {
+		t.Error("the mask took the file away from its owner, which it does not reach")
+	}
+}

--- a/connector/fssource/osperm_other.go
+++ b/connector/fssource/osperm_other.go
@@ -1,0 +1,23 @@
+//go:build !linux && !darwin && !dragonfly && !freebsd && !netbsd && !openbsd && !windows
+
+package fssource
+
+import (
+	"errors"
+	"io/fs"
+	"time"
+)
+
+// accessRules has nothing to read on a platform whose permissions this package
+// has not been taught.
+//
+// It refuses rather than returning an empty list. An empty list is a document
+// nobody may read, which would look like a working policy producing a very
+// strict answer, and a strict answer nobody asked for is how a whole corpus
+// quietly disappears from search.
+func accessRules(string, fs.FileInfo) ([]rule, error) {
+	return nil, errors.New("fssource: this platform's file permissions are not read by this policy")
+}
+
+// changeTime has no answer here either.
+func changeTime(fs.FileInfo) time.Time { return time.Time{} }

--- a/connector/fssource/osperm_posix.go
+++ b/connector/fssource/osperm_posix.go
@@ -1,0 +1,184 @@
+//go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd
+
+package fssource
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io/fs"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/tamnd/genba/connector/aclmap"
+)
+
+// The read bits of a Unix mode, and the read bit of a POSIX access control list
+// entry, which is the same value for a different reason.
+const (
+	readOwner = 0o400
+	readGroup = 0o040
+	readWorld = 0o004
+	aclRead   = 0o4
+)
+
+// idOf is how a numeric user or group id is written for a lookup.
+func idOf(id uint32) string { return strconv.FormatUint(uint64(id), 10) }
+
+// accessRules reads the permissions Unix keeps on one file.
+func accessRules(full string, info fs.FileInfo) ([]rule, error) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		// Every file system this runs on reports an owner, so reaching here means
+		// the file information came from somewhere that is not the operating
+		// system. Guessing at that point would be inventing an access control
+		// list.
+		return nil, errors.New("fssource: this file system does not report an owner")
+	}
+
+	raw, ok, err := posixACL(full)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		entries, err := decodePosixACL(raw)
+		if err != nil {
+			return nil, fmt.Errorf("fssource: %s: %w", full, err)
+		}
+		return aclRules(entries, st.Uid, st.Gid), nil
+	}
+	return modeRules(info.Mode().Perm(), st.Uid, st.Gid), nil
+}
+
+// modeRules turns the three read bits into three statements.
+//
+// The owner is the owner as well as a reader, which is what makes a file nobody
+// else can read come out as owned by one person rather than as a list with one
+// name in it. The two are the same grant today and they are not the same fact,
+// and the mode is what a feature such as everything of mine reads.
+func modeRules(mode fs.FileMode, uid, gid uint32) []rule {
+	out := make([]rule, 0, 3)
+	if mode&readOwner != 0 {
+		out = append(out, rule{subject: aclmap.User, id: idOf(uid), owner: true})
+	}
+	if mode&readGroup != 0 {
+		out = append(out, rule{subject: aclmap.Group, id: idOf(gid)})
+	}
+	if mode&readWorld != 0 {
+		out = append(out, rule{subject: aclmap.Domain})
+	}
+	return out
+}
+
+// The tags a POSIX access control list entry can carry.
+const (
+	aclUserObj  = 0x01
+	aclUser     = 0x02
+	aclGroupObj = 0x04
+	aclGroup    = 0x08
+	aclMask     = 0x10
+	aclOther    = 0x20
+)
+
+// aclEntry is one entry of a POSIX access control list.
+type aclEntry struct {
+	tag  uint16
+	perm uint16
+
+	// id is the user or group the entry names, and is meaningless for the
+	// entries that name a position rather than a person.
+	id uint32
+}
+
+// aclRules turns a POSIX access control list into statements, applying the
+// mask.
+//
+// The mask is the part that is easy to leave out and expensive to leave out. It
+// is the ceiling on every entry except the owner's and the world's, so a list
+// that names a group with read and carries a mask without it is a list that
+// does not let that group read the file. A reader that reported the entry and
+// ignored the mask would offer the file to a team that cannot open it, which is
+// the direction that hands somebody a document.
+func aclRules(entries []aclEntry, uid, gid uint32) []rule {
+	mask := uint16(0o7)
+	for _, e := range entries {
+		if e.tag == aclMask {
+			mask = e.perm
+		}
+	}
+
+	out := make([]rule, 0, len(entries))
+	for _, e := range entries {
+		switch e.tag {
+		case aclUserObj:
+			if e.perm&aclRead != 0 {
+				out = append(out, rule{subject: aclmap.User, id: idOf(uid), owner: true})
+			}
+		case aclUser:
+			if e.perm&mask&aclRead != 0 {
+				out = append(out, rule{subject: aclmap.User, id: idOf(e.id)})
+			}
+		case aclGroupObj:
+			if e.perm&mask&aclRead != 0 {
+				out = append(out, rule{subject: aclmap.Group, id: idOf(gid)})
+			}
+		case aclGroup:
+			if e.perm&mask&aclRead != 0 {
+				out = append(out, rule{subject: aclmap.Group, id: idOf(e.id)})
+			}
+		case aclOther:
+			if e.perm&aclRead != 0 {
+				out = append(out, rule{subject: aclmap.Domain})
+			}
+		}
+	}
+	return out
+}
+
+// decodePosixACL reads the on disk form of a POSIX access control list.
+//
+// The layout is a version word followed by fixed size entries, all little
+// endian whatever the machine is, which is what makes a disk written on one
+// architecture readable on another.
+func decodePosixACL(b []byte) ([]aclEntry, error) {
+	const (
+		version = 2
+		header  = 4
+		size    = 8
+	)
+	if len(b) < header {
+		return nil, errors.New("access control list shorter than its header")
+	}
+	if v := binary.LittleEndian.Uint32(b); v != version {
+		// A version this does not know is a layout this does not know, and
+		// reading it anyway would produce entries naming people at random.
+		return nil, fmt.Errorf("access control list version %d", v)
+	}
+	b = b[header:]
+	if len(b)%size != 0 {
+		return nil, errors.New("access control list ends inside an entry")
+	}
+
+	out := make([]aclEntry, 0, len(b)/size)
+	for len(b) > 0 {
+		out = append(out, aclEntry{
+			tag:  binary.LittleEndian.Uint16(b),
+			perm: binary.LittleEndian.Uint16(b[2:]),
+			id:   binary.LittleEndian.Uint32(b[4:]),
+		})
+		b = b[size:]
+	}
+	return out, nil
+}
+
+// changeTime is when the inode last changed, which is when the mode, the owner
+// or the access control list was last written.
+func changeTime(info fs.FileInfo) time.Time {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return time.Time{}
+	}
+	sec, nsec := inodeChange(st)
+	return time.Unix(sec, nsec)
+}

--- a/connector/fssource/osperm_posix_test.go
+++ b/connector/fssource/osperm_posix_test.go
@@ -1,0 +1,212 @@
+//go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd
+
+package fssource
+
+import (
+	"encoding/binary"
+	"io/fs"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/connector/aclmap"
+)
+
+// show writes a list of rules the way a failure should read, because a
+// difference between two slices of a struct with five fields is otherwise a
+// wall nobody reads twice.
+func show(rules []rule) string {
+	out := make([]string, 0, len(rules))
+	for _, r := range rules {
+		s := r.subject.String() + " " + r.id
+		if r.deny {
+			s = "deny " + s
+		}
+		if r.owner {
+			s += " (owner)"
+		}
+		out = append(out, s)
+	}
+	return "[" + strings.Join(out, ", ") + "]"
+}
+
+// TestOnlyTheReadBitsBecomeGrants is the whole of the Unix mapping. Write
+// access is not read access, and a mode that granted on any bit at all would
+// hand a document to everybody who can drop a file next to it.
+func TestOnlyTheReadBitsBecomeGrants(t *testing.T) {
+	const (
+		uid = 501
+		gid = 20
+	)
+	owner := rule{subject: aclmap.User, id: "501", owner: true}
+	group := rule{subject: aclmap.Group, id: "20"}
+	world := rule{subject: aclmap.Domain}
+
+	for _, c := range []struct {
+		mode fs.FileMode
+		want []rule
+		why  string
+	}{
+		{0o600, []rule{owner}, "a file only its owner can read"},
+		{0o640, []rule{owner, group}, "the group can read it too"},
+		{0o644, []rule{owner, group, world}, "and so can everybody with an account"},
+		{0o604, []rule{owner, world}, "a hole in the middle is a hole in the middle"},
+		{0o060, []rule{group}, "an owner who took away their own read bit is not a reader"},
+		{0o000, nil, "a file nobody can read"},
+		{0o222, nil, "writing is not reading"},
+		{0o111, nil, "nor is running"},
+		{0o333, nil, "nor is both of them at once"},
+	} {
+		got := modeRules(c.mode, uid, gid)
+		if !slices.Equal(got, c.want) {
+			t.Errorf("mode %04o gave %s, want %s: %s", c.mode, show(got), show(c.want), c.why)
+		}
+	}
+}
+
+// entry is the on disk form of one access control list entry.
+func entry(tag, perm uint16, id uint32) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint16(b, tag)
+	binary.LittleEndian.PutUint16(b[2:], perm)
+	binary.LittleEndian.PutUint32(b[4:], id)
+	return b
+}
+
+// list is a whole access control list as the file system stores it.
+func list(version uint32, entries ...[]byte) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, version)
+	for _, e := range entries {
+		b = append(b, e...)
+	}
+	return b
+}
+
+func TestAnAccessControlListNamesPeopleTheModeBitsCannot(t *testing.T) {
+	got := aclRules([]aclEntry{
+		{tag: aclUserObj, perm: 0o6},
+		{tag: aclUser, perm: 0o4, id: 1001},
+		{tag: aclGroupObj, perm: 0o4},
+		{tag: aclGroup, perm: 0o4, id: 2002},
+		{tag: aclMask, perm: 0o7},
+		{tag: aclOther, perm: 0o0},
+	}, 501, 20)
+
+	want := []rule{
+		{subject: aclmap.User, id: "501", owner: true},
+		{subject: aclmap.User, id: "1001"},
+		{subject: aclmap.Group, id: "20"},
+		{subject: aclmap.Group, id: "2002"},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("the list gave %s, want %s", show(got), show(want))
+	}
+}
+
+// TestTheMaskIsACeilingAndNotADecoration is the reason this package reads the
+// list at all. A file with a mask that has taken read away still shows a group
+// read bit in its mode, so a mapping built on the mode alone offers the file to
+// a team that cannot open it.
+func TestTheMaskIsACeilingAndNotADecoration(t *testing.T) {
+	entries := []aclEntry{
+		{tag: aclUserObj, perm: 0o6},
+		{tag: aclUser, perm: 0o4, id: 1001},
+		{tag: aclGroupObj, perm: 0o4},
+		{tag: aclGroup, perm: 0o4, id: 2002},
+		{tag: aclMask, perm: 0o2},
+		{tag: aclOther, perm: 0o4},
+	}
+	got := aclRules(entries, 501, 20)
+
+	// The owner and the world are the two the mask does not reach, which is
+	// what POSIX says and what makes the answer look odd at first reading.
+	want := []rule{
+		{subject: aclmap.User, id: "501", owner: true},
+		{subject: aclmap.Domain},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("a mask of 2 gave %s, want %s", show(got), show(want))
+	}
+}
+
+// TestAListWithNoMaskGrantsWhatItSays covers the ordering trap. The mask can
+// sit anywhere in the list, including after the entries it governs, so a reader
+// that applied it as it went would let through whatever came first.
+func TestAListWithNoMaskGrantsWhatItSays(t *testing.T) {
+	got := aclRules([]aclEntry{
+		{tag: aclGroup, perm: 0o4, id: 2002},
+		{tag: aclUserObj, perm: 0o4},
+	}, 501, 20)
+
+	want := []rule{
+		{subject: aclmap.Group, id: "2002"},
+		{subject: aclmap.User, id: "501", owner: true},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("a list without a mask gave %s, want %s", show(got), show(want))
+	}
+
+	// And with the mask last, the group it refuses is gone even though the
+	// entry was read before the mask was.
+	got = aclRules([]aclEntry{
+		{tag: aclGroup, perm: 0o4, id: 2002},
+		{tag: aclUserObj, perm: 0o4},
+		{tag: aclMask, perm: 0o1},
+	}, 501, 20)
+	want = []rule{{subject: aclmap.User, id: "501", owner: true}}
+	if !slices.Equal(got, want) {
+		t.Fatalf("a trailing mask gave %s, want %s", show(got), show(want))
+	}
+}
+
+func TestAnAccessControlListIsReadOffTheDisk(t *testing.T) {
+	raw := list(2,
+		entry(aclUserObj, 0o6, 0),
+		entry(aclUser, 0o4, 1001),
+		entry(aclMask, 0o7, 0),
+		entry(aclOther, 0o0, 0),
+	)
+	got, err := decodePosixACL(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := []aclEntry{
+		{tag: aclUserObj, perm: 0o6},
+		{tag: aclUser, perm: 0o4, id: 1001},
+		{tag: aclMask, perm: 0o7},
+		{tag: aclOther, perm: 0o0},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("decoded %v, want %v", got, want)
+	}
+}
+
+// TestAListThisReaderDoesNotUnderstandIsRefused is the one place a wrong answer
+// would be silent. Every one of these produces entries that name real accounts
+// at random, and an access control list nobody wrote is worse than none.
+func TestAListThisReaderDoesNotUnderstandIsRefused(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		raw  []byte
+	}{
+		{"shorter than its header", []byte{2, 0}},
+		{"a version from the future", list(3, entry(aclUserObj, 0o4, 0))},
+		{"a version from before there was one", list(0)},
+		{"ending inside an entry", append(list(2, entry(aclUserObj, 0o4, 0)), 1, 2, 3)},
+	} {
+		if _, err := decodePosixACL(c.raw); err == nil {
+			t.Errorf("a list %s was read without complaint", c.name)
+		}
+	}
+
+	// An empty list is a list, and it is a file nobody may read rather than a
+	// broken read. The two have to stay distinguishable.
+	got, err := decodePosixACL(list(2))
+	if err != nil {
+		t.Fatalf("an empty list was refused: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("an empty list decoded to %v", got)
+	}
+}

--- a/connector/fssource/osperm_test.go
+++ b/connector/fssource/osperm_test.go
@@ -1,0 +1,164 @@
+package fssource_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/fssource"
+)
+
+// theIdentity is the identity source the tests hand to the policy. Everything
+// the policy produces is a reference under this name, and a principal only
+// matches a reference that agrees about it, which is the mistake the name is
+// here to make visible.
+const theIdentity = "host"
+
+// osPolicy builds a policy over a directory holding one file, and returns both.
+func osPolicy(t *testing.T, body string, domains ...string) (policy *fssource.OSPolicy, root string) {
+	t.Helper()
+	root = t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "note.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := fssource.NewOSPolicy(root, "files", theIdentity, domains...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return policy, root
+}
+
+// named builds a principal holding one account name in the identity source the
+// tests use.
+func named(name string) *acl.Principal {
+	return &acl.Principal{
+		Tenant:     "acme",
+		Subject:    "u_" + name,
+		Identities: []acl.Identity{{Source: theIdentity, Value: name}},
+	}
+}
+
+// TestTheOperatingSystemIsAskedWhoMayReadAFile is the smoke test, and it is the
+// only one of these that runs everywhere. What it proves is that the platform
+// half of the policy read something real: a descriptor that named nobody would
+// pass every mapping test in this package and index a corpus nobody can find.
+func TestTheOperatingSystemIsAskedWhoMayReadAFile(t *testing.T) {
+	p, _ := osPolicy(t, "# a note\n")
+
+	perm, err := p.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	if perm.Mode == acl.ModeUnknown {
+		t.Fatalf("a file this process just wrote came back unresolved: %+v", perm)
+	}
+	if perm.Source != "files" {
+		t.Errorf("the descriptor is attributed to %q, want %q", perm.Source, "files")
+	}
+	if perm.Owner.Value == "" && len(perm.AllowUsers) == 0 && len(perm.AllowGroups) == 0 {
+		t.Fatalf("a file this process just wrote is readable by nobody: %+v", perm)
+	}
+	for _, ref := range append([]acl.Ref{perm.Owner}, perm.AllowUsers...) {
+		if ref.Value != "" && ref.Source != theIdentity {
+			t.Errorf("%q is written under identity source %q, want %q", ref.Value, ref.Source, theIdentity)
+		}
+	}
+}
+
+// TestSomebodyTheListDoesNotNameIsRefused is the default the whole package
+// exists to hold. The account is one no machine has, so every path through
+// Allows has to end in false.
+func TestSomebodyTheListDoesNotNameIsRefused(t *testing.T) {
+	p, _ := osPolicy(t, "# a note\n")
+
+	perm, err := p.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	if perm.Mode == acl.ModePublicToTenant {
+		t.Skip("this machine makes files readable by everybody with an account")
+	}
+	if perm.Allows(named("nobody-by-that-name")) {
+		t.Fatalf("a stranger was allowed by %+v", perm)
+	}
+}
+
+// TestTheNamesTheListCarriesAreTheNamesThatMatch checks the two halves of the
+// rule agree. The mapping writes references and Allows compares keys, and a
+// disagreement between them would be a policy that reads the file system
+// correctly and lets nobody in.
+func TestTheNamesTheListCarriesAreTheNamesThatMatch(t *testing.T) {
+	p, _ := osPolicy(t, "# a note\n")
+
+	perm, err := p.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	who := perm.Owner
+	if who.Value == "" && len(perm.AllowUsers) > 0 {
+		who = perm.AllowUsers[0]
+	}
+	if who.Value == "" {
+		t.Skip("this machine grants the file through a group rather than a person")
+	}
+	if !perm.Allows(named(who.Value)) {
+		t.Fatalf("%q is named on %+v and was refused", who.Value, perm)
+	}
+}
+
+// TestAPathThatIsNotThereIsAnErrorRatherThanAnEmptyList matters because an
+// empty list is a working answer meaning nobody may read the file. A deleted
+// file that came back that way would be indexed as a document under permissions
+// nobody wrote.
+func TestAPathThatIsNotThereIsAnErrorRatherThanAnEmptyList(t *testing.T) {
+	p, _ := osPolicy(t, "# a note\n")
+
+	if _, err := p.Permissions(t.Context(), "gone.md"); err == nil {
+		t.Error("a path that is not there was given an access control list")
+	}
+	if _, err := p.ChangedAt(t.Context(), "gone.md"); err == nil {
+		t.Error("a path that is not there was given a change time")
+	}
+}
+
+// TestTheIdentitySourceHasToBeNamed is the one piece of configuration that
+// cannot be guessed. Without it every reference is written under an empty
+// source, which matches whatever a principal happens to carry.
+func TestTheIdentitySourceHasToBeNamed(t *testing.T) {
+	root := t.TempDir()
+	for _, c := range []struct {
+		name             string
+		source, identity string
+	}{
+		{"no connector name", "", theIdentity},
+		{"no identity source", "files", ""},
+	} {
+		if _, err := fssource.NewOSPolicy(root, c.source, c.identity); err == nil {
+			t.Errorf("a policy with %s was built without complaint", c.name)
+		}
+	}
+}
+
+// TestReloadKeepsAnswering is a small thing with a large failure. Reload is
+// called at the start of every walk, and a policy that cleared the wrong state
+// or left a lock held would take the next sync of the tree with it.
+func TestReloadKeepsAnswering(t *testing.T) {
+	p, _ := osPolicy(t, "# a note\n")
+
+	before, err := p.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	p.Reload()
+	after, err := p.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions after a reload: %v", err)
+	}
+	if after.Owner != before.Owner || after.Mode != before.Mode {
+		t.Fatalf("a reload changed the answer from %+v to %+v", before, after)
+	}
+	if c := p.Counts(); c.Mapped < 2 {
+		t.Errorf("the mapping counted %d documents, want at least 2", c.Mapped)
+	}
+}

--- a/connector/fssource/osperm_unix_test.go
+++ b/connector/fssource/osperm_unix_test.go
@@ -1,0 +1,308 @@
+//go:build linux || darwin || dragonfly || freebsd || netbsd || openbsd
+
+package fssource_test
+
+import (
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/fssource"
+)
+
+// whoAmI is the account name the policy will resolve this process to, asked for
+// the same way the policy asks so that a machine with an unusual password
+// database does not turn a real failure into a puzzle.
+func whoAmI(t *testing.T) string {
+	t.Helper()
+	u, err := user.LookupId(strconv.Itoa(os.Getuid()))
+	if err != nil {
+		t.Skipf("this machine cannot name the account it is running as: %v", err)
+	}
+	return u.Username
+}
+
+// groupOf is the name of the group a file belongs to, which on the BSDs is
+// inherited from the directory rather than taken from the process.
+func groupOf(t *testing.T, path string) string {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("this file system does not report a group")
+	}
+	g, err := user.LookupGroupId(strconv.FormatUint(uint64(st.Gid), 10))
+	if err != nil {
+		t.Skipf("this machine cannot name group %d: %v", st.Gid, err)
+	}
+	return g.Name
+}
+
+// inGroup builds a principal whose only claim is membership of one group.
+func inGroup(group string) *acl.Principal {
+	return &acl.Principal{
+		Tenant:  "acme",
+		Subject: "u_visitor",
+		Groups:  acl.GroupSet{Members: []string{theIdentity + ":" + group}},
+	}
+}
+
+// chmod is os.Chmod with the failure reported where it happened, because a mode
+// that quietly did not take turns every assertion below into a lie.
+func chmod(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAFileOnlyItsOwnerCanReadIsOwnedRatherThanShared is the mode a feature
+// such as everything of mine reads. A list with one name in it behaves the same
+// way today and does not mean the same thing.
+func TestAFileOnlyItsOwnerCanReadIsOwnedRatherThanShared(t *testing.T) {
+	p, root := osPolicy(t, "# a note\n")
+	chmod(t, filepath.Join(root, "note.md"), 0o600)
+	me := whoAmI(t)
+
+	perm, err := p.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	if perm.Mode != acl.ModeOwnerOnly {
+		t.Errorf("mode 0600 came out as %v, want owner only", perm.Mode)
+	}
+	if want := (acl.Ref{Source: theIdentity, Value: me}); perm.Owner != want {
+		t.Errorf("the owner is %+v, want %+v", perm.Owner, want)
+	}
+	if len(perm.AllowUsers) != 0 || len(perm.AllowGroups) != 0 {
+		t.Errorf("a private file also allows %v and %v", perm.AllowUsers, perm.AllowGroups)
+	}
+	if !perm.Allows(named(me)) {
+		t.Error("the owner cannot read their own file")
+	}
+	if perm.Allows(named("somebody-else")) {
+		t.Error("a private file was shown to somebody else")
+	}
+}
+
+func TestTheGroupBitIsAGrantToTheGroup(t *testing.T) {
+	p, root := osPolicy(t, "# a note\n")
+	note := filepath.Join(root, "note.md")
+	chmod(t, note, 0o640)
+	group := groupOf(t, note)
+
+	perm, err := p.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	if perm.Mode != acl.ModeACL {
+		t.Errorf("mode 0640 came out as %v, want an access control list", perm.Mode)
+	}
+	want := acl.Ref{Source: theIdentity, Value: group}
+	if !slices.Contains(perm.AllowGroups, want) {
+		t.Fatalf("the group list is %v, want it to contain %+v", perm.AllowGroups, want)
+	}
+	if !perm.Allows(inGroup(group)) {
+		t.Errorf("somebody in %q was refused a file their group can read", group)
+	}
+	if perm.Allows(inGroup("some-other-team")) {
+		t.Errorf("somebody in another group was allowed by %+v", perm)
+	}
+}
+
+// TestTheWorldBitGrantsNothingUntilSomebodySaysWhoTheWorldIs is the one
+// mapping in this policy that cannot be made without configuration. Every
+// account on this host is not a tenant: on a laptop it is one person and on a
+// login server it is the company, and only the deployment knows which.
+func TestTheWorldBitGrantsNothingUntilSomebodySaysWhoTheWorldIs(t *testing.T) {
+	silent, root := osPolicy(t, "# a note\n")
+	chmod(t, filepath.Join(root, "note.md"), 0o644)
+
+	perm, err := silent.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	if perm.Mode != acl.ModeACL {
+		t.Errorf("without a domain, mode 0644 came out as %v, want an access control list", perm.Mode)
+	}
+	if perm.Allows(named("anybody-with-a-login")) {
+		t.Errorf("the world bit was read as a tenant nobody named: %+v", perm)
+	}
+
+	told, err := fssource.NewOSPolicy(root, "files", theIdentity, "acme.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	perm, err = told.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	if perm.Mode != acl.ModePublicToTenant {
+		t.Errorf("with a domain, mode 0644 came out as %v, want public to the tenant", perm.Mode)
+	}
+	if !perm.Allows(named("anybody-with-a-login")) {
+		t.Errorf("a world readable file was refused to the tenant it belongs to: %+v", perm)
+	}
+}
+
+func TestAFileNobodyCanReadAllowsNobody(t *testing.T) {
+	p, root := osPolicy(t, "# a note\n")
+	note := filepath.Join(root, "note.md")
+	chmod(t, note, 0o000)
+	me := whoAmI(t)
+
+	perm, err := p.Permissions(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("permissions: %v", err)
+	}
+	// Not unresolved. Nobody may read it is an answer the file system gave,
+	// and it is a different fact from nobody could work out who may read it.
+	if perm.Mode == acl.ModeUnknown {
+		t.Fatalf("a file with no read bits came back unresolved: %+v", perm)
+	}
+	if perm.Owner.Value != "" || len(perm.AllowUsers) != 0 || len(perm.AllowGroups) != 0 {
+		t.Fatalf("a file with no read bits still names somebody: %+v", perm)
+	}
+	if perm.Allows(named(me)) {
+		t.Error("the owner was allowed a file they took their own read bit away from")
+	}
+	if perm.Allows(inGroup(groupOf(t, note))) {
+		t.Error("the group was allowed a file with no group read bit")
+	}
+}
+
+// TestAChmodMovesTheChangeTimeAndNotTheModificationTime is what makes the sync
+// below possible at all. A revocation that waits for somebody to edit the file
+// is not a revocation.
+func TestAChmodMovesTheChangeTimeAndNotTheModificationTime(t *testing.T) {
+	p, root := osPolicy(t, "# a note\n")
+	note := filepath.Join(root, "note.md")
+
+	before, err := p.ChangedAt(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("changed at: %v", err)
+	}
+	if before.IsZero() {
+		t.Fatal("this platform has no change time, so a chmod can never be noticed")
+	}
+	info, err := os.Stat(note)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modified := info.ModTime()
+
+	// Filesystems with a coarse clock would otherwise report the two events in
+	// the same tick, and the comparison would pass or fail on timing.
+	time.Sleep(10 * time.Millisecond)
+	chmod(t, note, 0o600)
+
+	after, err := p.ChangedAt(t.Context(), "note.md")
+	if err != nil {
+		t.Fatalf("changed at: %v", err)
+	}
+	if !after.After(before) {
+		t.Errorf("a chmod left the change time at %v", after)
+	}
+	info, err = os.Stat(note)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(modified) {
+		t.Errorf("a chmod moved the modification time from %v to %v, so the file was rewritten",
+			modified, info.ModTime())
+	}
+}
+
+// TestAChmodIsAPermissionChangeAndNotARecrawl is the box, end to end and on the
+// permission model the operating system keeps. Taking read away from one file
+// has to reach the index without the sync reading a single byte of the tree.
+func TestAChmodIsAPermissionChangeAndNotARecrawl(t *testing.T) {
+	root := tree(t, map[string]string{
+		"a.md":      "# a\n",
+		"b.md":      "# b\n",
+		"docs/c.md": "# c\n",
+	})
+	policy, err := fssource.NewOSPolicy(root, "repo", theIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := fssource.New(root, "repo", policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	first, cursor := collect(t, s, connector.Cursor{})
+	if len(first) != 3 {
+		t.Fatalf("the first sync read %v, want three documents", ids(first))
+	}
+	for _, d := range first {
+		if d.Permissions.Mode != acl.ModeACL {
+			t.Fatalf("%s starts at %v, want an access control list with the group on it",
+				d.ID, d.Permissions.Mode)
+		}
+	}
+	after := s.Counters()
+
+	// The clock again, so that the change time lands unambiguously past a
+	// cursor taken a moment ago.
+	time.Sleep(10 * time.Millisecond)
+	chmod(t, filepath.Join(root, "a.md"), 0o600)
+
+	var changes []connector.Change
+	next, err := s.Sync(t.Context(), cursor, func(_ context.Context, ch connector.Change) error {
+		changes = append(changes, ch)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	if len(changes) != 1 {
+		got := make([]string, 0, len(changes))
+		for _, ch := range changes {
+			got = append(got, ch.Document.ID)
+		}
+		t.Fatalf("one chmod produced changes for %v, want repo:a.md alone", got)
+	}
+	got := changes[0]
+	if !got.PermissionsOnly {
+		t.Errorf("%s came back as a content change, so the file was read again", got.Document.ID)
+	}
+	if got.Document.ID != "repo:a.md" {
+		t.Errorf("the change is for %s, want repo:a.md", got.Document.ID)
+	}
+	if mode := got.Document.Permissions.Mode; mode != acl.ModeOwnerOnly {
+		t.Errorf("the file is now %v, want owner only", mode)
+	}
+
+	spent := s.Counters().Since(after)
+	if spent.Fetches != 0 || spent.Bytes != 0 {
+		t.Errorf("applying a permission change read %d files and %d bytes, so it was a recrawl",
+			spent.Fetches, spent.Bytes)
+	}
+
+	// And once. A cursor that did not move past the chmod would replay it on
+	// every sync from here on.
+	changes = nil
+	if _, err := s.Sync(t.Context(), next, func(_ context.Context, ch connector.Change) error {
+		changes = append(changes, ch)
+		return nil
+	}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("the chmod was reported again on the next sync: %d changes", len(changes))
+	}
+}

--- a/connector/fssource/osperm_windows.go
+++ b/connector/fssource/osperm_windows.go
@@ -1,0 +1,175 @@
+package fssource
+
+import (
+	"fmt"
+	"io/fs"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/tamnd/genba/connector/aclmap"
+)
+
+// The access rights that let somebody read a file.
+//
+// They are written out here rather than taken from a constant somewhere else
+// because which of them counts is the decision this file exists to make. Write
+// access is not read access on Windows any more than it is anywhere else, and a
+// mapping that treated the whole mask as one thing would hand a share to
+// everybody who can drop a file into it.
+const (
+	fileReadData = 0x00000001 // FILE_READ_DATA
+	genericRead  = 0x80000000 // GENERIC_READ, as it appears before it is mapped
+	genericAll   = 0x10000000 // GENERIC_ALL
+	readAccess   = fileReadData | genericRead | genericAll
+)
+
+// inheritOnly marks an entry that governs the files created inside a directory
+// rather than the object it is attached to.
+const inheritOnly = 0x08 // INHERIT_ONLY_ACE
+
+// The security identifiers that mean everybody.
+//
+// Everyone is exactly that, including accounts nobody in the company holds.
+// Authenticated Users is every account the machine's domain will authenticate,
+// which on a joined host is the company and on a standalone one is whoever has
+// a local account. Neither is a tenant, so both go through the same door as the
+// Unix world bit.
+const (
+	sidEveryone           = "S-1-1-0"
+	sidAuthenticatedUsers = "S-1-5-11"
+)
+
+// accessRules reads the security descriptor of one file.
+//
+// The file information the walk already has is no help here. Windows keeps the
+// permissions in a security descriptor rather than in the directory entry, so
+// there is a call per file whatever the caller is holding.
+func accessRules(full string, _ fs.FileInfo) ([]rule, error) {
+	sd, err := windows.GetNamedSecurityInfo(full, windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return nil, fmt.Errorf("fssource: %s: %w", full, err)
+	}
+
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return nil, fmt.Errorf("fssource: %s: %w", full, err)
+	}
+	if dacl == nil {
+		// A descriptor with no list at all grants everybody everything, which is
+		// what Windows does with it and is not what an absent list looks like.
+		return []rule{{subject: aclmap.Domain}}, nil
+	}
+
+	out := make([]rule, 0, dacl.AceCount)
+	for i := range uint32(dacl.AceCount) {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, i, &ace); err != nil {
+			// An entry that cannot be read is an entry that might be a refusal,
+			// and carrying on without it would apply the rest of the list as
+			// though this one had said nothing.
+			return nil, fmt.Errorf("fssource: %s: entry %d: %w", full, i, err)
+		}
+		r, ok, err := aceRule(ace)
+		if err != nil {
+			return nil, fmt.Errorf("fssource: %s: %w", full, err)
+		}
+		if ok {
+			out = append(out, r)
+		}
+	}
+	return markOwner(out, sd), nil
+}
+
+// aceRule turns one entry into a statement, and reports whether the entry has
+// anything to say about reading.
+func aceRule(ace *windows.ACCESS_ALLOWED_ACE) (rule, bool, error) {
+	deny := false
+	switch ace.Header.AceType {
+	case windows.ACCESS_ALLOWED_ACE_TYPE:
+	case windows.ACCESS_DENIED_ACE_TYPE:
+		deny = true
+	default:
+		// Auditing entries and the object entries a directory service uses say
+		// nothing about who may read a file.
+		return rule{}, false, nil
+	}
+	if ace.Header.AceFlags&inheritOnly != 0 {
+		// The entry is a template for the files made inside this directory and
+		// is not in force on the directory itself.
+		return rule{}, false, nil
+	}
+	if ace.Mask&readAccess == 0 {
+		return rule{}, false, nil
+	}
+
+	sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+	text := sid.String()
+	if text == sidEveryone || text == sidAuthenticatedUsers {
+		return rule{subject: aclmap.Domain, deny: deny}, true, nil
+	}
+
+	account, domain, kind, err := sid.LookupAccount("")
+	if err != nil {
+		// An entry left behind by a deleted account, which every file server of
+		// any age is full of. The identifier still names exactly one account and
+		// will never name another, so a grant can be carried under it and simply
+		// matches nobody.
+		//
+		// A refusal cannot. Whether it belongs in the user list or the group
+		// list decides whether it applies at all, and a refusal that does not
+		// apply is the one failure this package will not have.
+		if deny {
+			return rule{}, false, fmt.Errorf("a refusal by %s, whose account does not resolve", text)
+		}
+		return rule{subject: aclmap.User, id: text, name: text}, true, nil
+	}
+
+	name := account
+	if domain != "" {
+		name = domain + `\` + account
+	}
+	switch kind {
+	case windows.SidTypeUser, windows.SidTypeComputer:
+		return rule{subject: aclmap.User, id: text, name: name, deny: deny}, true, nil
+	case windows.SidTypeGroup, windows.SidTypeAlias, windows.SidTypeWellKnownGroup:
+		return rule{subject: aclmap.Group, id: text, name: name, deny: deny}, true, nil
+	default:
+		if deny {
+			return rule{}, false, fmt.Errorf("a refusal by %s, which is neither a person nor a group", name)
+		}
+		return rule{}, false, nil
+	}
+}
+
+// markOwner records which of the statements belongs to the file's owner.
+//
+// Owning a file on Windows is not permission to read it. The owner may rewrite
+// the list and then read it, which is not the same thing, and treating it as
+// the same would grant a whole tree to whichever account happened to create it.
+// So the owner is marked only where the list already lets them read.
+func markOwner(rules []rule, sd *windows.SECURITY_DESCRIPTOR) []rule {
+	owner, _, err := sd.Owner()
+	if err != nil || owner == nil {
+		return rules
+	}
+	text := owner.String()
+	for i := range rules {
+		if rules[i].subject == aclmap.User && !rules[i].deny && rules[i].id == text {
+			rules[i].owner = true
+			break
+		}
+	}
+	return rules
+}
+
+// changeTime has no answer on Windows.
+//
+// The file system does keep a change time, and reading it costs an open and a
+// query per file, which is a price a sync over a large tree pays once per file
+// per run for a fact that is almost always the same as last time. So a
+// permission change here waits for the next full sync rather than being noticed
+// between two.
+func changeTime(fs.FileInfo) time.Time { return time.Time{} }

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -87,8 +87,21 @@ type Reloader interface {
 
 Every file the walk skips as unchanged is asked about, so the answer has to be cheap.
 For `OwnersPolicy` it is a map read after the first file in each directory.
+For `OSPolicy` it is the inode change time, which the walk is already holding, so it costs nothing at all.
 `Reload` is called once at the start of every walk, and it is what stops a process that has been up for a week from answering with the OWNERS files as they were when it started.
 The cache lives for exactly one walk: long enough to cost one read per OWNERS file per sync instead of one per document, short enough that the next sync notices the edit.
+
+The inode change time is worth a sentence of its own, because it is the whole of how a `chmod` reaches the index.
+It moves when the mode, the owner or the access control list is written, and stays where it is when only the content is, which is exactly the event a sync comparing modification times cannot see.
+A revocation that takes effect the next time somebody happens to edit the file is not a revocation.
+
+Windows has no equivalent that can be read without opening every file, so `OSPolicy` answers with the zero time there and a permission change waits for the next full sync.
+That is stated rather than worked around, because the way to work around it is a stat that costs an open per file per sync.
+
+Asking twice is the other cost worth avoiding.
+A policy that reads the file system itself already has everything it needs in the `fs.FileInfo` the walk is carrying, and calling `Permissions` with a path would make it stat the file a second time.
+On a corpus of a million files that is a million system calls a sync spends finding out something it was told a moment ago, so the source hands the file information over where a policy can use it.
+That handover is deliberately not a public interface: it is one more thing every policy would have to implement, for a saving only the policies that read the file system get.
 
 ## What the sync could not have seen: reconciliation
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -104,7 +104,7 @@ Keeping all of them in one file means the staleness is in one place, next to the
 
 ### Files
 
-A directory tree has no permission model of its own worth reading, so the roles are the ones a policy over the tree invents.
+A directory tree has two permission models, and which one to read is a question about the tree rather than about the files in it.
 
 | Role | Reads |
 | --- | --- |
@@ -112,10 +112,49 @@ A directory tree has no permission model of its own worth reading, so the roles 
 | `approver` | yes |
 | `reviewer` | yes |
 
+The roles above are the ones a policy over the tree invents, and `OwnersPolicy` is the one that uses them.
 The OWNERS convention that Kubernetes and a number of other large repositories keep names approvers and reviewers, and both are people who can read the subtree.
 There is no deny and no link sharing.
 A subtree narrows what its parent allowed by replacing the list rather than by refusing anybody.
 A path with no OWNERS file anywhere above it has no answer at all and is quarantined, which is the case worth getting right: the default for "no rule found" is not "no restriction".
+
+The other model is the one the operating system already keeps, and `OSPolicy` reads it.
+
+| What the file system has | How it is read |
+| --- | --- |
+| the owner, where the owner read bit is set | a `User` grant marked as the owner |
+| the group, where the group read bit is set | a `Group` grant |
+| the world read bit | a `Domain` grant, and nothing at all until a domain is named |
+| a POSIX access control list | read in place of the mode bits, with the mask applied |
+| a Windows access control entry that allows reading | a `User` or `Group` grant |
+| a Windows entry that denies reading | a `Deny`, which beats every grant |
+| Everyone and Authenticated Users on Windows | the same `Domain` grant as the world bit |
+
+This is the right policy for a tree that is the file server, because there the operating system is the access control system and there is nothing better above it.
+It is the wrong policy for a copy of one.
+A tree that was rsynced to the crawler carries the permissions the copy has, which are the crawler's own, and indexing those would hand the lot to whoever the crawler runs as.
+
+Three of those rows are worth expanding on.
+
+The read bits are read literally, so an owner who took away their own read bit is not granted the file.
+There is an argument the other way, since they could put the bit back, and being wrong this way costs somebody a file of their own they cannot find while being wrong the other way costs a file shown to somebody who was refused it.
+
+The world bit cannot be mapped without being told something first.
+It says every account on this host may read the file, and a host's accounts are not a tenant: on a laptop they are one person, on a login server they are the company, and on a machine with a guest account they are more than the company.
+So it grants nothing until a deployment names the domain those accounts belong to.
+
+The mask on a POSIX list is a ceiling rather than a decoration, and it is the reason the list is read at all.
+The group bits in the mode of a file that carries a list are the mask, not the group's own permission, so a group the mask has taken read away from still looks allowed in the mode.
+A mapping built on the mode alone would offer that file to a team who cannot open it.
+
+The gap is macOS and the BSDs.
+They keep extended access control lists of the NFSv4 shape, in a place a program can only reach through the C library, and they are not read.
+A file carrying one gets the answer its mode bits give, which is narrower than the truth where the list grants and wider than it where the list refuses.
+That second case is the one gap in this policy that goes the wrong way, and it is written down rather than left to be found: on those systems this is a good answer for an ordinary tree and not a safe one for a tree somebody has been managing with the access control list editor.
+
+Every identifier is resolved to an account name, and a file whose owner does not resolve is quarantined rather than indexed under a number.
+A numeric user id is not an identity.
+It means one person on one host and somebody else on the next, so a grant written in terms of one would either match nobody or match the wrong person.
 
 ### Object storage
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.6
 
 require (
 	github.com/jackc/pgx/v5 v5.10.0
+	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.56.0
 )
 
@@ -17,7 +18,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	modernc.org/libc v1.74.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect


### PR DESCRIPTION
Closes part of #14.

A directory tree that is the file server already has an access control system on it, and until now this package could only read the OWNERS convention or hand the whole tree to the tenant.
`OSPolicy` reads what the operating system keeps: the owner, the group and the mode bits on Unix, the POSIX access control list where a file carries one, and the security descriptor on Windows.

## One vocabulary, one file per platform

The platform specific code produces a list of `rule` values, statements about users, groups and everybody, and everything above it works in those.
That is what keeps the mode bits, the access control list entries and the Windows access masks each inside the one file that knows what they mean, and it is why the mapping onto `aclmap` is tested once rather than three times.

`osperm.go` is the portable half. `osperm_posix.go` has the mode bits and the POSIX list, `osperm_linux.go` reads the list off the file, `osperm_bsd.go` says there is none, `osperm_windows.go` walks the discretionary list, and `osperm_other.go` refuses rather than returning an empty list, because an empty list is a working answer meaning nobody may read the file.

## The three decisions worth arguing about

The read bits are read literally, so an owner who took away their own read bit is not granted the file.
There is an argument the other way, since they could put the bit back.
Being wrong this way costs somebody a file of their own they cannot find, and being wrong the other way costs a file shown to somebody who was refused it.

The world bit grants nothing until a deployment names the domain the host's accounts belong to.
It says every account on this host may read the file, and a host's accounts are not a tenant: on a laptop they are one person, on a login server they are the company, and on a machine with a guest account they are more than the company.

A POSIX list is read in place of the mode bits, and the mask is applied.
The group bits in the mode of a file that carries a list are the mask rather than the group's own permission, so a group the mask has taken read away from still looks allowed in the mode, and a mapping built on the mode alone would offer the file to a team who cannot open it.

## Windows

This is the platform with refusals in it.
A deny beats every grant, which is what Windows does too.
Entries that exist only to be inherited by files created later are skipped, and Everyone and Authenticated Users go through the same door as the world bit.

Owning a file on Windows is not permission to read it, so the owner is marked only where the list already lets them read.
An entry left behind by a deleted account is carried as a grant that matches nobody, because the identifier still names exactly one account and always will, but the same entry as a refusal is an error: whether it belongs in the user list or the group list decides whether it applies at all.

## The gap

macOS and the BSDs keep extended access control lists of the NFSv4 shape, in a place a program can only reach through the C library, and they are not read.
A file carrying one gets the answer its mode bits give, which is narrower than the truth where the list grants and wider than it where the list refuses.
That second case is the one gap in this policy that goes the wrong way, so it is in the package documentation and in `docs/permissions.md` rather than left to be found.

## A chmod without a recrawl

The policy answers `ChangedAt` with the inode change time, which moves when the mode, the owner or the list is written and stays where it is when only the content is.
That is exactly the event a sync comparing modification times cannot see, and a revocation that takes effect the next time somebody happens to edit the file is not a revocation.
Windows has no equivalent that can be read without opening every file, so it answers with the zero time and waits for the next full sync, which is stated rather than worked around.

`Sync` now folds that time into the cursor it returns.
Without it a file whose mode was last written after it was last edited would come back as a permission change on the very next run, restating the list it was just given, for every such file in the tree.

## Not stating every file twice

A policy that reads the file system itself already has everything it needs in the `fs.FileInfo` the walk is carrying.
Two unexported interfaces hand it over, so `OSPolicy` does not stat every file a second time.
On a corpus of a million files that is a million system calls a sync spends finding out something it was told a moment ago.

They are unexported on purpose.
Exported, they would be one more thing every policy has to implement, for a saving only the policies that read the file system get.

## Configuration

```
genbad -tenant acme \
  -corpus /srv/shared -corpus-name shared \
  -corpus-acl os -corpus-identity corp.example -corpus-domain corp.example \
  -corpus-refresh 5m
```

`-corpus-identity` names the identity source the account names belong to, so somebody who signed in through the company directory matches a list that came out of a password file.
`-corpus-domain` is what a world readable file means, and leaving it out means it grants nothing.

This is the right policy for a tree that is the file server and the wrong one for a copy of one.
A tree that was rsynced to the crawler carries the permissions the copy has, which are the crawler's own, and indexing those would hand the lot to whoever the crawler runs as.
The README says that out loud next to the flag.

## Tests

The mapping units are tested directly: every mode from 0000 to 0644 against the grants it produces, a POSIX list with a mask that is a ceiling and one where the mask sits after the entries it governs, and the on disk decoder including the three lists it refuses to read.

The behaviour is tested through the real file system: a 0600 file comes out owned rather than shared, 0640 names the group, 0644 grants nothing extra until a domain is named and the whole tenant once one is, a file with no read bits allows nobody, a chmod moves the change time and not the modification time, and a chmod on one file in a tree of three produces one permissions only change and zero fetches.

On Linux the list reader is driven with `setfacl` rather than hand written bytes, because the decoder reads a layout nothing in this repository defines and the only way to know it is being read correctly is to have the kernel write it.
Those two tests skip where the tool or the file system is missing.

And the daemon end to end: a tree where one file is 0600, a query as the account that owns it, and the same query as somebody with no account on the machine.

## CI

There is a new Windows job running `go test ./connector/...`.
Cross compiling cannot tell you whether code that reads a security descriptor is right, and this is the only part of the tree that asks the operating system a question it can get wrong, so the job stays narrow rather than becoming a third row of the test matrix.

## What is left on #14

The object storage connector, incremental sync without a full walk, and the conformance suite box, which belongs with #17.
