### PR TITLE
connector: keep a crawl inside the limits of what it is reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ The same server can read an S3 compatible bucket, either instead of a directory 
 | `-bucket-path-style` | `false` | put the bucket in the path rather than in the host name, which MinIO and Ceph need |
 | `-bucket-refresh` | `0` | how often to list the bucket again, zero for once at startup |
 | `-bucket-reconcile` | `0` | how often to sweep the index against the bucket, zero for after every sync |
+| `-bucket-rate` | `5` | requests per second the crawl keeps itself under |
+| `-bucket-burst` | `10` | how many requests may go out back to back before the rate binds |
+| `-bucket-retries` | `4` | how many times to try a refused request again, negative for never |
 
 Credentials come from `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`, and there is no flag for them.
 A secret in argv is readable by every process on the machine for as long as the server runs, and it ends up in the shell history of whoever started it.
@@ -212,6 +215,12 @@ genbad -tenant acme \
 
 A server given both a corpus and a bucket runs them as two feeds with two cursors rather than one merged crawl, so a bucket that is refusing requests does not stop the directory being reindexed.
 `docs/ingestion.md` has the worked examples for both, including MinIO on a laptop.
+
+Every request the bucket makes goes out through one rate limiter, and there is no value of `-bucket-rate` meaning unlimited.
+A crawler that ignores a service's limits gets the credentials revoked, and that is a worse outcome than a slow crawl by a wide margin: a slow crawl finishes late, and a revoked key is an index that stops updating until somebody has a conversation about it.
+Anybody who knows their quota can set a rate high enough that it never binds, which is a number in the log rather than a special case in the code.
+A refusal that says to come back later is waited out rather than failed, with the wait doubling up to half a minute and the source's own `Retry-After` honoured over anything computed, and a source that has been refusing everything stops the sync rather than being retried all afternoon.
+The `bucket synced` line carries `retries`, `throttled`, `throttled_for` and `quota_pauses`, because a crawl that is being throttled looks exactly like a crawl that is slow and the difference decides whether you go looking at the network or ask for more quota.
 
 ## Metrics
 
@@ -306,6 +315,7 @@ func main() {
 | `connector` | the ingestion contract, cursors and checkpoints |
 | `connector/fssource` | the reference connector, a directory tree with OWNERS files, walked or watched |
 | `connector/objectsource` | an S3 compatible bucket, signed and paged, [docs/ingestion.md](docs/ingestion.md) |
+| `connector/limit` | the rate limit, backoff and circuit breaker every connector shares, as a round tripper |
 | `extract` | text and structure out of PDF, Word, PowerPoint, Excel, HTML and Markdown, [docs/extraction.md](docs/extraction.md) |
 | `ingest` | the pipeline that runs a connector into a store |
 | `config` | runtime configuration and the rules for loading it |

--- a/arch_test.go
+++ b/arch_test.go
@@ -135,6 +135,12 @@ var allowed = map[string][]string{
 	// that difference is allowed to show up as a dependency: an S3 client of our
 	// own is a file in the package rather than a layer under it.
 	"connector/objectsource": {"acl", "connector", "connector/aclmap", "doc", "extract"},
+	// limit imports nothing of ours at all. It is a round tripper and a token
+	// bucket, and the only thing it knows about a crawl is that requests go out
+	// on an http.Client. A rate limiter that imported connector would be one that
+	// could only limit our connectors, and the reason it is a round tripper in the
+	// first place is that the limit belongs to the service rather than to us.
+	"connector/limit": nil,
 	// ingest names acl because a permission change that arrives without the
 	// document is a map of access control lists and nothing else, and there is
 	// no way to carry one without saying what it is. It is the one type from
@@ -150,7 +156,7 @@ var allowed = map[string][]string{
 	"benchcorpus/gen": {"benchcorpus", "store/sqlitestore"},
 
 	"cmd/genba":  {""},
-	"cmd/genbad": {"", "api", "config", "connector", "connector/aclmap", "connector/fssource", "connector/objectsource", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
+	"cmd/genbad": {"", "api", "config", "connector", "connector/aclmap", "connector/fssource", "connector/limit", "connector/objectsource", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
 }
 
 func TestDependencyDirection(t *testing.T) {

--- a/cmd/genbad/bucket.go
+++ b/cmd/genbad/bucket.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
+	"github.com/tamnd/genba/connector/limit"
 	"github.com/tamnd/genba/connector/objectsource"
 	"github.com/tamnd/genba/store"
 )
@@ -62,6 +64,22 @@ type bucketOptions struct {
 	// Reconcile is how often to sweep the index against the bucket. Zero sweeps
 	// after every sync.
 	Reconcile time.Duration
+
+	// Rate and Burst are the ceiling the crawl keeps itself under, in requests
+	// per second and in how many may go out back to back before the rate binds.
+	//
+	// There is no value meaning unlimited. A crawler that ignores a service's
+	// limits gets the credentials revoked, and that is a worse outcome than a
+	// slow crawl by a wide margin: a slow crawl finishes late, and a revoked key
+	// is an index that stops updating until somebody has a conversation about it.
+	// Anybody who knows their quota can set a rate high enough that it never
+	// binds, which is a number in the log rather than a special case.
+	Rate  float64
+	Burst int
+
+	// Retries is how many times a refused request is tried again before the sync
+	// gives up on it. Negative turns retrying off.
+	Retries int
 
 	// Access, Secret and Session are the credentials, and they are read from the
 	// environment rather than taken from a flag.
@@ -127,7 +145,15 @@ func (o bucketOptions) validate() error {
 	if o.Reconcile < 0 {
 		return errors.New("bucket reconcile interval is negative")
 	}
-	return nil
+	return o.limits().Validate()
+}
+
+// limits is the ceiling the bucket crawl runs under.
+//
+// Everything left at zero takes the package's default, which is deliberately
+// cautious, so a server started with nothing but -bucket is still limited.
+func (o bucketOptions) limits() limit.Limits {
+	return limit.Limits{Rate: o.Rate, Burst: o.Burst, MaxRetries: o.Retries}
 }
 
 // bucketPolicyFor builds the permission policy named by the flags.
@@ -178,6 +204,12 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 		return nil, errors.New("ingesting a bucket needs -tenant")
 	}
 
+	// Every request the bucket makes, for listings, for permissions and for the
+	// objects themselves, goes out through one transport, because the quota they
+	// are spending is one quota. Sharing it is the whole reason the limiter is a
+	// round tripper rather than something the connector calls.
+	limiter := limit.NewTransport(cfg.limits(), limit.WithLogger(log))
+
 	client, err := objectsource.NewClient(objectsource.Config{
 		Endpoint:        cfg.Endpoint,
 		Region:          cfg.Region,
@@ -186,7 +218,10 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 		SecretAccessKey: cfg.Secret,
 		SessionToken:    cfg.Session,
 		PathStyle:       cfg.PathStyle,
-	})
+	}, objectsource.WithHTTPClient(&http.Client{
+		Transport: limiter,
+		Timeout:   patience(cfg.limits()),
+	}))
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +255,7 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 		Refresh:   cfg.Refresh,
 		Reconcile: cfg.Reconcile,
 		Fields:    []any{"bucket", cfg.Bucket, "prefix", cfg.Prefix, "source", cfg.Name},
-		Report:    func() []any { return requesting(client) },
+		Report:    func() []any { return requesting(client, limiter) },
 		Policy:    policy,
 		Release:   func() { _ = src.Close() },
 	}, log)
@@ -233,12 +268,42 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 // count that climbs by one per sync is a healthy incremental run, and a fetch
 // count that climbs with it on a bucket nobody is writing to means the cursor
 // is not doing its job.
