### PR TITLE
genbad: read a bucket as well as a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ The environment variable is the flag in upper case with a `GENBA_` prefix, and a
 | `GENBA_WRITE_TIMEOUT` | `60s` | request write timeout |
 | `GENBA_SHUTDOWN_GRACE` | `15s` | how long a shutdown waits for in flight requests |
 
-The corpus flags have no environment variables, because a directory to index is a thing you type once while trying the binary out rather than a property of a deployment.
+The source flags have no environment variables, because a directory or a bucket to index is a thing you type once while trying the binary out rather than a property of a deployment.
+The one exception is the object storage credentials, which are read from the environment and have no flag at all.
 
 | Flag | Default | What it does |
 | --- | --- | --- |
@@ -175,6 +176,42 @@ The sweep that finds deleted files walks the tree, so on a watched server it is 
 ```
 genbad -tenant acme -corpus ~/src/handbook -corpus-refresh 1s -corpus-watch -corpus-reconcile 5m
 ```
+
+The same server can read an S3 compatible bucket, either instead of a directory or as well as one.
+
+| Flag | Default | What it does |
+| --- | --- | --- |
+| `-bucket` | empty | bucket to index at startup |
+| `-bucket-endpoint` | empty | base URL of the service, for example `https://s3.eu-west-1.amazonaws.com` |
+| `-bucket-region` | `us-east-1` | region the bucket is in, which is part of what a signature authenticates |
+| `-bucket-prefix` | empty | read only the keys under this prefix, empty for the whole bucket |
+| `-bucket-name` | `objects` | source name the documents carry, and what `-source` filters on |
+| `-bucket-acl` | `tenant` | who may read it: `tenant` for everybody in the tenant, `bucket` for the bucket's own access control list, `object` for each object's |
+| `-bucket-identity` | empty | identity source the names in the access control lists belong to, for `-bucket-acl bucket` or `object` |
+| `-bucket-domain` | empty | mail domain that counts as this tenant in a grant written against an address |
+| `-bucket-path-style` | `false` | put the bucket in the path rather than in the host name, which MinIO and Ceph need |
+| `-bucket-refresh` | `0` | how often to list the bucket again, zero for once at startup |
+| `-bucket-reconcile` | `0` | how often to sweep the index against the bucket, zero for after every sync |
+
+Credentials come from `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`, and there is no flag for them.
+A secret in argv is readable by every process on the machine for as long as the server runs, and it ends up in the shell history of whoever started it.
+A bucket with no credentials at all is read unsigned, which is what a public bucket wants and what nothing else does.
+
+```
+genbad -tenant acme \
+  -bucket company-docs \
+  -bucket-endpoint https://s3.eu-west-1.amazonaws.com \
+  -bucket-region eu-west-1 \
+  -bucket-prefix handbook/ \
+  -bucket-acl bucket \
+  -bucket-identity google \
+  -bucket-domain acme.com \
+  -bucket-refresh 30s \
+  -bucket-reconcile 15m
+```
+
+A server given both a corpus and a bucket runs them as two feeds with two cursors rather than one merged crawl, so a bucket that is refusing requests does not stop the directory being reindexed.
+`docs/ingestion.md` has the worked examples for both, including MinIO on a laptop.
 
 ## Metrics
 

