### PR TITLE
fssource: watch the tree instead of walking it

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,19 @@ The corpus flags have no environment variables, because a directory to index is 
 | `-corpus-identity` | `unix` | identity source the account names in the tree belong to, for `-corpus-acl os` |
 | `-corpus-domain` | empty | domain the accounts on this host belong to, for `-corpus-acl os`, empty to grant nothing on the world bit |
 | `-corpus-refresh` | `0` | how often to sync again, zero for once at startup |
+| `-corpus-watch` | `false` | ask the operating system what changed instead of walking the tree, needs `-corpus-refresh` |
+| `-corpus-reconcile` | `0` | how often to sweep the index against the tree, zero for after every sync |
+
+`-corpus-watch` is what makes a short refresh interval affordable on a large tree.
+Without it every refresh walks, which is a stat of every file to find the four that moved, and with it the cost of a refresh is a function of how much changed rather than of how large the corpus is.
+A machine that cannot give out that many watches logs a line and carries on walking, so it is safe to set and never a reason for the server not to start.
+
+`-corpus-reconcile` exists because of it.
+The sweep that finds deleted files walks the tree, so on a watched server it is the whole remaining cost of a refresh, and separating the two lets a change be noticed in a second while both sides are still counted every few minutes.
+
+```
+genbad -tenant acme -corpus ~/src/handbook -corpus-refresh 1s -corpus-watch -corpus-reconcile 5m
+```
 
 ## Metrics
 
@@ -254,7 +267,7 @@ func main() {
 | `store/segdir` | the directory of segments, the manifest and the crash recovery, [docs/durability.md](docs/durability.md) |
 | `index` | query parsing, retrieval and ranking |
 | `connector` | the ingestion contract, cursors and checkpoints |
-| `connector/fssource` | the reference connector, a directory tree with OWNERS files |
+| `connector/fssource` | the reference connector, a directory tree with OWNERS files, walked or watched |
 | `connector/objectsource` | an S3 compatible bucket, signed and paged, [docs/ingestion.md](docs/ingestion.md) |
 | `extract` | text and structure out of PDF, Word, PowerPoint, Excel, HTML and Markdown, [docs/extraction.md](docs/extraction.md) |
 | `ingest` | the pipeline that runs a connector into a store |
@@ -317,6 +330,10 @@ Permissions come from the policy rather than from the walk, because a directory 
 The mode bits describe the account the crawler runs as, not the people in the company.
 `OwnersPolicy` reads the OWNERS files that Kubernetes and a number of other large repositories keep, taking the nearest one going up the tree, which is a real access control list maintained by real people over a corpus anybody can check out.
 A source built with no policy at all quarantines everything, so having not thought about permissions yet is a visible state in the stats rather than an invisible one in the index.
+
+A source can also be given a watcher, which asks the operating system what changed and turns a refresh into a read of the handful of files that moved rather than a walk of the whole tree.
+The watcher is untrusted until a walk has vouched for it, and anything out of the ordinary sends it back to untrusted, so a dropped event costs one walk rather than a document that never gets reindexed.
+`docs/ingestion.md` has the details.
 
 `connector/objectsource` is the second one, and the first that talks to a network service, which is where most of what a real connector has to get right lives.
 It reads an S3 compatible bucket, which is one connector rather than eight because Amazon's own service, MinIO, Ceph, Cloudflare R2, Backblaze B2, Wasabi and DigitalOcean Spaces all answer to the same two calls signed the same way.

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -45,6 +45,25 @@ type corpusOptions struct {
 
 	// Refresh is how often to sync again. Zero syncs once at startup.
 	Refresh time.Duration
+
+	// Watch asks the operating system what changed instead of walking the tree
+	// to find out.
+	//
+	// It turns the cost of a refresh from a function of how large the corpus is
+	// into a function of how much of it moved, which is the difference between
+	// a minute and a millisecond on a checkout of any size. A machine that
+	// cannot give out that many watches gets a line in the log and a server
+	// that walks, which is what it would have done anyway.
+	Watch bool
+
+	// Reconcile is how often to sweep the index against the tree. Zero sweeps
+	// after every sync.
+	//
+	// It is a separate interval because the sweep walks. On a server that syncs
+	// once a minute that hardly matters, and on one watching a large tree it is
+	// the whole remaining cost, so the two want to be set apart: notice a change
+	// in a second, and count both sides every quarter of an hour.
+	Reconcile time.Duration
 }
 
 // The values -corpus-acl takes.
@@ -76,6 +95,15 @@ func (o corpusOptions) validate() error {
 	}
 	if o.Refresh < 0 {
 		return errors.New("corpus refresh is negative")
+	}
+	if o.Reconcile < 0 {
+		return errors.New("corpus reconcile interval is negative")
+	}
+	if o.Watch && o.Refresh <= 0 {
+		// A watcher records what changes between one sync and the next, and with
+		// no next sync it records nothing anybody reads while holding a watch on
+		// every directory in the tree.
+		return errors.New("corpus watch needs a corpus refresh interval, since a watcher only saves anything across syncs")
 	}
 	return nil
 }
@@ -139,7 +167,20 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 	if err != nil {
 		return nil, err
 	}
-	src, err := fssource.New(cfg.Dir, cfg.Name, policy)
+	// A watcher that cannot be built is a line in the log and nothing else. The
+	// machine is at its inotify limit, or the tree is on a filesystem the
+	// backend does not support, and none of that is a reason for the server not
+	// to start: a source with no watcher walks, which is what every server did
+	// before there was one.
+	var watcher *fssource.Watcher
+	if cfg.Watch {
+		watcher, err = fssource.Watch(cfg.Dir)
+		if err != nil {
+			log.Warn("watching the corpus, refreshes will walk the tree instead", "dir", cfg.Dir, "error", err)
+		}
+	}
+
+	src, err := fssource.New(cfg.Dir, cfg.Name, policy, fssource.WithWatcher(watcher))
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +193,7 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 		return nil, err
 	}
 
+	var swept time.Time
 	sync := func(ctx context.Context) {
 		var before, after runtime.MemStats
 		runtime.ReadMemStats(&before)
@@ -164,7 +206,7 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 		}
 		runtime.ReadMemStats(&after)
 
-		log.Info("corpus synced",
+		log.Info("corpus synced", append([]any{
 			"dir", cfg.Dir,
 			"source", cfg.Name,
 			"indexed", stats.Indexed,
@@ -177,17 +219,31 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 			// first is the number that decides how much a machine can serve,
 			// and the second is the one that shows up as garbage collection.
 			"heap_mb", megabytes(int64(after.HeapAlloc)),
-			"allocated_mb", megabytes(int64(after.TotalAlloc-before.TotalAlloc)),
-		)
+			"allocated_mb", megabytes(int64(after.TotalAlloc - before.TotalAlloc)),
+		}, watching(watcher)...)...)
 
-		reconcile(ctx, pipeline, src, tenant, log)
+		// The sweep walks the tree, so on a server that is watching it is the
+		// whole of what a refresh costs. Running it on its own interval is what
+		// lets a change be noticed in a second while both sides are still
+		// counted often enough to catch what the watcher missed.
+		if cfg.Reconcile <= 0 || time.Since(swept) >= cfg.Reconcile {
+			swept = time.Now()
+			reconcile(ctx, pipeline, src, tenant, log)
+		}
 		reportMapping(policy, log)
 	}
 
 	sync(ctx)
 
+	stop := func() {
+		if watcher != nil {
+			_ = watcher.Close()
+		}
+		_ = src.Close()
+	}
+
 	if cfg.Refresh <= 0 {
-		return func() { _ = src.Close() }, nil
+		return stop, nil
 	}
 
 	done := make(chan struct{})
@@ -206,8 +262,27 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 	}()
 	return func() {
 		<-done
-		_ = src.Close()
+		stop()
 	}, nil
+}
+
+// watching is what the watcher has to say, for the sync log line.
+//
+// Walks is the number worth reading. On a healthy watcher it is one, from the
+// first sync, and it does not move again. Anything more says the record could
+// not be trusted that often, and the reason says which way, so an operator can
+// tell "the tree is being rewritten faster than the backend will report" apart
+// from "somebody edited an OWNERS file".
+func watching(w *fssource.Watcher) []any {
+	if w == nil {
+		return nil
+	}
+	s := w.Stats()
+	out := []any{"watches", s.Watches, "events", s.Events, "walks", s.Walks}
+	if s.Reason != "" {
+		out = append(out, "walking_because", s.Reason)
+	}
+	return out
 }
 
 // aclCounter is a permission policy that counts what it mapped.

--- a/cmd/genbad/corpus_test.go
+++ b/cmd/genbad/corpus_test.go
@@ -49,6 +49,9 @@ func TestCorpusFlagsAreChecked(t *testing.T) {
 		{"a directory with no name", corpusOptions{Dir: "/tmp"}, "name is empty"},
 		{"an unknown acl", corpusOptions{Dir: "/tmp", Name: "files", ACL: "everyone"}, "everyone"},
 		{"a negative refresh", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclTenant, Refresh: -time.Second}, "negative"},