-func requesting(c *objectsource.Client) []any {
+func requesting(c *objectsource.Client, t *limit.Transport) []any {
 	n := c.Counters()
+	s := t.Stats()
 	return []any{
 		"lists", n.Lists,
 		"metadata", n.Metadata,
 		"fetches", n.Fetches,
 		"fetched_mb", megabytes(n.Bytes),
+		// A crawl that is being throttled looks exactly like a crawl that is
+		// slow, and the difference decides whether somebody goes looking at the
+		// network or asks for more quota. These four are the difference.
+		"retries", s.Retries,
+		"throttled", s.Limiter.Waits,
+		"throttled_for", s.Limiter.Waited.Round(time.Millisecond).String(),
+		"quota_pauses", s.Limiter.Pauses,
 	}
+}
+
+// patience bounds one request from the client's side.
+//
+// The timeout on an http.Client covers everything the round tripper does, and
+// this round tripper waits on purpose, so a timeout meant for one request would
+// cut a legitimate backoff short and turn a source asking to be left alone for
+// thirty seconds into a failed sync. The budget is the time the retries can
+// spend plus the time one request is allowed to take.
+func patience(l limit.Limits) time.Duration {
+	retries := l.MaxRetries
+	switch {
+	case retries == 0:
+		retries = limit.DefaultMaxRetries
+	case retries < 0:
+		retries = 0
+	}
+	backoff := l.MaxBackoff
+	if backoff <= 0 {
+		backoff = limit.DefaultMaxBackoff
+	}
+	return objectsource.DefaultRequestTimeout + time.Duration(retries)*backoff
 }

--- a/cmd/genbad/bucket_test.go
+++ b/cmd/genbad/bucket_test.go
@@ -40,6 +40,9 @@ func TestBucketFlagsAreChecked(t *testing.T) {
 		{"both of them", with(func(o *bucketOptions) { o.Access, o.Secret = "AKIA", "shhh" }), ""},
 		{"a negative refresh", with(func(o *bucketOptions) { o.Refresh = -time.Second }), "negative"},
 		{"a negative reconcile interval", with(func(o *bucketOptions) { o.Reconcile = -time.Second }), "negative"},
+		{"a negative rate", with(func(o *bucketOptions) { o.Rate = -1 }), "negative"},
+		{"a negative burst", with(func(o *bucketOptions) { o.Burst = -1 }), "negative"},
+		{"retrying turned off", with(func(o *bucketOptions) { o.Retries = -1 }), ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -202,6 +205,47 @@ func TestABucketThatRefusesDoesNotStopTheServer(t *testing.T) {
 	}
 }
 
+// The crawl keeps itself under the rate it was given, which is the difference
+// between a connector that is welcome to keep reading and one whose credentials
+// get revoked while nobody is watching.
+func TestTheBucketCrawlStaysUnderItsRate(t *testing.T) {
+	store := newBucket(t)
+	for _, key := range []string{"a.md", "b.md", "c.md", "d.md"} {
+		store.put(key, "# "+key+"\n\nSomething worth reading.\n")
+	}
+
+	addr := freeAddr(t)
+	began := time.Now()
+	stop := serve(t, addr,
+		"-bucket", theBucket,
+		"-bucket-endpoint", store.url,
+		"-bucket-path-style",
+		"-bucket-rate", "20",
+		"-bucket-burst", "1",
+	)
+	defer stop()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+	took := time.Since(began)
+
+	hits := store.hits()
+	if hits < 5 {
+		t.Fatalf("the crawl made %d requests, want at least a listing and the four objects", hits)
+	}
+	// One request went out on the burst and every one after it waited fifty
+	// milliseconds, so a crawl that finished sooner than that was not limited at
+	// all. Against an in process service the same work takes single figures of
+	// milliseconds unlimited, so there is no way for this to pass by accident.
+	want := time.Duration(hits-1) * 50 * time.Millisecond
+	if took < want {
+		t.Errorf("the crawl took %v for %d requests, want at least %v", took, hits, want)
+	}
+
+	if got := searchAs(t, addr, "alice", "something worth reading"); got.Total < 4 {
+		t.Errorf("total = %d, want the four objects to still be indexed", got.Total)
+	}
+}
+
 // serve starts the server with the given flags and returns the function that
 // stops it and waits for it to be gone.
 func serve(t *testing.T, addr string, args ...string) func() {
@@ -242,9 +286,10 @@ const theBucket = "corpus"
 type bucketFake struct {
 	url string
 
-	mu      sync.Mutex
-	objects map[string]string
-	clock   time.Time
+	mu       sync.Mutex
+	objects  map[string]string
+	clock    time.Time
+	requests int
 }
 
 func newBucket(t *testing.T) *bucketFake {
@@ -276,10 +321,19 @@ func (f *bucketFake) remove(key string) {
 	f.clock = f.clock.Add(time.Minute)
 }
 
+// hits is how many requests the fake has answered, which is what a rate is
+// measured against.
+func (f *bucketFake) hits() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.requests
+}
+
 func (f *bucketFake) handle(w http.ResponseWriter, r *http.Request) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
+	f.requests++
 	w.Header().Set("Date", f.clock.UTC().Format(http.TimeFormat))
 	key := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/"+theBucket), "/")
 	if unescaped, err := url.PathUnescape(key); err == nil {

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tamnd/genba"
 	"github.com/tamnd/genba/api"
 	"github.com/tamnd/genba/config"
+	"github.com/tamnd/genba/connector/limit"
 	"github.com/tamnd/genba/index"
 	"github.com/tamnd/genba/store"
 	"github.com/tamnd/genba/store/memstore"
@@ -91,6 +92,9 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	fs.BoolVar(&bucket.PathStyle, "bucket-path-style", false, "put the bucket in the path rather than in the host name, which MinIO and Ceph need")
 	fs.DurationVar(&bucket.Refresh, "bucket-refresh", 0, "how often to list the bucket again, zero for once")
 	fs.DurationVar(&bucket.Reconcile, "bucket-reconcile", 0, "how often to sweep the index against the bucket, zero for after every sync")
+	fs.Float64Var(&bucket.Rate, "bucket-rate", limit.DefaultRate, "requests per second the crawl keeps itself under, there is no unlimited")
+	fs.IntVar(&bucket.Burst, "bucket-burst", limit.DefaultBurst, "how many requests may go out back to back before the rate binds")
+	fs.IntVar(&bucket.Retries, "bucket-retries", limit.DefaultMaxRetries, "how many times to try a refused request again, negative for never")
 
 	showVersion := fs.Bool("version", false, "print the version and exit")
 	fs.Usage = func() {

--- a/connector/limit/limit.go
+++ b/connector/limit/limit.go
@@ -1,0 +1,160 @@
+// Package limit keeps a connector inside the limits of the service it is
+// reading.
+//
+// A crawler that ignores an API's limits gets the company's integration token
+// revoked, and that is a worse outcome than a slow crawl by a wide margin. A
+// slow crawl finishes late. A revoked token is an index that stops updating,
+// a conversation with whoever owns the integration, and in most companies a
+// week before anybody is allowed to try again.
+//
+// # What it is
+//
+// [Transport] is an [net/http.RoundTripper] that wraps another one and does
+// four things around every request: it waits for a token so that the request
+// rate stays under a ceiling, it reads what the response says about the quota
+// and holds the next request back when the quota is gone, it retries what is
+// worth retrying with bounded jittered backoff, and it stops the source
+// altogether when it has been refusing everything.
+//
+// It is a round tripper rather than a wrapper around each connector because
+// that is the layer where the requests actually are. A connector built on
+// [net/http.Client] gets all of this by being handed a different client, which
+// is one line at the call site and nothing at all inside the connector.
+//
+//	client := &http.Client{Transport: limit.NewTransport(limit.Limits{Rate: 8, Burst: 16})}
+//	src, err := objectsource.New(objectsource.NewClient(cfg, objectsource.WithHTTPClient(client)), ...)
+//
+// # One limiter per source
+//
+// A limiter belongs to one source because a quota does. Two connectors reading
+// two different services have nothing to do with each other and sharing a
+// limiter between them would mean a slow wiki holding up a fast bucket. Two
+// connectors reading the same service with the same credentials share a quota
+// whether they like it or not, and those two should share one [Transport].
+//
+// # What is not here
+//
+// There is no queue and no worker pool. A connector's Sync is one goroutine
+// making one request at a time, blocked while the pipeline indexes what it
+// handed over, and that backpressure is the thing that keeps memory bounded.
+// Adding concurrency here would remove it.
+package limit
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// The defaults, which are deliberately cautious.
+//
+// A default that is too slow costs a longer first sync and nothing else. A
+// default that is too fast costs the token. Anybody who knows their quota can
+// say so, and anybody who does not is better served by the crawl that finishes
+// than by the one that gets cut off.
+const (
+	DefaultRate       = 5.0
+	DefaultBurst      = 10
+	DefaultMaxRetries = 4
+	DefaultMinBackoff = 500 * time.Millisecond
+	DefaultMaxBackoff = 30 * time.Second
+	DefaultFailures   = 5
+	DefaultCooldown   = time.Minute
+)
+
+// Limits is what a source is allowed to cost.
+//
+// Every field has a default and the zero value is a working configuration, so
+// a caller who only knows one of these numbers sets that one.
+type Limits struct {
+	// Rate is the sustained ceiling in requests per second. A negative rate is
+	// rejected and zero selects [DefaultRate].
+	//
+	// There is no value meaning unlimited, on purpose. A crawler with no ceiling
+	// is the thing this package exists to prevent, and an operator who wants one
+	// can ask for a rate high enough that it never binds, which is a number in
+	// the log rather than a special case in the code.
+	Rate float64
+
+	// Burst is how many requests may go out back to back before the rate binds.
+	//
+	// It exists because real work is lumpy. A page of a listing followed
+	// immediately by the four documents on it is a burst of five, and a limiter
+	// with no burst would space them out for no reason: the quota is a rate over
+	// a window and the window is not one request wide.
+	Burst int
+
+	// MaxRetries is how many times one request is tried again after a refusal
+	// worth retrying. Zero selects [DefaultMaxRetries] and a negative value
+	// turns retrying off.
+	MaxRetries int
+
+	// MinBackoff and MaxBackoff bound the wait between attempts. The wait
+	// doubles from the first towards the second and is jittered, and a source
+	// that named its own time in a header overrides both.
+	MinBackoff time.Duration
+	MaxBackoff time.Duration
+
+	// Failures is how many consecutive failures open the circuit. Zero selects
+	// [DefaultFailures].
+	Failures int
+
+	// Cooldown is how long the circuit stays open before one request is let
+	// through to find out whether the source has recovered.
+	Cooldown time.Duration
+}
+
+// withDefaults fills in what the caller left alone.
+func (l Limits) withDefaults() Limits {
+	if l.Rate == 0 {
+		l.Rate = DefaultRate
+	}
+	if l.Burst <= 0 {
+		l.Burst = DefaultBurst
+	}
+	if l.MaxRetries == 0 {
+		l.MaxRetries = DefaultMaxRetries
+	}
+	if l.MaxRetries < 0 {
+		l.MaxRetries = 0
+	}
+	if l.MinBackoff <= 0 {
+		l.MinBackoff = DefaultMinBackoff
+	}
+	if l.MaxBackoff <= 0 {
+		l.MaxBackoff = DefaultMaxBackoff
+	}
+	if l.MaxBackoff < l.MinBackoff {
+		l.MaxBackoff = l.MinBackoff
+	}
+	if l.Failures <= 0 {
+		l.Failures = DefaultFailures
+	}
+	if l.Cooldown <= 0 {
+		l.Cooldown = DefaultCooldown
+	}
+	return l
+}
+
+// Validate reports the first thing about the limits that would make a crawl
+// misbehave.
+//
+// It is separate from the defaults because the two answer different questions.
+// A field left at zero is somebody who did not have an opinion, and a field set
+// to minus one is somebody who had one and got it wrong.
+func (l Limits) Validate() error {
+	errs := make([]error, 0, 3)
+	if l.Rate < 0 {
+		errs = append(errs, fmt.Errorf("limit: rate %v is negative", l.Rate))
+	}
+	if l.Burst < 0 {
+		errs = append(errs, fmt.Errorf("limit: burst %d is negative", l.Burst))
+	}
+	if l.MinBackoff < 0 || l.MaxBackoff < 0 {
+		errs = append(errs, errors.New("limit: a backoff is negative"))
+	}
+	if l.Cooldown < 0 {
+		errs = append(errs, errors.New("limit: cooldown is negative"))
+	}
+	return errors.Join(errs...)
+}

--- a/connector/limit/limit_test.go
+++ b/connector/limit/limit_test.go
@@ -1,0 +1,294 @@
+package limit_test
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/connector/limit"
+)
+
+// start is a fixed point for the fake clock, so that every duration in these
+// tests is arithmetic rather than a race with the machine.
+var start = time.Date(2026, time.April, 1, 9, 0, 0, 0, time.UTC)
+
+// fakeClock is a clock that only moves when something waits on it.
+//
+// Sleeping jumps straight to the end of the wait and records how long it was
+// for, which is what makes an hour of backoff take a microsecond and makes the
+// assertions exact. A test that slept for real would either be slow enough that
+// nobody runs it or short enough that it fails on a loaded machine, and the
+// second kind of test gets deleted rather than fixed.
+//
+// A held clock records waits without moving. It is for the tests with more than
+// one goroutine in them, where a sleep that moved the shared clock would refill
+// the bucket for whoever was not sleeping and make the answer depend on how the
+// two were scheduled.
+type fakeClock struct {
+	held bool
+
+	mu    sync.Mutex
+	now   time.Time
+	slept []time.Duration
+}
+
+func newClock() *fakeClock {
+	return &fakeClock{now: start}
+}
+
+func newHeldClock() *fakeClock {
+	return &fakeClock{now: start, held: true}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Sleep(ctx context.Context, d time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d <= 0 {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.slept = append(c.slept, d)
+	if !c.held {
+		c.now = c.now.Add(d)
+	}
+	return nil
+}
+
+// advance moves the clock without anything having waited, which is how a test
+// says time passed while the crawl was doing something else.
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// sleeps is every wait the clock was asked for, in order.
+func (c *fakeClock) sleeps() []time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.slept)
+}
+
+// total is how long the clock was asked to wait for altogether.
+func (c *fakeClock) total() time.Duration {
+	var sum time.Duration
+	for _, d := range c.sleeps() {
+		sum += d
+	}
+	return sum
+}
+
+func TestTheDefaultsAreAWorkingConfiguration(t *testing.T) {
+	if err := (limit.Limits{}).Validate(); err != nil {
+		t.Fatalf("the zero limits are not usable: %v", err)
+	}
+	// A limiter built from nothing still limits, which is the property that
+	// matters: forgetting to configure one is not the same as turning it off.
+	clock := newClock()
+	l := limit.NewLimiter(limit.Limits{}, clock)
+	for range limit.DefaultBurst + 1 {
+		if err := l.Wait(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if clock.total() == 0 {
+		t.Error("a limiter with no configuration let an unlimited burst through")
+	}
+}
+
+func TestLimitsAreChecked(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit limit.Limits
+		ok    bool
+	}{
+		{"nothing set", limit.Limits{}, true},
+		{"a whole configuration", limit.Limits{Rate: 8, Burst: 16, MaxRetries: 3, MinBackoff: time.Second, MaxBackoff: time.Minute, Failures: 4, Cooldown: time.Minute}, true},
+		{"a negative rate", limit.Limits{Rate: -1}, false},
+		{"a negative burst", limit.Limits{Burst: -1}, false},
+		{"a negative backoff", limit.Limits{MinBackoff: -time.Second}, false},
+		{"a negative cooldown", limit.Limits{Cooldown: -time.Second}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.limit.Validate()
+			if tt.ok && err != nil {
+				t.Fatalf("rejected a usable set: %v", err)
+			}
+			if !tt.ok && err == nil {
+				t.Fatalf("accepted %+v", tt.limit)
+			}
+		})
+	}
+}
+
+// The burst goes out immediately and the rate binds after it, which is the
+// whole of what a token bucket is for: real work is lumpy and a quota is not
+// one request wide.
+func TestABurstGoesOutAtOnceAndTheRateBindsAfterIt(t *testing.T) {
+	clock := newClock()
+	l := limit.NewLimiter(limit.Limits{Rate: 10, Burst: 3}, clock)
+
+	for range 3 {
+		if err := l.Wait(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := clock.sleeps(); len(got) != 0 {
+		t.Fatalf("the burst waited for %v", got)
+	}
+
+	if err := l.Wait(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	// Ten a second is one every hundred milliseconds, and the bucket is empty.
+	if got := clock.total(); got != 100*time.Millisecond {
+		t.Errorf("the fourth request waited %v, want 100ms", got)
+	}
+}
+
+// The bucket refills while nothing is asking, so a crawl that paused for its
+// own reasons is not then punished for it.
+func TestTheBucketRefillsWhileNothingIsAsking(t *testing.T) {
+	clock := newClock()
+	l := limit.NewLimiter(limit.Limits{Rate: 10, Burst: 5}, clock)
+
+	for range 5 {
+		if err := l.Wait(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	clock.advance(time.Second)
+
+	for range 5 {
+		if err := l.Wait(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := clock.total(); got != 0 {
+		t.Errorf("a refilled bucket still waited %v", got)
+	}
+}
+
+// A pause is the source's own answer and outranks the ceiling the operator
+// configured, because the operator was guessing and the service knows.
+func TestAPauseOutranksTheBucket(t *testing.T) {
+	clock := newClock()
+	l := limit.NewLimiter(limit.Limits{Rate: 1000, Burst: 1000}, clock)
+
+	l.Pause(clock.Now().Add(30 * time.Second))
+	if at, held := l.Paused(); !held || !at.Equal(start.Add(30*time.Second)) {
+		t.Fatalf("Paused() = %v, %v", at, held)
+	}
+	if err := l.Wait(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if got := clock.total(); got != 30*time.Second {
+		t.Errorf("waited %v, want the thirty seconds the source asked for", got)
+	}
+	if got := l.Stats().Pauses; got != 1 {
+		t.Errorf("pauses = %d, want 1", got)
+	}
+}
+
+// A pause that has already run is not extended by a header that arrived late,
+// and a shorter one does not cut a longer one short.
+func TestAShorterPauseDoesNotShortenALongerOne(t *testing.T) {
+	clock := newClock()
+	l := limit.NewLimiter(limit.Limits{Rate: 1000, Burst: 1000}, clock)
+
+	l.Pause(clock.Now().Add(time.Minute))
+	l.Pause(clock.Now().Add(time.Second))
+	if err := l.Wait(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if got := clock.total(); got != time.Minute {
+		t.Errorf("waited %v, want the minute that was asked for first", got)
+	}
+}
+
+// A shutdown does not fire one last request. It would spend quota on a document
+// nobody is going to store.
+func TestACancelledContextStopsWaiting(t *testing.T) {
+	clock := newClock()
+	l := limit.NewLimiter(limit.Limits{Rate: 1, Burst: 1}, clock)
+	if err := l.Wait(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := l.Wait(ctx); err == nil {
+		t.Fatal("a cancelled crawl was let through")
+	}
+}
+
+// The counters are what say whether a ceiling is set sensibly, so they have to
+// be right.
+func TestTheLimiterCountsWhatItCost(t *testing.T) {
+	clock := newClock()
+	l := limit.NewLimiter(limit.Limits{Rate: 10, Burst: 1}, clock)
+
+	for range 4 {
+		if err := l.Wait(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := l.Stats()
+	if got.Waits != 3 {
+		t.Errorf("waits = %d, want the three that were held back", got.Waits)
+	}
+	if got.Waited != 300*time.Millisecond {
+		t.Errorf("waited = %v, want 300ms", got.Waited)
+	}
+}
+
+// Goroutines sharing a limiter queue behind each other rather than each
+// deciding on its own that it may go.
+//
+// The clock is held for this one so that the answer does not depend on the
+// order the eight were scheduled in. Every caller takes its token from the same
+// instant, so the bucket goes one token further into debt each time and each
+// caller waits ten milliseconds longer than the one before it, whoever got there
+// first.
+func TestConcurrentCallersQueueBehindEachOther(t *testing.T) {
+	clock := newHeldClock()
+	l := limit.NewLimiter(limit.Limits{Rate: 100, Burst: 1}, clock)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := l.Wait(t.Context()); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// One of the eight had the burst and went straight out. The other seven
+	// waited 10ms, 20ms and so on up to 70ms, which is 280ms of holding back.
+	if got := l.Stats().Waits; got != 7 {
+		t.Errorf("waits = %d, want the seven that were held back", got)
+	}
+	if got := l.Stats().Waited; got != 280*time.Millisecond {
+		t.Errorf("waited = %v, want 280ms", got)
+	}
+
+	// Nothing was let through twice on the same token, which is the thing a
+	// limiter with a lock in the wrong place gets wrong.
+	if got := len(clock.sleeps()); got != 7 {
+		t.Errorf("the clock was asked to wait %d times, want 7", got)
+	}
+}

--- a/connector/limit/limiter.go
+++ b/connector/limit/limiter.go
@@ -1,0 +1,196 @@
+package limit
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Clock is where a limiter reads the time and where it waits.
+//
+// It is an interface so that the tests can run an hour of backoff in a
+// microsecond. A limiter is almost entirely about durations, and a test suite
+// that checked those by sleeping would either be slow enough that nobody runs
+// it or short enough that it fails on a loaded machine, which is the failure
+// mode that gets a test deleted rather than fixed.
+type Clock interface {
+	// Now is the current time.
+	Now() time.Time
+
+	// Sleep waits for d, or returns the context's error if that happens first.
+	// A d of zero or less returns immediately.
+	Sleep(ctx context.Context, d time.Duration) error
+}
+
+// realClock is the wall clock.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+func (realClock) Sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// Limiter spaces requests out so that a source is asked for no more than it
+// said it would give.
+//
+// It is a token bucket, which is the shape that matches what services actually
+// enforce: a rate over a window, with a little room for a burst inside it. The
+// bucket is refilled by arithmetic on the clock rather than by a goroutine, so
+// a limiter that is never used costs nothing and a process holding a hundred of
+// them holds no timers.
+//
+// It is safe for concurrent use.
+type Limiter struct {
+	rate  float64
+	burst float64
+
+	mu     sync.Mutex
+	tokens float64
+	last   time.Time
+
+	// until is a wall the source itself asked for, out of a Retry-After or a
+	// quota reset. It outranks the bucket in both directions: nothing goes out
+	// before it whatever the bucket says, and it is not shortened by tokens
+	// having piled up while the crawl was waiting.
+	until time.Time
+
+	waits   int64
+	waited  time.Duration
+	paused  int64
+	clock   Clock
+	started bool
+}
+
+// NewLimiter returns a limiter for the given limits, with a full bucket.
+//
+// It starts full because the alternative punishes a process for having just
+// started. The first thing a crawl does is a listing followed by the documents
+// on it, and making that wait for a bucket to fill would add a delay that
+// protects nobody: no requests have been made yet, so no quota has been spent.
+func NewLimiter(l Limits, clock Clock) *Limiter {
+	l = l.withDefaults()
+	if clock == nil {
+		clock = realClock{}
+	}
+	return &Limiter{
+		rate:   l.Rate,
+		burst:  float64(l.Burst),
+		tokens: float64(l.Burst),
+		clock:  clock,
+	}
+}
+
+// Wait blocks until a request may go out, or until the context is done.
+//
+// It returns the context's error rather than going ahead when a crawl is being
+// shut down, which matters more here than it looks: a shutdown that fired one
+// last request would spend quota on a document nobody is going to store.
+func (l *Limiter) Wait(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	d := l.reserve(l.clock.Now())
+	if d <= 0 {
+		return nil
+	}
+	l.mu.Lock()
+	l.waits++
+	l.waited += d
+	l.mu.Unlock()
+	return l.clock.Sleep(ctx, d)
+}
+
+// reserve takes a token and returns how long to wait before using it.
+//
+// The token is taken now and the waiting is done afterwards, without the lock
+// held, which is what makes two callers queue behind each other instead of both
+// deciding they may go at once. A bucket that has gone into debt is exactly the
+// record of the requests that are already on their way.
+func (l *Limiter) reserve(now time.Time) time.Duration {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.started {
+		l.tokens += now.Sub(l.last).Seconds() * l.rate
+		if l.tokens > l.burst {
+			l.tokens = l.burst
+		}
+	}
+	l.started, l.last = true, now
+	l.tokens--
+
+	var wait time.Duration
+	if l.tokens < 0 {
+		wait = time.Duration(-l.tokens / l.rate * float64(time.Second))
+	}
+	if held := l.until.Sub(now); held > wait {
+		wait = held
+	}
+	return wait
+}
+
+// Pause holds every request back until the given time.
+//
+// This is what a source's own answer turns into. A Retry-After header or a
+// quota that reports nothing left is the service saying when it will talk
+// again, and it outranks whatever ceiling the operator configured, because the
+// operator was guessing and the service knows.
+//
+// A time already in the past does nothing, so a header that arrived late or a
+// clock that disagrees cannot shorten a pause that is already running.
+func (l *Limiter) Pause(until time.Time) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if until.After(l.until) {
+		l.until = until
+		l.paused++
+	}
+}
+
+// Paused reports when the limiter will next let a request out, and whether it
+// is being held back at all.
+func (l *Limiter) Paused() (time.Time, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.until.After(l.clock.Now()) {
+		return l.until, true
+	}
+	return time.Time{}, false
+}
+
+// LimiterStats is what the limiter has cost so far.
+type LimiterStats struct {
+	// Waits is how many requests were held back at all, and Waited is how long
+	// they were held back for in total.
+	//
+	// These are the two numbers that say whether a ceiling is set sensibly. A
+	// crawl where almost nothing waited is running below its limit and could go
+	// faster, and one where every request waited an hour is configured for a
+	// quota somebody has since been given more of.
+	Waits  int64
+	Waited time.Duration
+
+	// Pauses is how many times the source itself asked for a delay. This is the
+	// one to watch: it means the ceiling is set above what the service is
+	// actually willing to give, and the crawl is finding that out by being told
+	// off rather than by staying under it.
+	Pauses int64
+}
+
+// Stats returns what the limiter has cost.
+func (l *Limiter) Stats() LimiterStats {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return LimiterStats{Waits: l.waits, Waited: l.waited, Pauses: l.paused}
+}

--- a/connector/limit/transport.go
+++ b/connector/limit/transport.go
@@ -1,0 +1,504 @@
+package limit
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// ErrOpen is returned instead of making a request when the circuit is open.
+//
+// It is what "stop rather than retry forever" looks like from the connector's
+// side: the sync fails, the pipeline reports it, the run ends, and the next
+// scheduled refresh tries again. A crawler that kept retrying a source which
+// has been refusing everything for a minute is doing nothing except making the
+// outage look like load.
+var ErrOpen = errors.New("limit: the circuit is open, the source has been refusing requests")
+
+// Transport wraps a round tripper with a rate limit, retries and a circuit
+// breaker.
+//
+// It is safe for concurrent use, and it is meant to be shared by everything
+// that talks to one service with one set of credentials, because that is the
+// scope a quota has.
+type Transport struct {
+	base    http.RoundTripper
+	limits  Limits
+	limiter *Limiter
+	clock   Clock
+	log     *slog.Logger
+	jitter  func(time.Duration) time.Duration
+
+	mu        sync.Mutex
+	failures  int
+	openUntil time.Time
+	probing   bool
+	requests  int64
+	retries   int64
+	trips     int64
+}
+
+// Option configures a transport.
+type Option func(*Transport)
+
+// WithBase replaces the round tripper the requests are actually made on, which
+// is where a deployment puts its own proxy, its own connection pool or its own
+// TLS configuration.
+func WithBase(rt http.RoundTripper) Option {
+	return func(t *Transport) {
+		if rt != nil {
+			t.base = rt
+		}
+	}
+}
+
+// WithClock replaces the clock, which is how the tests run an hour of backoff
+// without waiting for one.
+func WithClock(c Clock) Option {
+	return func(t *Transport) {
+		if c != nil {
+			t.clock = c
+		}
+	}
+}
+
+// WithLogger installs the logger the waiting is reported to.
+//
+// A crawl that is being throttled looks exactly like a crawl that is slow, and
+// the difference decides whether somebody goes looking at the network or asks
+// for more quota. So a backoff is logged at warning level rather than at debug:
+// it is not the normal case, and an operator should not have to turn anything
+// on to find out it is happening.
+func WithLogger(l *slog.Logger) Option {
+	return func(t *Transport) {
+		if l != nil {
+			t.log = l
+		}
+	}
+}
+
+// WithJitter replaces the function that spreads a backoff out.
+//
+// The default takes a random duration between half the computed wait and the
+// whole of it. The spread is what stops a fleet of crawlers that were all
+// refused at the same moment from all coming back at the same moment, which
+// turns one overload into a series of them.
+//
+// It is replaceable so that a test can ask for the wait it computed rather than
+// a random fraction of it.
+func WithJitter(f func(time.Duration) time.Duration) Option {
+	return func(t *Transport) {
+		if f != nil {
+			t.jitter = f
+		}
+	}
+}
+
+// NewTransport returns a transport enforcing l.
+func NewTransport(l Limits, opts ...Option) *Transport {
+	t := &Transport{
+		base:   http.DefaultTransport,
+		limits: l.withDefaults(),
+		clock:  realClock{},
+		log:    slog.New(slog.DiscardHandler),
+		jitter: halfToFull,
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	t.limiter = NewLimiter(t.limits, t.clock)
+	return t
+}
+
+var _ http.RoundTripper = (*Transport)(nil)
+
+// Limiter returns the limiter this transport is enforcing, for a caller that
+// wants its counters.
+func (t *Transport) Limiter() *Limiter { return t.limiter }
+
+// RoundTrip waits its turn, makes the request, and tries again if the answer
+// was one worth trying again.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+	if err := t.closed(); err != nil {
+		return nil, err
+	}
+
+	for attempt := 0; ; attempt++ {
+		if err := t.limiter.Wait(ctx); err != nil {
+			return nil, err
+		}
+
+		t.mu.Lock()
+		t.requests++
+		t.mu.Unlock()
+
+		resp, err := t.base.RoundTrip(req)
+
+		// The quota is read off every answer rather than only off a refusal. A
+		// response saying none is left is the last request before the wall, and
+		// holding back there is the difference between a crawl that stays inside
+		// its quota and one that finds the edge by hitting it.
+		if until := spent(resp, t.clock.Now()); !until.IsZero() {
+			t.limiter.Pause(until)
+			t.log.Warn("the source says its quota is spent, holding back until the window rolls over",
+				"url", req.URL.Redacted(),
+				"until", until.UTC().Format(time.RFC3339),
+			)
+		}
+
+		wait, retry := t.verdict(req, resp, err, attempt)
+		if !retry {
+			t.record(resp, err)
+			return resp, err
+		}
+
+		// The body of a response that is about to be thrown away still has to be
+		// closed, or the connection is dropped instead of going back to the pool
+		// and a crawl that is being throttled quietly opens a socket per refusal.
+		reason := err
+		if resp != nil {
+			_ = resp.Body.Close()
+			reason = fmt.Errorf("limit: %s %s: %s", req.Method, req.URL.Redacted(), resp.Status)
+		}
+
+		t.log.Warn("waiting before trying a request again",
+			"method", req.Method,
+			"url", req.URL.Redacted(),
+			"attempt", attempt+1,
+			"of", t.limits.MaxRetries,
+			"wait", wait.Round(time.Millisecond),
+			"reason", reason,
+		)
+		t.mu.Lock()
+		t.retries++
+		t.mu.Unlock()
+
+		if err := t.clock.Sleep(ctx, wait); err != nil {
+			return nil, err
+		}
+		if err := t.closed(); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// verdict decides what to do with one answer, and is the whole of the retry
+// policy in one place.
+func (t *Transport) verdict(req *http.Request, resp *http.Response, err error, attempt int) (wait time.Duration, retry bool) {
+	if attempt >= t.limits.MaxRetries || !repeatable(req) {
+		return 0, false
+	}
+	if err != nil {
+		// A request that never got an answer is worth another go: a connection
+		// reset is the single most common thing that goes wrong on a long crawl
+		// and it means nothing at all about the document being read.
+		return t.backoff(attempt, 0), true
+	}
+	if !worthRetrying(resp.StatusCode) {
+		return 0, false
+	}
+	// What the source said beats what we would have guessed. A service that
+	// names a time knows when its window rolls over and we do not, and coming
+	// back before then spends an attempt on a refusal that was already certain.
+	return t.backoff(attempt, retryAfter(resp, t.clock.Now())), true
+}
+
+// record updates the breaker with how one request ended.
+//
+// The counter is of consecutive failures rather than of failures, because a
+// crawl of any size has a few of those and a source that is actually broken has
+// nothing else. One success anywhere in the run says the credentials are good,
+// the network is up and the service is answering, which is the whole of what
+// the breaker is there to decide.
+func (t *Transport) record(resp *http.Response, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !broken(resp, err) {
+		t.failures, t.probing = 0, false
+		return
+	}
+	t.failures++
+	if t.probing || t.failures >= t.limits.Failures {
+		t.openUntil = t.clock.Now().Add(t.limits.Cooldown)
+		t.trips++
+		t.probing = false
+		t.log.Error("a source is refusing requests, stopping until it recovers",
+			"consecutive_failures", t.failures,
+			"cooldown", t.limits.Cooldown,
+			"until", t.openUntil.UTC().Format(time.RFC3339),
+		)
+	}
+}
+
+// closed reports whether a request may go out, and lets exactly one through
+// once the cooldown is over to find out whether the source has recovered.
+func (t *Transport) closed() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.openUntil.IsZero() {
+		return nil
+	}
+	if t.clock.Now().Before(t.openUntil) {
+		return fmt.Errorf("%w, trying again at %s", ErrOpen, t.openUntil.UTC().Format(time.RFC3339))
+	}
+	// The cooldown is over. One request goes, and until it comes back the
+	// circuit is neither open nor closed: a failure reopens it immediately
+	// rather than after another five, because the five have already happened.
+	t.openUntil, t.probing = time.Time{}, true
+	return nil
+}
+
+// backoff is how long to wait before attempt+1, jittered and bounded.
+//
+// A source that named its own time is honoured exactly, with the jitter added
+// on top rather than taken off it, because coming back one millisecond early is
+// coming back before the window rolled over.
+func (t *Transport) backoff(attempt int, named time.Duration) time.Duration {
+	if named > 0 {
+		if named > t.limits.MaxBackoff {
+			named = t.limits.MaxBackoff
+		}
+		return named + t.jitter(t.limits.MinBackoff)
+	}
+	d := t.limits.MinBackoff << attempt
+	// Shifting a duration far enough overflows into a negative one, which would
+	// be a backoff of no time at all on the attempt that most needed one.
+	if d <= 0 || d > t.limits.MaxBackoff {
+		d = t.limits.MaxBackoff
+	}
+	return t.jitter(d)
+}
+
+// TransportStats is what a transport has done.
+type TransportStats struct {
+	// Requests is every attempt, including the ones that were retried.
+	Requests int64
+
+	// Retries is how many of those were second or later attempts. A crawl where
+	// this is a large fraction of Requests is one where the ceiling is set too
+	// high, and it is costing quota to find that out.
+	Retries int64
+
+	// Trips is how many times the circuit opened.
+	Trips int64
+
+	// Open says the circuit is open now, which means the source is not being
+	// read at all.
+	Open bool
+
+	// Limiter is what the waiting cost.
+	Limiter LimiterStats
+}
+
+// Stats returns what this transport has done.
+func (t *Transport) Stats() TransportStats {
+	t.mu.Lock()
+	s := TransportStats{
+		Requests: t.requests,
+		Retries:  t.retries,
+		Trips:    t.trips,
+		Open:     !t.openUntil.IsZero() && t.clock.Now().Before(t.openUntil),
+	}
+	t.mu.Unlock()
+	s.Limiter = t.limiter.Stats()
+	return s
+}
+
+// worthRetrying reports whether a status is one where the same request might
+// work in a moment.
+//
+// Too many requests is the obvious one. The five hundreds are here because they
+// are the source saying something went wrong at its end, and a gateway timeout
+// on one document says nothing about the next attempt at the same document. A
+// four hundred is not here: a request the service considers malformed is
+// malformed on every attempt, and retrying it burns quota to arrive at the same
+// answer more slowly.
+func worthRetrying(status int) bool {
+	switch status {
+	case http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+// broken reports whether an answer counts towards opening the circuit.
+//
+// Transport errors and the five hundreds count, because both mean the service
+// is not answering. Unauthorised counts, because a token that has been revoked
+// is exactly the state this is here to notice and it is not going to fix itself
+// on the next document.
+//
+// Forbidden deliberately does not count. At an object store it is the ordinary
+// answer for one object out of a million that this account may not read, and a
+// breaker that tripped on it would stop a healthy crawl over a handful of
+// objects that were never part of the corpus.
+//
+// Too many requests does not count either. It is the service working exactly as
+// designed and saying so, and it is handled by waiting rather than by stopping.
+func broken(resp *http.Response, err error) bool {
+	if err != nil {
+		return true
+	}
+	if resp == nil {
+		return true
+	}
+	return resp.StatusCode == http.StatusUnauthorized || resp.StatusCode/100 == 5
+}
+
+// repeatable reports whether a request can be sent a second time.
+//
+// Only a request with no body at all is, and that is not a limitation in
+// practice: a crawler reads, so everything that goes through here is a GET or a
+// HEAD with nothing attached. The alternative is rewinding the body between
+// attempts, which means either consuming the caller's reader and putting it
+// back or holding the whole of it in memory, and a round tripper is not allowed
+// to modify the request it was handed in the first place.
+//
+// The method is checked as well, because a body is not the only thing that
+// makes a second attempt wrong. A POST that timed out may well have been
+// carried out, and sending it again is how one order becomes two.
+func repeatable(req *http.Request) bool {
+	if req.Body != nil && req.Body != http.NoBody {
+		return false
+	}
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}
+
+// The headers a service uses to say how much quota is left and when it comes
+// back.
+//
+// There are three conventions and no way to tell which one a service follows
+// except by looking. Retry-After is the standard and is what a refusal carries.
+// The unprefixed RateLimit fields are the newer draft and carry a delta in
+// seconds. The X-RateLimit fields are what most large services shipped years
+// before the draft existed, and their reset is usually a Unix timestamp rather
+// than a delta.
+const (
+	headerRetryAfter    = "Retry-After"
+	headerReset         = "RateLimit-Reset"
+	headerRemaining     = "RateLimit-Remaining"
+	headerLegacyReset   = "X-RateLimit-Reset"
+	headerLegacyRemains = "X-RateLimit-Remaining"
+)
+
+// retryAfter is how long a response says to wait, and zero for one that does
+// not say.
+func retryAfter(resp *http.Response, now time.Time) time.Duration {
+	if resp == nil {
+		return 0
+	}
+	if v := resp.Header.Get(headerRetryAfter); v != "" {
+		// The header is either a number of seconds or an HTTP date, and both
+		// spellings are in use by services this connector will meet.
+		if secs, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return time.Duration(secs) * time.Second
+		}
+		if at, err := http.ParseTime(v); err == nil {
+			return at.Sub(now)
+		}
+	}
+	for _, h := range [...]string{headerReset, headerLegacyReset} {
+		if d := resetIn(resp.Header.Get(h), now); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// spent returns when the window rolls over, for a response saying the quota is
+// gone, and the zero time for everything else.
+//
+// It is read off every response rather than only off a refusal, because a
+// response saying none is left is the last request before the wall rather than
+// the first one after it. Acting there is the difference between a crawl that
+// stays inside its quota and one that finds the edge by hitting it.
+func spent(resp *http.Response, now time.Time) time.Time {
+	if resp == nil {
+		return time.Time{}
+	}
+	for _, pair := range [...][2]string{
+		{headerRemaining, headerReset},
+		{headerLegacyRemains, headerLegacyReset},
+	} {
+		v := resp.Header.Get(pair[0])
+		if v == "" {
+			continue
+		}
+		left, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || left > 0 {
+			continue
+		}
+		if d := resetIn(resp.Header.Get(pair[1]), now); d > 0 {
+			return now.Add(d)
+		}
+	}
+	return time.Time{}
+}
+
+// maxReset bounds what a reset header is believed to be saying.
+//
+// A service that reports a window rolling over in four hours has almost
+// certainly sent a timestamp in a format nobody expected, and a crawl that
+// believed it would stop for the afternoon. The cap is well above any real
+// window and well below any misreading worth acting on.
+const maxReset = time.Hour
+
+// resetIn reads a reset header, which is either a delta in seconds or a Unix
+// timestamp depending on which convention the service follows.
+//
+// The two are told apart by size. A delta is a number of seconds in a window,
+// so it is small, and a Unix timestamp has been ten figures since 2001. There
+// is no ambiguity in the range that matters: a delta large enough to be
+// mistaken for a timestamp would be a window of three hundred years.
+func resetIn(v string, now time.Time) time.Duration {
+	if v == "" {
+		return 0
+	}
+	// Some services send a fractional number of seconds, which parses as a
+	// float and not as an integer.
+	n, err := strconv.ParseFloat(v, 64)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	var d time.Duration
+	if n > 1e9 {
+		d = time.Unix(int64(n), 0).Sub(now)
+	} else {
+		d = time.Duration(n * float64(time.Second))
+	}
+	if d <= 0 || d > maxReset {
+		return 0
+	}
+	return d
+}
+
+// halfToFull is the default jitter: somewhere between half of the computed wait
+// and all of it.
+//
+// The lower bound is half rather than zero because a jitter that can return
+// almost nothing turns the first retry of a fleet into the same stampede the
+// jitter was added to prevent.
+func halfToFull(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	return d/2 + time.Duration(rand.Int64N(int64(d)/2+1))
+}

--- a/connector/limit/transport_test.go
+++ b/connector/limit/transport_test.go
@@ -1,0 +1,545 @@
+package limit_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/connector/limit"
+)
+
+// reply is one scripted answer from the service the transport is talking to.
+type reply struct {
+	status int
+	header http.Header
+	err    error
+}
+
+// service is a round tripper that answers from a script.
+//
+// The last reply in the script repeats, so a test that wants a source which
+// refuses everything writes one refusal rather than guessing how many attempts
+// the transport is going to make. Bodies count their own closes, because a
+// discarded response whose body is left open is a leaked connection and that is
+// exactly the sort of thing a retry loop gets wrong.
+type service struct {
+	mu      sync.Mutex
+	replies []reply
+	seen    []string
+
+	bodies atomic.Int64
+}
+
+func newService(replies ...reply) *service {
+	if len(replies) == 0 {
+		replies = []reply{{status: http.StatusOK}}
+	}
+	return &service{replies: replies}
+}
+
+func (s *service) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.mu.Lock()
+	s.seen = append(s.seen, req.Method+" "+req.URL.Path)
+	r := s.replies[0]
+	if len(s.replies) > 1 {
+		s.replies = s.replies[1:]
+	}
+	s.mu.Unlock()
+
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &http.Response{
+		StatusCode: r.status,
+		Status:     fmt.Sprintf("%d %s", r.status, http.StatusText(r.status)),
+		Header:     r.header.Clone(),
+		Body:       &countingBody{closes: &s.bodies},
+		Request:    req,
+	}, nil
+}
+
+// calls is how many requests actually reached the service, which is how a test
+// tells a request that was refused from one that was never made.
+func (s *service) calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.seen)
+}
+
+type countingBody struct{ closes *atomic.Int64 }
+
+func (countingBody) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (b *countingBody) Close() error {
+	b.closes.Add(1)
+	return nil
+}
+
+// header builds a response header from alternating names and values.
+func header(kv ...string) http.Header {
+	h := make(http.Header, len(kv)/2)
+	for i := 0; i+1 < len(kv); i += 2 {
+		h.Set(kv[i], kv[i+1])
+	}
+	return h
+}
+
+// noJitter and fullJitter pin the spread so that a test can assert the wait the
+// transport computed rather than a random fraction of it.
+func noJitter(time.Duration) time.Duration     { return 0 }
+func fullJitter(d time.Duration) time.Duration { return d }
+
+// get builds a request the transport is willing to retry.
+func get(t *testing.T, path string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.test"+path, http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+// status makes one request and returns what came back, failing the test if the
+// transport returned an error.
+//
+// A refusal is a response and not an error, which is the shape of almost every
+// case here, and the few that really are errors go through refused instead. The
+// status is all a caller gets because the body is closed on the way out, which
+// keeps every response the service handed over accounted for.
+func status(t *testing.T, rt http.RoundTripper, req *http.Request) int {
+	t.Helper()
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", req.Method, req.URL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
+}
+
+// refused makes one request that is expected not to happen, and returns why.
+func refused(t *testing.T, rt http.RoundTripper, req *http.Request) error {
+	t.Helper()
+	resp, err := rt.RoundTrip(req)
+	if err == nil {
+		defer func() { _ = resp.Body.Close() }()
+		t.Fatalf("%s %s went out and came back %s", req.Method, req.URL, resp.Status)
+	}
+	return err
+}
+
+// The ordinary case costs nothing: one request, no waiting, no retrying.
+func TestAnAnswerThatWorksIsAskedForOnce(t *testing.T) {
+	svc := newService()
+	clock := newClock()
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000},
+		limit.WithBase(svc), limit.WithClock(clock))
+
+	if got := status(t, tr, get(t, "/one")); got != http.StatusOK {
+		t.Fatalf("status = %d", got)
+	}
+	if got := svc.calls(); got != 1 {
+		t.Errorf("the service was asked %d times, want 1", got)
+	}
+	stats := tr.Stats()
+	if stats.Requests != 1 || stats.Retries != 0 || stats.Trips != 0 || stats.Open {
+		t.Errorf("stats = %+v", stats)
+	}
+	if got := clock.total(); got != 0 {
+		t.Errorf("an unthrottled request waited %v", got)
+	}
+}
+
+// Too many requests is the case this whole package exists for, and the answer
+// to it is to come back later rather than to fail the sync.
+func TestARefusalForTooManyRequestsIsTriedAgain(t *testing.T) {
+	svc := newService(
+		reply{status: http.StatusTooManyRequests},
+		reply{status: http.StatusOK},
+	)
+	clock := newClock()
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000, MinBackoff: 100 * time.Millisecond},
+		limit.WithBase(svc), limit.WithClock(clock), limit.WithJitter(fullJitter))
+
+	if got := status(t, tr, get(t, "/two")); got != http.StatusOK {
+		t.Fatalf("status = %d, want the answer from the second attempt", got)
+	}
+	if got := svc.calls(); got != 2 {
+		t.Errorf("the service was asked %d times, want 2", got)
+	}
+	if got := tr.Stats().Retries; got != 1 {
+		t.Errorf("retries = %d, want 1", got)
+	}
+	if got := clock.sleeps(); len(got) != 1 || got[0] != 100*time.Millisecond {
+		t.Errorf("waited %v, want one wait of 100ms", got)
+	}
+	// Both bodies were closed, the refusal the transport threw away and the
+	// answer the caller read. A retry loop that dropped the first one opens a
+	// socket per refusal, which is the last thing a throttled crawl needs.
+	if got, want := svc.bodies.Load(), int64(svc.calls()); got != want {
+		t.Errorf("%d of %d bodies were closed", got, want)
+	}
+}
+
+// A source that names its own time is honoured, in both spellings of the header
+// that are actually in use.
+func TestTheSourcesOwnRetryTimeIsHonoured(t *testing.T) {
+	tests := []struct {
+		name   string
+		header http.Header
+		want   time.Duration
+	}{
+		{"seconds", header("Retry-After", "20"), 20 * time.Second},
+		{"an http date", header("Retry-After", start.Add(30*time.Second).Format(http.TimeFormat)), 30 * time.Second},
+		{"a reset as a delta", header("RateLimit-Reset", "12"), 12 * time.Second},
+		{"a fractional reset", header("RateLimit-Reset", "1.5"), 1500 * time.Millisecond},
+		{"a legacy reset as a timestamp", header("X-RateLimit-Reset", strconv.FormatInt(start.Add(45*time.Second).Unix(), 10)), 45 * time.Second},
+		{"a date already gone by", header("Retry-After", start.Add(-time.Hour).Format(http.TimeFormat)), 0},
+		{"a reset too far off to believe", header("RateLimit-Reset", "7200"), 0},
+		{"nonsense", header("Retry-After", "soon"), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newService(
+				reply{status: http.StatusTooManyRequests, header: tt.header},
+				reply{status: http.StatusOK},
+			)
+			clock := newClock()
+			tr := limit.NewTransport(
+				limit.Limits{Rate: 1000, Burst: 1000, MinBackoff: time.Second, MaxBackoff: 5 * time.Minute},
+				limit.WithBase(svc), limit.WithClock(clock), limit.WithJitter(noJitter))
+
+			status(t, tr, get(t, "/three"))
+
+			// Nothing named means the computed backoff, which the jitter here
+			// takes down to nothing.
+			want := []time.Duration{tt.want}
+			if tt.want == 0 {
+				want = nil
+			}
+			if got := clock.sleeps(); len(got) != len(want) || (len(got) == 1 && got[0] != want[0]) {
+				t.Errorf("waited %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// The wait doubles and then stops doubling, so a source that is down for an
+// hour is asked about occasionally rather than exponentially less often until
+// the crawl gives up on its own.
+func TestTheWaitDoublesAndIsBounded(t *testing.T) {
+	svc := newService(reply{status: http.StatusServiceUnavailable})
+	clock := newClock()
+	tr := limit.NewTransport(limit.Limits{
+		Rate:       1000,
+		Burst:      1000,
+		MaxRetries: 4,
+		MinBackoff: 100 * time.Millisecond,
+		MaxBackoff: 300 * time.Millisecond,
+	}, limit.WithBase(svc), limit.WithClock(clock), limit.WithJitter(fullJitter))
+
+	if got := status(t, tr, get(t, "/four")); got != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want the refusal to be returned once the attempts ran out", got)
+	}
+	want := []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 300 * time.Millisecond, 300 * time.Millisecond}
+	if got := clock.sleeps(); !slices.Equal(got, want) {
+		t.Errorf("waited %v, want %v", got, want)
+	}
+	stats := tr.Stats()
+	if stats.Requests != 5 || stats.Retries != 4 {
+		t.Errorf("stats = %+v, want five attempts of which four were retries", stats)
+	}
+}
+
+// A four hundred is not retried. The service considers the request malformed
+// and it will be just as malformed the second time.
+func TestARefusalThatWillNotChangeIsNotTriedAgain(t *testing.T) {
+	for _, code := range []int{http.StatusBadRequest, http.StatusNotFound, http.StatusForbidden} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			svc := newService(reply{status: code})
+			tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000},
+				limit.WithBase(svc), limit.WithClock(newClock()))
+
+			if got := status(t, tr, get(t, "/five")); got != code {
+				t.Fatalf("status = %d, want the refusal to come straight back", got)
+			}
+			if got := svc.calls(); got != 1 {
+				t.Errorf("the service was asked %d times, want 1", got)
+			}
+		})
+	}
+}
+
+// A request that never got an answer is worth another go. A connection reset is
+// the most common thing that goes wrong on a long crawl and it says nothing at
+// all about the document being read.
+func TestARequestThatGotNoAnswerIsTriedAgain(t *testing.T) {
+	svc := newService(
+		reply{err: errors.New("connection reset by peer")},
+		reply{status: http.StatusOK},
+	)
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000},
+		limit.WithBase(svc), limit.WithClock(newClock()), limit.WithJitter(noJitter))
+
+	if got := status(t, tr, get(t, "/six")); got != http.StatusOK {
+		t.Fatalf("status = %d", got)
+	}
+	if got := svc.calls(); got != 2 {
+		t.Errorf("the service was asked %d times, want 2", got)
+	}
+}
+
+// Only a request that can be sent twice is sent twice.
+func TestARequestThatCannotBeRepeatedIsNotRetried(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		body   io.Reader
+	}{
+		{"a get with a body", http.MethodGet, strings.NewReader("query")},
+		{"a post", http.MethodPost, nil},
+		{"a delete", http.MethodDelete, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newService(reply{status: http.StatusServiceUnavailable})
+			tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000},
+				limit.WithBase(svc), limit.WithClock(newClock()))
+
+			req, err := http.NewRequestWithContext(t.Context(), tt.method, "https://example.test/seven", tt.body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			status(t, tr, req)
+			if got := svc.calls(); got != 1 {
+				t.Errorf("the service was asked %d times, want 1", got)
+			}
+		})
+	}
+}
+
+// A response saying the quota is gone is the last request before the wall, and
+// the next one waits for the window to roll over rather than finding the edge
+// by hitting it.
+func TestTheQuotaBeingSpentHoldsTheNextRequestBack(t *testing.T) {
+	tests := []struct {
+		name   string
+		header http.Header
+		want   time.Duration
+	}{
+		{"the draft headers", header("RateLimit-Remaining", "0", "RateLimit-Reset", "30"), 30 * time.Second},
+		{
+			"the older headers",
+			header("X-RateLimit-Remaining", "0", "X-RateLimit-Reset", strconv.FormatInt(start.Add(90*time.Second).Unix(), 10)),
+			90 * time.Second,
+		},
+		{"some quota left", header("RateLimit-Remaining", "4", "RateLimit-Reset", "30"), 0},
+		{"no reset to go with it", header("RateLimit-Remaining", "0"), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newService(reply{status: http.StatusOK, header: tt.header}, reply{status: http.StatusOK})
+			clock := newClock()
+			tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000},
+				limit.WithBase(svc), limit.WithClock(clock))
+
+			status(t, tr, get(t, "/eight"))
+			status(t, tr, get(t, "/nine"))
+
+			if got := clock.total(); got != tt.want {
+				t.Errorf("the second request waited %v, want %v", got, tt.want)
+			}
+			want := int64(0)
+			if tt.want > 0 {
+				want = 1
+			}
+			if got := tr.Stats().Limiter.Pauses; got != want {
+				t.Errorf("pauses = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// A source that has been refusing everything is stopped rather than retried
+// forever. The sync fails, the next scheduled refresh tries again, and the
+// outage stops looking like load.
+func TestTheCircuitOpensAfterEnoughFailures(t *testing.T) {
+	svc := newService(reply{status: http.StatusInternalServerError})
+	clock := newClock()
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000, MaxRetries: -1, Failures: 3, Cooldown: time.Minute},
+		limit.WithBase(svc), limit.WithClock(clock))
+
+	for range 3 {
+		status(t, tr, get(t, "/ten"))
+	}
+	if got := svc.calls(); got != 3 {
+		t.Fatalf("the service was asked %d times, want 3", got)
+	}
+
+	err := refused(t, tr, get(t, "/ten"))
+	if !errors.Is(err, limit.ErrOpen) {
+		t.Fatalf("err = %v, want the circuit to be open", err)
+	}
+	// The request never went out, which is the point of the breaker.
+	if got := svc.calls(); got != 3 {
+		t.Errorf("the service was asked %d times after the circuit opened, want 3", got)
+	}
+	stats := tr.Stats()
+	if stats.Trips != 1 || !stats.Open {
+		t.Errorf("stats = %+v, want one trip and an open circuit", stats)
+	}
+}
+
+// The breaker counts consecutive failures, because a crawl of any size has a
+// few failures and a source that is actually broken has nothing else.
+func TestOneGoodAnswerClearsTheCount(t *testing.T) {
+	svc := newService(
+		reply{status: http.StatusInternalServerError},
+		reply{status: http.StatusOK},
+		reply{status: http.StatusInternalServerError},
+		reply{status: http.StatusOK},
+	)
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000, MaxRetries: -1, Failures: 2},
+		limit.WithBase(svc), limit.WithClock(newClock()))
+
+	for range 4 {
+		status(t, tr, get(t, "/eleven"))
+	}
+	if got := tr.Stats().Trips; got != 0 {
+		t.Errorf("trips = %d, want the circuit to have stayed closed", got)
+	}
+}
+
+// Forbidden is the ordinary answer for one object out of a million that this
+// account may not read, and a breaker that tripped on it would stop a healthy
+// crawl over a handful of objects that were never part of the corpus.
+func TestForbiddenDoesNotStopACrawl(t *testing.T) {
+	svc := newService(reply{status: http.StatusForbidden})
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000, MaxRetries: -1, Failures: 2},
+		limit.WithBase(svc), limit.WithClock(newClock()))
+
+	for range 10 {
+		status(t, tr, get(t, "/twelve"))
+	}
+	if got := tr.Stats().Trips; got != 0 {
+		t.Errorf("trips = %d, want forbidden to be an ordinary answer", got)
+	}
+}
+
+// A revoked token is exactly the state the breaker is there to notice, and it
+// is not going to fix itself on the next document.
+func TestARevokedTokenStopsTheCrawl(t *testing.T) {
+	svc := newService(reply{status: http.StatusUnauthorized})
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000, MaxRetries: -1, Failures: 2},
+		limit.WithBase(svc), limit.WithClock(newClock()))
+
+	for range 2 {
+		status(t, tr, get(t, "/thirteen"))
+	}
+	if err := refused(t, tr, get(t, "/thirteen")); !errors.Is(err, limit.ErrOpen) {
+		t.Fatalf("err = %v, want the circuit to be open", err)
+	}
+}
+
+// Once the cooldown is over one request goes through to find out whether the
+// source has recovered, and a good answer puts the crawl back to normal.
+func TestTheCircuitClosesAgainWhenTheSourceRecovers(t *testing.T) {
+	svc := newService(
+		reply{status: http.StatusInternalServerError},
+		reply{status: http.StatusInternalServerError},
+		reply{status: http.StatusOK},
+	)
+	clock := newClock()
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000, MaxRetries: -1, Failures: 2, Cooldown: time.Minute},
+		limit.WithBase(svc), limit.WithClock(clock))
+
+	for range 2 {
+		status(t, tr, get(t, "/fourteen"))
+	}
+	if err := refused(t, tr, get(t, "/fourteen")); !errors.Is(err, limit.ErrOpen) {
+		t.Fatalf("err = %v, want the circuit to be open", err)
+	}
+
+	clock.advance(2 * time.Minute)
+	if got := status(t, tr, get(t, "/fourteen")); got != http.StatusOK {
+		t.Fatalf("the probe got %d", got)
+	}
+	if got := status(t, tr, get(t, "/fourteen")); got != http.StatusOK {
+		t.Fatalf("the request after the probe got %d", got)
+	}
+	stats := tr.Stats()
+	if stats.Open || stats.Trips != 1 {
+		t.Errorf("stats = %+v, want a closed circuit and the one trip it had", stats)
+	}
+}
+
+// A probe that fails reopens the circuit straight away rather than after
+// another full count of failures, because those failures have already happened.
+func TestAProbeThatFailsReopensTheCircuitAtOnce(t *testing.T) {
+	svc := newService(reply{status: http.StatusInternalServerError})
+	clock := newClock()
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000, MaxRetries: -1, Failures: 5, Cooldown: time.Minute},
+		limit.WithBase(svc), limit.WithClock(clock))
+
+	for range 5 {
+		status(t, tr, get(t, "/fifteen"))
+	}
+	clock.advance(2 * time.Minute)
+
+	status(t, tr, get(t, "/fifteen"))
+	if err := refused(t, tr, get(t, "/fifteen")); !errors.Is(err, limit.ErrOpen) {
+		t.Fatalf("err = %v, want the circuit open again after one failed probe", err)
+	}
+	if got := tr.Stats().Trips; got != 2 {
+		t.Errorf("trips = %d, want 2", got)
+	}
+}
+
+// The rate applies to requests made through the transport, which is the whole
+// reason it is a round tripper.
+func TestTheTransportSpacesRequestsOut(t *testing.T) {
+	svc := newService()
+	clock := newClock()
+	tr := limit.NewTransport(limit.Limits{Rate: 10, Burst: 1, MaxRetries: -1},
+		limit.WithBase(svc), limit.WithClock(clock))
+
+	for range 3 {
+		status(t, tr, get(t, "/sixteen"))
+	}
+	if got := clock.total(); got != 200*time.Millisecond {
+		t.Errorf("three requests out of a bucket of one waited %v, want 200ms", got)
+	}
+	if got := tr.Limiter().Stats().Waits; got != 2 {
+		t.Errorf("waits = %d, want 2", got)
+	}
+}
+
+// A shutdown does not fire one last request.
+func TestACancelledRequestNeverGoesOut(t *testing.T) {
+	svc := newService()
+	tr := limit.NewTransport(limit.Limits{Rate: 1, Burst: 1},
+		limit.WithBase(svc), limit.WithClock(newClock()))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.test/seventeen", http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The refusal comes from the limiter rather than from the service, which is
+	// the whole point: the request never went out at all.
+	if err := refused(t, tr, req); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want the cancellation", err)
+	}
+	if got := svc.calls(); got != 0 {
+		t.Errorf("the service was asked %d times, want 0", got)
+	}
+}

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -288,6 +288,7 @@ A bucket with no credentials at all is read unsigned, which is what a public buc
 `-bucket-acl bucket` reads the bucket's own access control list once per sync and gives that answer for every object in it, which is one request rather than a million.
 `-bucket-acl object` reads each object's own list, which is exact and costs a request per object per sync, so it is worth reaching for only when the objects really do differ.
 `-bucket-domain` is what a grant written against an email address is checked against, and a grant to an address outside it is quarantined rather than published.