--- a/arch_test.go
+++ b/arch_test.go
@@ -150,7 +150,7 @@ var allowed = map[string][]string{
 	"benchcorpus/gen": {"benchcorpus", "store/sqlitestore"},
 
 	"cmd/genba":  {""},
-	"cmd/genbad": {"", "api", "config", "connector", "connector/aclmap", "connector/fssource", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
+	"cmd/genbad": {"", "api", "config", "connector", "connector/aclmap", "connector/fssource", "connector/objectsource", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
 }
 
 func TestDependencyDirection(t *testing.T) {

--- a/cmd/genbad/bucket.go
+++ b/cmd/genbad/bucket.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/tamnd/genba/connector/objectsource"
+	"github.com/tamnd/genba/store"
+)
+
+// bucketOptions is what the -bucket flags add up to.
+//
+// They are the object storage half of the same idea the -corpus flags are: a
+// server that is useful the first time it starts, pointed at something the
+// person running it already has. A bucket is the thing most companies already
+// have a lot of documents in, and it needs no agent installed anywhere and no
+// vendor application to be approved before anybody can try it.
+type bucketOptions struct {
+	// Bucket is the bucket to read. Empty means do not ingest.
+	Bucket string
+
+	// Endpoint is the service's base URL, for example
+	// https://s3.eu-west-1.amazonaws.com or http://127.0.0.1:9000.
+	Endpoint string
+
+	// Region is the region the bucket is in, which is part of what a signature
+	// authenticates rather than only a piece of routing. A service with no
+	// regions still expects to be signed with one.
+	Region string
+
+	// Prefix narrows the source to one part of the bucket, and narrows the
+	// listing rather than filtering it afterwards, so scoping tightly inside a
+	// very large bucket costs what the scope costs.
+	Prefix string
+
+	// Name is the source name the documents carry, and what a query filters on.
+	Name string
+
+	// ACL selects how permissions are decided: "tenant", "bucket" or "object".
+	ACL string
+
+	// Identity names the identity source the names in the access control lists
+	// belong to, and is what the mapping writes its references under.
+	Identity string
+
+	// Domain is the mail domain that counts as this tenant, which is what a
+	// grant written against an email address is checked against. Empty leaves
+	// every such grant foreign, which is the safe reading.
+	Domain string
+
+	// PathStyle puts the bucket in the path rather than in the host name. It is
+	// what MinIO, Ceph and anything else on a single host name need, and what
+	// S3 itself does not.
+	PathStyle bool
+
+	// Refresh is how often to list the bucket again. Zero syncs once at startup.
+	Refresh time.Duration
+
+	// Reconcile is how often to sweep the index against the bucket. Zero sweeps
+	// after every sync.
+	Reconcile time.Duration
+
+	// Access, Secret and Session are the credentials, and they are read from the
+	// environment rather than taken from a flag.
+	//
+	// A secret in argv is readable by every process on the machine for as long
+	// as the server runs, and it ends up in the shell history of whoever started
+	// it. There is no flag for these on purpose, and the names are the ones
+	// every other tool in this space already uses, so a machine that can already
+	// reach the bucket needs nothing new set.
+	Access  string
+	Secret  string
+	Session string
+}
+
+// The values -bucket-acl takes. The tenant one is shared with -corpus-acl,
+// where it means the same thing.
+const (
+	aclBucket = "bucket"
+	aclObject = "object"
+)
+
+// credentials fills in the keys from the environment.
+func (o *bucketOptions) credentials(getenv func(string) string) {
+	o.Access = getenv("AWS_ACCESS_KEY_ID")
+	o.Secret = getenv("AWS_SECRET_ACCESS_KEY")
+	o.Session = getenv("AWS_SESSION_TOKEN")
+}
+
+func (o bucketOptions) validate() error {
+	if o.Bucket == "" {
+		return nil
+	}
+	if o.Endpoint == "" {
+		// There is no default worth guessing. The endpoint decides which company
+		// the request goes to, and a wrong guess here is a bucket name and a set
+		// of credentials sent somewhere nobody meant to send them.
+		return errors.New("a bucket needs -bucket-endpoint, for example https://s3.eu-west-1.amazonaws.com")
+	}
+	if o.Name == "" {
+		return errors.New("bucket source name is empty")
+	}
+	switch o.ACL {
+	case aclTenant:
+	case aclBucket, aclObject:
+		if o.Identity == "" {
+			// Every reference the mapping writes carries this name, and without
+			// one they would all be compared against the bare account name.
+			return fmt.Errorf("bucket acl %q needs an identity source", o.ACL)
+		}
+	default:
+		return fmt.Errorf("unknown bucket acl %q, want %q, %q or %q", o.ACL, aclTenant, aclBucket, aclObject)
+	}
+	// Half a set of credentials signs nothing and is answered with a refusal
+	// that says the signature did not match, which sends whoever reads it
+	// looking at the clock and the region rather than at the one variable they
+	// forgot to export.
+	if (o.Access == "") != (o.Secret == "") {
+		return errors.New("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY have to be set together, or neither for a public bucket")
+	}
+	if o.Refresh < 0 {
+		return errors.New("bucket refresh is negative")
+	}
+	if o.Reconcile < 0 {
+		return errors.New("bucket reconcile interval is negative")
+	}
+	return nil
+}
+
+// bucketPolicyFor builds the permission policy named by the flags.
+//
+// The three are in order of what they cost and of how exact they are. The
+// tenant policy asks nothing and is right for a bucket of published
+// documentation. The bucket policy reads one access control list per sync and
+// is right for the common case where a bucket is one team's and the objects in
+// it were all written by one process. The object policy reads one per object
+// per sync, which on a bucket of any size is the most expensive thing this
+// binary can be asked to do, and is right only when the objects really do
+// differ.
+func bucketPolicyFor(c *objectsource.Client, o bucketOptions) (objectsource.Policy, error) {
+	var domains []string
+	if o.Domain != "" {
+		domains = append(domains, o.Domain)
+	}
+	switch o.ACL {
+	case aclTenant:
+		return objectsource.PublicToTenant(o.Name), nil
+	case aclBucket:
+		p, err := objectsource.NewBucketPolicy(c, o.Name, o.Identity, domains...)
+		if err != nil {
+			return nil, err
+		}
+		return p, nil
+	case aclObject:
+		p, err := objectsource.NewObjectPolicy(c, o.Name, o.Identity, domains...)
+		if err != nil {
+			return nil, err
+		}
+		return p, nil
+	default:
+		return nil, fmt.Errorf("unknown bucket acl %q", o.ACL)
+	}
+}
+
+// ingestBucket syncs the configured bucket into the store.
+//
+// It runs on the same schedule the directory does, for the same reason: the
+// first sync finishes before the listener opens, and later ones are incremental
+// against the cursor the last one saved.
+func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant string, log *slog.Logger) (func(), error) {
+	if cfg.Bucket == "" {
+		return func() {}, nil
+	}
+	if tenant == "" {
+		return nil, errors.New("ingesting a bucket needs -tenant")
+	}
+
+	client, err := objectsource.NewClient(objectsource.Config{
+		Endpoint:        cfg.Endpoint,
+		Region:          cfg.Region,
+		Bucket:          cfg.Bucket,
+		AccessKeyID:     cfg.Access,
+		SecretAccessKey: cfg.Secret,
+		SessionToken:    cfg.Session,
+		PathStyle:       cfg.PathStyle,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// The policy is built on the same client as the source, so that what the
+	// permission lookups cost and what the reads cost land in one set of
+	// counters rather than two that have to be added up by hand.
+	policy, err := bucketPolicyFor(client, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	src, err := objectsource.New(client, cfg.Name, policy,
+		objectsource.WithPrefix(cfg.Prefix),
+		objectsource.WithSkipped(func(key string, reason error) {
+			// An object nobody could read is not an error and does not stop the
+			// sync, and an index quietly missing all of them looks exactly like
+			// an index that is complete. This is the only place that difference
+			// is visible.
+			log.Warn("object passed over", "bucket", cfg.Bucket, "key", key, "reason", reason)
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return runFeed(ctx, st, feed{
+		Kind:      "bucket",
+		Source:    src,
+		Tenant:    tenant,
+		Refresh:   cfg.Refresh,
+		Reconcile: cfg.Reconcile,
+		Fields:    []any{"bucket", cfg.Bucket, "prefix", cfg.Prefix, "source", cfg.Name},
+		Report:    func() []any { return requesting(client) },
+		Policy:    policy,
+		Release:   func() { _ = src.Close() },
+	}, log)
+}
+
+// requesting is what the bucket cost, for the sync log line.
+//
+// These are the numbers a bill is made of, and they are cumulative rather than
+// per sync so that the shape over time is what an operator reads. A listing
+// count that climbs by one per sync is a healthy incremental run, and a fetch
+// count that climbs with it on a bucket nobody is writing to means the cursor
+// is not doing its job.
+func requesting(c *objectsource.Client) []any {
+	n := c.Counters()
+	return []any{
+		"lists", n.Lists,
+		"metadata", n.Metadata,
+		"fetches", n.Fetches,
+		"fetched_mb", megabytes(n.Bytes),
+	}
+}

--- a/cmd/genbad/bucket_test.go
+++ b/cmd/genbad/bucket_test.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBucketFlagsAreChecked(t *testing.T) {
+	usable := bucketOptions{Bucket: "corpus", Endpoint: "https://s3.eu-west-1.amazonaws.com", Name: "objects", ACL: aclTenant}
+	with := func(f func(*bucketOptions)) bucketOptions {
+		o := usable
+		f(&o)
+		return o
+	}
+
+	tests := []struct {
+		name string
+		opts bucketOptions
+		want string
+	}{
+		{"nothing set is fine", bucketOptions{}, ""},
+		{"a usable set", usable, ""},
+		{"a bucket with nowhere to read it from", with(func(o *bucketOptions) { o.Endpoint = "" }), "endpoint"},
+		{"a bucket with no source name", with(func(o *bucketOptions) { o.Name = "" }), "name is empty"},
+		{"an unknown acl", with(func(o *bucketOptions) { o.ACL = "everyone" }), "everyone"},
+		{"the bucket acl with nobody to name accounts", with(func(o *bucketOptions) { o.ACL = aclBucket }), "identity source"},
+		{"the bucket acl told where the names come from", with(func(o *bucketOptions) { o.ACL, o.Identity = aclBucket, "google" }), ""},
+		{"the object acl with nobody to name accounts", with(func(o *bucketOptions) { o.ACL = aclObject }), "identity source"},
+		{"a key with no secret", with(func(o *bucketOptions) { o.Access = "AKIA" }), "together"},
+		{"a secret with no key", with(func(o *bucketOptions) { o.Secret = "shhh" }), "together"},
+		{"both of them", with(func(o *bucketOptions) { o.Access, o.Secret = "AKIA", "shhh" }), ""},
+		{"a negative refresh", with(func(o *bucketOptions) { o.Refresh = -time.Second }), "negative"},
+		{"a negative reconcile interval", with(func(o *bucketOptions) { o.Reconcile = -time.Second }), "negative"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.validate()
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("rejected a usable set: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("accepted %+v", tt.opts)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error is %q, want it to mention %q", err, tt.want)
+			}
+		})
+	}
+}
+
+// Credentials come from the environment and there is no flag for them, because
+// argv is readable by every process on the machine.
+func TestBucketCredentialsComeFromTheEnvironment(t *testing.T) {
+	var o bucketOptions
+	o.credentials(env(map[string]string{
+		"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7EXAMPLE",
+		"AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"AWS_SESSION_TOKEN":     "temporary",
+	}))
+	if o.Access != "AKIAIOSFODNN7EXAMPLE" || o.Secret == "" || o.Session != "temporary" {
+		t.Fatalf("credentials = %+v", o)
+	}
+
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), []string{"-bucket-secret-access-key", "shhh"}, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("a flag was accepted for the secret key")
+	}
+}
+
+func TestABucketWithoutATenantIsRefused(t *testing.T) {
+	args := []string{"-bucket", "corpus", "-bucket-endpoint", "https://example.invalid", "-log-level", "error"}
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), args, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("a bucket was ingested with no tenant to file it under")
+	}
+	if !strings.Contains(err.Error(), "tenant") {
+		t.Errorf("error is %q, want it to say what is missing", err)
+	}
+}
+
+// The point of the whole thing: start the server on a bucket and get real
+// results back out of the API.
+func TestAStartedServerAnswersQueriesAboutTheBucket(t *testing.T) {
+	store := newBucket(t)
+	store.put("handbook/README.md", "# The handbook\n\nHow we work.\n")
+	store.put("handbook/guides/deploy.md", "# Deploying\n\nPush the button.\n")
+	store.put("elsewhere/private.md", "# Private\n\nNot in the prefix.\n")
+
+	addr := freeAddr(t)
+	stop := serve(t, addr,
+		"-bucket", theBucket,
+		"-bucket-endpoint", store.url,
+		"-bucket-path-style",
+		"-bucket-prefix", "handbook/",
+		"-bucket-name", "docs",
+		"-bucket-refresh", "100ms",
+	)
+	defer stop()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	res := searchAs(t, addr, "alice", "deploying")
+	if res.Total == 0 {
+		t.Fatal("the bucket was ingested but a query about it found nothing")
+	}
+	var found bool
+	for _, h := range res.Hits {
+		if strings.HasSuffix(h.ID, "handbook/guides/deploy.md") {
+			found = true
+			if h.Title != "Deploying" {
+				t.Errorf("title is %q, want the heading from the object", h.Title)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("results %v do not include the object the query names", res.Hits)
+	}
+
+	// The prefix narrows the listing rather than filtering it afterwards, so
+	// what is outside it was never read.
+	if got := searchAs(t, addr, "alice", "not in the prefix"); got.Total != 0 {
+		t.Errorf("an object outside the prefix was indexed: %v", got.Hits)
+	}
+
+	// An object written after the server started is picked up by the next
+	// listing, and one removed goes on the sweep that follows it.
+	store.put("handbook/guides/rollback.md", "# Rolling back\n\nPress the other button.\n")
+	waitForResults(t, addr, "rolling back", true)
+
+	store.remove("handbook/guides/deploy.md")
+	waitForResults(t, addr, "deploying", false)
+
+	if got := searchAs(t, addr, "alice", "handbook"); got.Total == 0 {
+		t.Error("the rest of the bucket went missing")
+	}
+}
+
+// A server pointed at a directory and a bucket at once indexes both, and a
+// query reaches across the two.
+func TestAServerReadsADirectoryAndABucketTogether(t *testing.T) {
+	store := newBucket(t)
+	store.put("notes.md", "# Notes\n\nSomething only the bucket has.\n")
+
+	addr := freeAddr(t)
+	stop := serve(t, addr,
+		"-corpus", corpusTree(t),
+		"-corpus-name", "handbook",
+		"-bucket", theBucket,
+		"-bucket-endpoint", store.url,
+		"-bucket-path-style",
+		"-bucket-name", "docs",
+	)
+	defer stop()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	if got := searchAs(t, addr, "alice", "deploying"); got.Total == 0 {
+		t.Error("the directory was not indexed")
+	}
+	if got := searchAs(t, addr, "alice", "only the bucket has"); got.Total == 0 {
+		t.Error("the bucket was not indexed")
+	}
+}
+
+// A bucket that cannot be reached is a warning and a server that is still
+// serving, because the other source is still good and an empty index that says
+// nothing about why is worse than one that is missing a feed and says so.
+func TestABucketThatRefusesDoesNotStopTheServer(t *testing.T) {
+	refuser := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer refuser.Close()
+
+	addr := freeAddr(t)
+	stop := serve(t, addr,
+		"-corpus", corpusTree(t),
+		"-corpus-name", "handbook",
+		"-bucket", theBucket,
+		"-bucket-endpoint", refuser.URL,
+		"-bucket-path-style",
+	)
+	defer stop()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	if got := searchAs(t, addr, "alice", "deploying"); got.Total == 0 {
+		t.Error("a bucket that refused took the directory down with it")
+	}
+}
+
+// serve starts the server with the given flags and returns the function that
+// stops it and waits for it to be gone.
+func serve(t *testing.T, addr string, args ...string) func() {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, append([]string{
+			"-addr", addr,
+			"-tenant", "acme",
+			"-log-level", "error",
+		}, args...), env(nil), &out, &errOut)
+	}()
+	return func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("the server stopped with %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("the server did not shut down")
+		}
+	}
+}
+
+// theBucket is the name the fake answers to.
+const theBucket = "corpus"
+
+// bucketFake is an S3 compatible service with one bucket in it.
+//
+// It is here rather than in a container because what these tests are about is
+// the wiring: that the flags reach a client, that the client reaches a service,
+// and that what comes back is searchable. What a real service would add is
+// whether it accepts these signatures and returns this XML, and that is checked
+// against the published examples in connector/objectsource.
+type bucketFake struct {
+	url string
+
+	mu      sync.Mutex
+	objects map[string]string
+	clock   time.Time
+}
+
+func newBucket(t *testing.T) *bucketFake {
+	t.Helper()
+	f := &bucketFake{
+		objects: make(map[string]string),
+		clock:   time.Date(2026, time.March, 2, 12, 0, 0, 0, time.UTC),
+	}
+	srv := httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(srv.Close)
+	f.url = srv.URL
+	return f
+}
+
+func (f *bucketFake) put(key, body string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.objects[key] = body
+	// Every write moves the clock on, so that an object written after the last
+	// sync is genuinely newer than the cursor rather than being in the same
+	// second as it.
+	f.clock = f.clock.Add(time.Minute)
+}
+
+func (f *bucketFake) remove(key string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.objects, key)
+	f.clock = f.clock.Add(time.Minute)
+}
+
+func (f *bucketFake) handle(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	w.Header().Set("Date", f.clock.UTC().Format(http.TimeFormat))
+	key := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/"+theBucket), "/")
+	if unescaped, err := url.PathUnescape(key); err == nil {
+		key = unescaped
+	}
+
+	switch {
+	case r.URL.Query().Get("list-type") == "2":
+		f.list(w, r.URL.Query().Get("prefix"))
+	case key == "":
+		http.Error(w, "no key", http.StatusNotFound)
+	default:
+		body, ok := f.objects[key]
+		if !ok {
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`<Error><Code>NoSuchKey</Code><Message>not here</Message></Error>`))
+			return
+		}
+		w.Header().Set("Last-Modified", f.clock.UTC().Format(http.TimeFormat))
+		w.Header().Set("ETag", `"`+key+`"`)
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+// list answers a ListObjectsV2 in one page, which is all these corpora need.
+func (f *bucketFake) list(w http.ResponseWriter, prefix string) {
+	type contents struct {
+		Key          string `xml:"Key"`
+		LastModified string `xml:"LastModified"`
+		ETag         string `xml:"ETag"`
+		Size         int64  `xml:"Size"`
+	}
+	type result struct {
+		XMLName     xml.Name   `xml:"ListBucketResult"`
+		IsTruncated bool       `xml:"IsTruncated"`
+		Contents    []contents `xml:"Contents"`
+	}
+
+	keys := make([]string, 0, len(f.objects))
+	for k := range f.objects {
+		if strings.HasPrefix(k, prefix) {
+			keys = append(keys, k)
+		}
+	}
+	// A listing is ordered by key, and the connector's resumption depends on
+	// that, so the fake had better be too.
+	sort.Strings(keys)
+
+	out := result{}
+	for _, k := range keys {
+		out.Contents = append(out.Contents, contents{
+			Key:          k,
+			LastModified: f.clock.UTC().Format(time.RFC3339),
+			ETag:         `"` + k + `"`,
+			Size:         int64(len(f.objects[k])),
+		})
+	}
+	w.Header().Set("Content-Type", "application/xml")
+	_ = xml.NewEncoder(w).Encode(out)
+}

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -5,14 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"runtime"
 	"time"
 