+		{"a negative reconcile interval", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclTenant, Reconcile: -time.Second}, "negative"},
+		{"watching with nothing to watch for", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclTenant, Watch: true}, "refresh"},
+		{"watching between refreshes", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclTenant, Watch: true, Refresh: time.Second}, ""},
 		{"a usable set", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOwners}, ""},
 		{"the os policy with nobody to name accounts", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOS}, "identity source"},
 		{"the os policy told where the names come from", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOS, Identity: "unix"}, ""},
@@ -242,6 +245,77 @@ func TestADeletedFileStopsComingBack(t *testing.T) {
 	// as one that works, right up until nothing can be found.
 	if got := searchAs(t, addr, "alice", "handbook"); got.Total == 0 {
 		t.Error("the sweep removed documents the tree still holds")
+	}
+}
+
+// A server told to watch the tree has to keep answering the same way a server
+// walking it does. The whole design of the watcher is that it falls back to
+// walking whenever it cannot vouch for what it recorded, so the only thing a
+// test at this level can usefully insist on is that the answers are right, on
+// a corpus that keeps changing under it.
+func TestAWatchedCorpusKeepsUpWithTheTree(t *testing.T) {
+	root := corpusTree(t)
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, []string{
+			"-addr", addr,
+			"-tenant", "acme",
+			"-corpus", root,
+			"-corpus-name", "handbook",
+			"-corpus-refresh", "100ms",
+			"-corpus-watch",
+			"-log-level", "error",
+		}, env(nil), &out, &errOut)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("the server did not shut down")
+		}
+	}()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	if got := searchAs(t, addr, "alice", "deploying"); got.Total == 0 {
+		t.Fatal("the first sync did not index the tree")
+	}
+
+	// A file nobody had written when the server started.
+	if err := os.WriteFile(filepath.Join(root, "guides", "rollback.md"), []byte("# Rolling back\n\nPress the other button.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	waitForResults(t, addr, "rolling back", true)
+
+	// And one that was there and is not any more, which no watcher and no walk
+	// can find without the sweep counting both sides.
+	if err := os.Remove(filepath.Join(root, "guides", "deploy.md")); err != nil {
+		t.Fatal(err)
+	}
+	waitForResults(t, addr, "deploying", false)
+
+	if got := searchAs(t, addr, "alice", "handbook"); got.Total == 0 {
+		t.Error("the rest of the corpus went missing")
+	}
+}
+
+// waitForResults waits for a query to start or stop finding something.
+func waitForResults(t *testing.T, addr, query string, want bool) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if got := searchAs(t, addr, "alice", query); (got.Total > 0) == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("after fifteen seconds a query for %q still does not find %v", query, want)
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }
 

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -76,6 +76,8 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	fs.StringVar(&corpus.Identity, "corpus-identity", "unix", "identity source the account names in the tree belong to, for -corpus-acl os")
 	fs.StringVar(&corpus.Domain, "corpus-domain", "", "domain the accounts on this host belong to, for -corpus-acl os, empty for none")
 	fs.DurationVar(&corpus.Refresh, "corpus-refresh", 0, "how often to reindex the directory, zero for once")