+`-bucket-rate`, `-bucket-burst` and `-bucket-retries` are the ceiling the crawl keeps itself under, and the section below is about what they do and why there is no value meaning unlimited.
 
 A service that is not S3 itself almost certainly needs `-bucket-path-style`, which puts the bucket in the path rather than in the host name.
 MinIO on a laptop is the shortest way to try the whole thing:
@@ -304,6 +305,59 @@ genbad \
 Both feeds log the same numbers after every sync, under `corpus synced` and `bucket synced`.
 The directory adds what its watcher has to say, and the bucket adds the request counts, which are what a bill is made of.
 A listing count that climbs by one per sync is a healthy incremental run, and a fetch count that climbs with it on a bucket nobody is writing to means the cursor is not doing its job.
+
+## Staying inside a service's limits
+
+A crawler that ignores an API's limits gets the company's integration token revoked, and that is a worse outcome than a slow crawl by a wide margin.
+A slow crawl finishes late.
+A revoked token is an index that stops updating, a conversation with whoever owns the integration, and in most companies a week before anybody is allowed to try again.
+
+`connector/limit` is where that is dealt with, and it is an `http.RoundTripper` rather than something each connector calls.
+That is the layer the requests actually are at, so a connector built on `http.Client` gets all of it by being handed a different client and needs no code of its own:
+
+```go
+client := &http.Client{Transport: limit.NewTransport(limit.Limits{Rate: 8, Burst: 16})}
+src, err := objectsource.New(objectsource.NewClient(cfg, objectsource.WithHTTPClient(client)), name, policy)
+```
+
+The transport does four things around every request.
+
+It waits for a token, so the request rate stays under a ceiling.
+The bucket is a token bucket rather than a fixed delay because real work is lumpy: a page of a listing followed immediately by the four documents on it is a burst of five, and a quota is a rate over a window rather than a rule about one request at a time.
+It refills by arithmetic on the clock rather than by a goroutine, so a limiter that is never used costs nothing and a process holding a hundred of them holds no timers.
+
+It reads what the response says about the quota, off every response and not only off a refusal.
+A response saying none is left is the last request before the wall rather than the first one after it, and holding back there is the difference between a crawl that stays inside its quota and one that finds the edge by hitting it.
+Three header conventions are in use and there is no way to tell which one a service follows except by looking, so all three are read: `Retry-After`, the newer `RateLimit-Reset` and `RateLimit-Remaining`, and the older `X-RateLimit-Reset` and `X-RateLimit-Remaining`.
+A reset is a delta in seconds under one convention and a Unix timestamp under the other, and the two are told apart by size, because a delta large enough to be mistaken for a timestamp would be a window of three hundred years.
+Anything claiming a window more than an hour away is ignored, on the grounds that it is almost certainly a format nobody expected rather than a service that really wants to be left alone until the afternoon.
+
+It retries what is worth retrying.
+Too many requests and the five hundreds are, because both mean the same request might work in a moment.
+A four hundred is not: a request the service considers malformed is malformed on every attempt, and retrying it burns quota to arrive at the same answer more slowly.
+The wait doubles from `MinBackoff` towards `MaxBackoff` and is jittered between half and all of itself, which is what stops a fleet of crawlers that were all refused at the same moment from all coming back at the same moment.
+A source that named its own time is honoured exactly, with the jitter added on top rather than taken off it, because coming back one millisecond early is coming back before the window rolled over.
+Only a request with no body and an idempotent method is ever sent twice, because a round tripper is not allowed to modify the request it was handed and a POST that timed out may well have been carried out.
+
+It stops the source when it has been refusing everything.
+After `Failures` consecutive failures the circuit opens and every request fails with `limit.ErrOpen` until `Cooldown` has passed, at which point exactly one goes through to find out whether the source has recovered.
+A crawler that kept retrying a source which has been down for a minute is doing nothing except making the outage look like load.
+The count is of consecutive failures rather than of failures, because a crawl of any size has a few of those and a source that is actually broken has nothing else: one success anywhere in the run says the credentials are good, the network is up and the service is answering.
+Unauthorised counts towards it, because a revoked token is exactly the state this is here to notice.
+Forbidden deliberately does not, because at an object store it is the ordinary answer for one object out of a million that this account may not read, and a breaker that tripped on it would stop a healthy crawl over objects that were never part of the corpus.
+Too many requests does not either, because that is the service working exactly as designed and saying so.
+
+The defaults are cautious on purpose: five requests a second, a burst of ten, four retries, and a minute of cooldown.
+A default that is too slow costs a longer first sync and nothing else, and a default that is too fast costs the token.
+There is no value meaning unlimited, and an operator who wants one asks for a rate high enough that it never binds, which is a number in the log rather than a special case in the code.
+
+A limiter belongs to one source, because a quota does.
+Two connectors reading two different services have nothing to do with each other, and sharing a limiter between them would mean a slow wiki holding up a fast bucket.
+Two connectors reading the same service with the same credentials share a quota whether they like it or not, and those two should share one transport.
+
+What comes out of it lands in the sync line.
+The `bucket synced` line carries `retries`, `throttled`, `throttled_for` and `quota_pauses` alongside the request counts, because a crawl that is being throttled looks exactly like a crawl that is slow.
+`quota_pauses` is the one to watch: it means the ceiling is set above what the service is actually willing to give, and the crawl is finding that out by being told off rather than by staying under it.
 
 ## Writing a connector
 