-	"github.com/tamnd/genba"
-	"github.com/tamnd/genba/connector"
-	"github.com/tamnd/genba/connector/aclmap"
 	"github.com/tamnd/genba/connector/fssource"
-	"github.com/tamnd/genba/ingest"
 	"github.com/tamnd/genba/store"
 )
 
@@ -185,85 +180,22 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 		return nil, err
 	}
 
-	// Checkpoints live in memory because the only storage driver that ships
-	// today does too. Restarting loses the index, so a cursor that survived the
-	// restart would skip everything the new empty index needs.
-	pipeline, err := ingest.New(st, connector.NewMemoryCheckpoints(), ingest.WithLogger(log))
-	if err != nil {
-		return nil, err
-	}
-
-	var swept time.Time
-	sync := func(ctx context.Context) {
-		var before, after runtime.MemStats
-		runtime.ReadMemStats(&before)
-
-		stats, err := pipeline.Run(ctx, genba.TenantID(tenant), src)
-		if err != nil {
-			log.Error("corpus sync failed", "dir", cfg.Dir, "error", err,
-				"indexed", stats.Indexed, "quarantined", stats.Quarantined)
-			return
-		}
-		runtime.ReadMemStats(&after)
-
-		log.Info("corpus synced", append([]any{
-			"dir", cfg.Dir,
-			"source", cfg.Name,
-			"indexed", stats.Indexed,
-			"quarantined", stats.Quarantined,
-			"bytes", stats.Bytes,
-			"duration", stats.Duration.Round(time.Millisecond),
-			"docs_per_second", int(stats.Rate()),
-			"mb_per_second", throughput(stats.Bytes, stats.Duration),
-			// What the corpus costs to hold, and what it cost to build. The
-			// first is the number that decides how much a machine can serve,
-			// and the second is the one that shows up as garbage collection.
-			"heap_mb", megabytes(int64(after.HeapAlloc)),
-			"allocated_mb", megabytes(int64(after.TotalAlloc - before.TotalAlloc)),
-		}, watching(watcher)...)...)
-
-		// The sweep walks the tree, so on a server that is watching it is the
-		// whole of what a refresh costs. Running it on its own interval is what
-		// lets a change be noticed in a second while both sides are still
-		// counted often enough to catch what the watcher missed.
-		if cfg.Reconcile <= 0 || time.Since(swept) >= cfg.Reconcile {
-			swept = time.Now()
-			reconcile(ctx, pipeline, src, tenant, log)
-		}
-		reportMapping(policy, log)
-	}
-
-	sync(ctx)
-
-	stop := func() {
-		if watcher != nil {
-			_ = watcher.Close()
-		}
-		_ = src.Close()
-	}
-
-	if cfg.Refresh <= 0 {
-		return stop, nil
-	}
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		t := time.NewTicker(cfg.Refresh)
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				sync(ctx)
+	return runFeed(ctx, st, feed{
+		Kind:      "corpus",
+		Source:    src,
+		Tenant:    tenant,
+		Refresh:   cfg.Refresh,
+		Reconcile: cfg.Reconcile,
+		Fields:    []any{"dir", cfg.Dir, "source", cfg.Name},
+		Report:    func() []any { return watching(watcher) },
+		Policy:    policy,
+		Release: func() {
+			if watcher != nil {
+				_ = watcher.Close()
 			}
-		}
-	}()
-	return func() {
-		<-done
-		stop()
-	}, nil
+			_ = src.Close()
+		},
+	}, log)
 }
 
 // watching is what the watcher has to say, for the sync log line.
