### PR TITLE
Add an object storage connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ func main() {
 | `index` | query parsing, retrieval and ranking |
 | `connector` | the ingestion contract, cursors and checkpoints |
 | `connector/fssource` | the reference connector, a directory tree with OWNERS files |
+| `connector/objectsource` | an S3 compatible bucket, signed and paged, [docs/ingestion.md](docs/ingestion.md) |
 | `extract` | text and structure out of PDF, Word, PowerPoint, Excel, HTML and Markdown, [docs/extraction.md](docs/extraction.md) |
 | `ingest` | the pipeline that runs a connector into a store |
 | `config` | runtime configuration and the rules for loading it |
@@ -317,6 +318,34 @@ The mode bits describe the account the crawler runs as, not the people in the co
 `OwnersPolicy` reads the OWNERS files that Kubernetes and a number of other large repositories keep, taking the nearest one going up the tree, which is a real access control list maintained by real people over a corpus anybody can check out.
 A source built with no policy at all quarantines everything, so having not thought about permissions yet is a visible state in the stats rather than an invisible one in the index.
 
+`connector/objectsource` is the second one, and the first that talks to a network service, which is where most of what a real connector has to get right lives.
+It reads an S3 compatible bucket, which is one connector rather than eight because Amazon's own service, MinIO, Ceph, Cloudflare R2, Backblaze B2, Wasabi and DigitalOcean Spaces all answer to the same two calls signed the same way.
+
+```go
+client, err := objectsource.NewClient(objectsource.Config{
+	Endpoint:        "https://s3.eu-west-1.amazonaws.com",
+	Region:          "eu-west-1",
+	Bucket:          "acme-reports",
+	AccessKeyID:     os.Getenv("AWS_ACCESS_KEY_ID"),
+	SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+})
+if err != nil {
+	log.Fatal(err)
+}
+policy, err := objectsource.NewBucketPolicy(client, "reports", "okta", "acme.com")
+if err != nil {
+	log.Fatal(err)
+}
+src, err := objectsource.New(client, "reports", policy, objectsource.WithPrefix("quarterly/"))
+if err != nil {
+	log.Fatal(err)
+}
+```
+
+The signing is signature version 4 written out in the package rather than taken from a vendor SDK, so the binary stays one file with no cloud provider dependency tree under it, and it is pinned against the published worked examples rather than against itself.
+`WithPrefix` narrows the listing rather than filtering it afterwards, so a source pointed at one folder of a bucket of a hundred million objects costs what that folder costs, and several sources can read the same bucket under different prefixes with different policies.
+Which of the two ways the bucket goes in the URL is a setting rather than a guess, because it is the one thing that genuinely differs between these services.
+
 What a source said about who may read a document is turned into the model in one place, `connector/aclmap`, rather than once per connector.
 Every system names permissions differently, and the same idea is a `reader` in one, `READ` in another, `VIEW` in a third and `BROWSE_PROJECTS` in a fourth.
 Mapping each of those is easy on its own, and the collection of them is where a search engine leaks, because every connector would otherwise decide on its own what a grant to a partner's domain means and what to do with a statement it does not understand.
@@ -333,6 +362,7 @@ Each budget bounds one file rather than the run: a zip bomb, a truncated archive
 
 Everything after the first sync is incremental.
 A second run over an unchanged tree reads no files at all, an OWNERS edit costs one write per document rather than a recrawl of the subtree, and a reconciliation sweep after every sync catches what a change feed cannot report, starting with the file somebody deleted.
+The same holds over a network: a second sync of an unchanged bucket fetches no objects and reads no bytes, and rewriting the bucket's access control list costs one write per object rather than a fetch of the whole bucket.
 [docs/ingestion.md](docs/ingestion.md) has the details, including the optional capabilities a connector implements to get each of those and the rule that stops a timed out enumeration from emptying a working index.
 
 ## Storage

--- a/arch_test.go
+++ b/arch_test.go
@@ -130,6 +130,11 @@ var allowed = map[string][]string{
 	// place for the permission rule to live.
 	"connector/aclmap":   {"acl"},
 	"connector/fssource": {"acl", "connector", "connector/aclmap", "doc", "extract"},
+	// objectsource sits at the same level as fssource and names the same five
+	// packages. It talks to a network service and fssource does not, and none of
+	// that difference is allowed to show up as a dependency: an S3 client of our
+	// own is a file in the package rather than a layer under it.
+	"connector/objectsource": {"acl", "connector", "connector/aclmap", "doc", "extract"},
 	// ingest names acl because a permission change that arrives without the
 	// document is a map of access control lists and nothing else, and there is
 	// no way to carry one without saying what it is. It is the one type from

--- a/connector/objectsource/client.go
+++ b/connector/objectsource/client.go
@@ -1,0 +1,444 @@
+package objectsource
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/tamnd/genba/connector"
+)
+
+// DefaultRequestTimeout bounds one request to the store.
+//
+// It covers reading the body as well as making the call, which is why it is
+// generous. A sixteen megabyte report over a slow link is a normal thing for
+// this connector to be doing and is not a hung request.
+const DefaultRequestTimeout = 2 * time.Minute
+
+// DefaultPageSize is how many objects one listing asks for. A thousand is the
+// most S3 will return and the most every service that copies it will return.
+const DefaultPageSize = 1000
+
+// Config says where a bucket is and how to prove the right to read it.
+type Config struct {
+	// Endpoint is the service's base URL, for example
+	// https://s3.eu-west-1.amazonaws.com or http://127.0.0.1:9000.
+	Endpoint string
+
+	// Region is the region the bucket is in, which is part of what a signature
+	// authenticates. Empty means us-east-1, which is what services that have no
+	// regions at all expect to be signed with.
+	Region string
+
+	// Bucket is the bucket to read.
+	Bucket string
+
+	// AccessKeyID and SecretAccessKey are the credentials. Both empty sends
+	// unsigned requests, which is what a public bucket wants and what nothing
+	// else does.
+	AccessKeyID     string
+	SecretAccessKey string
+
+	// SessionToken is set when the credentials are temporary.
+	SessionToken string
+
+	// PathStyle puts the bucket in the path rather than in the host name.
+	//
+	// It is off by default because that is what S3 itself wants, and it has to
+	// be turned on for almost everything else: MinIO, Ceph and a development
+	// service on localhost have one host name and no way to give a bucket its
+	// own.
+	PathStyle bool
+}
+
+// Client talks to one bucket.
+//
+// It is safe for concurrent use and is meant to be shared. A [Source] and the
+// [Policy] that answers for it should be built on the same client, so that what
+// the permission lookups cost shows up in the same counters as what the reads
+// cost.
+type Client struct {
+	cfg      Config
+	endpoint *url.URL
+	http     *http.Client
+
+	lists    atomic.Int64
+	metadata atomic.Int64
+	fetches  atomic.Int64
+	bytes    atomic.Int64
+}
+
+// ClientOption configures a client.
+type ClientOption func(*Client)
+
+// WithHTTPClient replaces the HTTP client, which is where a deployment puts its
+// own transport, proxy or connection pool.
+func WithHTTPClient(h *http.Client) ClientOption {
+	return func(c *Client) {
+		if h != nil {
+			c.http = h
+		}
+	}
+}
+
+// NewClient returns a client for the bucket described by cfg.
+func NewClient(cfg Config, opts ...ClientOption) (*Client, error) {
+	if cfg.Endpoint == "" {
+		return nil, errors.New("objectsource: empty endpoint")
+	}
+	if cfg.Bucket == "" {
+		return nil, errors.New("objectsource: empty bucket")
+	}
+	if cfg.Region == "" {
+		cfg.Region = "us-east-1"
+	}
+	u, err := url.Parse(cfg.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("objectsource: endpoint: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("objectsource: endpoint %q is not http or https", cfg.Endpoint)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("objectsource: endpoint %q names no host", cfg.Endpoint)
+	}
+
+	c := &Client{
+		cfg:      cfg,
+		endpoint: u,
+		http:     &http.Client{Timeout: DefaultRequestTimeout},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
+}
+
+// Bucket returns the bucket this client reads.
+func (c *Client) Bucket() string { return c.cfg.Bucket }
+
+// Counters returns what this client has spent on the store.
+//
+// Everything built on it contributes, so a source and its permission policy
+// report one set of numbers rather than two that have to be added up by hand.
+func (c *Client) Counters() connector.Counters {
+	return connector.Counters{
+		Lists:    c.lists.Load(),
+		Metadata: c.metadata.Load(),
+		Fetches:  c.fetches.Load(),
+		Bytes:    c.bytes.Load(),
+	}
+}
+
+// object is one thing in the bucket, as the store described it.
+type object struct {
+	Key          string    `xml:"Key"`
+	LastModified time.Time `xml:"LastModified"`
+	ETag         string    `xml:"ETag"`
+	Size         int64     `xml:"Size"`
+	StorageClass string    `xml:"StorageClass"`
+}
+
+// version is the string that says which revision of an object this is.
+//
+// The entity tag is the right answer where there is one, because for an
+// ordinary upload it is a hash of the content and two objects with the same tag
+// are the same bytes. Where there is none the modification time has to do, and
+// a second of resolution is enough to notice a document was rewritten.
+func (o object) version() string {
+	if tag := strings.Trim(o.ETag, `"`); tag != "" {
+		return tag
+	}
+	if o.LastModified.IsZero() {
+		return ""
+	}
+	return o.LastModified.UTC().Format(time.RFC3339)
+}
+
+// page is one response to a listing.
+type page struct {
+	objects []object
+	next    string
+	more    bool
+
+	// at is the store's own clock, read out of the response. It is what the
+	// cursor is compared against, because comparing a time the store wrote
+	// against a time this process read off its own clock is how a sync that
+	// looks correct on a developer's laptop loses documents in production.
+	at time.Time
+}
+
+// listBucketResult is the ListObjectsV2 response.
+type listBucketResult struct {
+	XMLName               xml.Name `xml:"ListBucketResult"`
+	IsTruncated           bool     `xml:"IsTruncated"`
+	NextContinuationToken string   `xml:"NextContinuationToken"`
+	Contents              []object `xml:"Contents"`
+}
+
+// list asks for one page of objects under a prefix.
+//
+// after is a key to resume past and is only honoured on the first page of a
+// listing, which is the API's rule rather than this function's: once there is a
+// continuation token, the token is the whole of where to carry on from.
+func (c *Client) list(ctx context.Context, prefix, after, token string, limit int) (page, error) {
+	q := url.Values{"list-type": {"2"}}
+	if prefix != "" {
+		q.Set("prefix", prefix)
+	}
+	if token != "" {
+		q.Set("continuation-token", token)
+	} else if after != "" {
+		q.Set("start-after", after)
+	}
+	if limit > 0 {
+		q.Set("max-keys", strconv.Itoa(limit))
+	}
+
+	c.lists.Add(1)
+	resp, err := c.do(ctx, http.MethodGet, "", q)
+	if err != nil {
+		return page{}, err
+	}
+	defer drain(resp)
+
+	var out listBucketResult
+	if err := xml.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return page{}, fmt.Errorf("objectsource: listing %s: %w", c.cfg.Bucket, err)
+	}
+	return page{
+		objects: out.Contents,
+		next:    out.NextContinuationToken,
+		more:    out.IsTruncated,
+		at:      serverTime(resp),
+	}, nil
+}
+
+// get reads one object, refusing one over the limit.
+//
+// It reads a byte past the limit on purpose, because an object exactly at the
+// limit is fine and an object over it has to be told apart from one that
+// happens to end there. Trusting the size the listing reported would be the
+// alternative, and a listing is a description rather than the thing.
+func (c *Client) get(ctx context.Context, key string, limit int64) ([]byte, object, error) {
+	c.fetches.Add(1)
+	resp, err := c.do(ctx, http.MethodGet, key, nil)
+	if err != nil {
+		return nil, object{}, err
+	}
+	defer drain(resp)
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	c.bytes.Add(int64(len(raw)))
+	if err != nil {
+		return nil, object{}, fmt.Errorf("objectsource: reading %s: %w", key, err)
+	}
+	if int64(len(raw)) > limit {
+		return nil, object{}, fmt.Errorf("objectsource: %s is over the limit of %d bytes", key, limit)
+	}
+
+	o := object{
+		Key:          key,
+		ETag:         resp.Header.Get("ETag"),
+		Size:         int64(len(raw)),
+		StorageClass: resp.Header.Get("X-Amz-Storage-Class"),
+	}
+	if t, err := http.ParseTime(resp.Header.Get("Last-Modified")); err == nil {
+		o.LastModified = t
+	}
+	return raw, o, nil
+}
+
+// accessControl is the response to an acl request, on a bucket or on an object.
+//
+// The grantee's xsi:type attribute is not read. What kind of grantee it is can
+// be told from which of the fields is filled in, and a document is not worth
+// quarantining over an XML namespace declaration a service left out.
+type accessControl struct {
+	XMLName xml.Name `xml:"AccessControlPolicy"`
+	Owner   grantee  `xml:"Owner"`
+	Grants  []struct {
+		Grantee    grantee `xml:"Grantee"`
+		Permission string  `xml:"Permission"`
+	} `xml:"AccessControlList>Grant"`
+}
+
+// grantee is whoever a statement is about.
+type grantee struct {
+	ID          string `xml:"ID"`
+	DisplayName string `xml:"DisplayName"`
+	URI         string `xml:"URI"`
+	Email       string `xml:"EmailAddress"`
+}
+
+// acl reads the access control list of one object, or of the bucket when the
+// key is empty.
+func (c *Client) acl(ctx context.Context, key string) (accessControl, time.Time, error) {
+	c.metadata.Add(1)
+	resp, err := c.do(ctx, http.MethodGet, key, url.Values{"acl": {""}})
+	if err != nil {
+		return accessControl{}, time.Time{}, err
+	}
+	defer drain(resp)
+
+	var out accessControl
+	if err := xml.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return accessControl{}, time.Time{}, fmt.Errorf("objectsource: reading the access control list of %s/%s: %w",
+			c.cfg.Bucket, key, err)
+	}
+	return out, serverTime(resp), nil
+}
+
+// do makes one signed request and reports a status outside the two hundreds as
+// an error.
+func (c *Client) do(ctx context.Context, method, key string, query url.Values) (*http.Response, error) {
+	u := *c.endpoint
+	host, p := c.target(key)
+	u.Host = host
+	u.Path = p
+	// The raw path is set as well as the path so that the transport writes the
+	// same encoding the signature was calculated over. Without it a key with a
+	// plus or a space in it signs one way and is sent another, and the store
+	// refuses a request that is perfectly well formed.
+	u.RawPath = escape(p, true)
+	u.RawQuery = canonicalQuery(query)
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("objectsource: %w", err)
+	}
+	if c.cfg.AccessKeyID != "" {
+		sign(req, emptyPayload, c.cfg, time.Now())
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("objectsource: %s %s: %w", method, u.Redacted(), err)
+	}
+	if resp.StatusCode/100 != 2 {
+		defer drain(resp)
+		return nil, readError(resp, key)
+	}
+	return resp, nil
+}
+
+// target is the host and path one key is read from.
+//
+// Which of the two the bucket goes in is the difference between S3 and almost
+// everything that speaks its protocol, and it is a property of the deployment
+// rather than of the request, so it is a setting rather than a guess.
+func (c *Client) target(key string) (host, path string) {
+	base := strings.TrimSuffix(c.endpoint.Path, "/")
+	if c.cfg.PathStyle {
+		return c.endpoint.Host, base + "/" + c.cfg.Bucket + "/" + key
+	}
+	return c.cfg.Bucket + "." + c.endpoint.Host, base + "/" + key
+}
+
+// url is where a key can be read from, for a result row to link to.
+func (c *Client) url(key string) string {
+	u := *c.endpoint
+	host, p := c.target(key)
+	u.Host = host
+	u.Path = p
+	u.RawPath = escape(p, true)
+	u.RawQuery = ""
+	return u.String()
+}
+
+// apiError is what the store said when it refused.
+type apiError struct {
+	Status  int
+	Code    string
+	Message string
+	Key     string
+}
+
+func (e *apiError) Error() string {
+	where := e.Key
+	if where == "" {
+		where = "the bucket"
+	}
+	if e.Code == "" {
+		return "objectsource: " + where + ": " + strconv.Itoa(e.Status) + " " + http.StatusText(e.Status)
+	}
+	return "objectsource: " + where + ": " + e.Code + ": " + e.Message
+}
+
+// gone reports whether this error means the object is not there any more,
+// rather than that something else went wrong.
+//
+// The distinction decides whether a document is deleted from the index, so the
+// reading is deliberately narrow. A bucket that has been renamed also answers
+// with four hundred and four, and treating that as an object that no longer
+// exists would empty the whole index the first time somebody typoed a setting.
+func (e *apiError) gone() bool {
+	if e.Code != "" {
+		return e.Code == "NoSuchKey"
+	}
+	return e.Status == http.StatusNotFound && e.Key != ""
+}
+
+// errorBody is the XML every one of these services returns with a refusal.
+type errorBody struct {
+	XMLName xml.Name `xml:"Error"`
+	Code    string   `xml:"Code"`
+	Message string   `xml:"Message"`
+}
+
+// maxErrorBody bounds what is read out of a refusal, because the response to a
+// request that went to the wrong host is an HTML page of unknown size.
+const maxErrorBody = 8 << 10
+
+func readError(resp *http.Response, key string) error {
+	var body errorBody
+	// A body that does not parse is not itself a failure. The status is the
+	// part that matters and the code is what makes the log line useful, so a
+	// service that answered with something else still produces an error naming
+	// what happened.
+	_ = xml.NewDecoder(io.LimitReader(resp.Body, maxErrorBody)).Decode(&body)
+	return &apiError{
+		Status:  resp.StatusCode,
+		Code:    body.Code,
+		Message: body.Message,
+		Key:     key,
+	}
+}
+
+// gone turns a refusal that means the object is not there into
+// [connector.ErrGone], and leaves everything else alone.
+func gone(err error) error {
+	var api *apiError
+	if errors.As(err, &api) && api.gone() {
+		return connector.ErrGone
+	}
+	return err
+}
+
+// serverTime is the store's own clock, from the response.
+//
+// A service that sends no Date header leaves this zero, and the caller falls
+// back to not knowing rather than to this machine's clock, which is the thing
+// the header exists to avoid trusting.
+func serverTime(resp *http.Response) time.Time {
+	t, err := http.ParseTime(resp.Header.Get("Date"))
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// drain closes a response body after reading what is left of it, so the
+// connection goes back to the pool instead of being thrown away.
+func drain(resp *http.Response) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxErrorBody))
+	_ = resp.Body.Close()
+}