### PR DESCRIPTION
Closes #16.

A crawler that ignores an API's limits gets the company's integration token revoked, and that is a worse outcome than a slow crawl by a wide margin.
A slow crawl finishes late.
A revoked token is an index that stops updating, a conversation with whoever owns the integration, and in most companies a week before anybody is allowed to try again.

`connector/limit` is where that is dealt with, and it is an `http.RoundTripper` rather than something each connector calls.
That is the layer the requests actually are at, so a connector built on `http.Client` gets all of it by being handed a different client and needs no code of its own.

```go
client := &http.Client{Transport: limit.NewTransport(limit.Limits{Rate: 8, Burst: 16})}
src, err := objectsource.New(objectsource.NewClient(cfg, objectsource.WithHTTPClient(client)), name, policy)
```

It does four things around every request.

It waits for a token, so the request rate stays under a ceiling.
The bucket is a token bucket rather than a fixed delay because real work is lumpy: a page of a listing followed immediately by the four documents on it is a burst of five, and a quota is a rate over a window rather than a rule about one request at a time.
It refills by arithmetic on the clock rather than by a goroutine, so a limiter that is never used costs nothing and a process holding a hundred of them holds no timers.

It reads what the response says about the quota, off every response and not only off a refusal.
A response saying none is left is the last request before the wall rather than the first one after it.
Three header conventions are in use and there is no way to tell which one a service follows except by looking, so all three are read.
A reset is a delta in seconds under one convention and a Unix timestamp under the other, and the two are told apart by size, because a delta large enough to be mistaken for a timestamp would be a window of three hundred years.
Anything claiming a window more than an hour away is ignored, on the grounds that it is almost certainly a format nobody expected rather than a service that really wants to be left alone until the afternoon.