@@ -283,98 +215,4 @@ func watching(w *fssource.Watcher) []any {
 		out = append(out, "walking_because", s.Reason)
 	}
 	return out
-}
-
-// aclCounter is a permission policy that counts what it mapped.
-type aclCounter interface {
-	Counts() aclmap.Counts
-}
-
-// reportMapping says what the permission mapping could not represent.
-//
-// A document held back because its source said something the model cannot carry
-// is invisible from every other angle. It is not an error, the sync succeeded,
-// and the only symptom is somebody who cannot find a document they know exists.
-// So it is counted by reason, and the reasons want different actions: a foreign
-// domain is a decision about the tenant, an unmappable deny is usually a source
-// feature nobody has written the mapping for, and a malformed grant is a bug in
-// a connector.
-func reportMapping(policy fssource.Policy, log *slog.Logger) {
-	counter, ok := policy.(aclCounter)
-	if !ok {
-		return
-	}
-	c := counter.Counts()
-	if c.Quarantined() == 0 {
-		return
-	}
-	log.Warn("permissions that could not be mapped",
-		"mapped", c.Mapped,
-		"quarantined", c.Quarantined(),
-		"foreign_domain", c.ForeignDomain,
-		"unmappable_deny", c.UnmappableDeny,
-		"malformed", c.Malformed,
-		"ignored_roles", c.Ignored,
-	)
-}
-
-// reconcile sweeps the index against the tree and repairs what the sync could
-// not have seen.
-//
-// It runs after every sync rather than on a schedule of its own, and the reason
-// is that a directory tree has no change feed. A sync walks the tree and emits
-// what is newer than the cursor, which means a file somebody deleted produces
-// no event at all: there is nothing left to walk past. Without this the deleted
-// document stays in the index and keeps being served, and the only thing that
-// would ever remove it is a restart.
-//
-// The cost is a second walk of the same tree, stat only, plus a two column scan
-// of the index. On a corpus where the sync itself is already a stat per file
-// that is roughly double the cheap half of the work and none of the expensive
-// half, which is the right trade for the alternative being an index that serves
-// documents that no longer exist.
-func reconcile(ctx context.Context, pipeline *ingest.Pipeline, src connector.Connector, tenant string, log *slog.Logger) {
-	rec, err := pipeline.Reconcile(ctx, genba.TenantID(tenant), src)
-	if err != nil {
-		// Not fatal, and not even unusual. A store that cannot list what it holds
-		// or a connector that cannot enumerate simply has no sweep, and the sync
-		// that just finished is still good.
-		log.Warn("corpus reconciliation skipped", "source", src.Source(), "error", err)
-		return
-	}
-	if rec.Drift() == 0 {
-		return
-	}
-	// Logged at warning level because drift is the interesting event. An index
-	// that agrees with its source produces nothing here, so a line in the log
-	// means the incremental path missed something and is worth going to look at.
-	log.Warn("corpus reconciled",
-		"source", rec.Source,
-		"source_items", rec.SourceItems,
-		"index_items", rec.IndexItems,
-		"missing", rec.Missing.Count,
-		"stale", rec.Stale.Count,
-		"extra", rec.Extra.Count,
-		"repaired", rec.Repaired,
-		"deleted", rec.Deleted,
-		"sample_missing", rec.Missing.IDs,
-		"sample_stale", rec.Stale.IDs,
-		"sample_extra", rec.Extra.IDs,
-		"requests", rec.Requests.Requests(),
-		"duration", rec.Duration.Round(time.Millisecond),
-	)
-}
-
-// megabytes converts a byte count for the log.
-func megabytes(n int64) float64 {
-	return float64(n) / (1 << 20)
-}
-
-// throughput is megabytes a second, and zero for a run too short for the clock
-// to have moved, which would otherwise divide by zero and log an infinity.
-func throughput(bytes int64, d time.Duration) float64 {
-	if d <= 0 {
-		return 0
-	}
-	return megabytes(bytes) / d.Seconds()
 }