--- a/connector/objectsource/client_test.go
+++ b/connector/objectsource/client_test.go
@@ -1,0 +1,161 @@
+package objectsource
+
+import (
+	"testing"
+	"time"
+)
+
+// Where the bucket goes in the URL is the one thing that differs between the
+// services this connector supports, and getting it wrong is a request that
+// either goes to a host that does not resolve or reads a bucket called the
+// bucket's name inside the bucket.
+func TestWhereTheBucketGoesInTheRequest(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		endpoint string
+		style    bool
+		key      string
+		host     string
+		path     string
+	}{
+		{
+			name:     "the hosted style S3 itself wants",
+			endpoint: "https://s3.eu-west-1.amazonaws.com",
+			key:      "reports/q1.pdf",
+			host:     "corpus.s3.eu-west-1.amazonaws.com",
+			path:     "/reports/q1.pdf",
+		},
+		{
+			name:     "the path style everything on a single host needs",
+			endpoint: "http://127.0.0.1:9000",
+			style:    true,
+			key:      "reports/q1.pdf",
+			host:     "127.0.0.1:9000",
+			path:     "/corpus/reports/q1.pdf",
+		},
+		{
+			name:     "a listing, which is the bucket with no key",
+			endpoint: "http://127.0.0.1:9000",
+			style:    true,
+			host:     "127.0.0.1:9000",
+			path:     "/corpus/",
+		},
+		{
+			name:     "an endpoint that already has a path, which is what a gateway looks like",
+			endpoint: "https://gateway.example.com/storage/",
+			style:    true,
+			key:      "a.md",
+			host:     "gateway.example.com",
+			path:     "/storage/corpus/a.md",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			client, err := NewClient(Config{Endpoint: c.endpoint, Bucket: "corpus", PathStyle: c.style})
+			if err != nil {
+				t.Fatal(err)
+			}
+			host, path := client.target(c.key)
+			if host != c.host {
+				t.Errorf("host is %q, want %q", host, c.host)
+			}
+			if path != c.path {
+				t.Errorf("path is %q, want %q", path, c.path)
+			}
+		})
+	}
+}
+
+// A link in a result row has to survive being pasted somewhere, which means the
+// characters that are legal in a key and not in a URL have to be encoded.
+func TestALinkToAnObjectIsEscaped(t *testing.T) {
+	client, err := NewClient(Config{Endpoint: "https://s3.eu-west-1.amazonaws.com", Bucket: "corpus"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]string{
+		"notes/q1 report.pdf": "https://corpus.s3.eu-west-1.amazonaws.com/notes/q1%20report.pdf",
+		"a+b/c.md":            "https://corpus.s3.eu-west-1.amazonaws.com/a%2Bb/c.md",
+		"~tilde-and_dot.md":   "https://corpus.s3.eu-west-1.amazonaws.com/~tilde-and_dot.md",
+	} {
+		if got := client.url(key); got != want {
+			t.Errorf("%q links to\n%s\nwant\n%s", key, got, want)
+		}
+	}
+}
+
+// The version is what tells a rewritten object from an unchanged one, and a
+// version that is empty makes every object look stale on every sweep.
+func TestTheVersionOfAnObject(t *testing.T) {
+	when := time.Date(2026, time.March, 2, 12, 0, 0, 0, time.UTC)
+	for _, c := range []struct {
+		name string
+		o    object
+		want string
+	}{
+		{
+			name: "the entity tag, with the quotes the store puts round it taken off",
+			o:    object{ETag: `"9b2cf5"`, LastModified: when},
+			want: "9b2cf5",
+		},
+		{
+			name: "the modification time, for a store that sends no entity tag",
+			o:    object{LastModified: when},
+			want: "2026-03-02T12:00:00Z",
+		},
+		{
+			name: "nothing at all, which is a store that described nothing",
+			o:    object{},
+			want: "",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.o.version(); got != c.want {
+				t.Errorf("version is %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// The reading of a refusal decides whether a document is deleted from the
+// index, so it is deliberately narrow. Anything wider empties the index the
+// first time a setting is typoed or the store has a bad afternoon.
+func TestWhatCountsAsAnObjectThatIsNoLongerThere(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		err  apiError
+		want bool
+	}{
+		{
+			name: "the store said the key is not there",
+			err:  apiError{Status: 404, Code: "NoSuchKey", Key: "a.md"},
+			want: true,
+		},
+		{
+			name: "four hundred and four with no code, from a service that sends none",
+			err:  apiError{Status: 404, Key: "a.md"},
+			want: true,
+		},
+		{
+			name: "the bucket is not there, which is a setting rather than a deletion",
+			err:  apiError{Status: 404, Code: "NoSuchBucket", Key: "a.md"},
+		},
+		{
+			name: "a listing that came back empty handed names no key",
+			err:  apiError{Status: 404},
+		},
+		{
+			name: "the credentials are wrong",
+			err:  apiError{Status: 403, Code: "AccessDenied", Key: "a.md"},
+		},
+		{
+			name: "the store is having a bad afternoon",
+			err:  apiError{Status: 500, Code: "InternalError", Key: "a.md"},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.err.gone(); got != c.want {
+				t.Errorf("gone is %v, want %v, from %v", got, c.want, c.err.Error())
+			}
+		})
+	}
+}

--- a/connector/objectsource/fake_test.go
+++ b/connector/objectsource/fake_test.go
@@ -1,0 +1,320 @@
+package objectsource_test
+
+import (
+	"cmp"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/connector/objectsource"
+)
+
+// A bucket in memory, speaking enough of the protocol to be worth testing
+// against.
+//
+// It is here rather than in a container because what these tests are about is
+// the connector: paging, the cursor, what gets fetched and what does not, and
+// what an access control list turns into. A real service would answer all of
+// those the same way and would also make the suite need Docker, a network and
+// several seconds. The parts a fake cannot check, which are whether a real
+// service accepts these signatures and returns this XML, are checked by
+// sign_test.go against the published examples and by the shape of the types
+// against the documented responses.
+
+const theBucket = "corpus"
+
+// The grantee URIs the protocol defines, spelled out here rather than reached
+// for inside the package, so that a test breaks if somebody changes one.
+const (
+	uriAllUsers           = "http://acs.amazonaws.com/groups/global/AllUsers"
+	uriAuthenticatedUsers = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+)
+
+// stored is one object the fake holds.
+type stored struct {
+	body     string
+	modified time.Time
+	acl      string
+}
+
+// fakeStore is an S3 compatible service with one bucket in it.
+type fakeStore struct {
+	server *httptest.Server
+
+	mu      sync.Mutex
+	objects map[string]stored
+	acl     string
+	clock   time.Time
+
+	// calls is every request line the service was sent, which is how a test
+	// says something was done with one listing rather than with a thousand.
+	calls []string
+}
+
+// newStore starts a fake service and stops it when the test ends.
+func newStore(t *testing.T) *fakeStore {
+	t.Helper()
+	f := &fakeStore{
+		objects: make(map[string]stored),
+		clock:   time.Date(2026, time.March, 2, 12, 0, 0, 0, time.UTC),
+	}
+	f.server = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+// client is a client pointed at the fake, with credentials, so that every
+// request in these tests is signed the way a real one would be.
+func (f *fakeStore) client(t *testing.T) *objectsource.Client {
+	t.Helper()
+	c, err := objectsource.NewClient(objectsource.Config{
+		Endpoint:        f.server.URL,
+		Region:          "eu-west-1",
+		Bucket:          theBucket,
+		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		PathStyle:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// put writes an object, at the service's current time.
+func (f *fakeStore) put(key, body string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.objects[key] = stored{body: body, modified: f.clock}
+}
+
+// putAt writes an object with a modification time of its own.
+func (f *fakeStore) putAt(key, body string, at time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.objects[key] = stored{body: body, modified: at}
+}
+
+// remove deletes an object, which is the event a listing can never report.
+func (f *fakeStore) remove(key string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.objects, key)
+}
+
+// setACL replaces the bucket's access control list.
+func (f *fakeStore) setACL(list string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.acl = list
+}
+
+// setObjectACL gives one object a list of its own.
+func (f *fakeStore) setObjectACL(key, list string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	o := f.objects[key]
+	o.acl = list
+	f.objects[key] = o
+}
+
+// tick moves the service's clock, which is the clock the connector's cursor is
+// written against.
+func (f *fakeStore) tick(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clock = f.clock.Add(d)
+}
+
+// now is the service's current time.
+func (f *fakeStore) now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.clock
+}
+
+// requests returns every request line the service has been sent since the last
+// call, and forgets them.
+func (f *fakeStore) requests() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := f.calls
+	f.calls = nil
+	return out
+}
+
+func (f *fakeStore) handle(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, r.Method+" "+r.URL.RequestURI())
+
+	// Every request has to be signed. A connector that quietly stopped signing
+	// would pass every other test here and fail against every real service.
+	auth := r.Header.Get("Authorization")
+	switch {
+	case !strings.HasPrefix(auth, "AWS4-HMAC-SHA256 Credential="):
+		refuse(w, http.StatusForbidden, "AccessDenied", "the request is not signed")
+		return
+	case r.Header.Get("X-Amz-Date") == "", r.Header.Get("X-Amz-Content-Sha256") == "":
+		refuse(w, http.StatusForbidden, "AccessDenied", "the signature is missing a header it covers")
+		return
+	}
+
+	// The service's own clock, which the connector reads and holds its cursor
+	// behind. Set explicitly so that a test can move it.
+	w.Header().Set("Date", f.clock.UTC().Format(http.TimeFormat))
+
+	prefix := "/" + theBucket
+	if !strings.HasPrefix(r.URL.Path, prefix) {
+		refuse(w, http.StatusNotFound, "NoSuchBucket", "no such bucket")
+		return
+	}
+	key := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, prefix), "/")
+
+	if _, ok := r.URL.Query()["acl"]; ok {
+		f.serveACL(w, key)
+		return
+	}
+	if key == "" {
+		f.serveList(w, r)
+		return
+	}
+	f.serveObject(w, key)
+}
+
+func (f *fakeStore) serveACL(w http.ResponseWriter, key string) {
+	list := f.acl
+	if key != "" {
+		o, ok := f.objects[key]
+		if !ok {
+			refuse(w, http.StatusNotFound, "NoSuchKey", "no such key")
+			return
+		}
+		list = cmp.Or(o.acl, f.acl)
+	}
+	if list == "" {
+		refuse(w, http.StatusNotFound, "NoSuchBucketPolicy", "this bucket has no access control list")
+		return
+	}
+	writeXML(w, list)
+}
+
+func (f *fakeStore) serveObject(w http.ResponseWriter, key string) {
+	o, ok := f.objects[key]
+	if !ok {
+		refuse(w, http.StatusNotFound, "NoSuchKey", "no such key")
+		return
+	}
+	w.Header().Set("ETag", `"`+etagOf(key, o.body)+`"`)
+	w.Header().Set("Last-Modified", o.modified.UTC().Format(http.TimeFormat))
+	w.Header().Set("Content-Length", strconv.Itoa(len(o.body)))
+	_, _ = w.Write([]byte(o.body))
+}
+
+func (f *fakeStore) serveList(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	if q.Get("list-type") != "2" {
+		refuse(w, http.StatusBadRequest, "InvalidArgument", "only version two listings are served")
+		return
+	}
+
+	keys := make([]string, 0, len(f.objects))
+	for k := range f.objects {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	// The two ways a listing is narrowed, applied the way the API applies them:
+	// the prefix, then wherever the caller said to carry on from. A
+	// continuation token and a start after point are the same thing here, which
+	// is exactly what the real service's opaque token amounts to.
+	after := cmp.Or(q.Get("continuation-token"), q.Get("start-after"))
+	limit := 1000
+	if n, err := strconv.Atoi(q.Get("max-keys")); err == nil && n > 0 {
+		limit = n
+	}
+
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?><ListBucketResult>`)
+	var (
+		sent      int
+		last      string
+		truncated bool
+	)
+	for _, k := range keys {
+		if !strings.HasPrefix(k, q.Get("prefix")) || k <= after {
+			continue
+		}
+		if sent == limit {
+			truncated = true
+			break
+		}
+		o := f.objects[k]
+		b.WriteString("<Contents><Key>" + k + "</Key>")
+		b.WriteString("<LastModified>" + o.modified.UTC().Format("2006-01-02T15:04:05.000Z") + "</LastModified>")
+		b.WriteString(`<ETag>&quot;` + etagOf(k, o.body) + `&quot;</ETag>`)
+		b.WriteString("<Size>" + strconv.Itoa(len(o.body)) + "</Size>")
+		b.WriteString("<StorageClass>STANDARD</StorageClass></Contents>")
+		sent, last = sent+1, k
+	}
+	if truncated {
+		b.WriteString("<IsTruncated>true</IsTruncated>")
+		b.WriteString("<NextContinuationToken>" + last + "</NextContinuationToken>")
+	} else {
+		b.WriteString("<IsTruncated>false</IsTruncated>")
+	}
+	b.WriteString("</ListBucketResult>")
+	writeXML(w, b.String())
+}
+
+func writeXML(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/xml")
+	_, _ = w.Write([]byte(body))
+}
+
+func refuse(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte("<Error><Code>" + code + "</Code><Message>" + message + "</Message></Error>"))
+}
+
+// etagOf is a stand in for the content hash a real service returns. It only has
+// to change when the bytes do, which is the whole of what a version is for.
+func etagOf(key, body string) string {
+	return strconv.Itoa(len(body)) + "-" + strconv.Itoa(len(key))
+}
+
+// The access control lists the tests hand the fake.
+
+// ownedBy is a list where one person owns the object and can read it, which is
+// what a bucket written by one account and read by nobody else looks like.
+func ownedBy(email string) string {
+	return `<AccessControlPolicy>` +
+		`<Owner><ID>abc123</ID><DisplayName>` + email + `</DisplayName><EmailAddress>` + email + `</EmailAddress></Owner>` +
+		`<AccessControlList>` + userGrant(email, "FULL_CONTROL") + `</AccessControlList>` +
+		`</AccessControlPolicy>`
+}
+
+// listOf builds a list with an owner and whatever statements are given.
+func listOf(owner string, grants ...string) string {
+	return `<AccessControlPolicy>` +
+		`<Owner><ID>abc123</ID><DisplayName>` + owner + `</DisplayName><EmailAddress>` + owner + `</EmailAddress></Owner>` +
+		`<AccessControlList>` + strings.Join(grants, "") + `</AccessControlList>` +
+		`</AccessControlPolicy>`
+}
+
+func userGrant(email, permission string) string {
+	return `<Grant><Grantee><ID>` + email + `</ID><DisplayName>` + email + `</DisplayName>` +
+		`<EmailAddress>` + email + `</EmailAddress></Grantee>` +
+		`<Permission>` + permission + `</Permission></Grant>`
+}
+
+func groupGrant(uri, permission string) string {
+	return `<Grant><Grantee><URI>` + uri + `</URI></Grantee>` +
+		`<Permission>` + permission + `</Permission></Grant>`
+}

--- a/connector/objectsource/maintain.go
+++ b/connector/objectsource/maintain.go
@@ -1,0 +1,115 @@
+package objectsource
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/doc"
+)
+
+var (
+	_ connector.Enumerator = (*Source)(nil)
+	_ connector.Fetcher    = (*Source)(nil)
+	_ connector.Counted    = (*Source)(nil)
+)
+
+// Enumerate calls fn for every object the source would index, with its entity
+// tag as the version.
+//
+// It is the same listing [Source.Sync] makes and it fetches nothing. That is
+// the whole difference in price: a thousand objects described per request
+// against one object read per request, which on a real bucket is a minute
+// against an afternoon, and it is the reason the reconciliation sweep can run
+// on the refresh interval rather than nightly.
+func (s *Source) Enumerate(ctx context.Context, fn func(connector.Item) bool) error {
+	var token string
+	for {
+		page, err := s.client.list(ctx, s.prefix, "", token, s.pageSize)
+		if err != nil {
+			return err
+		}
+		for _, o := range page.objects {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if !s.wanted(o) {
+				continue
+			}
+			if !fn(connector.Item{ID: s.id(o.Key), Version: o.version()}) {
+				// A listing this one stopped on purpose is not a failed
+				// listing, and reporting it as one would make a reconciliation
+				// that used an early exit delete the entire index.
+				return nil
+			}
+		}
+		if !page.more || page.next == "" {
+			return nil
+		}
+		token = page.next
+	}
+}
+
+// Fetch reads one object by document id.
+//
+// It returns [connector.ErrGone] for an object that is no longer there, which
+// is the normal answer on a bucket people are writing to rather than a failure.
+func (s *Source) Fetch(ctx context.Context, id string) (doc.Document, error) {
+	if err := ctx.Err(); err != nil {
+		return doc.Document{}, err
+	}
+	key, ok := s.key(id)
+	if !ok {
+		// An id this source did not mint names an object it does not have.
+		// Saying so is the same answer as a deleted object, and it is the safe
+		// one: the caller drops it from the index rather than storing something
+		// read from a key an id was allowed to steer.
+		return doc.Document{}, connector.ErrGone
+	}
+
+	raw, fetched, err := s.client.get(ctx, key, s.limitFor(key))
+	if err != nil {
+		return doc.Document{}, gone(err)
+	}
+	return s.document(ctx, fetched, raw)
+}
+
+// Counters returns what this source has spent on the store.
+//
+// The numbers come from the client, so a permission policy sharing that client
+// is counted here too. That is the point: the question an operator is asking is
+// what the sync cost, and a policy reading an access control list per object is
+// the most expensive thing in it.
+func (s *Source) Counters() connector.Counters { return s.client.Counters() }
+
+// id is the document id for one key.
+func (s *Source) id(key string) string { return s.name + ":" + key }
+
+// key is the inverse of id, and is where a key that tried to leave the prefix
+// is stopped.
+//
+// The cleaning is not tidiness. An id arrives from the index, the index was
+// written by a connector, and a connector is a lot of code to trust with a
+// string that turns into a path in a URL. A key holding a dot dot segment could
+// be rewritten by a proxy on the way and end up naming something outside the
+// bucket, so anything that does not survive being cleaned is refused rather
+// than repaired. That also turns away the handful of legal keys with an empty
+// path segment in them, which is a fair price for the rule being one line.
+func (s *Source) key(id string) (string, bool) {
+	key, ok := strings.CutPrefix(id, s.name+":")
+	if !ok || key == "" {
+		return "", false
+	}
+	if strings.TrimPrefix(path.Clean("/"+key), "/") != key {
+		return "", false
+	}
+	// The prefix is the whole of what this source was pointed at. An id naming
+	// something outside it belongs to a different source over the same bucket,
+	// and answering for it would let one prefix's index quietly hold another's
+	// documents under another's permissions.
+	if !strings.HasPrefix(key, s.prefix) {
+		return "", false
+	}
+	return key, true
+}

--- a/connector/objectsource/objectsource.go
+++ b/connector/objectsource/objectsource.go
@@ -1,0 +1,717 @@
+// Package objectsource is a connector that reads an S3 compatible bucket.
+//
+// It is the second reference connector and the first one that talks to a
+// network service, which is where most of what a real connector has to get
+// right lives: paging, signing, a source that answers slowly, and a listing
+// that is ordered by key rather than by when anything changed.
+//
+// The protocol is S3's and the services that speak it are many. Amazon's own,
+// MinIO, Ceph, Cloudflare R2, Backblaze B2, Wasabi, DigitalOcean Spaces and
+// several others all answer to ListObjectsV2 and GetObject signed with
+// signature version 4, which is why this is one connector rather than eight.
+// What differs between them is where the bucket goes in the URL, which is
+// [Config.PathStyle], and whether they keep access control lists at all.
+//
+// # Permissions come from a policy
+//
+// The connector maps objects to documents. It does not decide who may read
+// them, for the same reason the filesystem connector does not: a bucket says
+// very little about access on its own. Access control lists on objects are off
+// by default on new buckets and the real answer is usually in an identity
+// policy naming roles this index has never heard of, so [Policy] is where that
+// answer is plugged in.
+//
+// There is no permissive default. A source built without a policy quarantines
+// everything, which is loud and safe, rather than publishing a bucket to
+// everybody, which is quiet and not.
+//
+// # Prefix scoping
+//
+// A bucket is not usually all one thing. [WithPrefix] narrows a source to one
+// part of one, and it narrows the listing rather than filtering it afterwards,
+// so a source pointed at reports/ in a bucket of a hundred million objects
+// costs what reports/ costs. Several sources can read the same bucket under
+// different prefixes with different policies, which is how a bucket where one
+// prefix is public and another is not gets indexed correctly.
+//
+// # Incremental sync
+//
+// The cursor is the newest modification time the last run saw. A later run
+// still lists everything under the prefix, because ListObjectsV2 is ordered by
+// key and there is no change feed to ask instead, and it fetches only what is
+// newer. That is the same trade the filesystem connector makes: the listing
+// cannot be avoided, the reads can, and the listing is a thousand objects per
+// request against one request per object.
+//
+// A run that is interrupted resumes from the key it got to rather than from the
+// beginning, because the listing is ordered by key and that makes the last key
+// emitted a safe place to carry on from.
+//
+// An object whose content did not change can still have had its permissions
+// rewritten, and nothing in a listing says so. A [Policy] that can say when its
+// answer last changed turns that into a permission change carrying no body,
+// which is how a revocation reaches the index without the bucket being read
+// again.
+package objectsource
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/gif"  // registers the GIF config decoder
+	_ "image/jpeg" // registers the JPEG config decoder
+	_ "image/png"  // registers the PNG config decoder
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/extract"
+)
+
+// DefaultMaxObjectSize is the largest object read into a document body.
+//
+// Past this it is almost never prose somebody wants to search. A bucket is a
+// place people put build artefacts and database dumps, so the limit matters
+// more here than it does on a source tree.
+const DefaultMaxObjectSize = 1 << 20
+
+// DefaultMaxImageSize is the largest image read into a document's content. It
+// is larger than the body limit because the two are about different things: a
+// one megabyte text file is almost certainly not prose and a one megabyte
+// screenshot is a screenshot.
+const DefaultMaxImageSize = 4 << 20
+
+// DefaultMaxDocumentSize is the largest PDF or Office file read for extraction.
+// The bytes are compressed and the text inside them is a fraction of them, so
+// the number that actually bounds the work is [extract.Options.MaxDecompressed]
+// rather than this one.
+const DefaultMaxDocumentSize = 16 << 20
+
+// Source reads documents out of one bucket, or out of one prefix of one.
+type Source struct {
+	client *Client
+	name   string
+	prefix string
+	policy Policy
+
+	pageSize  int
+	maxSize   int64
+	maxImage  int64
+	maxDoc    int64
+	includeIf func(key string) bool
+	skipped   func(key string, reason error)
+}
+
+// Option configures a source.
+type Option func(*Source)
+
+// WithPrefix narrows the source to the objects whose key starts with p.
+//
+// It is the prefix the listing is made with, not a filter applied to the
+// results, so it costs nothing to scope a source tightly inside a very large
+// bucket. It is matched exactly as the API matches it, which means a prefix of
+// "docs" also covers "docs-archive/", and a prefix meant to be a folder should
+// end in a slash.
+func WithPrefix(p string) Option {
+	return func(s *Source) { s.prefix = strings.TrimPrefix(p, "/") }
+}
+
+// WithMaxObjectSize sets the largest object that will be read. A value below
+// one selects [DefaultMaxObjectSize].
+func WithMaxObjectSize(n int64) Option {
+	return func(s *Source) {
+		if n > 0 {
+			s.maxSize = n
+		}
+	}
+}
+
+// WithMaxImageSize sets the largest image read into a document's content. A
+// value below one selects [DefaultMaxImageSize].
+func WithMaxImageSize(n int64) Option {
+	return func(s *Source) {
+		if n > 0 {
+			s.maxImage = n
+		}
+	}
+}
+
+// WithMaxDocumentSize sets the largest PDF or Office file read for extraction.
+// A value below one selects [DefaultMaxDocumentSize].
+func WithMaxDocumentSize(n int64) Option {
+	return func(s *Source) {
+		if n > 0 {
+			s.maxDoc = n
+		}
+	}
+}
+
+// WithPageSize sets how many objects one listing asks for. A value below one
+// selects [DefaultPageSize].
+func WithPageSize(n int) Option {
+	return func(s *Source) {
+		if n > 0 {
+			s.pageSize = n
+		}
+	}
+}
+
+// WithInclude replaces the rule for which keys are read.
+//
+// The default reads the formats the extractor understands and the images a
+// preview can show, decided from the key's extension. That is a guess about a
+// name, and it is made before anything has been fetched on purpose: the
+// alternative in a bucket is downloading a terabyte of archives to find out
+// none of them were documents.
+func WithInclude(f func(key string) bool) Option {
+	return func(s *Source) {
+		if f != nil {
+			s.includeIf = f
+		}
+	}
+}
+
+// WithSkipped installs a callback for objects the sync passed over.
+//
+// A sync does not abandon a bucket because one object in it could not be read.
+// What it must not be is silent: an index quietly missing everything nobody
+// could read looks exactly like an index that is complete, and the difference
+// only shows up when somebody cannot find a document they know exists. This is
+// how a caller finds out, and the default does nothing.
+func WithSkipped(f func(key string, reason error)) Option {
+	return func(s *Source) {
+		if f != nil {
+			s.skipped = f
+		}
+	}
+}
+
+// New returns a source reading c's bucket, naming itself name, and asking
+// policy who may read each object.
+//
+// A nil policy is allowed and quarantines every document. That is deliberate:
+// it makes "I have not thought about permissions yet" a visible state in the
+// stats rather than an invisible one in the index.
+func New(c *Client, name string, policy Policy, opts ...Option) (*Source, error) {
+	if c == nil {
+		return nil, errors.New("objectsource: nil client")
+	}
+	if name == "" {
+		return nil, errors.New("objectsource: empty source name")
+	}
+
+	s := &Source{
+		client:    c,
+		name:      name,
+		policy:    policy,
+		pageSize:  DefaultPageSize,
+		maxSize:   DefaultMaxObjectSize,
+		maxImage:  DefaultMaxImageSize,
+		maxDoc:    DefaultMaxDocumentSize,
+		includeIf: defaultInclude,
+		skipped:   func(string, error) {},
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s, nil
+}
+
+var _ connector.Connector = (*Source)(nil)
+
+// Source returns the connector's name.
+func (s *Source) Source() string { return s.name }
+
+// Close releases nothing. The HTTP client is shared and outlives the source,
+// because the policy answering for this source is usually holding it too.
+func (s *Source) Close() error { return nil }
+
+// syncPoint is what this connector puts in a cursor.
+//
+// Since is how far the last completed run got through the store's modification
+// times, and is what decides whether an object is fetched. After is the key an
+// interrupted run reached, and is only set on the cursors carried by individual
+// changes. A run that finishes clears it, so a cursor with a key in it is
+// exactly the record of a run that did not.
+//
+// Perms is the same high water mark for permission changes, and it is a
+// separate field because the two are read off different clocks and only one of
+// them is held back. A modification time comes from the store and has a second
+// of resolution, so Since is kept a second behind the store's clock, and a
+// permission change is something this process noticed rather than something the
+// store recorded. Folding the second into the first would mean either losing a
+// write made in the same second or rewriting the permissions of every object in
+// the bucket twice for every change, depending on which way the fold went.
+type syncPoint struct {
+	Since time.Time `json:"since"`
+	Perms time.Time `json:"perms,omitempty"`
+	After string    `json:"after,omitempty"`
+}
+
+// Sync lists the prefix and emits every object modified after the cursor.
+func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(context.Context, connector.Change) error) (connector.Cursor, error) {
+	start, err := parseCursor(from)
+	if err != nil {
+		return connector.Cursor{}, err
+	}
+
+	// A policy that caches its answer is told the sync is starting, so that a
+	// bucket whose access control list was rewritten since the last run is read
+	// again. Without this a long running process would keep serving the list
+	// the bucket had when it started, which is the failure mode where a
+	// revocation appears to have been applied and has not.
+	if r, ok := s.policy.(Reloader); ok {
+		r.Reload()
+	}
+
+	var (
+		highest = start.Since
+		latest  = start.Perms
+		clock   time.Time
+		token   string
+	)
+	for {
+		page, err := s.client.list(ctx, s.prefix, start.After, token, s.pageSize)
+		if err != nil {
+			return connector.Cursor{}, err
+		}
+		if page.at.After(clock) {
+			clock = page.at
+		}
+
+		for _, o := range page.objects {
+			if err := ctx.Err(); err != nil {
+				return connector.Cursor{}, err
+			}
+			if !s.wanted(o) {
+				continue
+			}
+			if o.LastModified.After(highest) {
+				highest = o.LastModified
+			}
+
+			// Not After rather than Before, so an object written in the same
+			// second as the cursor is not emitted again on every later run.
+			if !start.Since.IsZero() && !o.LastModified.After(start.Since) {
+				at, err := s.refresh(ctx, o, start, emit)
+				if err != nil {
+					return connector.Cursor{}, err
+				}
+				if at.After(latest) {
+					latest = at
+				}
+				continue
+			}
+
+			// The cursor has to cover when the permissions last changed as well
+			// as when the content did, because the next run compares both
+			// against it. An error here is the policy's problem and read below
+			// reports it.
+			if at, err := s.changedAt(ctx, o.Key); err == nil && at.After(latest) {
+				latest = at
+			}
+
+			document, err := s.read(ctx, o)
+			if err != nil {
+				s.skipped(o.Key, err)
+				continue
+			}
+			if err := emit(ctx, connector.Change{
+				Document: document,
+				Cursor:   resume(start, o.Key),
+			}); err != nil {
+				return connector.Cursor{}, err
+			}
+		}
+
+		if !page.more || page.next == "" {
+			break
+		}
+		token = page.next
+	}
+
+	// The store's clock has a second of resolution and a listing of a large
+	// bucket takes a great deal longer than that, so an object written later in
+	// the same second as the newest one this run saw would be filed under a
+	// time the cursor has already passed, and would never be read again.
+	// Holding the cursor a second behind the store's own clock leaves that one
+	// second to be looked at once more on the next run. It costs re-reading a
+	// handful of objects on the run after a write, it costs nothing at all on a
+	// bucket that has been quiet, and it buys never silently losing one.
+	if !clock.IsZero() {
+		if edge := clock.Add(-time.Second); highest.After(edge) {
+			highest = edge
+		}
+	}
+	if highest.IsZero() && latest.IsZero() {
+		return from, nil
+	}
+	return cursorAt(syncPoint{Since: highest, Perms: latest}, highest), nil
+}
+
+// refresh emits a permission change for an object whose content did not change
+// but whose access control list did, and returns when that rule last changed.
+//
+// This is the whole of "a revocation takes effect without a resync" on object
+// storage. A list rewritten on the bucket changes who may read every object
+// under it without any of them being touched, and a sync that only compares
+// modification times sees nothing at all.
+func (s *Source) refresh(ctx context.Context, o object, start syncPoint, emit func(context.Context, connector.Change) error) (time.Time, error) {
+	at, err := s.changedAt(ctx, o.Key)
+	if err != nil {
+		// A policy that cannot answer for one object is not a reason to abandon
+		// the bucket. It is reported, and the document keeps the access control
+		// list it already had until something can say otherwise.
+		s.skipped(o.Key, err)
+		return time.Time{}, nil
+	}
+	if at.IsZero() || !at.After(start.Perms) {
+		return at, nil
+	}
+
+	perms, err := s.permissions(ctx, o.Key)
+	if err != nil {
+		// The rule that used to govern this object stopped resolving.
+		// Quarantining is the only safe reading: a document nobody can
+		// currently say who may read is not one to keep serving on last week's
+		// answer.
+		perms = connector.Unresolved(s.name)
+		s.skipped(o.Key, err)
+	}
+	return at, emit(ctx, connector.Change{
+		Document:        doc.Document{ID: s.id(o.Key), Permissions: perms},
+		PermissionsOnly: true,
+		Cursor:          resume(start, o.Key),
+	})
+}
+
+// wanted decides whether an object is part of the corpus, and reports the ones
+// it turns away for a reason worth knowing about.
+func (s *Source) wanted(o object) bool {
+	// A key ending in a slash is the empty object a console writes when
+	// somebody makes a folder. There is nothing in it and there never was.
+	if o.Key == "" || strings.HasSuffix(o.Key, "/") {
+		return false
+	}
+	if !s.includeIf(o.Key) {
+		return false
+	}
+	if limit := s.limitFor(o.Key); o.Size > limit {
+		s.skipped(o.Key, fmt.Errorf("%d bytes is over the limit of %d", o.Size, limit))
+		return false
+	}
+	return true
+}
+
+// permissions asks the policy who may read an object.
+//
+// A nil policy is not an oversight and not an error. It is the state a source
+// built without one is in, and the answer is that nothing resolved, which
+// quarantines every document rather than publishing the bucket.
+func (s *Source) permissions(ctx context.Context, key string) (acl.Permissions, error) {
+	if s.policy == nil {
+		return connector.Unresolved(s.name), nil
+	}
+	return s.policy.Permissions(ctx, key)
+}
+
+// changedAt asks the policy when the rule governing an object last changed, and
+// returns the zero time for a policy that cannot say.
+func (s *Source) changedAt(ctx context.Context, key string) (time.Time, error) {
+	if p, ok := s.policy.(Versioned); ok {
+		return p.ChangedAt(ctx, key)
+	}
+	return time.Time{}, nil
+}
+
+// limitFor is the size limit that applies to one key. An image gets the image
+// limit, a format that has to be extracted gets the document limit, and
+// everything else gets the body limit.
+func (s *Source) limitFor(key string) int64 {
+	switch {
+	case imageMedia(key) != "":
+		return s.maxImage
+	case needsExtraction(extract.MediaByName(key)):
+		return s.maxDoc
+	default:
+		return s.maxSize
+	}
+}
+
+// read fetches one object and turns it into a document.
+func (s *Source) read(ctx context.Context, o object) (doc.Document, error) {
+	raw, fetched, err := s.client.get(ctx, o.Key, s.limitFor(o.Key))
+	if err != nil {
+		return doc.Document{}, err
+	}
+	return s.document(ctx, merge(o, fetched), raw)
+}
+
+// document turns bytes into a document.
+func (s *Source) document(ctx context.Context, o object, raw []byte) (doc.Document, error) {
+	var (
+		media   = mediaOf(raw, o.Key)
+		text    string
+		title   string
+		content *doc.Content
+		pages   int
+		partial bool
+	)
+	if strings.HasPrefix(media, "image/") {
+		// An image has no body. Its key is what a query can match, which is how
+		// somebody finds architecture.png by typing architecture, and the bytes
+		// are what the preview shows.
+		content = &doc.Content{Bytes: raw}
+		content.Width, content.Height = pixels(raw)
+	} else {
+		out, err := extract.Extract(ctx, bytes.NewReader(raw), o.Key)
+		if err != nil {
+			// One unreadable object is one document skipped and reported. A
+			// hostile PDF does not cost the sync the hundred thousand objects
+			// after it.
+			return doc.Document{}, err
+		}
+		text, title, pages, partial = out.Text, out.Title, out.Pages, out.Truncated
+		if out.Media != "" {
+			// What the bytes say beats what the key says, because a key is
+			// whatever somebody typed when they uploaded.
+			media = out.Media
+		}
+	}
+
+	rel := s.relative(o.Key)
+	if title == "" {
+		title = path.Base(rel)
+	}
+	props := map[string]string{
+		"key":         o.Key,
+		"bucket":      s.client.Bucket(),
+		"path":        rel,
+		"extension":   strings.TrimPrefix(path.Ext(o.Key), "."),
+		doc.MediaType: media,
+		"size_bytes":  strconv.FormatInt(o.Size, 10),
+	}
+	if tag := strings.Trim(o.ETag, `"`); tag != "" {
+		props["etag"] = tag
+	}
+	if o.StorageClass != "" {
+		props["storage_class"] = o.StorageClass
+	}
+	if pages > 0 {
+		props["pages"] = strconv.Itoa(pages)
+	}
+	if partial {
+		// The body is a prefix of the document rather than the whole of it, and
+		// a reader that cannot tell the difference will report a document as
+		// missing a phrase that is in it.
+		props["truncated"] = "true"
+	}
+
+	perms, err := s.permissions(ctx, o.Key)
+	if err != nil {
+		// The document keeps the unresolved descriptor and is quarantined by
+		// the pipeline. Failing to answer is not permission to publish.
+		perms = connector.Unresolved(s.name)
+		s.skipped(o.Key, err)
+	}
+
+	return doc.Document{
+		ID:        s.id(o.Key),
+		Kind:      kindOf(media),
+		Title:     title,
+		Body:      text,
+		URL:       s.client.url(o.Key),
+		Container: containerOf(rel),
+		// Object storage keeps one time and calls it the last modification. An
+		// object that was overwritten has no record of when it first appeared,
+		// so saying the two are the same is the honest answer rather than
+		// leaving a creation date empty and having every result sort last.
+		ModifiedAt:   o.LastModified,
+		CreatedAt:    o.LastModified,
+		SourceUpdate: o.version(),
+		Permissions:  perms,
+		Properties:   props,
+		Content:      content,
+	}, nil
+}
+
+// relative is a key with the source's prefix taken off, which is what a person
+// reading a result row wants to see. The prefix is a deployment's decision
+// about where in a bucket the corpus lives and is the same on every row.
+func (s *Source) relative(key string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(key, s.prefix), "/")
+}
+
+// merge fills in from a fetched object whatever a listed one did not carry.
+//
+// Both paths into a document go through here. A sync has the listing's
+// description and a repair after reconciliation has only the response headers,
+// and the difference should not reach the document.
+func merge(listed, fetched object) object {
+	if listed.Key == "" {
+		listed.Key = fetched.Key
+	}
+	if listed.LastModified.IsZero() {
+		listed.LastModified = fetched.LastModified
+	}
+	if listed.ETag == "" {
+		listed.ETag = fetched.ETag
+	}
+	if listed.Size == 0 {
+		listed.Size = fetched.Size
+	}
+	if listed.StorageClass == "" {
+		listed.StorageClass = fetched.StorageClass
+	}
+	return listed
+}
+
+// parseCursor reads a sync point out of a cursor.
+func parseCursor(c connector.Cursor) (syncPoint, error) {
+	if c.IsZero() {
+		return syncPoint{}, nil
+	}
+	var p syncPoint
+	if err := json.Unmarshal([]byte(c.Value), &p); err != nil {
+		// A cursor this connector cannot read is one written by a different
+		// version or a different connector. Refusing is better than silently
+		// resyncing the whole bucket, which on a large one looks like a hang
+		// and costs real money.
+		return syncPoint{}, fmt.Errorf("objectsource: unreadable cursor %q: %w", c.Value, err)
+	}
+	return p, nil
+}
+
+// cursorAt encodes a sync point.
+func cursorAt(p syncPoint, at time.Time) connector.Cursor {
+	// The only way this fails is a time that cannot be formatted, and there is
+	// no such time. An empty value would be read back as no cursor at all,
+	// which resyncs the bucket rather than losing anything.
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return connector.Cursor{}
+	}
+	return connector.Cursor{Value: string(raw), Time: at}
+}
+
+// resume is the cursor carried by one change, and is where an interrupted run
+// picks up.
+//
+// It holds the key rather than the time, and that is the whole reason it is
+// safe. A listing is ordered by key and not by when anything changed, so the
+// times attached to the changes go up and down as the run proceeds. A cursor
+// that stored the time of the change just written would tell the next run to
+// skip every object with an older time, and the ones further down the listing
+// that had not been read yet would be skipped for ever.
+//
+// Both high water marks are carried through unchanged. They belong to the run
+// that is still going and only move when it finishes, so a run resumed from
+// here compares against exactly what it was comparing against before.
+func resume(start syncPoint, key string) connector.Cursor {
+	return cursorAt(syncPoint{Since: start.Since, Perms: start.Perms, After: key}, start.Since)
+}
+
+// mediaOf is what an object actually is.
+//
+// The bytes decide. A key is whatever somebody typed when they uploaded, and
+// the content type the store reports is whatever their tool sent with it, which
+// is application/octet-stream far more often than it is true. The name only
+// gets a say for the formats that announce nothing in their first bytes, which
+// is the vector image formats and every text format there is.
+func mediaOf(raw []byte, key string) string {
+	media := extract.Detect(raw, key)
+	switch media {
+	case "text/plain", "application/octet-stream":
+		if m := imageMedia(key); m != "" {
+			return m
+		}
+	}
+	return media
+}
+
+// imageMedia is the image type a key claims, or empty.
+//
+// It is by name because that is all there is at the point it is asked, which is
+// while deciding whether to fetch the object at all.
+func imageMedia(key string) string {
+	switch strings.ToLower(path.Ext(key)) {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".svg":
+		return "image/svg+xml"
+	default:
+		return ""
+	}
+}
+
+// needsExtraction reports whether a media type is one whose text has to be
+// extracted rather than read.
+func needsExtraction(media string) bool {
+	switch media {
+	case "application/pdf",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return true
+	default:
+		return false
+	}
+}
+
+// kindOf maps a media type onto a document kind. Anything unrecognised is a
+// file, which is the kind that promises the least.
+func kindOf(media string) doc.Kind {
+	switch {
+	case strings.HasPrefix(media, "image/"):
+		return doc.KindImage
+	case strings.HasPrefix(media, "text/x-"), media == "text/javascript":
+		return doc.KindCode
+	case strings.HasPrefix(media, "text/"):
+		return doc.KindPage
+	default:
+		return doc.KindFile
+	}
+}
+
+// containerOf is the folder an object lives in, relative to the prefix. An
+// object at the top has no container rather than one called ".", because that
+// dot travels all the way to the result row and to the facet list, where it
+// means nothing to anybody.
+func containerOf(rel string) string {
+	if dir := path.Dir(rel); dir != "." && dir != "/" {
+		return dir
+	}
+	return ""
+}
+
+// defaultInclude reads the formats the extractor understands and the images a
+// preview can show.
+func defaultInclude(key string) bool {
+	return imageMedia(key) != "" || extract.MediaByName(key) != ""
+}
+
+// pixels reads the dimensions out of an encoded image without decoding it.
+//
+// The standard library answers for png, jpeg and gif. It does not answer for
+// webp or svg, and rather than pull in a decoder for each, those record a zero,
+// which the interface reads as no box to reserve.
+func pixels(raw []byte) (width, height int) {
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
+	if err != nil {
+		return 0, 0
+	}
+	return cfg.Width, cfg.Height
+}