It retries what is worth retrying, which is too many requests and the five hundreds.
A four hundred is not on that list: a request the service considers malformed is malformed on every attempt.
The wait doubles towards a ceiling and is jittered between half and all of itself, which is what stops a fleet of crawlers that were all refused at the same moment from all coming back at the same moment.
A source that named its own time is honoured exactly, with the jitter added on top rather than taken off it, because coming back one millisecond early is coming back before the window rolled over.
Only a request with no body and an idempotent method is ever sent twice, because a round tripper is not allowed to modify the request it was handed and a POST that timed out may well have been carried out.

It stops the source when it has been refusing everything.
After five consecutive failures the circuit opens and every request fails with `limit.ErrOpen` until the cooldown has passed, at which point exactly one goes through to find out whether the source has recovered.
The count is of consecutive failures rather than of failures, because a crawl of any size has a few of those and a source that is actually broken has nothing else.
Unauthorised counts towards it, because a revoked token is exactly the state this is here to notice.
Forbidden deliberately does not, because at an object store it is the ordinary answer for one object out of a million that this account may not read, and a breaker that tripped on it would stop a healthy crawl over objects that were never part of the corpus.
Too many requests does not either, because that is the service working as designed and saying so.

There is no value of the rate meaning unlimited.
Anybody who knows their quota can ask for a rate high enough that it never binds, which is a number in the log rather than a special case in the code.
The defaults are cautious on purpose, five a second with a burst of ten, because a default that is too slow costs a longer first sync and a default that is too fast costs the token.

The clock is an interface, so the whole suite runs an hour of backoff in a microsecond and there is no timing assertion in it that a loaded machine can break.
The one test with more than one goroutine holds the clock still, so the answer does not depend on the order the goroutines were scheduled in.

`genbad` grows `-bucket-rate`, `-bucket-burst` and `-bucket-retries`, and every request the bucket makes goes out through one transport, for listings, for permissions and for the objects themselves, because the quota they are spending is one quota.
The `bucket synced` line carries `retries`, `throttled`, `throttled_for` and `quota_pauses` alongside the request counts, because a crawl that is being throttled looks exactly like a crawl that is slow and the difference decides whether you go looking at the network or ask for more quota.
The client's own timeout grows with the retry budget, because a timeout meant for one request would otherwise cut a legitimate backoff short and turn a source asking to be left alone for thirty seconds into a failed sync.

There is an end to end test that starts a real server against an in memory bucket with a rate of twenty a second and a burst of one, and checks the crawl really did take as long as that arithmetic says it should while still indexing everything.