--- a/cmd/genbad/feed.go
+++ b/cmd/genbad/feed.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"slices"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/aclmap"
+	"github.com/tamnd/genba/ingest"
+	"github.com/tamnd/genba/store"
+)
+
+// feed is one connector wired to run on a schedule.
+//
+// The two sources this binary can be pointed at, a directory and a bucket,
+// differ in how they are built and in nothing at all about how they are run.
+// Both sync once before the listener opens, both sync again on an interval,
+// both sweep the index against the source afterwards, and both want the same
+// numbers in the log. Keeping that in one place is what stops the third one
+// from being a third copy of the same loop with one of the numbers missing.
+type feed struct {
+	// Kind is the word the log lines start with, so that a server reading two
+	// sources says which one it is talking about.
+	Kind string
+
+	// Source is the connector to sync.
+	Source connector.Connector
+
+	// Tenant is who the documents belong to.
+	Tenant string
+
+	// Refresh is how often to sync again. Zero syncs once at startup.
+	Refresh time.Duration
+
+	// Reconcile is how often to sweep the index against the source. Zero sweeps
+	// after every sync.
+	Reconcile time.Duration
+
+	// Fields say where the documents came from and are on every line this feed
+	// logs.
+	Fields []any
+
+	// Report is asked after every sync for whatever the source has to say about
+	// itself, which is where a watcher's counters and a client's request counts
+	// come from. A nil Report adds nothing.
+	Report func() []any
+
+	// Policy is the permission policy, for the mapping report. It is an any
+	// because the two connectors have unrelated policy interfaces and what is
+	// wanted here is the one method some of their implementations share.
+	Policy any
+
+	// Release is called once the last sync has returned, and is where a watcher
+	// and a source get closed.
+	Release func()
+}
+
+// runFeed syncs f once and then on its interval, and returns the function that
+// waits for it to stop.
+//
+// The first sync runs before this returns, and the caller runs it before the
+// listener opens, so that a request arriving the moment the log says the server
+// is up finds a corpus rather than an empty index.
+func runFeed(ctx context.Context, st store.Store, f feed, log *slog.Logger) (func(), error) {
+	// Checkpoints live in memory because the only storage driver that ships
+	// today does too. Restarting loses the index, so a cursor that survived the
+	// restart would skip everything the new empty index needs.
+	pipeline, err := ingest.New(st, connector.NewMemoryCheckpoints(), ingest.WithLogger(log))
+	if err != nil {
+		return nil, err
+	}
+
+	var swept time.Time
+	sync := func(ctx context.Context) {
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+
+		stats, err := pipeline.Run(ctx, genba.TenantID(f.Tenant), f.Source)
+		if err != nil {
+			log.Error(f.Kind+" sync failed", append(slices.Clone(f.Fields),
+				"error", err,
+				"indexed", stats.Indexed,
+				"quarantined", stats.Quarantined,
+			)...)
+			return
+		}
+		runtime.ReadMemStats(&after)
+
+		fields := append(slices.Clone(f.Fields),
+			"indexed", stats.Indexed,
+			"quarantined", stats.Quarantined,
+			"bytes", stats.Bytes,
+			"duration", stats.Duration.Round(time.Millisecond),
+			"docs_per_second", int(stats.Rate()),
+			"mb_per_second", throughput(stats.Bytes, stats.Duration),
+			// What the corpus costs to hold, and what it cost to build. The
+			// first is the number that decides how much a machine can serve,
+			// and the second is the one that shows up as garbage collection.
+			"heap_mb", megabytes(int64(after.HeapAlloc)),
+			"allocated_mb", megabytes(int64(after.TotalAlloc-before.TotalAlloc)),
+		)
+		if f.Report != nil {
+			fields = append(fields, f.Report()...)
+		}
+		log.Info(f.Kind+" synced", fields...)
+
+		// The sweep walks the source, which on a watched directory is the whole
+		// of what a refresh costs and on a bucket is a request per thousand
+		// objects that the sync just made as well. Running it on its own
+		// interval is what lets a change be noticed in a second while both
+		// sides are still counted often enough to catch what the sync missed.
+		if f.Reconcile <= 0 || time.Since(swept) >= f.Reconcile {
+			swept = time.Now()
+			reconcile(ctx, pipeline, f.Source, f.Tenant, log)
+		}
+		reportMapping(f.Policy, log)
+	}
+
+	sync(ctx)
+
+	release := f.Release
+	if release == nil {
+		release = func() {}
+	}
+	if f.Refresh <= 0 {
+		return release, nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		t := time.NewTicker(f.Refresh)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				sync(ctx)
+			}
+		}
+	}()
+	return func() {
+		<-done
+		release()
+	}, nil
+}
+
+// aclCounter is a permission policy that counts what it mapped.
+type aclCounter interface {
+	Counts() aclmap.Counts
+}
+
+// reportMapping says what the permission mapping could not represent.
+//
+// A document held back because its source said something the model cannot carry
+// is invisible from every other angle. It is not an error, the sync succeeded,
+// and the only symptom is somebody who cannot find a document they know exists.
+// So it is counted by reason, and the reasons want different actions: a foreign
+// domain is a decision about the tenant, an unmappable deny is usually a source
+// feature nobody has written the mapping for, and a malformed grant is a bug in
+// a connector.
+func reportMapping(policy any, log *slog.Logger) {
+	counter, ok := policy.(aclCounter)
+	if !ok {
+		return
+	}
+	c := counter.Counts()
+	if c.Quarantined() == 0 {
+		return
+	}
+	log.Warn("permissions that could not be mapped",
+		"mapped", c.Mapped,
+		"quarantined", c.Quarantined(),
+		"foreign_domain", c.ForeignDomain,
+		"unmappable_deny", c.UnmappableDeny,
+		"malformed", c.Malformed,
+		"ignored_roles", c.Ignored,
+	)
+}
+
+// reconcile sweeps the index against the source and repairs what the sync could
+// not have seen.
+//
+// A sync emits what is newer than the cursor, which means a document somebody
+// deleted usually produces no event at all: there is nothing left to walk past
+// or to list. Without this the deleted document stays in the index and keeps
+// being served, and the only thing that would ever remove it is a restart.
+//
+// The cost is a second pass over the source, metadata only, plus a two column
+// scan of the index. On a corpus where the sync itself is already a stat per
+// file that is roughly double the cheap half of the work and none of the
+// expensive half, which is the right trade for the alternative being an index
+// that serves documents that no longer exist.
+func reconcile(ctx context.Context, pipeline *ingest.Pipeline, src connector.Connector, tenant string, log *slog.Logger) {
+	rec, err := pipeline.Reconcile(ctx, genba.TenantID(tenant), src)
+	if err != nil {
+		// Not fatal, and not even unusual. A store that cannot list what it holds
+		// or a connector that cannot enumerate simply has no sweep, and the sync
+		// that just finished is still good.
+		log.Warn("reconciliation skipped", "source", src.Source(), "error", err)
+		return
+	}
+	if rec.Drift() == 0 {
+		return
+	}
+	// Logged at warning level because drift is the interesting event. An index
+	// that agrees with its source produces nothing here, so a line in the log
+	// means the incremental path missed something and is worth going to look at.
+	log.Warn("reconciled",
+		"source", rec.Source,
+		"source_items", rec.SourceItems,
+		"index_items", rec.IndexItems,
+		"missing", rec.Missing.Count,
+		"stale", rec.Stale.Count,
+		"extra", rec.Extra.Count,
+		"repaired", rec.Repaired,
+		"deleted", rec.Deleted,
+		"sample_missing", rec.Missing.IDs,
+		"sample_stale", rec.Stale.IDs,
+		"sample_extra", rec.Extra.IDs,
+		"requests", rec.Requests.Requests(),
+		"duration", rec.Duration.Round(time.Millisecond),
+	)
+}
+
+// megabytes converts a byte count for the log.
+func megabytes(n int64) float64 {
+	return float64(n) / (1 << 20)
+}
+
+// throughput is megabytes a second, and zero for a run too short for the clock
+// to have moved, which would otherwise divide by zero and log an infinity.
+func throughput(bytes int64, d time.Duration) float64 {
+	if d <= 0 {
+		return 0
+	}
+	return megabytes(bytes) / d.Seconds()
+}

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -79,11 +79,28 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	fs.BoolVar(&corpus.Watch, "corpus-watch", false, "ask the operating system what changed instead of walking the tree, needs -corpus-refresh")
 	fs.DurationVar(&corpus.Reconcile, "corpus-reconcile", 0, "how often to sweep the index against the directory, zero for after every sync")
 