+	fs.BoolVar(&corpus.Watch, "corpus-watch", false, "ask the operating system what changed instead of walking the tree, needs -corpus-refresh")
+	fs.DurationVar(&corpus.Reconcile, "corpus-reconcile", 0, "how often to sweep the index against the directory, zero for after every sync")
 
 	showVersion := fs.Bool("version", false, "print the version and exit")
 	fs.Usage = func() {

--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -24,8 +24,15 @@
 // The cursor is the highest modification time the last run saw. A later run
 // walks the same tree and skips anything not newer, so the cost of a no change
 // sync is a stat of every file rather than a read of every file. That is the
-// honest limit of what a plain filesystem supports: without a change feed there
-// is no way to avoid the walk, only the read.
+// honest limit of what a plain filesystem supports on its own: without a change
+// feed there is no way to avoid the walk, only the read.
+//
+// A [Watcher] is how the walk goes too. The operating system already knows
+// which files were written, and a source built with [WithWatcher] asks it
+// instead of asking the tree, which turns the cost of a sync from a function of
+// how large the corpus is into a function of how much of it moved. A watcher
+// that cannot vouch for what it recorded says so, and that sync walks, so the
+// worst a watcher can do is cost what not having one costs.
 package fssource
 
 import (
@@ -38,9 +45,11 @@ import (
 	_ "image/jpeg" // registers the JPEG config decoder
 	_ "image/png"  // registers the PNG config decoder
 	"io/fs"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -143,6 +152,28 @@ type (
 	}
 )
 
+// Ruled is the optional capability of a [Policy] whose answers come out of
+// files in the tree it is being asked about.
+//
+// It exists for the watched sync and for nothing else. A watcher reports the
+// file that changed, and an OWNERS file that changed governs who may read every
+// document in the subtree below it, none of which the watcher will ever
+// mention. A sync that read only the reported paths would apply the edit to the
+// OWNERS file itself and to nothing it rules.
+//
+// So a policy says which paths are its rules, and a sync that finds one of them
+// among the changes walks the tree that round instead. That is the expensive
+// answer, and it is the right one: an OWNERS edit is rare, and getting it wrong
+// means a revocation that silently did not happen.
+//
+// [OSPolicy] needs none of this. Its rule for a file is the file's own mode,
+// and changing that raises an event on the file itself.
+type Ruled interface {
+	// IsRule reports whether a path, relative to the root and separated by
+	// forward slashes, is one of the policy's rule files.
+	IsRule(relPath string) bool
+}
+
 // Reloader is the optional capability of a [Policy] that caches.
 //
 // A source calls it once at the start of every walk. That is the contract the
@@ -176,6 +207,7 @@ type Source struct {
 	skipDir   func(name string) bool
 	includeIf func(name string) bool
 	skipped   func(path string, reason error)
+	watcher   *Watcher
 
 	counters counters
 }
@@ -253,6 +285,30 @@ func WithInclude(f func(name string) bool) Option {
 	}
 }
 
+// WithWatcher makes the source ask a watcher what changed instead of walking
+// the tree to find out.
+//
+// The watcher is built separately and owned by the caller, because building one
+// fails for reasons that are a property of the machine rather than of the
+// program, and a caller that cannot have one should carry on with a source that
+// walks rather than fail to start.
+//
+//	w, err := fssource.Watch(root)
+//	if err != nil {
+//		log.Warn("watching the tree, syncs will walk it instead", "err", err)
+//	}
+//	src, err := fssource.New(root, "docs", policy, fssource.WithWatcher(w))
+//
+// A nil watcher is allowed and means exactly what passing no option means, so
+// the error above does not need a second branch.
+//
+// The watcher has to be watching the same tree the source is reading, and
+// [New] refuses the pair if it is not. It also has to skip the same directories,
+// which is what [WithWatchSkipDir] is for.
+func WithWatcher(w *Watcher) Option {
+	return func(s *Source) { s.watcher = w }
+}
+
 // New returns a source reading root, naming itself name, and asking policy who
 // may read each file.
 //
@@ -292,6 +348,12 @@ func New(root, name string, policy Policy, opts ...Option) (*Source, error) {
 	for _, opt := range opts {
 		opt(s)
 	}
+	if s.watcher != nil && s.watcher.root != abs {
+		// A watcher on a different tree would report changes this source cannot
+		// place and, far worse, would report nothing about the tree it is
+		// actually reading while looking to the sync like a healthy record.
+		return nil, fmt.Errorf("fssource: the watcher is on %s and the source is on %s", s.watcher.root, abs)
+	}
 	return s, nil
 }
 
@@ -309,6 +371,11 @@ func (s *Source) Close() error { return nil }
 // including files that were skipped as unchanged, so that a run which finds
 // nothing new still moves the clock forward and a run interrupted halfway does
 // not lose the files it already passed.
+//
+// A source built with [WithWatcher] reads the paths the watcher recorded and
+// does not walk at all, whenever the watcher can vouch for its record. When it
+// cannot, this is what runs, which is why the two paths have to agree on which
+// files are in the corpus.
 func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(context.Context, connector.Change) error) (connector.Cursor, error) {
 	since, err := parseCursor(from)
 	if err != nil {
@@ -322,6 +389,11 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 	// have been applied and has not.
 	if r, ok := s.policy.(Reloader); ok {
 		r.Reload()
+	}
+
+	changed, gen, watching := s.watched()
+	if watching {
+		return s.syncWatched(ctx, from, since, changed, emit)
 	}
 
 	var highest time.Time
@@ -364,6 +436,153 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 	})
 	if walkErr != nil {
 		return connector.Cursor{}, walkErr
+	}
+	if s.watcher != nil {
+		// The tree has now been read end to end, so anything the watcher records
+		// from here is the whole of what changed. A walk that failed does not get
+		// here, and the watcher stays untrusted, because a record that starts
+		// somewhere in the middle of a tree is not a record.
+		s.watcher.caughtUp(gen)
+	}
+
+	if highest.IsZero() {
+		return from, nil
+	}
+	return connector.Cursor{Value: version(highest), Time: highest}, nil
+}
+
+// watched returns the paths the watcher recorded, the generation that record
+// belongs to, and false when this sync has to walk the tree instead.
+func (s *Source) watched() (changed map[string]watchOps, gen int64, ok bool) {
+	if s.watcher == nil {
+		return nil, 0, false
+	}
+	changed, gen, reason := s.watcher.pending()
+	if reason != nil {
+		return nil, gen, false
+	}
+	if p, ruled := s.policy.(Ruled); ruled {
+		for rel := range changed {
+			if p.IsRule(rel) {
+				// Throwing the record away rather than walking with it in hand is
+				// deliberate. The walk covers every path in it, and the next sync
+				// then has to be told the tree is known again, which is what the
+				// generation this returns is for.
+				gen = s.watcher.lose(fmt.Errorf("fssource: %s is a permission rule and governs files no event will name", rel))
+				return nil, gen, false
+			}
+		}
+	}
+	return changed, gen, true
+}
+
+// syncWatched reads the paths the watcher recorded, and nothing else.
+//
+// This is the whole point of the watcher: the cost of a sync stops being a
+// function of how large the tree is and becomes a function of how much of it
+// moved. A corpus of two million files where thirty changed costs thirty stats
+// instead of two million.
+//
+// What it cannot do is see a file whose modification time went backwards under
+// it, so the high water mark starts at the cursor rather than at zero. A file
+// restored from a backup with its old time, which is what "cp -p" does, would
+// otherwise drag the cursor into the past and make the next walk re-read
+// everything written since then.
+func (s *Source) syncWatched(ctx context.Context, from connector.Cursor, since time.Time, changed map[string]watchOps, emit func(context.Context, connector.Change) error) (connector.Cursor, error) {
+	highest := since
+	// Sorted, so that a sync over the same set of changes does the same work in
+	// the same order twice, which is what makes a failure reproducible.
+	rels := slices.Sorted(maps.Keys(changed))
+
+	for _, rel := range rels {
+		if err := ctx.Err(); err != nil {
+			return connector.Cursor{}, err
+		}
+		full := filepath.Join(s.root, filepath.FromSlash(rel))
+
+		// The stat decides whether the file is there, not the event. A file
+		// written and then deleted, or deleted and then written again, produces
+		// both kinds of event and only one of them is still true, and the
+		// filesystem is the one that knows which.
+		s.counters.metadata.Add(1)
+		info, err := os.Lstat(full)
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			// This is the case a walk can never report. There is nothing left to
+			// walk past, so a tree traversal finds a deleted file by not finding
+			// it, which is to say it needs a full reconciliation sweep. A watcher
+			// is told.
+			if !s.includeIf(path.Base(rel)) {
+				continue
+			}
+			if err := emit(ctx, connector.Change{
+				Document: doc.Document{ID: s.id(rel)},
+				Deleted:  true,
+			}); err != nil {
+				return connector.Cursor{}, err
+			}
+			continue
+		case err != nil:
+			s.skipped(full, err)
+			continue
+		case info.IsDir() || !info.Mode().IsRegular():
+			continue
+		case !s.includeIf(path.Base(rel)):
+			continue
+		}
+		if limit := s.limitFor(rel); info.Size() > limit {
+			s.skipped(full, errTooBig(info.Size(), limit))
+			continue
+		}
+
+		// A mode change and nothing else is a permission change, which is a write
+		// of one descriptor rather than a read of the file. On a filesystem this
+		// is the cheap half of the whole design, and the watcher is what makes it
+		// exact: a walk has to ask every file in the tree whether its rule moved,
+		// and here the operating system already said which one did.
+		//
+		// Nothing about this file goes into the cursor. Not its modification
+		// time, which was not read, and not the time its rule changed, which is
+		// later still on a policy that answers with the inode change time. Some
+		// backends report an ordinary write as an attribute change first and the
+		// write a moment later, so a sync landing between the two would move the
+		// cursor past content it never read, and a later fall back to walking
+		// would skip that file for good. Leaving the cursor where it is costs one
+		// permission change written twice.
+		if ops := changed[rel]; ops.chmod && !ops.write && !ops.remove {
+			perms, err := s.permissions(ctx, rel, info)
+			if err != nil {
+				perms = connector.Unresolved(s.name)
+				s.skipped(full, err)
+			}
+			if err := emit(ctx, connector.Change{
+				Document:        doc.Document{ID: s.id(rel), Permissions: perms},
+				PermissionsOnly: true,
+			}); err != nil {
+				return connector.Cursor{}, err
+			}
+			continue
+		}
+
+		mod := info.ModTime()
+		if mod.After(highest) {
+			highest = mod
+		}
+		if at, err := s.changedAt(ctx, rel, info); err == nil && at.After(highest) {
+			highest = at
+		}
+
+		document, err := s.read(ctx, full, rel, info)
+		if err != nil {
+			s.skipped(full, err)
+			continue
+		}
+		if err := emit(ctx, connector.Change{
+			Document: document,
+			Cursor:   connector.Cursor{Value: version(mod), Time: mod},
+		}); err != nil {
+			return connector.Cursor{}, err
+		}
 	}
 
 	if highest.IsZero() {

--- a/connector/fssource/owners.go
+++ b/connector/fssource/owners.go
@@ -103,7 +103,19 @@ var (
 	_ Policy    = (*OwnersPolicy)(nil)
 	_ Versioned = (*OwnersPolicy)(nil)
 	_ Reloader  = (*OwnersPolicy)(nil)
+	_ Ruled     = (*OwnersPolicy)(nil)
 )
+
+// IsRule reports whether a path is an OWNERS file.
+//
+// A watched sync that sees one of these gives up on its record and walks the
+// tree that round, because this is the one edit whose effect is nowhere near
+// the file that changed. Rewriting the OWNERS file at the root of a repository
+// changes who may read every document in it, and the only event anybody raised
+// was about the OWNERS file.
+func (o *OwnersPolicy) IsRule(relPath string) bool {
+	return path.Base(relPath) == OwnersFile
+}
 
 // Reload drops the cache so that the next lookup reads the tree again.
 //

--- a/connector/fssource/watch.go
+++ b/connector/fssource/watch.go
@@ -1,0 +1,469 @@
+package fssource
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watching a tree rather than walking it.
+//
+// A sync of a directory tree cannot avoid the walk. There is no change feed to
+// ask, so finding the files that changed means asking the filesystem about
+// every file, and on a corpus of a few million that is a few million system
+// calls to find out that thirty of them moved.
+//
+// The operating system already knows. A watcher is how it is asked to say so,
+// and the whole of what this file does is turn that stream of events into the
+// same set of paths a walk would have produced, plus an honest answer about
+// when it cannot.
+//
+// That last part is the important half. A watcher is an optimisation that is
+// wrong rather than slow when it fails: a dropped event is a document that
+// never gets reindexed and nothing anywhere reports it. So this one starts out
+// untrusted, goes back to untrusted the moment anything is out of the ordinary,
+// and a sync that finds it untrusted walks the tree. The failure mode is a slow
+// sync, which is what would have happened anyway.
+
+// DefaultMaxWatches bounds how many directories one watcher holds.
+//
+// Every backend charges for a watch and they charge differently. Linux keeps a
+// per user limit on inotify watches that a large tree will reach, and the
+// kqueue backend the BSDs and macOS use needs an open file descriptor per
+// watched file, which reaches the process limit a great deal sooner. Rather
+// than find that out as a stream of errors halfway through a tree, a watcher
+// that would need more than this refuses to be built and says how many it
+// wanted, and the caller falls back to walking.
+const DefaultMaxWatches = 4096
+
+// DefaultMaxPending bounds how many changed paths one watcher will hold between
+// syncs.
+//
+// Past this the record has stopped being a saving. Walking the tree is bounded
+// work and remembering an unbounded list of paths is not, so a tree that is
+// being rewritten wholesale, which is what a build directory nobody excluded
+// looks like, goes back to the walk instead of growing a map until the process
+// is killed.
+const DefaultMaxPending = 100_000
+
+// errNotWalkedYet is the state a watcher starts in.
+//
+// It has watches on the tree and no idea what is in it, so the first sync has
+// to walk. That is not a limitation worth working around: the first sync of an
+// empty index reads the whole corpus anyway.
+var errNotWalkedYet = errors.New("fssource: the tree has not been walked yet")
+
+// watchOps is what happened to one path since the last sync, folded together.
+//
+// Several events on one path are one piece of work. A file written twice is
+// read once, and a file that was written and then had its mode changed is read
+// once as well, because reading it answers both questions.
+type watchOps struct {
+	write  bool
+	remove bool
+	chmod  bool
+}
+
+// Watcher records what changed in a tree, so that a sync can read those files
+// instead of walking to find them.
+//
+// It is built separately from the [Source] and owned by the caller, because
+// building one can fail in ways that are a property of the machine rather than
+// of the program: a tree over the inotify limit, a filesystem the backend does
+// not support, a process near its descriptor limit. A caller that gets an error
+// here logs it and carries on with a source that walks, which is the behaviour
+// it would have had anyway.
+type Watcher struct {
+	// root is the tree as the caller named it, and resolved is the same tree
+	// with symbolic links followed. Both are kept because the backend reports
+	// paths under whichever one it was given, and on macOS a temporary directory
+	// is reached through a link, so a watcher that only knew one of them would
+	// fail to place every event it received.
+	root     string
+	resolved string
+
+	skipDir    func(name string) bool
+	maxWatches int
+	maxPending int
+
+	notify *fsnotify.Watcher
+	done   chan struct{}
+
+	events atomic.Int64
+	walks  atomic.Int64
+
+	mu   sync.Mutex
+	seen map[string]watchOps
+	lost error
+	// lostAt counts the times the record was thrown away, and is how a sync
+	// finds out whether that happened while it was walking. A walk that started
+	// at one generation and finished at another read a tree that was moving
+	// under it, and cannot be the thing that makes the record trustworthy.
+	lostAt  int64
+	watches int
+}
+
+// WatchOption configures a watcher.
+type WatchOption func(*Watcher)
+
+// WithMaxWatches sets how many directories a watcher will hold. A value below
+// one selects [DefaultMaxWatches].
+func WithMaxWatches(n int) WatchOption {
+	return func(w *Watcher) {
+		if n > 0 {
+			w.maxWatches = n
+		}
+	}
+}
+
+// WithMaxPending sets how many changed paths a watcher will remember between
+// syncs. A value below one selects [DefaultMaxPending].
+func WithMaxPending(n int) WatchOption {
+	return func(w *Watcher) {
+		if n > 0 {
+			w.maxPending = n
+		}
+	}
+}
+
+// WithWatchSkipDir replaces the rule for directories that are not watched. The
+// argument is the base name.
+//
+// It should be the same rule the source walks with. A watcher that descended
+// into a directory the source skips would spend its watches on a dependency
+// tree and report changes to files nothing indexes, and one that skipped a
+// directory the source reads would silently miss every change in it.
+func WithWatchSkipDir(f func(name string) bool) WatchOption {
+	return func(w *Watcher) {
+		if f != nil {
+			w.skipDir = f
+		}
+	}
+}
+
+// Watch starts watching root and everything under it.
+//
+// The watcher is not trusted until a sync has walked the tree, so the first
+// sync after this is a full walk whatever happens.
+func Watch(root string, opts ...WatchOption) (*Watcher, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("fssource: %w", err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("fssource: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("fssource: %s is not a directory", abs)
+	}
+
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		resolved = abs
+	}
+
+	w := &Watcher{
+		root:       abs,
+		resolved:   resolved,
+		skipDir:    defaultSkipDir,
+		maxWatches: DefaultMaxWatches,
+		maxPending: DefaultMaxPending,
+		done:       make(chan struct{}),
+		seen:       make(map[string]watchOps),
+		lost:       errNotWalkedYet,
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+
+	notify, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("fssource: watching %s: %w", abs, err)
+	}
+	w.notify = notify
+
+	if err := w.watchTree(resolved); err != nil {
+		_ = notify.Close()
+		return nil, err
+	}
+
+	go w.collect()
+	return w, nil
+}
+
+// Close stops the watcher and releases every watch it holds.
+//
+// A source built with this watcher goes back to walking, which is what it does
+// with no watcher at all, so closing one is safe while a sync is running.
+func (w *Watcher) Close() error {
+	err := w.notify.Close()
+	<-w.done
+
+	// Whatever was recorded stops meaning anything the moment the watches are
+	// gone, and leaving it behind would let one last sync trust a record that
+	// stopped being kept.
+	w.lose(errors.New("fssource: the watcher is closed"))
+	return err
+}
+
+// WatchStats is what a watcher has done.
+//
+// Walks is the number worth looking at. It is how many times the record could
+// not be trusted and a sync had to walk the tree, and on a healthy watcher it
+// is one, from the first sync. Anything more says the tree is churning past
+// what the backend will carry, and Reason says which way.
+type WatchStats struct {
+	Watches int
+	Events  int64
+	Pending int
+	Walks   int64
+	Reason  string
+}
+
+// Stats reports what the watcher has done.
+func (w *Watcher) Stats() WatchStats {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	s := WatchStats{
+		Watches: w.watches,
+		Events:  w.events.Load(),
+		Pending: len(w.seen),
+		Walks:   w.walks.Load(),
+	}
+	if w.lost != nil {
+		s.Reason = w.lost.Error()
+	}
+	return s
+}
+
+// watchTree adds a watch to dir and to every directory under it.
+func (w *Watcher) watchTree(dir string) error {
+	return filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// A directory that cannot be read is one the source cannot read
+			// either, so there is nothing under it to miss.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if p != dir && w.skipDir(d.Name()) {
+			return fs.SkipDir
+		}
+		return w.add(p)
+	})
+}
+
+// add puts a watch on one directory, refusing past the limit.
+func (w *Watcher) add(dir string) error {
+	w.mu.Lock()
+	over := w.watches >= w.maxWatches
+	w.mu.Unlock()
+	if over {
+		return fmt.Errorf("fssource: %s needs more than %d watches, which is the limit", w.root, w.maxWatches)
+	}
+	if err := w.notify.Add(dir); err != nil {
+		return fmt.Errorf("fssource: watching %s: %w", dir, err)
+	}
+	w.mu.Lock()
+	w.watches++
+	w.mu.Unlock()
+	return nil
+}
+
+// collect turns the backend's events into the record, until the watcher is
+// closed.
+func (w *Watcher) collect() {
+	defer close(w.done)
+	for {
+		select {
+		case ev, ok := <-w.notify.Events:
+			if !ok {
+				return
+			}
+			w.record(ev)
+		case err, ok := <-w.notify.Errors:
+			if !ok {
+				return
+			}
+			// Every error the backend reports means it stopped being able to
+			// tell us everything, and the one that matters most is the queue
+			// overflowing, which is precisely the case where the record is
+			// missing exactly the changes there were too many of.
+			w.lose(err)
+		}
+	}
+}
+
+// record folds one event into the set of paths that changed.
+func (w *Watcher) record(ev fsnotify.Event) {
+	w.events.Add(1)
+
+	rel, ok := w.relative(ev.Name)
+	if !ok {
+		// An event about something outside the tree is a watch this watcher did
+		// not make, which means it does not understand its own state.
+		w.lose(fmt.Errorf("fssource: an event arrived for %s, which is not under %s", ev.Name, w.root))
+		return
+	}
+	if rel == "." {
+		// The root directory itself. Backends report attribute changes on a
+		// watched directory as an event about the directory, and there is no
+		// document behind it to record.
+		return
+	}
+
+	// A directory that appeared has to be watched before anything in it can be
+	// noticed, and by the time this runs files may already have been written
+	// into it, so it is walked as well as watched. A directory the source skips
+	// is neither walked nor watched, for the same reason the walk does not
+	// descend into it.
+	if ev.Has(fsnotify.Create) {
+		if info, err := os.Lstat(ev.Name); err == nil && info.IsDir() {
+			if w.skipDir(filepath.Base(ev.Name)) {
+				return
+			}
+			if err := w.watchTree(ev.Name); err != nil {
+				w.lose(err)
+				return
+			}
+			w.recordTree(ev.Name)
+			return
+		}
+	}
+
+	w.mark(rel, watchOps{
+		write:  ev.Has(fsnotify.Create) || ev.Has(fsnotify.Write),
+		remove: ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename),
+		chmod:  ev.Has(fsnotify.Chmod),
+	})
+}
+
+// recordTree marks every file under a directory that has just appeared.
+func (w *Watcher) recordTree(dir string) {
+	err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if p != dir && w.skipDir(d.Name()) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if rel, ok := w.relative(p); ok {
+			w.mark(rel, watchOps{write: true})
+		}
+		return nil
+	})
+	if err != nil {
+		w.lose(err)
+	}
+}
+
+// mark folds one path's operations into the record.
+//
+// It keeps recording while the record is untrusted and a sync is off walking
+// the tree, which looks like waste and is not. An event that lands after the
+// walk has already passed that file is the one case where dropping it would
+// lose a change for good, and the cost of keeping it is reading a file that was
+// just read.
+func (w *Watcher) mark(rel string, ops watchOps) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, held := w.seen[rel]; !held && len(w.seen) >= w.maxPending {
+		w.loseLocked(fmt.Errorf("fssource: more than %d paths changed, which is more than a walk costs", w.maxPending))
+		return
+	}
+	was := w.seen[rel]
+	w.seen[rel] = watchOps{
+		write:  was.write || ops.write,
+		remove: was.remove || ops.remove,
+		chmod:  was.chmod || ops.chmod,
+	}
+}
+
+// lose says the record can no longer be trusted, and why, and returns the
+// generation that says so.
+func (w *Watcher) lose(err error) int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.loseLocked(err)
+	return w.lostAt
+}
+
+func (w *Watcher) loseLocked(err error) {
+	w.lost = err
+	w.lostAt++
+	clear(w.seen)
+}
+
+// pending returns what changed since the last sync and hands the record over,
+// or the reason the tree has to be walked instead. The generation it returns is
+// what a walk gives back to [Watcher.caughtUp].
+//
+// It clears the record either way. On the walking path that is safe because the
+// walk covers everything that was in it, and events that arrive while the walk
+// is running go into the new record and are looked at next time, which costs
+// re-reading a file that was just read.
+func (w *Watcher) pending() (changed map[string]watchOps, gen int64, reason error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.lost != nil {
+		w.walks.Add(1)
+		clear(w.seen)
+		return nil, w.lostAt, w.lost
+	}
+	seen := w.seen
+	w.seen = make(map[string]watchOps)
+	return seen, w.lostAt, nil
+}
+
+// caughtUp says a walk finished, so the record can be trusted from here.
+//
+// The generation is the one [Watcher.pending] gave out at the start of that
+// walk. A different one now means the record was thrown away while the walk was
+// running, which is the case where a file the walk had already passed changed
+// again and nothing is left that remembers it. Then the walk does not count and
+// the next sync walks as well.
+//
+// It is also only called after a walk that completed. One that failed halfway
+// leaves the watcher untrusted, because the alternative is trusting a record
+// that begins somewhere in the middle of a tree.
+func (w *Watcher) caughtUp(gen int64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.lostAt != gen {
+		return
+	}
+	w.lost = nil
+}
+
+// relative places an event's path inside the tree, and returns "." for the root
+// itself.
+func (w *Watcher) relative(p string) (string, bool) {
+	up := ".." + string(filepath.Separator)
+	for _, base := range [...]string{w.resolved, w.root} {
+		rel, err := filepath.Rel(base, p)
+		switch {
+		case err != nil, filepath.IsAbs(rel), rel == "..", strings.HasPrefix(rel, up):
+			continue
+		}
+		return filepath.ToSlash(rel), true
+	}
+	return "", false
+}