--- a/connector/objectsource/objectsource_test.go
+++ b/connector/objectsource/objectsource_test.go
@@ -1,0 +1,685 @@
+package objectsource_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/objectsource"
+	"github.com/tamnd/genba/doc"
+)
+
+const (
+	sourceName = "bucket"
+	identity   = "corp"
+)
+
+func TestTheBucketIsReadIntoDocuments(t *testing.T) {
+	store := newStore(t)
+	store.put("notes/release.md", "# Release\n\nThe first one.\n")
+	store.put("notes/todo.txt", "buy milk")
+	store.settle()
+
+	source := open(t, store, nil)
+	changes, _ := syncAll(t, source, connector.Cursor{})
+
+	if len(changes) != 2 {
+		t.Fatalf("read %d documents, want 2: %v", len(changes), keysOf(changes))
+	}
+
+	first := changes[0].Document
+	switch {
+	case first.ID != "bucket:notes/release.md":
+		t.Errorf("id is %q", first.ID)
+	case first.Title != "Release":
+		// The heading inside the file beats the file's name, because that is
+		// what somebody reading a result row is looking for.
+		t.Errorf("title is %q, want the heading", first.Title)
+	case !strings.Contains(first.Body, "The first one."):
+		t.Errorf("body is %q", first.Body)
+	case first.Container != "notes":
+		t.Errorf("container is %q", first.Container)
+	case first.Kind != doc.KindPage:
+		t.Errorf("kind is %v, want a page", first.Kind)
+	case first.Properties["bucket"] != theBucket:
+		t.Errorf("bucket property is %q", first.Properties["bucket"])
+	case first.Properties["key"] != "notes/release.md":
+		t.Errorf("key property is %q", first.Properties["key"])
+	case first.SourceUpdate == "":
+		t.Error("the document carries no version, so nothing can tell whether it was rewritten")
+	}
+	if !strings.HasSuffix(first.URL, "/"+theBucket+"/notes/release.md") {
+		t.Errorf("url is %q, which does not name the object", first.URL)
+	}
+}
+
+// A source built without a policy has to quarantine, because the alternative to
+// an answer about who may read a bucket is not "everybody".
+func TestABucketWithNoPolicyIsQuarantinedRatherThanPublished(t *testing.T) {
+	store := newStore(t)
+	store.put("secret.txt", "the numbers")
+	store.settle()
+
+	changes, _ := syncAll(t, open(t, store, nil), connector.Cursor{})
+	if len(changes) != 1 {
+		t.Fatalf("read %d documents, want 1", len(changes))
+	}
+	if got := changes[0].Document.Permissions.Mode; got != acl.ModeUnknown {
+		t.Errorf("the mode is %v, want it unresolved", got)
+	}
+}
+
+func TestASecondSyncOverAnUnchangedBucketFetchesNothing(t *testing.T) {
+	store := newStore(t)
+	store.put("a.md", "one")
+	store.put("b.md", "two")
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+	_, cursor := syncAll(t, source, connector.Cursor{})
+
+	before := source.Counters()
+	changes, next := syncAll(t, source, cursor)
+
+	if len(changes) != 0 {
+		t.Fatalf("the second sync emitted %d changes, want none: %v", len(changes), keysOf(changes))
+	}
+	spent := source.Counters().Since(before)
+	switch {
+	case spent.Fetches != 0:
+		t.Errorf("the second sync fetched %d objects, want none", spent.Fetches)
+	case spent.Bytes != 0:
+		t.Errorf("the second sync read %d bytes of object, want none", spent.Bytes)
+	case spent.Lists == 0:
+		t.Error("the second sync made no listing, so it did not look at the bucket at all")
+	}
+	if next.IsZero() {
+		t.Error("the second sync returned no cursor, so the next one would start over")
+	}
+}
+
+func TestAnObjectWrittenSinceTheCursorIsTheOnlyOneRead(t *testing.T) {
+	store := newStore(t)
+	store.put("old.md", "unchanged")
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+	_, cursor := syncAll(t, source, connector.Cursor{})
+
+	store.put("new.md", "written after the cursor")
+	store.settle()
+
+	before := source.Counters()
+	changes, _ := syncAll(t, source, cursor)
+
+	if got := keysOf(changes); !slices.Equal(got, []string{"bucket:new.md"}) {
+		t.Fatalf("the second sync emitted %v, want only the new object", got)
+	}
+	if spent := source.Counters().Since(before); spent.Fetches != 1 {
+		t.Errorf("the second sync fetched %d objects, want exactly the one that changed", spent.Fetches)
+	}
+}
+
+func TestAnObjectRewrittenSinceTheCursorIsReadAgain(t *testing.T) {
+	store := newStore(t)
+	store.put("page.md", "the first version")
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+	first, cursor := syncAll(t, source, connector.Cursor{})
+
+	store.put("page.md", "the second version, which is longer")
+	store.settle()
+
+	second, _ := syncAll(t, source, cursor)
+	if len(second) != 1 {
+		t.Fatalf("the second sync emitted %d changes, want the rewritten object", len(second))
+	}
+	if !strings.Contains(second[0].Document.Body, "the second version") {
+		t.Errorf("the body is %q, want the new one", second[0].Document.Body)
+	}
+	if first[0].Document.SourceUpdate == second[0].Document.SourceUpdate {
+		t.Error("the version did not change when the bytes did, so nothing downstream can tell them apart")
+	}
+}
+
+func TestListingIsPagedRightThrough(t *testing.T) {
+	store := newStore(t)
+	want := make([]string, 0, 7)
+	for _, name := range []string{"a", "b", "c", "d", "e", "f", "g"} {
+		store.put(name+".md", "the "+name+" file")
+		want = append(want, "bucket:"+name+".md")
+	}
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName), objectsource.WithPageSize(2))
+	store.requests()
+	changes, _ := syncAll(t, source, connector.Cursor{})
+
+	if got := keysOf(changes); !slices.Equal(got, want) {
+		t.Fatalf("read %v, want %v", got, want)
+	}
+	// Seven objects two at a time is four listings, and a connector that
+	// stopped after the first page would read the first two and report success.
+	if got := countListings(store.requests()); got != 4 {
+		t.Errorf("made %d listings, want 4", got)
+	}
+}
+
+func TestOnlyTheKeysUnderThePrefixAreRead(t *testing.T) {
+	store := newStore(t)
+	store.put("reports/q1.md", "the first quarter")
+	store.put("reports/q2.md", "the second quarter")
+	store.put("scratch/notes.md", "not part of the corpus")
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName), objectsource.WithPrefix("reports/"))
+	store.requests()
+	changes, _ := syncAll(t, source, connector.Cursor{})
+
+	want := []string{"bucket:reports/q1.md", "bucket:reports/q2.md"}
+	if got := keysOf(changes); !slices.Equal(got, want) {
+		t.Fatalf("read %v, want %v", got, want)
+	}
+	// The prefix has to be in the request rather than applied to the answer. A
+	// connector that filtered afterwards would pass the assertion above and
+	// would cost a full listing of a bucket it was pointed at one folder of.
+	if !slices.ContainsFunc(store.requests(), func(r string) bool {
+		return strings.Contains(r, "prefix=reports%2F")
+	}) {
+		t.Error("no listing carried the prefix, so it was a filter rather than a narrower question")
+	}
+	// The document's path is relative to the prefix, because where in the
+	// bucket the corpus lives is the same on every row and means nothing to
+	// anybody reading one.
+	if got := changes[0].Document.Properties["path"]; got != "q1.md" {
+		t.Errorf("the path is %q, want it relative to the prefix", got)
+	}
+}
+
+func TestAnInterruptedSyncResumesFromTheKeyItReached(t *testing.T) {
+	store := newStore(t)
+	for _, name := range []string{"a", "b", "c", "d"} {
+		store.put(name+".md", "the "+name+" file")
+	}
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+
+	// Stop after two documents, the way a process being shut down does, and
+	// keep the cursor the second one carried.
+	var (
+		got  []string
+		stop = errors.New("stopping here")
+		last connector.Cursor
+	)
+	_, err := source.Sync(t.Context(), connector.Cursor{}, func(_ context.Context, c connector.Change) error {
+		got = append(got, c.Document.ID)
+		last = c.Cursor
+		if len(got) == 2 {
+			return stop
+		}
+		return nil
+	})
+	if !errors.Is(err, stop) {
+		t.Fatalf("the sync returned %v, want the error the callback gave it", err)
+	}
+	if last.IsZero() {
+		t.Fatal("the changes carried no cursor, so an interrupted sync has nowhere to carry on from")
+	}
+
+	rest, _ := syncAll(t, source, last)
+	if want := []string{"bucket:c.md", "bucket:d.md"}; !slices.Equal(keysOf(rest), want) {
+		t.Fatalf("the resumed sync read %v, want %v", keysOf(rest), want)
+	}
+	// A resume that started over would be correct and would also re-read the
+	// whole bucket, which on a real one is the difference between a minute and
+	// a day.
+	if got := len(rest); got != 2 {
+		t.Errorf("the resumed sync emitted %d changes, want the two it had not reached", got)
+	}
+}
+
+func TestABucketAccessControlListChangeIsAPermissionChangeAndNotAResync(t *testing.T) {
+	store := newStore(t)
+	store.put("one.md", "the first file")
+	store.put("two.md", "the second file")
+	store.setACL(listOf("owner@example.com", userGrant("reader@example.com", "READ")))
+	store.settle()
+
+	client := store.client(t)
+	policy, err := objectsource.NewBucketPolicy(client, sourceName, identity, "example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := objectsource.New(client, sourceName, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, cursor := syncAll(t, source, connector.Cursor{})
+	if len(first) != 2 {
+		t.Fatalf("the first sync emitted %d changes, want 2", len(first))
+	}
+	if got := refs(first[0].Document.Permissions.AllowUsers); !slices.Equal(got, []string{"reader@example.com"}) {
+		t.Fatalf("the first sync allowed %v", got)
+	}
+
+	// Somebody takes the reader off the list. Not one object is touched.
+	store.setACL(listOf("owner@example.com", userGrant("someone.else@example.com", "READ")))
+	store.settle()
+
+	before := source.Counters()
+	second, next := syncAll(t, source, cursor)
+
+	if len(second) != 2 {
+		t.Fatalf("the revocation produced %d changes, want one per object", len(second))
+	}
+	for _, c := range second {
+		if !c.PermissionsOnly {
+			t.Fatalf("%s came back as a whole document, so the body was refetched for a permission change", c.Document.ID)
+		}
+		if got := refs(c.Document.Permissions.AllowUsers); !slices.Equal(got, []string{"someone.else@example.com"}) {
+			t.Errorf("%s allows %v, want the new list", c.Document.ID, got)
+		}
+	}
+	if spent := source.Counters().Since(before); spent.Fetches != 0 {
+		t.Errorf("the revocation cost %d object fetches, want none", spent.Fetches)
+	}
+
+	// And it settles. A permission change that re-emitted on every later sync
+	// would rewrite the whole bucket for ever after one edit.
+	store.settle()
+	third, _ := syncAll(t, source, next)
+	if len(third) != 0 {
+		t.Errorf("the sync after the revocation emitted %d changes, want none", len(third))
+	}
+}
+
+// The bucket's list is read once per sync however many objects there are. That
+// is the entire reason this policy exists rather than the per object one.
+func TestTheBucketAccessControlListIsReadOncePerSync(t *testing.T) {
+	store := newStore(t)
+	for _, name := range []string{"a", "b", "c", "d", "e"} {
+		store.put(name+".md", "the "+name+" file")
+	}
+	store.setACL(listOf("owner@example.com", groupGrant(uriAllUsers, "READ")))
+	store.settle()
+
+	client := store.client(t)
+	policy, err := objectsource.NewBucketPolicy(client, sourceName, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := objectsource.New(client, sourceName, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store.requests()
+	changes, _ := syncAll(t, source, connector.Cursor{})
+	if len(changes) != 5 {
+		t.Fatalf("read %d documents, want 5", len(changes))
+	}
+	if got := countACLs(store.requests()); got != 1 {
+		t.Errorf("read the access control list %d times for five objects, want once", got)
+	}
+}
+
+func TestEnumerateDescribesEverythingAndFetchesNothing(t *testing.T) {
+	store := newStore(t)
+	store.put("a.md", "one")
+	store.put("b.md", "two")
+	store.put("c.md", "three")
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+	before := source.Counters()
+
+	var got []connector.Item
+	if err := source.Enumerate(t.Context(), func(i connector.Item) bool {
+		got = append(got, i)
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("described %d objects, want 3", len(got))
+	}
+	for _, i := range got {
+		if i.Version == "" {
+			t.Errorf("%s was described with no version, so reconciliation cannot tell it apart from a stale copy", i.ID)
+		}
+	}
+	if spent := source.Counters().Since(before); spent.Fetches != 0 {
+		t.Errorf("enumerating fetched %d objects, want none", spent.Fetches)
+	}
+}
+
+// A caller that stops early has not failed, and reporting that it did would
+// make a reconciliation sweep read "nothing is in the source" and delete the
+// index.
+func TestEnumerateStoppingEarlyIsNotAFailure(t *testing.T) {
+	store := newStore(t)
+	for _, name := range []string{"a", "b", "c", "d"} {
+		store.put(name+".md", "the "+name+" file")
+	}
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName), objectsource.WithPageSize(2))
+
+	var seen int
+	err := source.Enumerate(t.Context(), func(connector.Item) bool {
+		seen++
+		return seen < 3
+	})
+	if err != nil {
+		t.Fatalf("stopping early reported %v, want no error", err)
+	}
+	if seen != 3 {
+		t.Errorf("saw %d objects, want the callback to have been stopped at 3", seen)
+	}
+}
+
+func TestFetchReadsOneObject(t *testing.T) {
+	store := newStore(t)
+	store.put("notes/plan.md", "# Plan\n\nShip it.\n")
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+	document, err := source.Fetch(t.Context(), "bucket:notes/plan.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if document.Title != "Plan" {
+		t.Errorf("title is %q", document.Title)
+	}
+	if !strings.Contains(document.Body, "Ship it.") {
+		t.Errorf("body is %q", document.Body)
+	}
+	if document.Permissions.Mode != acl.ModePublicToTenant {
+		t.Errorf("the mode is %v, want the policy's answer", document.Permissions.Mode)
+	}
+}
+
+func TestFetchOfSomethingGoneIsErrGone(t *testing.T) {
+	store := newStore(t)
+	store.put("temporary.md", "here for now")
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+	store.remove("temporary.md")
+
+	if _, err := source.Fetch(t.Context(), "bucket:temporary.md"); !errors.Is(err, connector.ErrGone) {
+		t.Errorf("fetching a deleted object returned %v, want ErrGone", err)
+	}
+}
+
+// A store that is refusing, or that has been pointed at a bucket that does not
+// exist, must not read as "every document was deleted". The failure that would
+// cause is an index emptied by a typo in a setting.
+func TestAStoreThatRefusesIsNotADeletion(t *testing.T) {
+	store := newStore(t)
+	store.put("real.md", "here")
+	store.settle()
+
+	client, err := objectsource.NewClient(objectsource.Config{
+		Endpoint:        store.server.URL,
+		Region:          "eu-west-1",
+		Bucket:          "a-bucket-that-is-not-there",
+		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		PathStyle:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := objectsource.New(client, sourceName, objectsource.PublicToTenant(sourceName))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = source.Fetch(t.Context(), "bucket:real.md")
+	switch {
+	case err == nil:
+		t.Fatal("fetching from a bucket that is not there succeeded")
+	case errors.Is(err, connector.ErrGone):
+		t.Fatal("a missing bucket read as a deleted object, which would empty the index")
+	case !strings.Contains(err.Error(), "NoSuchBucket"):
+		t.Errorf("the error is %v, want it to say what the store said", err)
+	}
+}
+
+func TestAnIdFromAnotherSourceIsRefused(t *testing.T) {
+	store := newStore(t)
+	store.put("shared.md", "in the bucket")
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+	for _, id := range []string{"elsewhere:shared.md", "shared.md", "bucket:", ""} {
+		if _, err := source.Fetch(t.Context(), id); !errors.Is(err, connector.ErrGone) {
+			t.Errorf("fetching %q returned %v, want ErrGone", id, err)
+		}
+	}
+}
+
+func TestAnIdThatTriesToLeaveThePrefixIsRefused(t *testing.T) {
+	store := newStore(t)
+	store.put("public/open.md", "anybody may read this")
+	store.put("private/closed.md", "nobody may")
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName), objectsource.WithPrefix("public/"))
+	for _, id := range []string{
+		"bucket:private/closed.md",
+		"bucket:public/../private/closed.md",
+		"bucket:public//closed.md",
+	} {
+		if _, err := source.Fetch(t.Context(), id); !errors.Is(err, connector.ErrGone) {
+			t.Errorf("fetching %q returned %v, want ErrGone", id, err)
+		}
+	}
+	if _, err := source.Fetch(t.Context(), "bucket:public/open.md"); err != nil {
+		t.Errorf("fetching a key inside the prefix failed: %v", err)
+	}
+}
+
+// The store's modification times have a second of resolution and a listing of a
+// real bucket takes a great deal longer than that. An object written later in
+// the same second as the newest one a run saw would be filed under a time the
+// cursor had already passed, and would never be looked at again.
+func TestAnObjectWrittenInTheSameSecondIsNotLost(t *testing.T) {
+	store := newStore(t)
+	store.put("first.md", "written at noon")
+	// No settling. The run finishes in the same second as the write, which is
+	// what happens on a small bucket and on every developer's laptop.
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+	if changes, cursor := syncAll(t, source, connector.Cursor{}); len(changes) != 1 {
+		t.Fatalf("the first sync read %d documents, want 1", len(changes))
+	} else {
+		// A second object lands in the same second, after the listing went past
+		// where its key sorts.
+		store.putAt("second.md", "written in the same second", store.now())
+		store.settle()
+
+		got, _ := syncAll(t, source, cursor)
+		if !slices.Contains(keysOf(got), "bucket:second.md") {
+			t.Errorf("the second sync read %v, and the object written in the same second is not in it", keysOf(got))
+		}
+	}
+}
+
+func TestAnObjectOverTheSizeLimitIsSkippedAndReported(t *testing.T) {
+	store := newStore(t)
+	store.put("small.md", "short enough")
+	store.put("huge.md", strings.Repeat("x", 4096))
+	store.settle()
+
+	var skipped []string
+	source := open(t, store,
+		objectsource.PublicToTenant(sourceName),
+		objectsource.WithMaxObjectSize(1024),
+		objectsource.WithSkipped(func(key string, reason error) {
+			skipped = append(skipped, key+": "+reason.Error())
+		}),
+	)
+	before := source.Counters()
+	changes, _ := syncAll(t, source, connector.Cursor{})
+
+	if got := keysOf(changes); !slices.Equal(got, []string{"bucket:small.md"}) {
+		t.Fatalf("read %v, want only the small object", got)
+	}
+	if len(skipped) != 1 || !strings.HasPrefix(skipped[0], "huge.md:") {
+		t.Fatalf("the skipped objects were %v, want the large one reported", skipped)
+	}
+	// The size came from the listing, so the object was never fetched. An
+	// implementation that downloaded it to find out how big it was would pass
+	// every other assertion here.
+	if spent := source.Counters().Since(before); spent.Fetches != 1 {
+		t.Errorf("fetched %d objects, want only the one that was in the corpus", spent.Fetches)
+	}
+}
+
+func TestTheFormatsNobodyCanSearchAreNotFetchedAtAll(t *testing.T) {
+	store := newStore(t)
+	store.put("readme.md", "prose")
+	store.put("backup.tar.gz", "not prose")
+	store.put("disk.img", "not prose either")
+	// The empty object a console writes when somebody makes a folder. There is
+	// nothing in it and there never was.
+	store.put("folder/", "")
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+	before := source.Counters()
+	changes, _ := syncAll(t, source, connector.Cursor{})
+
+	if got := keysOf(changes); !slices.Equal(got, []string{"bucket:readme.md"}) {
+		t.Fatalf("read %v, want only the document", got)
+	}
+	if spent := source.Counters().Since(before); spent.Fetches != 1 {
+		t.Errorf("fetched %d objects, want the one that was worth reading", spent.Fetches)
+	}
+}
+
+func TestAnImageBecomesContentRatherThanBody(t *testing.T) {
+	store := newStore(t)
+	store.put("shots/architecture.png", string(onePixelPNG()))
+	store.settle()
+
+	source := open(t, store, objectsource.PublicToTenant(sourceName))
+	changes, _ := syncAll(t, source, connector.Cursor{})
+
+	if len(changes) != 1 {
+		t.Fatalf("read %d documents, want the image", len(changes))
+	}
+	got := changes[0].Document
+	switch {
+	case got.Kind != doc.KindImage:
+		t.Errorf("kind is %v, want an image", got.Kind)
+	case got.Content == nil:
+		t.Fatal("the image carries no content, so a preview has nothing to show")
+	case got.Content.Width != 1 || got.Content.Height != 1:
+		t.Errorf("the image is %dx%d, want 1x1", got.Content.Width, got.Content.Height)
+	case got.Body != "":
+		t.Errorf("the image has a body of %q, want none", got.Body)
+	case got.Title != "architecture.png":
+		// The name is the only thing a query can match on an image, which is how
+		// somebody finds this by typing architecture.
+		t.Errorf("title is %q, want the file name", got.Title)
+	}
+}
+
+// open builds a source over the fake with the default settings.
+func open(t *testing.T, store *fakeStore, policy objectsource.Policy, opts ...objectsource.Option) *objectsource.Source {
+	t.Helper()
+	source, err := objectsource.New(store.client(t), sourceName, policy, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := source.Close(); err != nil {
+			t.Errorf("closing the source: %v", err)
+		}
+	})
+	return source
+}
+
+// syncAll runs one sync to the end and collects what it emitted.
+func syncAll(t *testing.T, s *objectsource.Source, from connector.Cursor) ([]connector.Change, connector.Cursor) {
+	t.Helper()
+	var got []connector.Change
+	next, err := s.Sync(t.Context(), from, func(_ context.Context, c connector.Change) error {
+		got = append(got, c)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("syncing: %v", err)
+	}
+	return got, next
+}
+
+func keysOf(changes []connector.Change) []string {
+	out := make([]string, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, c.Document.ID)
+	}
+	return out
+}
+
+func refs(list []acl.Ref) []string {
+	out := make([]string, 0, len(list))
+	for _, r := range list {
+		out = append(out, r.Value)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func countListings(requests []string) int {
+	return countMatching(requests, "list-type=2")
+}
+
+func countACLs(requests []string) int {
+	return countMatching(requests, "acl")
+}
+
+func countMatching(requests []string, part string) int {
+	var n int
+	for _, r := range requests {
+		if strings.Contains(r, part) {
+			n++
+		}
+	}
+	return n
+}
+
+// onePixelPNG is the smallest image the standard library will read the size of,
+// which is all this needs to be.
+func onePixelPNG() []byte {
+	return []byte{
+		0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+		0x89, 0x00, 0x00, 0x00, 0x0a, 'I', 'D', 'A', 'T',
+		0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05,
+		0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00,
+		0x00, 0x00, 'I', 'E', 'N', 'D', 0xae, 0x42, 0x60, 0x82,
+	}
+}
+
+// settle moves the store's clock on, the way real time passes between somebody
+// writing an object and a sync noticing it.
+//
+// It matters because the connector holds its cursor a second behind the store's
+// own clock on purpose, so a test that wrote and synced in the same instant
+// would be testing that safety margin rather than whatever it meant to test.
+func (f *fakeStore) settle() { f.tick(time.Minute) }

--- a/connector/objectsource/policy.go
+++ b/connector/objectsource/policy.go
@@ -1,0 +1,316 @@
+package objectsource
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/aclmap"
+)
+
+// Policy decides who may read an object.
+//
+// It is a separate thing from the source for the same reason it is on a
+// filesystem: where the answer lives is a property of the deployment. Some
+// buckets carry an access control list per object, some carry one on the bucket
+// and nothing on the objects, and a great many carry neither because the
+// account turned object ownership on and does all of it with policy documents
+// that name roles this index has never heard of.
+//
+// Returning an error quarantines that one document and does not stop the sync.
+type Policy interface {
+	Permissions(ctx context.Context, key string) (acl.Permissions, error)
+}
+
+// PolicyFunc adapts a function to [Policy].
+type PolicyFunc func(ctx context.Context, key string) (acl.Permissions, error)
+
+// Permissions calls f.
+func (f PolicyFunc) Permissions(ctx context.Context, key string) (acl.Permissions, error) {
+	return f(ctx, key)
+}
+
+// PublicToTenant is a policy where every object is readable by everybody in the
+// tenant.
+//
+// It is correct for a bucket of published documentation and wrong for almost
+// everything else, so it has to be asked for by name.
+func PublicToTenant(source string) Policy {
+	return PolicyFunc(func(context.Context, string) (acl.Permissions, error) {
+		return acl.Permissions{Mode: acl.ModePublicToTenant, Source: source}, nil
+	})
+}
+
+// Versioned is the optional capability of a [Policy] that can say when its
+// answer for a key last changed.
+//
+// It is what turns a permission change into a write rather than a resync of the
+// whole bucket. The answer has to be cheap, because it is asked once per object
+// the listing decided was unchanged, which on a real bucket is once per object.
+type Versioned interface {
+	// ChangedAt returns when the rule governing key last changed, on the
+	// store's clock. A zero time means the policy has no idea, and nothing is
+	// refreshed on the strength of it.
+	ChangedAt(ctx context.Context, key string) (time.Time, error)
+}
+
+// Reloader is the optional capability of a [Policy] that caches. It is called
+// once at the start of every sync.
+type Reloader interface {
+	Reload()
+}
+
+// BucketPolicy answers for every object with the bucket's own access control
+// list.
+//
+// This is the cheap model and the common one. A bucket where the objects were
+// written by one process and are read by one team has the same answer for all
+// of them, and reading that answer once per sync rather than once per object is
+// the difference between one request and a million.
+//
+// It is also the model that can notice a revocation. An object's own access
+// control list can be rewritten without the object changing, and nothing in a
+// listing says so, which means there is no incremental way to find out. A
+// bucket's list is one request, so this policy reads it every sync and compares
+// it with the last one, and when it differs every object in the bucket gets a
+// permission change without a single byte being fetched.
+type BucketPolicy struct {
+	client *Client
+	source string
+	acls   *aclmap.Normalizer
+
+	mu      sync.Mutex
+	loaded  bool
+	perms   acl.Permissions
+	err     error
+	seen    string
+	changed time.Time
+}
+
+var (
+	_ Policy    = (*BucketPolicy)(nil)
+	_ Versioned = (*BucketPolicy)(nil)
+	_ Reloader  = (*BucketPolicy)(nil)
+)
+
+// NewBucketPolicy returns a policy reading c's bucket access control list.
+//
+// The source is the connector's name and identity is the identity source the
+// names in the list belong to. Any domains given are the ones that count as
+// this tenant, which for object storage means the mail domains that appear in
+// grants written against an email address.
+func NewBucketPolicy(c *Client, source, identity string, domains ...string) (*BucketPolicy, error) {
+	n, err := aclmap.New(aclmap.ObjectStore(source, identity, domains...))
+	if err != nil {
+		return nil, err
+	}
+	return &BucketPolicy{client: c, source: source, acls: n}, nil
+}
+
+// Permissions returns the bucket's answer, which is every object's answer.
+func (p *BucketPolicy) Permissions(ctx context.Context, _ string) (acl.Permissions, error) {
+	return p.load(ctx)
+}
+
+// ChangedAt returns when this process last saw the bucket's list change.
+//
+// The store keeps no such time, so this is when the difference was noticed
+// rather than when it happened, read off the store's clock so that it can be
+// compared with the modification times in a listing. That is late rather than
+// wrong: the change is applied on the first sync after it was made, which is
+// the same latency a content change gets.
+func (p *BucketPolicy) ChangedAt(ctx context.Context, _ string) (time.Time, error) {
+	if _, err := p.load(ctx); err != nil {
+		return time.Time{}, err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.changed, nil
+}
+
+// Reload forgets the list so the next question reads it again.
+//
+// It does not forget when the list last changed, which is the whole state worth
+// keeping across a sync. A process that has been up for a week and never
+// reloaded would answer with the permissions the bucket had when it started,
+// which is the failure where a revocation looks applied and is not.
+func (p *BucketPolicy) Reload() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.loaded = false
+}
+
+// Counts returns what the mapping could and could not represent.
+func (p *BucketPolicy) Counts() aclmap.Counts { return p.acls.Counts() }
+
+// load reads the bucket's list at most once per sync.
+func (p *BucketPolicy) load(ctx context.Context) (acl.Permissions, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.loaded {
+		return p.perms, p.err
+	}
+
+	list, at, err := p.client.acl(ctx, "")
+	if err != nil {
+		// Recorded rather than retried per object. A bucket whose list cannot be
+		// read has one problem, and asking it a million more times turns one
+		// failure into a denial of service against the store.
+		p.loaded, p.perms, p.err = true, connector.Unresolved(p.source), err
+		return p.perms, p.err
+	}
+
+	if mark := fingerprint(list); mark != p.seen {
+		if p.seen != "" {
+			p.changed = at
+		}
+		p.seen = mark
+	}
+	p.perms, p.err = p.acls.Normalize(grantsOf(list))
+	p.loaded = true
+	return p.perms, p.err
+}
+
+// ObjectPolicy reads the access control list of every object.
+//
+// It is the exact model, and it costs a request per object per sync, which on a
+// bucket of any size is the most expensive thing this connector can be asked to
+// do. Reach for it when the objects really do have different lists, and reach
+// for [BucketPolicy] otherwise.
+//
+// It deliberately does not implement [Versioned]. The only way to find out
+// whether one object's list changed is to read it, so a policy that answered
+// that question would be doing the expensive thing on every object the listing
+// had already decided was unchanged, which is the work the incremental path
+// exists to avoid.
+type ObjectPolicy struct {
+	client *Client
+	source string
+	acls   *aclmap.Normalizer
+}
+
+var _ Policy = (*ObjectPolicy)(nil)
+
+// NewObjectPolicy returns a policy reading each object's own access control
+// list.
+func NewObjectPolicy(c *Client, source, identity string, domains ...string) (*ObjectPolicy, error) {
+	n, err := aclmap.New(aclmap.ObjectStore(source, identity, domains...))
+	if err != nil {
+		return nil, err
+	}
+	return &ObjectPolicy{client: c, source: source, acls: n}, nil
+}
+
+// Permissions reads one object's list.
+func (p *ObjectPolicy) Permissions(ctx context.Context, key string) (acl.Permissions, error) {
+	list, _, err := p.client.acl(ctx, key)
+	if err != nil {
+		return connector.Unresolved(p.source), err
+	}
+	return p.acls.Normalize(grantsOf(list))
+}
+
+// Counts returns what the mapping could and could not represent.
+func (p *ObjectPolicy) Counts() aclmap.Counts { return p.acls.Counts() }
+
+// The grantee URIs S3 defines, which every service copying it also uses.
+const (
+	uriAllUsers           = "http://acs.amazonaws.com/groups/global/AllUsers"
+	uriAuthenticatedUsers = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+
+	// authenticatedUsers is what a grant to every account holder at the
+	// provider is called once it is written down as a domain. It is not this
+	// tenant and it cannot be enumerated, so it quarantines like any other
+	// domain nobody has mapped, which is the point of naming it at all.
+	authenticatedUsers = "authenticated-users"
+)
+
+// grantsOf turns one access control list into statements, in the store's own
+// words, with nothing interpreted.
+//
+// Which permission confers read, what a grant to a domain means and what to do
+// with something unrecognised are all decided in aclmap, once, for every
+// connector. What is decided here is only who a statement is about.
+func grantsOf(list accessControl) []aclmap.Grant {
+	owner := nameOf(list.Owner)
+	out := make([]aclmap.Grant, 0, len(list.Grants))
+	for _, g := range list.Grants {
+		subject, id := subjectOf(g.Grantee)
+		out = append(out, aclmap.Grant{
+			Subject: subject,
+			ID:      id,
+			Effect:  aclmap.Allow,
+			Role:    g.Permission,
+			// Owning an object is not reading it. The owner is marked here only
+			// where the list already gives that account read, which is the same
+			// reading the file system policy takes: an account that can give
+			// itself permission has not been given it yet.
+			Owner: subject == aclmap.User && id != "" && id == owner,
+		})
+	}
+	return out
+}
+
+// subjectOf says who a grantee is.
+//
+// A group URI is the only kind that reaches outside the account, and the two
+// that do are told apart because they mean very different things: one is the
+// open internet and the other is every customer the provider has.
+func subjectOf(g grantee) (subject aclmap.Subject, id string) {
+	switch {
+	case g.URI == uriAllUsers:
+		return aclmap.Anyone, ""
+	case g.URI == uriAuthenticatedUsers:
+		return aclmap.Domain, authenticatedUsers
+	case g.URI != "":
+		// Every other group the service defines is a set of accounts it
+		// maintains, which is what a group is.
+		return aclmap.Group, strings.ToLower(g.URI[strings.LastIndex(g.URI, "/")+1:])
+	default:
+		// An empty name here is a statement about nobody, which aclmap counts as
+		// malformed and quarantines. That is the right answer and it is left to
+		// aclmap to give, rather than being dropped quietly on the way.
+		return aclmap.User, nameOf(g)
+	}
+}
+
+// nameOf is the best identity a grantee carries.
+//
+// An email address names a person and is what a company directory can be
+// matched against. A display name is what the console shows. A canonical user
+// id is neither: it names an account at the provider, it is a sixty four
+// character hex string, and it will not match anything a person signs in with.
+// It is used anyway when it is all there is, because a grant filed under it is
+// still a grant somebody can go and look up, and dropping the statement would
+// silently widen the list.
+func nameOf(g grantee) string {
+	switch {
+	case g.Email != "":
+		return strings.ToLower(g.Email)
+	case g.DisplayName != "":
+		return g.DisplayName
+	default:
+		return g.ID
+	}
+}
+
+// fingerprint is a stable rendering of a list, for telling whether it changed.
+//
+// It is built from the parsed statements rather than from the bytes, because
+// the bytes carry a request id in some services and the order of grants is not
+// promised in any of them, and a fingerprint that moved on its own would
+// rewrite the permissions of every object in the bucket on every sync.
+func fingerprint(list accessControl) string {
+	lines := make([]string, 0, len(list.Grants)+1)
+	lines = append(lines, "owner="+nameOf(list.Owner))
+	for _, g := range list.Grants {
+		subject, id := subjectOf(g.Grantee)
+		lines = append(lines, subject.String()+":"+id+"="+strings.ToLower(g.Permission))
+	}
+	slices.Sort(lines)
+	return strings.Join(lines, "\n")
+}

--- a/connector/objectsource/policy_test.go
+++ b/connector/objectsource/policy_test.go
@@ -1,0 +1,233 @@
+package objectsource_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/objectsource"
+)
+
+// What an access control list turns into.
+//
+// These are the assertions worth having about this connector, because they are
+// the ones whose failure is a document shown to somebody who was not meant to
+// see it. Each case is a list a real bucket can have, and the answer is the
+// permission descriptor the rest of the platform filters on.
+func TestWhatAnAccessControlListMeans(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		list  string
+		check func(t *testing.T, got acl.Permissions)
+	}{
+		{
+			name: "a read grant to somebody in the tenant is a reader",
+			list: listOf("owner@example.com", userGrant("reader@example.com", "READ")),
+			check: func(t *testing.T, got acl.Permissions) {
+				if want := []string{"reader@example.com"}; !slices.Equal(refs(got.AllowUsers), want) {
+					t.Errorf("allows %v, want %v", refs(got.AllowUsers), want)
+				}
+				if got.Mode != acl.ModeACL {
+					t.Errorf("the mode is %v, want a list", got.Mode)
+				}
+			},
+		},
+		{
+			name: "writing to a bucket is not reading from it",
+			list: listOf("owner@example.com",
+				userGrant("reader@example.com", "READ"),
+				userGrant("uploader@example.com", "WRITE"),
+			),
+			check: func(t *testing.T, got acl.Permissions) {
+				// This is the mapping most worth pinning. WRITE on a bucket is
+				// permission to put objects in it, and a mapping that read every
+				// permission as read would hand a private bucket to whoever can
+				// upload to it.
+				if want := []string{"reader@example.com"}; !slices.Equal(refs(got.AllowUsers), want) {
+					t.Errorf("allows %v, want %v", refs(got.AllowUsers), want)
+				}
+			},
+		},
+		{
+			name: "changing the list is not reading the object either",
+			list: listOf("owner@example.com",
+				userGrant("reader@example.com", "READ"),
+				userGrant("auditor@example.com", "READ_ACP"),
+				userGrant("admin@example.com", "WRITE_ACP"),
+			),
+			check: func(t *testing.T, got acl.Permissions) {
+				if want := []string{"reader@example.com"}; !slices.Equal(refs(got.AllowUsers), want) {
+					t.Errorf("allows %v, want %v", refs(got.AllowUsers), want)
+				}
+			},
+		},
+		{
+			name: "full control includes reading",
+			list: listOf("owner@example.com", userGrant("everything@example.com", "FULL_CONTROL")),
+			check: func(t *testing.T, got acl.Permissions) {
+				if want := []string{"everything@example.com"}; !slices.Equal(refs(got.AllowUsers), want) {
+					t.Errorf("allows %v, want %v", refs(got.AllowUsers), want)
+				}
+			},
+		},
+		{
+			name: "a bucket left open to the internet is public",
+			list: listOf("owner@example.com", groupGrant(uriAllUsers, "READ")),
+			check: func(t *testing.T, got acl.Permissions) {
+				if got.Mode != acl.ModePublicToTenant {
+					t.Errorf("the mode is %v, want it public", got.Mode)
+				}
+			},
+		},
+		{
+			name: "every account at the provider is not this company",
+			list: listOf("owner@example.com", groupGrant(uriAuthenticatedUsers, "READ")),
+			check: func(t *testing.T, got acl.Permissions) {
+				// Anybody with an account at the provider is a set nobody here
+				// can enumerate and is emphatically not the tenant. Quarantining
+				// is the only honest answer, and the alternative is publishing a
+				// bucket to every customer the provider has.
+				if got.Mode != acl.ModeUnknown {
+					t.Errorf("the mode is %v, want it unresolved", got.Mode)
+				}
+			},
+		},
+		{
+			name: "a bucket owned by one account and shared with nobody is owner only",
+			list: ownedBy("owner@example.com"),
+			check: func(t *testing.T, got acl.Permissions) {
+				if got.Mode != acl.ModeOwnerOnly {
+					t.Errorf("the mode is %v, want owner only", got.Mode)
+				}
+				if got.Owner.Value != "owner@example.com" {
+					t.Errorf("the owner is %q", got.Owner.Value)
+				}
+			},
+		},
+		{
+			name: "a grant naming nobody is not a grant to everybody",
+			list: `<AccessControlPolicy><Owner><ID>abc123</ID></Owner><AccessControlList>` +
+				`<Grant><Grantee></Grantee><Permission>READ</Permission></Grant>` +
+				`</AccessControlList></AccessControlPolicy>`,
+			check: func(t *testing.T, got acl.Permissions) {
+				if got.Mode != acl.ModeUnknown {
+					t.Errorf("the mode is %v, want it unresolved", got.Mode)
+				}
+			},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			store := newStore(t)
+			store.setACL(c.list)
+
+			policy, err := objectsource.NewBucketPolicy(store.client(t), sourceName, identity, "example.com")
+			if err != nil {
+				t.Fatal(err)
+			}
+			// An error here is the quarantine being reported rather than
+			// something going wrong, and the descriptor is what is being
+			// checked either way.
+			got, _ := policy.Permissions(t.Context(), "")
+			if got.Source != sourceName {
+				t.Errorf("the descriptor names %q as its source, want %q", got.Source, sourceName)
+			}
+			c.check(t, got)
+		})
+	}
+}
+
+// The identity source has to be on every reference, because a name on its own
+// says nothing about which directory it can be looked up in, and two
+// directories with the same name in them is the normal case rather than the odd
+// one.
+func TestEveryReferenceNamesTheDirectoryItCameFrom(t *testing.T) {
+	store := newStore(t)
+	store.setACL(listOf("owner@example.com",
+		userGrant("reader@example.com", "READ"),
+		userGrant("other@example.com", "READ"),
+	))
+
+	policy, err := objectsource.NewBucketPolicy(store.client(t), sourceName, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := policy.Permissions(t.Context(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range got.AllowUsers {
+		if r.Source != identity {
+			t.Errorf("%q came from %q, want %q", r.Value, r.Source, identity)
+		}
+	}
+}
+
+// A bucket whose list cannot be read is one problem, and asking it once per
+// object turns one problem into a denial of service against the store.
+func TestABucketWithNoAccessControlListIsAskedOncePerSync(t *testing.T) {
+	store := newStore(t)
+	for _, name := range []string{"a", "b", "c", "d", "e"} {
+		store.put(name+".md", "the "+name+" file")
+	}
+	store.settle()
+
+	client := store.client(t)
+	policy, err := objectsource.NewBucketPolicy(client, sourceName, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := objectsource.New(client, sourceName, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store.requests()
+	changes, _ := syncAll(t, source, connector.Cursor{})
+	if len(changes) != 5 {
+		t.Fatalf("read %d documents, want 5", len(changes))
+	}
+	for _, c := range changes {
+		if c.Document.Permissions.Mode != acl.ModeUnknown {
+			t.Errorf("%s is %v, want it quarantined", c.Document.ID, c.Document.Permissions.Mode)
+		}
+	}
+	if got := countACLs(store.requests()); got != 1 {
+		t.Errorf("asked for the access control list %d times, want once", got)
+	}
+}
+
+// The per object policy really does read one list per object, which is why it
+// has to be asked for by name rather than being the default.
+func TestTheObjectPolicyReadsTheListOfEachObject(t *testing.T) {
+	store := newStore(t)
+	store.put("open.md", "anybody in the tenant")
+	store.put("closed.md", "one person")
+	store.setACL(listOf("owner@example.com", userGrant("owner@example.com", "READ")))
+	store.setObjectACL("open.md", listOf("owner@example.com", groupGrant(uriAllUsers, "READ")))
+	store.setObjectACL("closed.md", listOf("owner@example.com", userGrant("one@example.com", "READ")))
+	store.settle()
+
+	client := store.client(t)
+	policy, err := objectsource.NewObjectPolicy(client, sourceName, identity, "example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := objectsource.New(client, sourceName, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changes, _ := syncAll(t, source, connector.Cursor{})
+	byID := make(map[string]acl.Permissions, len(changes))
+	for _, c := range changes {
+		byID[c.Document.ID] = c.Document.Permissions
+	}
+
+	if got := byID["bucket:open.md"].Mode; got != acl.ModePublicToTenant {
+		t.Errorf("open.md is %v, want it public", got)
+	}
+	if got := refs(byID["bucket:closed.md"].AllowUsers); !slices.Equal(got, []string{"one@example.com"}) {
+		t.Errorf("closed.md allows %v, want the one person named on it", got)
+	}
+}

--- a/connector/objectsource/sign.go
+++ b/connector/objectsource/sign.go
@@ -1,0 +1,206 @@
+package objectsource
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"maps"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Signature version 4 is the one thing every S3 compatible service agrees on.
+//
+// It is written out here rather than taken from a vendor SDK because the whole
+// of what this connector needs is one function over an *http.Request, and the
+// SDK that provides it arrives with a credential chain, a retry policy, a
+// middleware stack and several hundred other services attached. The algorithm
+// has not changed since 2012 and sign_test.go pins it against the worked
+// examples in the specification, so owning it is a known quantity in a way that
+// owning the dependency is not.
+
+const (
+	// signingAlgorithm names the scheme in the Authorization header.
+	signingAlgorithm = "AWS4-HMAC-SHA256"
+
+	// signingService is what the credential scope calls this API. Every S3
+	// compatible service uses the same word, whatever it calls itself.
+	signingService = "s3"
+
+	// emptyPayload is the SHA-256 of no bytes at all, which is what every
+	// request this connector makes carries, because it only ever reads.
+	emptyPayload = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+// sign authenticates a request in place.
+//
+// It rewrites the query string as well as adding headers. The signature covers
+// a canonical form of the query, and the only way to be certain the signed form
+// is the sent form is to send the signed one, rather than to hope that whoever
+// built the URL encoded it the same way.
+func sign(r *http.Request, hashedPayload string, cfg Config, now time.Time) {
+	stamp := now.UTC().Format("20060102")
+	timestamp := now.UTC().Format("20060102T150405Z")
+
+	r.Header.Set("X-Amz-Date", timestamp)
+	r.Header.Set("X-Amz-Content-Sha256", hashedPayload)
+	if cfg.SessionToken != "" {
+		r.Header.Set("X-Amz-Security-Token", cfg.SessionToken)
+	}
+	r.URL.RawQuery = canonicalQuery(r.URL.Query())
+
+	names, headers := canonicalHeaders(r)
+	canonical := strings.Join([]string{
+		r.Method,
+		canonicalURI(r),
+		r.URL.RawQuery,
+		headers,
+		names,
+		hashedPayload,
+	}, "\n")
+
+	scope := stamp + "/" + cfg.Region + "/" + signingService + "/aws4_request"
+	toSign := strings.Join([]string{
+		signingAlgorithm,
+		timestamp,
+		scope,
+		hashHex([]byte(canonical)),
+	}, "\n")
+
+	key := chain([]byte("AWS4"+cfg.SecretAccessKey), stamp, cfg.Region, signingService, "aws4_request")
+	signature := hex.EncodeToString(mac(key, toSign))
+
+	r.Header.Set("Authorization", signingAlgorithm+
+		" Credential="+cfg.AccessKeyID+"/"+scope+
+		", SignedHeaders="+names+
+		", Signature="+signature)
+}
+
+// canonicalURI is the path as it will appear on the wire.
+//
+// It reads the escaped path rather than escaping the path again, because the
+// two have to be the same string and the request has already been built. The
+// encoding that gets them to agree is in [escape], and the client sets it as
+// the URL's raw path so that this and the transport read the same bytes.
+func canonicalURI(r *http.Request) string {
+	if p := r.URL.EscapedPath(); p != "" {
+		return p
+	}
+	return "/"
+}
+
+// canonicalQuery sorts and encodes a query the way the signature expects.
+//
+// Parameters are ordered by name and then by value, and everything outside the
+// unreserved set is percent encoded, including the slash. That last part is why
+// url.Values.Encode is not used: it writes a space as a plus, which the
+// signature reads as a literal plus.
+func canonicalQuery(q url.Values) string {
+	parts := make([]string, 0, len(q))
+	for _, k := range slices.Sorted(maps.Keys(q)) {
+		values := slices.Clone(q[k])
+		slices.Sort(values)
+		for _, v := range values {
+			parts = append(parts, escape(k, false)+"="+escape(v, false))
+		}
+	}
+	return strings.Join(parts, "&")
+}
+
+// canonicalHeaders returns the signed header names and the block of headers
+// they refer to.
+//
+// Every header on the request is signed, plus the host, which is the point of
+// the exercise: a proxy that rewrote the bucket out of the host would produce a
+// request that no longer verifies.
+func canonicalHeaders(r *http.Request) (names, block string) {
+	host := r.Host
+	if host == "" {
+		host = r.URL.Host
+	}
+
+	values := make(map[string]string, len(r.Header)+1)
+	values["host"] = host
+	for k, v := range r.Header {
+		name := strings.ToLower(k)
+		// The header being built is not part of what it signs.
+		if name == "authorization" {
+			continue
+		}
+		values[name] = strings.Join(collapse(v), ",")
+	}
+
+	keys := slices.Sorted(maps.Keys(values))
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte(':')
+		b.WriteString(values[k])
+		b.WriteByte('\n')
+	}
+	return strings.Join(keys, ";"), b.String()
+}
+
+// collapse trims each header value and squeezes runs of spaces inside it down
+// to one, which is what the signature is calculated over.
+func collapse(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		out = append(out, strings.Join(strings.Fields(v), " "))
+	}
+	return out
+}
+
+// hexDigits is upper case because percent escapes in a canonical request are.
+const hexDigits = "0123456789ABCDEF"
+
+// escape is the percent encoding the signature is defined in terms of, which is
+// RFC 3986 and not the one net/url writes.
+//
+// A path keeps its slashes and a query parameter does not, which is the only
+// difference between the two uses.
+func escape(s string, keepSlash bool) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := range len(s) {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9',
+			c == '-', c == '_', c == '.', c == '~':
+			b.WriteByte(c)
+		case c == '/' && keepSlash:
+			b.WriteByte('/')
+		default:
+			b.WriteByte('%')
+			b.WriteByte(hexDigits[c>>4])
+			b.WriteByte(hexDigits[c&0xf])
+		}
+	}
+	return b.String()
+}
+
+// chain derives the signing key, which is a hash of the secret narrowed one
+// step at a time to a day, a region and a service.
+//
+// The narrowing is the reason a signature that leaks is worth so much less than
+// the key: it only authenticates that day, in that region, for that service.
+func chain(key []byte, parts ...string) []byte {
+	for _, p := range parts {
+		key = mac(key, p)
+	}
+	return key
+}
+
+func mac(key []byte, s string) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(s))
+	return h.Sum(nil)
+}
+
+func hashHex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/connector/objectsource/sign_test.go
+++ b/connector/objectsource/sign_test.go
@@ -1,0 +1,91 @@
+package objectsource
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The worked examples from the signature version 4 documentation, which are the
+// only way to know an implementation of this is right rather than merely
+// consistent with itself. A signer that agrees with nobody produces a request
+// every service refuses, and the error it gets back says the signature did not
+// match and nothing whatever about why.
+//
+// The credentials are the ones in the specification and have never been real.
+const (
+	exampleKeyID  = "AKIAIOSFODNN7EXAMPLE"
+	exampleSecret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	exampleHost   = "examplebucket.s3.amazonaws.com"
+)
+
+func TestTheSignatureMatchesTheWorkedExamples(t *testing.T) {
+	when := time.Date(2013, time.May, 24, 0, 0, 0, 0, time.UTC)
+	cfg := Config{
+		Region:          "us-east-1",
+		AccessKeyID:     exampleKeyID,
+		SecretAccessKey: exampleSecret,
+	}
+
+	for _, c := range []struct {
+		name    string
+		url     string
+		headers map[string]string
+		signed  string
+		want    string
+	}{
+		{
+			name:    "reading an object with a range",
+			url:     "https://" + exampleHost + "/test.txt",
+			headers: map[string]string{"Range": "bytes=0-9"},
+			signed:  "host;range;x-amz-content-sha256;x-amz-date",
+			want:    "f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
+		},
+		{
+			name:   "listing a bucket, which is where the query is canonicalised",
+			url:    "https://" + exampleHost + "/?max-keys=2&prefix=J",
+			signed: "host;x-amz-content-sha256;x-amz-date",
+			want:   "34b48302e7b5fa45bde8084f4b7868a86f0a534bc59db6670ed5711ef69dc6f7",
+		},
+		{
+			name:   "a subresource, which is a parameter with no value at all",
+			url:    "https://" + exampleHost + "/?lifecycle",
+			signed: "host;x-amz-content-sha256;x-amz-date",
+			want:   "fea454ca298b7da1c68078a5d1bdbfbbe0d65c699e0f91ac7a200a0136783543",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, c.url, http.NoBody)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for k, v := range c.headers {
+				req.Header.Set(k, v)
+			}
+
+			sign(req, emptyPayload, cfg, when)
+
+			auth := req.Header.Get("Authorization")
+			if got, want := field(auth, "Signature="), c.want; got != want {
+				t.Errorf("signature is\n%s\nwant\n%s\nfrom %s", got, want, auth)
+			}
+			if got := field(auth, "SignedHeaders="); got != c.signed {
+				t.Errorf("signed headers are %q, want %q", got, c.signed)
+			}
+			if want := "AWS4-HMAC-SHA256 Credential=" + exampleKeyID + "/20130524/us-east-1/s3/aws4_request"; !strings.HasPrefix(auth, want) {
+				t.Errorf("the credential is %q, want it to start with %q", auth, want)
+			}
+		})
+	}
+}
+
+// field pulls one comma separated part out of an Authorization header.
+func field(auth, name string) string {
+	for part := range strings.SplitSeq(auth, ",") {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(part), name); ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -37,6 +37,20 @@ spent := src.Counters().Since(before)
 A second sync over an unchanged tree of eight files spends eight metadata lookups, zero fetches and zero bytes.
 That is the floor for a source without a change feed, and the test that says so is `TestASecondSyncOverAnUnchangedTreeReadsNothing`.
 
+### The same problem over a network
+
+`objectsource` makes the same trade against an S3 compatible bucket, and two things about it are different enough to be worth writing down.
+
+The listing is ordered by key rather than by when anything changed, so the modification times a run sees go up and down as it proceeds.
+A cursor holding the time of the change just written would tell the next run to skip everything older, and the objects further down the listing that had not been read yet would be skipped for ever.
+So the cursor a change carries holds the last key instead, and the high water mark is only written when the run finishes.
+That is also what makes an interrupted run resumable: the next one lists again with `start-after` set to the key it reached.
+
+The store's modification times have a second of resolution and a listing of a large bucket takes a great deal longer than that.
+An object written later in the same second as the newest one a run saw would be filed under a time the cursor had already passed.
+The cursor is therefore held one second behind the store's own clock, read from the `Date` header of the response rather than from this machine's clock, and that second is looked at once more on the next run.
+It costs re-reading a handful of objects after a write and it costs nothing on a bucket that has been quiet.
+
 ## Who may read it: permissions without a recrawl
 
 A permission change is not a content change, and a sync built only on modification times cannot see one at all.
@@ -102,6 +116,13 @@ Asking twice is the other cost worth avoiding.
 A policy that reads the file system itself already has everything it needs in the `fs.FileInfo` the walk is carrying, and calling `Permissions` with a path would make it stat the file a second time.
 On a corpus of a million files that is a million system calls a sync spends finding out something it was told a moment ago, so the source hands the file information over where a policy can use it.
 That handover is deliberately not a public interface: it is one more thing every policy would have to implement, for a saving only the policies that read the file system get.
+
+Object storage has no equivalent of the inode change time and no per object "the list changed at" anywhere.
+The only way to find out whether one object's list was rewritten is to read it, which is the request per object the incremental path exists to avoid.
+So `BucketPolicy` reads the bucket's list once per sync, fingerprints the statements in it rather than the bytes, and compares that with the last sync's.
+A bucket whose fingerprint moved gives every object under it a permission change without a single byte being fetched, and a bucket whose fingerprint did not costs one request for the whole sync.
+The fingerprint is built from the parsed statements because the order of grants is not promised by any of these services and some of them put a request id in the response, and a fingerprint that moved on its own would rewrite the permissions of the whole bucket on every sync.
+`ObjectPolicy` deliberately does not implement `Versioned` at all, which is the honest answer rather than an expensive one.
 
 ## What the sync could not have seen: reconciliation
 
@@ -173,3 +194,4 @@ Everything else is optional, and each piece buys one thing.
 | `Change.PermissionsOnly` | a permission change costs a write instead of a recrawl |
 
 `connector/fssource` implements all four and is the one to read before writing another.
+`connector/objectsource` implements all four as well, over a network service, and is the one to read for the parts a local source never has to deal with: signing, paging, and a listing whose order has nothing to do with what changed.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -175,6 +175,15 @@ The two group grantees are the ones that reach outside a company.
 `AllUsers` is the open internet and maps to a public document, reported as an `Anyone` grant.
 `AuthenticatedUsers` is every account holder at the provider, which is not this tenant and cannot be enumerated, so a connector reports it as a `Domain` grant to `authenticated-users` and it quarantines like any other foreign domain.
 
+`connector/objectsource` reports these, and it takes the list from one of two places.
+`BucketPolicy` reads the bucket's own list once per sync and gives every object the same answer, which is one request rather than one per object and is correct whenever the objects were written by one process and are read by one team.
+`ObjectPolicy` reads the list of each object, which is exact and costs a request per object per sync.
+Neither is the default, because there is no permissive default: a source built without a policy quarantines every document, so a bucket nobody has thought about yet is loud rather than public.
+
+A canonical user id is used as an identity only when it is all a grant carries.
+It names an account at the provider rather than a person and will not match anything somebody signs in with, so an email address is preferred and a display name after that.
+Owning an object is not reading it, and the owner is marked as one only where the list already gives that account `READ` or `FULL_CONTROL`.
+
 ### Drive
 
 The roles are Drive's own, and all six of them can read the file.

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -367,6 +367,18 @@ func Detect(data []byte, name string) string {
 	return "application/octet-stream"
 }
 
+// MediaByName is what a file's name claims it is, and empty when the name
+// claims nothing this package recognises.
+//
+// [Detect] is the better answer and this is not a substitute for it. It exists
+// for the callers that have to decide whether to read a file at all before they
+// have a single byte of it: a connector reading a bucket over the network
+// cannot sniff its way through a terabyte of archives to find out none of them
+// were documents.
+func MediaByName(name string) string {
+	return byExtension(strings.ToLower(path.Ext(name)))
+}
+
 // magic is one file signature.
 type magic struct {
 	prefix []byte


### PR DESCRIPTION
Part of #14.

genba can index a directory tree.
This adds the second connector, and the first one that talks to a network service, which is where most of what a real connector has to get right lives: signing, paging, a source that answers slowly, and a listing whose order has nothing to do with what changed.

## One connector, eight services

The protocol is S3's, and Amazon's own service, MinIO, Ceph, Cloudflare R2, Backblaze B2, Wasabi and DigitalOcean Spaces all answer to `ListObjectsV2` and `GetObject` signed with signature version 4.
That is why this is one connector rather than eight.
What actually differs between them is where the bucket goes in the URL, which is `Config.PathStyle`, and that is a setting rather than a guess because getting it wrong is either a host that does not resolve or a bucket read from inside itself.

```go
client, err := objectsource.NewClient(objectsource.Config{
	Endpoint:        "https://s3.eu-west-1.amazonaws.com",
	Region:          "eu-west-1",
	Bucket:          "acme-reports",
	AccessKeyID:     os.Getenv("AWS_ACCESS_KEY_ID"),
	SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
})
policy, err := objectsource.NewBucketPolicy(client, "reports", "okta", "acme.com")
src, err := objectsource.New(client, "reports", policy, objectsource.WithPrefix("quarterly/"))
```

`WithPrefix` narrows the listing rather than filtering it afterwards, so a source pointed at one folder of a bucket of a hundred million objects costs what that folder costs.
Several sources can read the same bucket under different prefixes with different policies, which is how a bucket where one prefix is public and another is not gets indexed correctly.

## The signing is written out rather than vendored

Signature version 4 is about two hundred lines and it is in the package.
The alternative is a cloud provider SDK, which is a large dependency tree under a binary whose whole point is being one file, and it would sit underneath a connector that only ever makes three kinds of request.

Writing it out means it has to be right rather than merely consistent with itself, because a signer that agrees with nobody produces a request every service refuses and the error it gets back says the signature did not match and nothing whatever about why.
So it is pinned against the three published worked examples: reading an object with an extra signed header, a listing where the query has to be canonicalised, and a subresource, which is a parameter with no value at all.

The raw path is set on the URL as well as the path, so the transport writes exactly the bytes the signature was calculated over.
Without that a key with a plus or a space in it signs one way and is sent another.

## Two things the incremental path has to get right

A listing is ordered by key and not by when anything changed, so the modification times a run sees go up and down as it proceeds.
A cursor holding the time of the change just written would tell the next run to skip everything older, and the objects further down the listing that had not been read yet would be skipped for ever.
So the cursor a change carries holds the last key instead, and the high water mark is only written when the run finishes.
That is also what makes an interrupted run resumable: the next one lists again with `start-after` set to the key it reached, which `TestAnInterruptedSyncResumesFromTheKeyItReached` checks.

The store's modification times have a second of resolution and a listing of a large bucket takes a great deal longer than that.
An object written later in the same second as the newest one a run saw would be filed under a time the cursor had already passed and would never be read again.
So the cursor is held one second behind the store's own clock, read from the response `Date` header rather than from this machine's clock, and that second is looked at once more on the next run.
It costs re-reading a handful of objects after a write, it costs nothing on a bucket that has been quiet, and `TestAnObjectWrittenInTheSameSecondIsNotLost` is what says so.

The cursor carries two high water marks rather than one, because content times come from the store and are held back by that second, and a permission change is something this process noticed rather than something the store recorded.
Folding them into one field means either losing a write made in the same second or rewriting the permissions of every object in the bucket twice for every edit, depending on which way the fold goes.

## Permissions, and no permissive default

A source built without a policy quarantines every document.
That is deliberate: it makes "nobody has thought about permissions for this bucket yet" a loud state in the stats rather than a quiet one in the index.

`BucketPolicy` reads the bucket's own access control list once per sync and gives every object the same answer, which is one request rather than one per object and is correct whenever the objects were written by one process and are read by one team.
It is also the only one that can notice a revocation.
An object's list can be rewritten without the object changing and nothing in a listing says so, so this policy fingerprints the statements it read and compares that with the last sync's.
A bucket whose fingerprint moved gives every object under it a permission change without a single byte being fetched.
The fingerprint is built from the parsed statements rather than from the bytes, because the order of grants is not promised by any of these services and some put a request id in the response, and a fingerprint that moved on its own would rewrite the whole bucket on every sync.

`ObjectPolicy` reads each object's own list, which is exact and costs a request per object per sync.
It deliberately does not implement `Versioned`, and the doc comment says why: the only way to find out whether one object's list changed is to read it, which is exactly the work the incremental path exists to avoid.

The mapping itself is `connector/aclmap`, so this connector decides only who a statement is about.
Three parts of that are worth calling out because they are the ones whose failure is a document shown to the wrong person.
`WRITE` on a bucket is permission to put objects into it and not to read them, so it confers nothing.
`AuthenticatedUsers` is every account holder at the provider, which is not this tenant and cannot be enumerated, so it quarantines rather than becoming public.
And owning an object is not reading it, so the owner is marked as one only where the list already gives that account read.

The refusal reading is deliberately narrow for the same reason.
Only `NoSuchKey`, or a bare 404 that names a key, is read as an object that is no longer there.
`NoSuchBucket` is a setting somebody typed wrong, and treating it as a deletion would empty the whole index the first time that happened.

## What gets fetched

A key's extension decides whether the object is read at all, which is a guess about a name made before anything has been fetched, and it is made on purpose.
The alternative in a bucket is downloading a terabyte of archives to find out none of them were documents.
Once the bytes are there they overrule the name, because a key is whatever somebody typed when they uploaded.

Size limits are per format rather than one number, because a one megabyte text file is almost certainly not prose and a one megabyte screenshot is a screenshot.
The limit is checked against the size the listing reported, so an object that is too large is never fetched, and it is reported through `WithSkipped` rather than dropped quietly.
Images become content with their dimensions read out of the header rather than a body, so a preview has something to show and the key is still what a query matches.

## Tests

The suite runs against an in memory S3 compatible service on `httptest`, so it needs no Docker, no network and no credentials, and it finishes in a third of a second.
The fake refuses any request that is not signed, which is what stops a connector that quietly stopped signing from passing everything else here and failing against every real service.
It reports its own clock in the `Date` header so the cursor arithmetic can be driven exactly rather than slept through.

What a fake cannot check is whether a real service accepts these signatures, and that is what the worked example vectors are for.

Twenty six tests, including: a second sync over an unchanged bucket fetching nothing at all, only the object written since the cursor being read, paging right through seven objects two at a time, the prefix being in the request rather than applied to the answer, a bucket access control list change costing zero fetches and then settling instead of re-emitting for ever, enumeration describing everything and fetching nothing, an id from another source or one that tries to climb out of its prefix being refused, and the whole mapping table from a list to a permission descriptor.

`go test ./... -count=1`, `go test -race ./connector/...`, `go vet ./...` and `golangci-lint run` are all clean.
There is no `nolint` anywhere in the diff.

## Still to come on #14

The incremental sync without a full walk and the worked configuration examples in `genbad` are the next change.
The conformance suite box belongs to #17.