+	var bucket bucketOptions
+	fs.StringVar(&bucket.Bucket, "bucket", "", "S3 compatible bucket to index at startup")
+	fs.StringVar(&bucket.Endpoint, "bucket-endpoint", "", "base URL of the object storage service, for example https://s3.eu-west-1.amazonaws.com")
+	fs.StringVar(&bucket.Region, "bucket-region", "us-east-1", "region the bucket is in, which is part of what a signature authenticates")
+	fs.StringVar(&bucket.Prefix, "bucket-prefix", "", "read only the keys under this prefix, empty for the whole bucket")
+	fs.StringVar(&bucket.Name, "bucket-name", "objects", "source name the indexed objects carry")
+	fs.StringVar(&bucket.ACL, "bucket-acl", aclTenant, "who may read the objects: tenant, bucket or object")
+	fs.StringVar(&bucket.Identity, "bucket-identity", "", "identity source the names in the access control lists belong to, for -bucket-acl bucket or object")
+	fs.StringVar(&bucket.Domain, "bucket-domain", "", "mail domain that counts as this tenant in a grant written against an address, empty for none")
+	fs.BoolVar(&bucket.PathStyle, "bucket-path-style", false, "put the bucket in the path rather than in the host name, which MinIO and Ceph need")
+	fs.DurationVar(&bucket.Refresh, "bucket-refresh", 0, "how often to list the bucket again, zero for once")
+	fs.DurationVar(&bucket.Reconcile, "bucket-reconcile", 0, "how often to sweep the index against the bucket, zero for after every sync")
+
 	showVersion := fs.Bool("version", false, "print the version and exit")
 	fs.Usage = func() {
 		fmt.Fprintf(stderr, "genbad runs the genba server.\n\nUsage:\n  genbad [flags]\n\nFlags:\n")
 		fs.PrintDefaults()
-		fmt.Fprintf(stderr, "\nEvery flag also has an environment variable, named GENBA_ plus the flag in upper case.\n")
+		fmt.Fprintf(stderr, "\nThe server flags also have environment variables, named GENBA_ plus the flag in upper case.\n")
+		fmt.Fprintf(stderr, "The corpus and bucket flags do not, because what to index is typed once rather than deployed.\n")
+		fmt.Fprintf(stderr, "Object storage credentials are the other way round and are read only from AWS_ACCESS_KEY_ID,\n")
+		fmt.Fprintf(stderr, "AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN, because a secret in argv is readable by every\n")
+		fmt.Fprintf(stderr, "process on the machine.\n")
 	}
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -96,6 +113,10 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		return err
 	}
 	if err := corpus.validate(); err != nil {
+		return err
+	}
+	bucket.credentials(getenv)
+	if err := bucket.validate(); err != nil {
 		return err
 	}
 