--- a/connector/fssource/watch_test.go
+++ b/connector/fssource/watch_test.go
@@ -1,0 +1,635 @@
+package fssource_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/fssource"
+)
+
+// A watcher is asynchronous by nature. The write returns before the event about
+// it does, and no backend promises how long that takes, so a test that wrote a
+// file and immediately synced would be testing the scheduler.
+//
+// What these tests do instead is what a refresh loop does: sync again. A sync
+// that runs before the event arrives takes an empty record and leaves the
+// events that follow for the next one, so asking again is free of consequences
+// and eventually correct. The deadline is what turns "eventually" into a test
+// failure rather than a hang.
+
+// watch starts a watcher on root and closes it when the test ends.
+func watch(t *testing.T, root string, opts ...fssource.WatchOption) *fssource.Watcher {
+	t.Helper()
+	w, err := fssource.Watch(root, opts...)
+	if err != nil {
+		t.Fatalf("watching %s: %v", root, err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+	return w
+}
+
+// watched returns a source over root that asks a watcher what changed.
+func watched(t *testing.T, root string, w *fssource.Watcher, opts ...fssource.Option) *fssource.Source {
+	t.Helper()
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"), append(opts, fssource.WithWatcher(w))...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// changes runs one sync and returns everything it emitted, in the order it did.
+func changes(t *testing.T, s *fssource.Source, from connector.Cursor) ([]connector.Change, connector.Cursor) {
+	t.Helper()
+	var got []connector.Change
+	next, err := s.Sync(t.Context(), from, func(_ context.Context, ch connector.Change) error {
+		got = append(got, ch)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	return got, next
+}
+
+// until syncs repeatedly until want is happy with everything seen so far.
+func until(t *testing.T, s *fssource.Source, from connector.Cursor, want func([]connector.Change) bool) ([]connector.Change, connector.Cursor) {
+	t.Helper()
+	var all []connector.Change
+	next := from
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		got, cur := changes(t, s, next)
+		all = append(all, got...)
+		next = cur
+		if want(all) {
+			return all, next
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("after ten seconds the syncs had produced %v", changed(all))
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// settle gives an event that should never be acted on time to arrive, so that a
+// test asserting nothing happened is asserting something.
+func settle() { time.Sleep(250 * time.Millisecond) }
+
+// changed is every id a run of syncs emitted.
+func changed(all []connector.Change) []string {
+	out := make([]string, 0, len(all))
+	for _, ch := range all {
+		out = append(out, ch.Document.ID)
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
+}
+
+// read is the ids that were actually read, which is what a sync spends its time
+// on and what these tests are usually counting.
+func read(all []connector.Change) []string {
+	var out []string
+	for _, ch := range all {
+		if !ch.PermissionsOnly && !ch.Deleted {
+			out = append(out, ch.Document.ID)
+		}
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
+}
+
+func reported(all []connector.Change, id string) bool {
+	return slices.Contains(changed(all), id)
+}
+
+func wasRead(all []connector.Change, id string) bool {
+	return slices.Contains(read(all), id)
+}
+
+// waitFor blocks until the watcher's record holds at least n paths.
+//
+// Reading the record instead of syncing is the point wherever a test needs two
+// events about one path to be in there together. A sync would take the first
+// one away and decide on it alone.
+func waitFor(t *testing.T, w *fssource.Watcher, n int) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if held := w.Stats().Pending; held >= n {
+			return
+		} else if time.Now().After(deadline) {
+			t.Fatalf("after ten seconds the watcher held %d paths, want %d", held, n)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// find returns the last change emitted for one id.
+func find(all []connector.Change, id string) (connector.Change, bool) {
+	for i := len(all) - 1; i >= 0; i-- {
+		if all[i].Document.ID == id {
+			return all[i], true
+		}
+	}
+	return connector.Change{}, false
+}
+
+func put(t *testing.T, root, rel, body string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTheFirstWatchedSyncWalksTheWholeTree(t *testing.T) {
+	root := tree(t, map[string]string{
+		"README.md":       "# top\n",
+		"docs/install.md": "# installing\n",
+	})
+	w := watch(t, root)
+	s := watched(t, root, w)
+
+	got, _ := changes(t, s, connector.Cursor{})
+	if want := []string{"repo:README.md", "repo:docs/install.md"}; !slices.Equal(read(got), want) {
+		t.Fatalf("read %v, want %v", read(got), want)
+	}
+
+	// A watcher that has just been built knows what is happening to the tree and
+	// nothing about what is in it, so the first sync has to read the tree to
+	// find out. That is not a cost worth avoiding: the first sync of an empty
+	// index reads the whole corpus anyway.
+	if stats := w.Stats(); stats.Walks != 1 || stats.Reason != "" {
+		t.Fatalf("after the first sync the watcher is %+v, want one walk and no outstanding reason", stats)
+	}
+}
+
+func TestAWatchedSyncReadsWhatChangedAndDoesNotWalk(t *testing.T) {
+	root := tree(t, map[string]string{
+		"README.md":         "# top\n",
+		"docs/install.md":   "# installing\n",
+		"docs/deep/note.md": "# note\n",
+		"cmd/main.go":       "package main\n",
+	})
+	w := watch(t, root)
+	s := watched(t, root, w)
+
+	_, cursor := changes(t, s, connector.Cursor{})
+	before := s.Counters()
+
+	put(t, root, "docs/install.md", "# installing\n\nrun the thing\n")
+	got, _ := until(t, s, cursor, func(all []connector.Change) bool {
+		return wasRead(all, "repo:docs/install.md")
+	})
+
+	if want := []string{"repo:docs/install.md"}; !slices.Equal(read(got), want) {
+		t.Fatalf("read %v, want %v", read(got), want)
+	}
+	// This is the whole claim of the change. Not "it read fewer files" but "it
+	// never looked at the tree at all", which is what makes the cost of a sync a
+	// function of how much moved rather than of how large the corpus is.
+	if spent := s.Counters().Since(before); spent.Lists != 0 {
+		t.Fatalf("the sync listed %d directories, want none at all", spent.Lists)
+	}
+}
+
+func TestNothingChangingCostsNothing(t *testing.T) {
+	root := tree(t, map[string]string{
+		"README.md":       "# top\n",
+		"docs/install.md": "# installing\n",
+	})
+	w := watch(t, root)
+	s := watched(t, root, w)
+
+	_, cursor := changes(t, s, connector.Cursor{})
+	before := s.Counters()
+
+	got, next := changes(t, s, cursor)
+	if len(read(got)) != 0 {
+		t.Fatalf("read %v, want nothing", read(got))
+	}
+	if spent := s.Counters().Since(before); spent.Lists != 0 || spent.Fetches != 0 || spent.Bytes != 0 {
+		t.Fatalf("a quiet sync spent %+v, want nothing", spent)
+	}
+	// A sync that read nothing must not move the cursor backwards either, or the
+	// next one after a fallback to walking would re-read the whole tree.
+	if next.Value != cursor.Value {
+		t.Fatalf("the cursor moved from %q to %q with nothing to move it", cursor.Value, next.Value)
+	}
+}
+
+func TestAFileCreatedAfterTheWatchStartedIsFound(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	w := watch(t, root)
+	s := watched(t, root, w)
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	put(t, root, "CHANGELOG.md", "# what changed\n")
+	got, _ := until(t, s, cursor, func(all []connector.Change) bool {
+		return wasRead(all, "repo:CHANGELOG.md")
+	})
+
+	d, _ := find(got, "repo:CHANGELOG.md")
+	if d.Document.Title != "what changed" {
+		t.Fatalf("title %q, want the heading out of the file", d.Document.Title)
+	}
+}
+
+func TestADirectoryCreatedAfterTheWatchStartedIsWatchedToo(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	w := watch(t, root)
+	s := watched(t, root, w)
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	// A directory and a file inside it, in that order and quickly, which is what
+	// a checkout or a code generator does. The watch on the new directory is put
+	// on after it exists, so the file may well be there before the watcher hears
+	// about the directory, and the directory is walked as well as watched for
+	// exactly that reason.
+	put(t, root, "guides/start.md", "# getting started\n")
+	got, cursor := until(t, s, cursor, func(all []connector.Change) bool {
+		return wasRead(all, "repo:guides/start.md")
+	})
+	if !slices.Contains(read(got), "repo:guides/start.md") {
+		t.Fatalf("read %v, want the file in the new directory", read(got))
+	}
+
+	// And the watch is now on it, so the next file lands without a walk.
+	before := s.Counters()
+	put(t, root, "guides/next.md", "# what next\n")
+	until(t, s, cursor, func(all []connector.Change) bool {
+		return wasRead(all, "repo:guides/next.md")
+	})
+	if spent := s.Counters().Since(before); spent.Lists != 0 {
+		t.Fatalf("the sync listed %d directories, so the new directory was not being watched", spent.Lists)
+	}
+}
+
+func TestADeletedFileIsAChangeOnlyAWatcherCanSee(t *testing.T) {
+	root := tree(t, map[string]string{
+		"README.md":   "# top\n",
+		"docs/old.md": "# on its way out\n",
+	})
+	w := watch(t, root)
+	s := watched(t, root, w)
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	if err := os.Remove(filepath.Join(root, "docs", "old.md")); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := until(t, s, cursor, func(all []connector.Change) bool {
+		return reported(all, "repo:docs/old.md")
+	})
+
+	ch, _ := find(got, "repo:docs/old.md")
+	if !ch.Deleted {
+		t.Fatalf("the change for the removed file is %+v, want a deletion", ch)
+	}
+
+	// Worth saying out loud, because it is the one thing the walk can never do.
+	// A walk finds a deleted file by not finding it, which is to say it does not
+	// find it, and the index keeps serving the document until a reconciliation
+	// sweep counts both sides.
+	plain, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	walked, _ := changes(t, plain, cursor)
+	if reported(walked, "repo:docs/old.md") {
+		t.Fatal("the walking source reported the deletion, which it has no way of knowing about")
+	}
+}
+
+func TestAFileWrittenAndThenDeletedIsADeletionRatherThanARead(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	w := watch(t, root)
+	s := watched(t, root, w)
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	// Both events describe the same path and only one of them is still true, so
+	// the record is not what decides. The filesystem is.
+	//
+	// Waiting for the write to reach the record before removing the file is what
+	// makes this the case it is meant to be. Removing it first would leave the
+	// backends free to notice nothing at all, since some of them find out what
+	// changed in a directory by listing it, and a file that came and went
+	// between two listings never appears in either.
+	put(t, root, "scratch.md", "# temporary\n")
+	waitFor(t, w, 1)
+	if err := os.Remove(filepath.Join(root, "scratch.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := changes(t, s, cursor)
+	ch, _ := find(got, "repo:scratch.md")
+	if !ch.Deleted {
+		t.Fatalf("the change is %+v, want a deletion", ch)
+	}
+	if slices.Contains(read(got), "repo:scratch.md") {
+		t.Fatal("the file that is no longer there was read")
+	}
+}
+
+func TestTheWatchedSyncPassesOverTheSameDirectoriesTheWalkDoes(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	w := watch(t, root)
+	s := watched(t, root, w)
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	// A dependency tree written after the watcher started. It holds far more
+	// files than the corpus and none of the content, and a watcher that
+	// descended into it would spend its watches there and report every one of
+	// them as a change.
+	put(t, root, "node_modules/left-pad/index.js", "module.exports = 1\n")
+	put(t, root, ".git/COMMIT_EDITMSG", "wip\n")
+	put(t, root, "docs/real.md", "# a real document\n")
+
+	got, _ := until(t, s, cursor, func(all []connector.Change) bool {
+		return wasRead(all, "repo:docs/real.md")
+	})
+	settle()
+	more, _ := changes(t, s, cursor)
+	got = append(got, more...)
+
+	for _, id := range changed(got) {
+		if strings.Contains(id, "node_modules") || strings.Contains(id, ".git") {
+			t.Fatalf("the sync reported %s, which is in a directory it does not index", id)
+		}
+	}
+}
+
+func TestALostRecordMakesTheNextSyncWalk(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	// Two paths is all this watcher will hold, which is what a real one looks
+	// like when a build rewrites ten thousand files at once. Past that the
+	// record has stopped being a saving and walking is bounded work.
+	w := watch(t, root, fssource.WithMaxPending(2))
+	s := watched(t, root, w)
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	for _, name := range []string{"a.md", "b.md", "c.md", "d.md", "e.md"} {
+		put(t, root, "docs/"+name, "# "+name+"\n")
+	}
+
+	got, _ := until(t, s, cursor, func(all []connector.Change) bool {
+		return wasRead(all, "repo:docs/a.md") && wasRead(all, "repo:docs/e.md")
+	})
+
+	// Everything is found, which is the point. Losing the record costs a walk
+	// and not a document.
+	for _, name := range []string{"a.md", "b.md", "c.md", "d.md", "e.md"} {
+		if !slices.Contains(read(got), "repo:docs/"+name) {
+			t.Fatalf("read %v, which is missing docs/%s", read(got), name)
+		}
+	}
+	if stats := w.Stats(); stats.Walks < 2 {
+		t.Fatalf("the watcher walked %d times, want the first one and at least one more for the overflow", stats.Walks)
+	}
+}
+
+func TestAClosedWatcherLeavesASourceThatWalks(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	w := watch(t, root)
+	s := watched(t, root, w)
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+	put(t, root, "docs/after.md", "# written with nobody watching\n")
+
+	got, _ := changes(t, s, cursor)
+	if !slices.Contains(read(got), "repo:docs/after.md") {
+		t.Fatalf("read %v, want the file written after the watcher was closed", read(got))
+	}
+}
+
+func TestATreeThatNeedsMoreWatchesThanTheLimitIsRefused(t *testing.T) {
+	root := tree(t, map[string]string{
+		"README.md":       "# top\n",
+		"docs/install.md": "# installing\n",
+		"cmd/main.go":     "package main\n",
+	})
+	// Refusing is the useful answer. Every backend charges for a watch and they
+	// charge differently, and the caller can log this and carry on with a source
+	// that walks. Handing back a watcher holding some of the tree would be a
+	// record that looks healthy and is missing whole directories.
+	_, err := fssource.Watch(root, fssource.WithMaxWatches(1))
+	if err == nil {
+		t.Fatal("a tree of three directories was watched with a limit of one")
+	}
+	if !strings.Contains(err.Error(), "limit") {
+		t.Fatalf("the error is %q, and does not say what the limit was", err)
+	}
+}
+
+func TestAWatcherOnAnotherTreeIsRefused(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	elsewhere := tree(t, map[string]string{"README.md": "# somewhere else\n"})
+
+	w := watch(t, elsewhere)
+	_, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"), fssource.WithWatcher(w))
+	if err == nil {
+		t.Fatal("a source took a watcher pointed at a different tree")
+	}
+	// The failure this prevents is silent: the watcher would report nothing
+	// about the tree being read while looking to every sync like a record that
+	// is up to date.
+	if !strings.Contains(err.Error(), elsewhere) || !strings.Contains(err.Error(), root) {
+		t.Fatalf("the error is %q, and does not name both trees", err)
+	}
+}
+
+func TestANilWatcherIsTheSameAsNoWatcher(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	s, err := fssource.New(root, "repo", fssource.PublicToTenant("repo"), fssource.WithWatcher(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This is what lets a caller log the error from Watch and carry on with one
+	// branch instead of two.
+	got, _ := changes(t, s, connector.Cursor{})
+	if want := []string{"repo:README.md"}; !slices.Equal(read(got), want) {
+		t.Fatalf("read %v, want %v", read(got), want)
+	}
+}
+
+func TestACursorDoesNotGoBackwardsWhenAFileArrivesWithAnOldTime(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	w := watch(t, root)
+	s := watched(t, root, w)
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	// What "cp -p" does, and what restoring from a backup does. The file is new
+	// to the index and old to the filesystem.
+	put(t, root, "docs/restored.md", "# from last year\n")
+	old := time.Now().Add(-365 * 24 * time.Hour)
+	if err := os.Chtimes(filepath.Join(root, "docs", "restored.md"), old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	_, next := until(t, s, cursor, func(all []connector.Change) bool {
+		return wasRead(all, "repo:docs/restored.md")
+	})
+	if next.Time.Before(cursor.Time) {
+		t.Fatalf("the cursor went from %s back to %s, which would make the next walk re-read the tree", cursor.Time, next.Time)
+	}
+}
+
+func TestAFileOverTheSizeLimitIsPassedOverAndReported(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	w := watch(t, root)
+
+	var skipped []string
+	s := watched(t, root, w, fssource.WithMaxFileSize(32), fssource.WithSkipped(func(p string, _ error) {
+		skipped = append(skipped, filepath.Base(p))
+	}))
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	put(t, root, "docs/huge.md", strings.Repeat("far too much prose. ", 64))
+	put(t, root, "docs/small.md", "# small\n")
+	got, _ := until(t, s, cursor, func(all []connector.Change) bool {
+		return wasRead(all, "repo:docs/small.md") && slices.Contains(skipped, "huge.md")
+	})
+
+	if slices.Contains(read(got), "repo:docs/huge.md") {
+		t.Fatal("the file over the limit was read")
+	}
+	if !slices.Contains(skipped, "huge.md") {
+		t.Fatalf("skipped %v, and the file over the limit was dropped without a word", skipped)
+	}
+}
+
+func TestAnEditToAPermissionRuleMakesTheSyncWalkTheTree(t *testing.T) {
+	root := tree(t, map[string]string{
+		"OWNERS":        "approvers:\n  - alice\n",
+		"README.md":     "# top\n",
+		"net/design.md": "# networking\n",
+		"net/deep/x.md": "# deeper\n",
+	})
+	w := watch(t, root)
+	policy := policyFor(t, root)
+	s, err := fssource.New(root, "repo", policy, fssource.WithWatcher(w))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, cursor := changes(t, s, connector.Cursor{})
+	before := s.Counters()
+
+	// The one edit whose effect is nowhere near the file that changed. Who may
+	// read every document in the tree just moved, and the only thing any backend
+	// will ever say is that OWNERS was written.
+	time.Sleep(10 * time.Millisecond)
+	put(t, root, "OWNERS", "approvers:\n  - alice\n  - bob\n")
+
+	got, _ := until(t, s, cursor, func(all []connector.Change) bool {
+		return reported(all, "repo:net/deep/x.md")
+	})
+
+	// Walking is the expensive answer and it is the right one. A revocation that
+	// was applied to the OWNERS file and to nothing it governs is not a
+	// revocation.
+	if spent := s.Counters().Since(before); spent.Lists == 0 {
+		t.Fatal("the sync did not walk the tree, so the files the rule governs kept last week's answer")
+	}
+	ch, _ := find(got, "repo:net/deep/x.md")
+	if !ch.PermissionsOnly {
+		t.Fatalf("the change for a file the rule governs is %+v, want a permission change", ch)
+	}
+	if reason := w.Stats().Reason; reason != "" {
+		t.Fatalf("after the walk the watcher still says %q, and would walk again for nothing", reason)
+	}
+}
+
+func TestChangingOnlyTheModeIsAPermissionChangeAndNotAReRead(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows has no mode to change. os.Chmod there toggles the read only
+		// attribute, and OSPolicy reads an access control list this test has no
+		// way to write.
+		t.Skip("a POSIX mode is what this is about")
+	}
+	root := tree(t, map[string]string{
+		"README.md":     "# top\n",
+		"docs/plan.md":  "# the plan\n",
+		"docs/other.md": "# something else\n",
+	})
+	w := watch(t, root)
+	policy, err := fssource.NewOSPolicy(root, "repo", "corp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := fssource.New(root, "repo", policy, fssource.WithWatcher(w))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, cursor := changes(t, s, connector.Cursor{})
+	before := s.Counters()
+
+	if err := os.Chmod(filepath.Join(root, "docs", "plan.md"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := until(t, s, cursor, func(all []connector.Change) bool {
+		return reported(all, "repo:docs/plan.md")
+	})
+
+	ch, _ := find(got, "repo:docs/plan.md")
+	if !ch.PermissionsOnly {
+		t.Fatalf("the change is %+v, want a permission change", ch)
+	}
+	// The cheap half of the whole design. A walk has to ask every file in the
+	// tree whether its rule moved, and here the operating system already said
+	// which one did, so the sync costs one write and reads no bytes.
+	if spent := s.Counters().Since(before); spent.Fetches != 0 || spent.Bytes != 0 {
+		t.Fatalf("a mode change cost %+v, want no reading at all", spent)
+	}
+}
+
+func TestTheWatchedAndWalkedSyncsAgreeOnWhatIsInTheCorpus(t *testing.T) {
+	files := map[string]string{
+		"README.md":            "# top\n",
+		"docs/install.md":      "# installing\n",
+		"cmd/main.go":          "package main\n",
+		"assets/logo.png":      "\x89PNG\r\n\x1a\n binary",
+		".hidden/secret.md":    "# should not appear\n",
+		"node_modules/dep.js":  "module.exports = 1",
+		"docs/notes.unknownxt": "not an extension we read",
+	}
+	root := tree(t, files)
+	w := watch(t, root)
+	s := watched(t, root, w)
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	// Every file rewritten with the same contents, so the two paths are being
+	// asked the same question. They have to give the same answer, because the
+	// watched sync falls back to the walking one whenever the record cannot be
+	// trusted, and a corpus that changed shape depending on which ran would be a
+	// corpus that changed shape at random.
+	elsewhere := tree(t, files)
+	plain, err := fssource.New(elsewhere, "repo", fssource.PublicToTenant("repo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	byWalking, _ := changes(t, plain, connector.Cursor{})
+
+	for rel, body := range files {
+		put(t, root, rel, body+"\n")
+	}
+	byWatching, _ := until(t, s, cursor, func(all []connector.Change) bool {
+		return len(read(all)) >= len(read(byWalking))
+	})
+
+	if !slices.Equal(read(byWatching), read(byWalking)) {
+		t.Fatalf("watching read %v and walking read %v", read(byWatching), read(byWalking))
+	}
+}

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -24,8 +24,9 @@ A crash between the two replays documents, which is harmless because storing the
 The other order loses documents and nothing downstream ever notices they are missing.
 
 For `fssource` the cursor is the highest modification time the last walk saw, and the saving is the read rather than the walk.
-A filesystem has no change feed, so there is no way to avoid statting every file, but there is every way to avoid opening them.
+A filesystem has no change feed of its own, so a sync that only knows how to walk cannot avoid statting every file, but there is every way to avoid opening them.
 That is what the counters measure.
+Asking the operating system to report changes instead removes the walk as well, and is the section after next.
 
 ```go
 before := src.Counters()
@@ -36,6 +37,59 @@ spent := src.Counters().Since(before)
 `Counters` is optional, and a connector that implements it reports four numbers: listings, metadata lookups, fetches and bytes.
 A second sync over an unchanged tree of eight files spends eight metadata lookups, zero fetches and zero bytes.
 That is the floor for a source without a change feed, and the test that says so is `TestASecondSyncOverAnUnchangedTreeReadsNothing`.
+
+### Not walking at all
+
+The walk is the floor for a filesystem asked nothing but "what is here".
+It is not the floor for a filesystem that was asked to say when something changes, and every operating system worth deploying on will do that.
+
+```go
+w, err := fssource.Watch(root)
+if err != nil {
+	log.Warn("watching the tree, syncs will walk it instead", "err", err)
+}
+src, err := fssource.New(root, "docs", policy, fssource.WithWatcher(w))
+```
+
+The watcher is built separately from the source and owned by the caller, because building one fails for reasons that belong to the machine rather than to the program.
+A tree over the inotify limit, a filesystem the backend does not support, a process near its descriptor limit.
+None of those are a reason for a server not to start, so `Watch` returns an error the caller logs, and a nil watcher means exactly what passing no watcher means.
+
+A watcher is an optimisation that is wrong rather than slow when it fails.
+A dropped event is a document that never gets reindexed and nothing anywhere reports it, which is the same shape of failure as a permission change that quietly went nowhere.
+So the record starts out untrusted, goes back to untrusted the moment anything is out of the ordinary, and a sync that finds it untrusted walks the tree.
+Untrusted covers the first sync, a queue that overflowed, any error the backend reported, more changed paths than a walk would have cost, and the watcher being closed.
+The worst a watcher can do is cost what not having one costs.
+
+Three things about it are worth writing down.
+
+A deletion is a change only a watcher can see.
+A walk finds a deleted file by not finding it, which is to say it does not find it, and until now the only thing that ever removed one from the index was the reconciliation sweep below.
+A watched sync emits the deletion directly, and the sweep goes back to being the thing that catches what everything else missed.
+
+Existence is decided by the stat and not by the event.
+A file that was written and then deleted produces both kinds of event and only one of them is still true, and the filesystem is the one that knows which.
+
+The last one is the reason there is an interface for it.
+
+```go
+type Ruled interface {
+	IsRule(relPath string) bool
+}
+```
+
+An edit to an OWNERS file changes who may read every document in the subtree below it.
+The only event anybody raises is about the OWNERS file, and a sync that read the reported paths and nothing else would apply the edit to the OWNERS file and to nothing it governs.
+So a policy says which paths are its rules, and a sync that finds one of them among the changes throws the record away and walks that round.
+That is the expensive answer and it is the right one, because the cheap answer is a revocation that appears to have been applied and has not.
+`OSPolicy` needs none of this, since its rule for a file is the file's own mode and changing that raises an event on the file itself.
+
+The thing that took the longest to get right is not in any of that.
+Some backends report an ordinary write as an attribute change first and the write itself a moment later, so a sync landing between the two sees a mode change and nothing else.
+That is the cheap path, a permission change with no read, and taking it is correct.
+What is not correct is moving the cursor, because the file's modification time is now newer than the cursor while its content has not been read, and the next sync that falls back to walking would skip it for ever.
+So the permission only path puts nothing into the cursor at all.
+It costs one permission change written twice and it is the difference between a watcher that saves work and one that loses documents.
 
 ### The same problem over a network
 
@@ -176,6 +230,10 @@ Twenty ids is what an operator actually uses, because it is enough to go and loo
 `genbad` runs a sweep after every sync and logs at warning level only when something drifted.
 An index that agrees with its source produces nothing in the log, so a line there means the incremental path missed something.
 
+On a server that is watching the tree, the sweep is the only part of a refresh that still walks, which makes it the whole cost.
+So it has its own interval, `-corpus-reconcile`, and the two settings are meant to be set apart: notice a change in a second, count both sides every few minutes.
+The default is unchanged and sweeps after every sync.
+
 ### What it costs to hold
 
 The sweep keeps an id and a version per source document in memory for its duration, which is tens of megabytes for a corpus of a few million.
@@ -192,6 +250,8 @@ Everything else is optional, and each piece buys one thing.
 | `Fetcher` | repair, so what reconciliation finds is fixed rather than only reported |
 | `Counted` | the numbers that say whether the incremental path is actually incremental |
 | `Change.PermissionsOnly` | a permission change costs a write instead of a recrawl |
+| `Change.Deleted` | a deletion reaches the index without waiting for a sweep |
 
-`connector/fssource` implements all four and is the one to read before writing another.
-`connector/objectsource` implements all four as well, over a network service, and is the one to read for the parts a local source never has to deal with: signing, paging, and a listing whose order has nothing to do with what changed.
+`connector/fssource` implements every one of them and is the one to read before writing another.
+`connector/objectsource` implements all but the deletion, over a network service, and is the one to read for the parts a local source never has to deal with: signing, paging, and a listing whose order has nothing to do with what changed.
+A bucket listing is the same shape of problem as a walk, and an object that is no longer in it is found by the sweep for the same reason.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tamnd/genba
 go 1.26.6
 
 require (
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/jackc/pgx/v5 v5.10.0
 	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.56.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3 h1:LMLX+LgTNWpfvCBdFebv6EsYotImrt/Ppc5cXIriCSo=
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3/go.mod h1:jl5iWTm0/hd5PjEYEOuwAJ57L/CibdZfrqZ5XA5GrCk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
Part of #14.

A refresh of a corpus walks the whole tree, stats every file and compares each modification time against the cursor.
On a handbook that is nothing.
On a monorepo it is tens of thousands of stats to find the three files somebody touched, and it is the same tens of thousands every time the refresh interval comes round.
This adds a watcher so that a refresh reads what changed instead.

## What it does

`fssource.Watch(root)` returns a watcher, and `fssource.WithWatcher(w)` hands it to a source.
A sync with a trusted watcher reads only the paths the operating system named and never lists a directory.
A sync with an untrusted one walks the tree exactly the way it did before.

```go
watcher, err := fssource.Watch(root)
if err != nil {
	log.Warn("watching the corpus, refreshes will walk the tree instead", "error", err)
}
src, err := fssource.New(root, "repo", policy, fssource.WithWatcher(watcher))
```

The watcher is built separately and passed in rather than being an option that can fail inside `New`, because a machine at its inotify limit should log a line and carry on walking rather than fail to start.
`WithWatcher(nil)` is legal and means what passing no option means, so the caller needs one branch instead of two.

## Untrusted by default

A watcher is an optimisation that is wrong rather than slow when it fails.
A dropped event is a document that never gets reindexed, and nothing anywhere reports it.
So this one starts out untrusted, goes back to untrusted the moment anything is out of the ordinary, and a sync that finds it untrusted walks the tree.

Five things make it untrusted:

- it has not been vouched for by a walk yet
- the kernel reported a dropped or an errored event
- more than `DefaultMaxPending` paths changed, at which point a walk is cheaper anyway
- an event arrived for a path that is not under the root
- one of the changed paths is a permission rule, which governs files no event will ever name

The last one is the `Ruled` interface, which `OwnersPolicy` implements by recognising an OWNERS file.
Editing an OWNERS file changes who may read every file in that subtree while touching none of them, so the sync walks.

Once a walk finishes it vouches for the record, and from then on the watcher is trusted until something on that list happens again.
That handoff is a generation counter rather than a flag, because an event can land while the walk is halfway through the tree, past the file the event is about.
Clearing the record after such a walk loses that change for ever.
With the counter, a walk only vouches for the record it was told to replace, and a later event bumps the generation so the next sync walks again.

## Deletions

A walking sync cannot see a deletion at all.
The file is not there, so nothing reports it, and the document sits in the index until the reconciliation sweep removes it.
A watched sync gets the event, so it emits `Change{Deleted: true}` and the document goes immediately.

Existence is decided by the `os.Lstat` at sync time rather than by the event, because a file created and deleted twice between two syncs should produce whatever the tree actually holds now, not a replay.

## The cursor and a chmod

On macOS an ordinary write arrives as `Chmod` first and `Write` a moment later.
A sync landing between the two takes the permission only path, which re-resolves permissions without reading the file.
Folding that file's modification time into the cursor there would advance the cursor past content nobody had read, and a later fallback walk would skip the file for ever because its modification time is already behind the cursor.
So the permission only path contributes nothing to the cursor.
It costs one permission change written twice and it is the difference between a watcher that saves work and one that loses documents.

The cursor also never goes backwards, so a `cp -p` that lands a file with last year's timestamp does not rewind it.

## Bounds

`DefaultMaxWatches` is 4096 and `DefaultMaxPending` is 100000.
The first is there because the kqueue backend on macOS and the BSDs costs a file descriptor per watched file and inotify has a per user cap, so a tree larger than the limit is refused at `Watch` time and the caller walks.
The second is there because a walk is bounded work and an unbounded map is not.

## Flags

```
-corpus-watch      ask the operating system what changed instead of walking the tree, needs -corpus-refresh
-corpus-reconcile  how often to sweep the index against the directory, zero for after every sync
```

```
genbad -tenant acme -corpus ~/src/handbook -corpus-refresh 1s -corpus-watch -corpus-reconcile 5m
```

`-corpus-reconcile` exists because on a watched server the sweep is the only walk left, and running it after every sync gives back everything the watcher saved.
It defaults to zero, which is what happens today.

`-corpus-watch` without `-corpus-refresh` is rejected, since a watcher only saves anything across syncs and there is one sync.

The `corpus synced` log line carries the watch count, the event count, the number of fallback walks, and the reason for the most recent one when there is one.

## Tests

`connector/fssource/watch_test.go` covers the first sync walking, a later sync reading only what changed and doing no listing at all, nothing changing costing nothing, a new file, a new directory being watched too, a deletion being reported by a watched source and not by a walking one, a write followed by a delete coming out as a deletion, the same directory skips as the walk, a lost record making the next sync walk, a closed watcher leaving a source that walks, a tree over the watch limit being refused, a watcher on the wrong tree being refused, a nil watcher, the cursor not going backwards, the size limit, an OWNERS edit forcing a walk, a mode change being a permission change and not a re-read, and a watched and a walked sync agreeing on the corpus they produce.

`cmd/genbad/corpus_test.go` starts a real server with `-corpus-watch`, adds a file and waits for it to be searchable, then removes one and waits for it to stop being searchable.

Green on darwin/arm64, freebsd/amd64, linux/amd64, linux/arm64, windows/amd64 and windows/arm64.
`go test ./connector/fssource/ -count=30 -race` is clean.

## What this does not do

Box four of #14 asks for a worked configuration example for both connectors.
This is the filesystem half.
The object storage side still needs its own wiring, so that box stays unticked.