@@ -111,13 +132,22 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		}
 	}()
 
-	// The first sync runs here, before the listener opens, so that the server is
-	// useful the moment it says it is up.
+	// The first sync of each source runs here, before the listener opens, so
+	// that the server is useful the moment it says it is up. A server pointed at
+	// both indexes both, and the two are separate feeds with separate cursors
+	// rather than one merged crawl, because a bucket that is refusing requests
+	// should not stop a directory being reindexed.
 	waitForCorpus, err := ingestCorpus(ctx, st, corpus, cfg.Tenant, log)
 	if err != nil {
 		return err
 	}
 	defer waitForCorpus()
+
+	waitForBucket, err := ingestBucket(ctx, st, bucket, cfg.Tenant, log)
+	if err != nil {
+		return err
+	}
+	defer waitForBucket()
 
 	opts := []api.Option{api.WithLogger(log)}
 	if h := web.Handler(); h != nil {

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -239,6 +239,72 @@ The default is unchanged and sweeps after every sync.
 The sweep keeps an id and a version per source document in memory for its duration, which is tens of megabytes for a corpus of a few million.
 The alternative is sorting both sides on disk and merging them, which is the right answer an order of magnitude further up and is not worth its complexity yet.
 
+## Configuring a source
+
+`genbad` can be pointed at a directory, at a bucket, or at both at once.
+The two are separate feeds with separate cursors rather than one merged crawl, because a bucket that is refusing requests should not stop a directory being reindexed.
+
+A directory, watched, sweeping every five minutes:
+
+```
+genbad \
+  -tenant acme \
+  -corpus ~/src/handbook \
+  -corpus-name handbook \
+  -corpus-acl owners \
+  -corpus-refresh 1s \
+  -corpus-watch \
+  -corpus-reconcile 5m
+```
+
+`-corpus-acl owners` reads the OWNERS files in the tree, which is a real access control list maintained by real people.
+The other two are `tenant`, where everybody in the tenant may read everything, and `os`, which reads the mode bits and needs `-corpus-identity` to say which directory the account names belong to.
+
+A bucket, listed every thirty seconds, scoped to one prefix:
+
+```
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+genbad \
+  -tenant acme \
+  -bucket company-docs \
+  -bucket-endpoint https://s3.eu-west-1.amazonaws.com \
+  -bucket-region eu-west-1 \
+  -bucket-prefix handbook/ \
+  -bucket-name handbook \
+  -bucket-acl bucket \
+  -bucket-identity google \
+  -bucket-domain acme.com \
+  -bucket-refresh 30s \
+  -bucket-reconcile 15m
+```
+
+The credentials are read from the environment and there is no flag for them.
+A secret in argv is readable by every process on the machine for as long as the server runs, and it ends up in the shell history of whoever started it.
+The names are the ones every other tool in this space already uses, so a machine that can already reach the bucket needs nothing new set.
+A bucket with no credentials at all is read unsigned, which is what a public bucket wants and what nothing else does.
+
+`-bucket-acl bucket` reads the bucket's own access control list once per sync and gives that answer for every object in it, which is one request rather than a million.
+`-bucket-acl object` reads each object's own list, which is exact and costs a request per object per sync, so it is worth reaching for only when the objects really do differ.
+`-bucket-domain` is what a grant written against an email address is checked against, and a grant to an address outside it is quarantined rather than published.
+
+A service that is not S3 itself almost certainly needs `-bucket-path-style`, which puts the bucket in the path rather than in the host name.
+MinIO on a laptop is the shortest way to try the whole thing:
+
+```
+genbad \
+  -tenant acme \
+  -bucket corpus \
+  -bucket-endpoint http://127.0.0.1:9000 \
+  -bucket-path-style \
+  -bucket-refresh 5s
+```
+
+Both feeds log the same numbers after every sync, under `corpus synced` and `bucket synced`.
+The directory adds what its watcher has to say, and the bucket adds the request counts, which are what a bill is made of.
+A listing count that climbs by one per sync is a healthy incremental run, and a fetch count that climbs with it on a bucket nobody is writing to means the cursor is not doing its job.
+
 ## Writing a connector
 
 The required interface is still three methods, and a connector that implements only those works.


### PR DESCRIPTION
Closes #14.

`objectsource` has been able to read a bucket for a while and nothing could ask it to.
There were no flags for it, so trying it meant writing a Go program.
This wires it into `genbad` and finishes the last box on #14, which asked for a working configuration example for both connectors.

## Flags

```
-bucket             bucket to index at startup
-bucket-endpoint    base URL of the service, for example https://s3.eu-west-1.amazonaws.com
-bucket-region      region the bucket is in, which is part of what a signature authenticates
-bucket-prefix      read only the keys under this prefix
-bucket-name        source name the documents carry
-bucket-acl         tenant, bucket or object
-bucket-identity    identity source the names in the access control lists belong to
-bucket-domain      mail domain that counts as this tenant
-bucket-path-style  put the bucket in the path rather than in the host name
-bucket-refresh     how often to list the bucket again
-bucket-reconcile   how often to sweep the index against the bucket
```

```
genbad -tenant acme \
  -bucket company-docs \
  -bucket-endpoint https://s3.eu-west-1.amazonaws.com \
  -bucket-region eu-west-1 \
  -bucket-prefix handbook/ \
  -bucket-acl bucket \
  -bucket-identity google \
  -bucket-domain acme.com \
  -bucket-refresh 30s \
  -bucket-reconcile 15m
```

## Credentials are not flags

They come from `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` and there is no flag for any of them.
A secret in argv is readable by every process on the machine for as long as the server runs, and it ends up in the shell history of whoever started it.
The names are the ones every other tool in this space already uses, so a machine that can already reach the bucket needs nothing new set.
A bucket with no credentials at all is read unsigned, which is what a public bucket wants.

Half a set is rejected at startup, because the alternative is a refusal that says the signature did not match, which sends whoever reads it looking at the clock and the region rather than at the one variable they forgot to export.

## The three permission models

`-bucket-acl tenant` asks nothing and is right for published documentation.
`-bucket-acl bucket` reads the bucket's own access control list once per sync and gives that answer for every object in it, which is one request rather than a million, and it is also the only one of the three that can notice a revocation without a resync.
`-bucket-acl object` reads each object's own list, which is exact and costs a request per object per sync.

The policy is built on the same client as the source, so what the permission lookups cost and what the reads cost land in one set of counters rather than two that have to be added up by hand.

## Two feeds, one server

A server can be given both a corpus and a bucket, and they run as two feeds with two cursors rather than one merged crawl.
A bucket that is refusing requests does not stop the directory being reindexed, and there is a test for exactly that.

The sync loop that both use is now in `cmd/genbad/feed.go`.
It was the loop `ingestCorpus` had, moved out unchanged: sync once before the listener opens, sync again on the interval, sweep the index against the source on its own interval, log the same numbers each time.
`reportMapping` now takes an `any` rather than an `fssource.Policy`, since the two connectors have unrelated policy interfaces and what it wants is the one method some of their implementations share.

Each feed adds its own fields to the log line.
The directory adds what its watcher has to say, and the bucket adds the request counts, which are what a bill is made of.
A listing count that climbs by one per sync is a healthy incremental run, and a fetch count that climbs with it on a bucket nobody is writing to means the cursor is not doing its job.

## Tests

`cmd/genbad/bucket_test.go` runs a small in memory S3 service and starts a real server against it.
It covers the flag checks, the credentials coming from the environment and not from a flag, a bucket with no tenant being refused, a query finding an object by its heading, the prefix keeping what is outside it out of the index, an object added after startup becoming searchable, an object removed leaving the index on the sweep, a server reading a directory and a bucket at once, and a bucket that answers every request with a refusal leaving the directory feed working.

The fake is in the test rather than in a container because what these tests are about is the wiring: that the flags reach a client, that the client reaches a service, and that what comes back is searchable.
Whether a real service accepts these signatures and returns this XML is checked against the published examples in `connector/objectsource`.

`arch_test.go` gains `connector/objectsource` on the `cmd/genbad` row.

Docs: `docs/ingestion.md` has a new "Configuring a source" section with worked examples for a watched directory, a scoped bucket and MinIO on a laptop, and the README has the flag table and the credentials note.
