### PR TITLE
connector: make the conformance suite the definition of a connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ func main() {
 | `store/segdir` | the directory of segments, the manifest and the crash recovery, [docs/durability.md](docs/durability.md) |
 | `index` | query parsing, retrieval and ranking |
 | `connector` | the ingestion contract, cursors and checkpoints |
+| `connector/connectortest` | the conformance suite that defines what a connector is |
 | `connector/fssource` | the reference connector, a directory tree with OWNERS files, walked or watched |
 | `connector/objectsource` | an S3 compatible bucket, signed and paged, [docs/ingestion.md](docs/ingestion.md) |
 | `connector/limit` | the rate limit, backoff and circuit breaker every connector shares, as a round tripper |
@@ -428,6 +429,13 @@ Everything after the first sync is incremental.
 A second run over an unchanged tree reads no files at all, an OWNERS edit costs one write per document rather than a recrawl of the subtree, and a reconciliation sweep after every sync catches what a change feed cannot report, starting with the file somebody deleted.
 The same holds over a network: a second sync of an unchanged bucket fetches no objects and reads no bytes, and rewriting the bucket's access control list costs one write per object rather than a fetch of the whole bucket.
 [docs/ingestion.md](docs/ingestion.md) has the details, including the optional capabilities a connector implements to get each of those and the rule that stops a timed out enumeration from emptying a working index.
+
+What a connector is gets decided by `connector/connectortest` rather than by the interface.
+The interface says what compiles, and the suite says what works: that a full sync finds everything, that resuming from a cursor loses nothing that came after it, that a second sync of a source nothing changed in reads nothing, that a deleted document stops being part of the source one way or the other, and that every document says who may read it.
+A connector that cannot work out an access control list and says so is quarantined and passes.
+A connector that indexes a document without one fails, which is the whole reason the suite exists.
+The optional capabilities are optional in the suite too, so a connector that cannot list its source skips those cases, and one that can is held to them.
+Running it is not optional either: a test at the root of the module finds the packages that declare a connector and fails any of them whose tests do not run the suite, because a conformance suite nobody runs is documentation.
 
 ## Storage
 

--- a/arch_test.go
+++ b/arch_test.go
@@ -128,8 +128,15 @@ var allowed = map[string][]string{
 	// imports acl and nothing else of ours, and it must stay that way: a
 	// mapping layer that could reach a store or a document would be a second
 	// place for the permission rule to live.
-	"connector/aclmap":   {"acl"},
-	"connector/fssource": {"acl", "connector", "connector/aclmap", "doc", "extract"},
+	"connector/aclmap": {"acl"},
+	// connectortest sits above the connectors and beside none of them, the way
+	// storetest sits above the drivers. It names acl, connector and doc because
+	// those are the three things a change is made of, and it must never name a
+	// connector: a suite that imported the reference implementation would be a
+	// suite that could only be run by packages allowed to import it, and would
+	// slowly turn into a description of that one connector.
+	"connector/connectortest": {"acl", "connector", "doc"},
+	"connector/fssource":      {"acl", "connector", "connector/aclmap", "doc", "extract"},
 	// objectsource sits at the same level as fssource and names the same five
 	// packages. It talks to a network service and fssource does not, and none of
 	// that difference is allowed to show up as a dependency: an S3 client of our

--- a/conformance_test.go
+++ b/conformance_test.go
@@ -1,0 +1,88 @@
+package genba_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The two strings this test looks for. The first is the compile time assertion
+// every connector in this repository carries, and the second is the line that
+// runs the suite against it.
+const (
+	declaresAConnector = "connector.Connector = "
+	runsTheSuite       = "connectortest.Run("
+)
+
+// TestEveryConnectorRunsTheConformanceSuite is how the suite is enforced rather
+// than merely offered.
+//
+// A conformance suite nobody runs is documentation, and documentation about
+// permissions is what gets skipped when a connector is written in a hurry
+// against a source somebody needs indexed by Friday. So the rule is mechanical:
+// a package that declares a connector has to run the suite against it, and this
+// test is what fails in continuous integration when the next one does not.
+//
+// It reads the files rather than the types because the thing being checked is
+// that a test exists. A reflective check would need the test to be running to
+// find out that the test is not there.
+func TestEveryConnectorRunsTheConformanceSuite(t *testing.T) {
+	var found int
+	for _, pkg := range packages(t) {
+		if !strings.HasPrefix(pkg, "connector/") || !declares(t, pkg) {
+			continue
+		}
+		found++
+		t.Run(name(pkg), func(t *testing.T) {
+			if !covered(t, pkg) {
+				t.Errorf("%s implements connector.Connector and no test in it calls connectortest.Run, so nothing checks that the documents it indexes carry the access control lists that govern them", name(pkg))
+			}
+		})
+	}
+	if found == 0 {
+		// The walk found no connectors at all, which means the way they are
+		// written has changed and this test has quietly stopped checking
+		// anything.
+		t.Fatalf("no package in the module declares a connector, so this test is not checking what it says it is")
+	}
+}
+
+// declares reports whether a package implements the connector interface, which
+// every connector here says in one line at the top of the file.
+func declares(t *testing.T, pkg string) bool {
+	t.Helper()
+	return contains(t, pkg, declaresAConnector, false)
+}
+
+// covered reports whether a package's own tests run the conformance suite.
+func covered(t *testing.T, pkg string) bool {
+	t.Helper()
+	return contains(t, pkg, runsTheSuite, true)
+}
+
+// contains reports whether any Go file in a package has a string in it, looking
+// at either the package's own files or its tests.
+func contains(t *testing.T, pkg, want string, tests bool) bool {
+	t.Helper()
+	entries, err := os.ReadDir(dir(pkg))
+	if err != nil {
+		t.Fatalf("reading %s: %v", name(pkg), err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), "_test.go") != tests {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir(pkg), e.Name()))
+		if err != nil {
+			t.Fatalf("reading %s: %v", e.Name(), err)
+		}
+		if strings.Contains(string(body), want) {
+			return true
+		}
+	}
+	return false
+}

--- a/connector/connectortest/cases.go
+++ b/connector/connectortest/cases.go
@@ -1,0 +1,478 @@
+package connectortest
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+)
+
+// The documents the suite works with. They are named so that the order they
+// sort in is the order they were written in, because a connector that walks its
+// source in name order and one that walks it in modification order then agree,
+// and a case about resuming can say what came after what.
+const (
+	first  = "a.md"
+	second = "b.md"
+	third  = "c.md"
+	fourth = "d.md"
+)
+
+// The marker in each body, which is what a case looks for rather than comparing
+// the whole text. A connector is allowed to do work on the way past.
+const (
+	firstText  = "the first document is about gearboxes"
+	secondText = "the second document is about bearings"
+	thirdText  = "the third document is about hydraulics"
+	fourthText = "the fourth document is about castings"
+)
+
+// The source name is what a resume point is filed under, so it has to be there
+// and it has to stay the same.
+func testSourceName(t *testing.T, f Fixture) {
+	name := f.Connector.Source()
+	if name == "" {
+		t.Fatal("the connector has no source name, and the resume point for a source is filed under that name")
+	}
+	if again := f.Connector.Source(); again != name {
+		t.Fatalf("the source name changed from %q to %q between two calls, so a restart would resume from nothing", name, again)
+	}
+	if strings.TrimSpace(name) != name {
+		t.Errorf("the source name %q has whitespace around it, which will not survive a round trip through a query filter", name)
+	}
+}
+
+// A full sync is the claim a connector makes about what its source holds. If it
+// is short by one document, nothing else in the system will ever notice.
+func testFullSync(t *testing.T, f Fixture) {
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	write(t, f, third, thirdText)
+
+	changes, next := syncFrom(t, f, connector.Cursor{})
+	want := []string{f.ID(first), f.ID(second), f.ID(third)}
+	slices.Sort(want)
+	if got := sorted(changes); !slices.Equal(got, want) {
+		t.Fatalf("a full sync of three documents emitted %v, want %v", got, want)
+	}
+	if next.IsZero() {
+		t.Error("a sync that found three documents came back with no cursor, so the next run starts from the beginning again")
+	}
+	for _, ch := range changes {
+		if ch.Deleted || ch.PermissionsOnly {
+			t.Errorf("a full sync of a source nothing has been removed from emitted %s as a deletion or a permission change", ch.Document.ID)
+		}
+	}
+	if ch := find(changes, f.ID(second)); ch != nil && !mentions(ch.Document.Body, "bearings") {
+		t.Errorf("%s came back with body %q, which does not contain what was written to it", ch.Document.ID, ch.Document.Body)
+	}
+}
+
+// A sync from the beginning is a statement about the source rather than about
+// what the connector remembers, so two of them say the same thing.
+func testFullSyncRepeats(t *testing.T, f Fixture) {
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+
+	once, _ := syncFrom(t, f, connector.Cursor{})
+	twice, _ := syncFrom(t, f, connector.Cursor{})
+	if got, want := sorted(twice), sorted(once); !slices.Equal(got, want) {
+		t.Fatalf("two full syncs of the same source emitted %v and %v", want, got)
+	}
+	for _, ch := range once {
+		other := find(twice, ch.Document.ID)
+		if other == nil {
+			continue
+		}
+		if other.Document.Body != ch.Document.Body {
+			t.Errorf("%s came back with a different body on the second full sync", ch.Document.ID)
+		}
+		if !samePermissions(other.Document.Permissions, ch.Document.Permissions) {
+			t.Errorf("%s came back with different permissions on the second full sync", ch.Document.ID)
+		}
+	}
+}
+
+// Every document says who may read it. This is the one rule with no way out,
+// and it is checked on its own as well as on every change the suite sees so
+// that a connector which forgot fails a case that says so by name.
+func testPermissions(t *testing.T, f Fixture) {
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+
+	changes, _ := syncFrom(t, f, connector.Cursor{})
+	if len(changes) == 0 {
+		t.Fatal("a sync of a source with two documents in it emitted nothing")
+	}
+	for _, ch := range changes {
+		if ch.Deleted {
+			continue
+		}
+		if ch.Document.Permissions.Source == "" {
+			t.Errorf("%s was indexed without permissions, and a document indexed without the access control list that governs it is readable by everybody", ch.Document.ID)
+		}
+	}
+}
+
+// A document whose access control list could not be worked out is quarantined
+// rather than guessed at, and the rest of the sync carries on.
+//
+// The two halves matter equally. Publishing the document is the failure nobody
+// recovers from, and dropping the whole sync because one share would not resolve
+// is how an index quietly stops being complete.
+func testUnresolved(t *testing.T, f Fixture) {
+	if f.Unresolvable == nil {
+		t.Skip("the fixture cannot put a document's permissions beyond working out")
+	}
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	f.Unresolvable(t, second)
+
+	changes, _ := syncFrom(t, f, connector.Cursor{})
+	ch := find(changes, f.ID(second))
+	if ch == nil {
+		t.Fatalf("%s had permissions that would not resolve and was dropped from the sync, so nothing above the connector knows it exists", f.ID(second))
+	}
+	if got := ch.Document.Permissions.Mode; got != acl.ModeUnknown {
+		t.Errorf("%s had permissions that would not resolve and was indexed with mode %v, and a connector that cannot answer must not guess", ch.Document.ID, got)
+	}
+	if find(changes, f.ID(first)) == nil {
+		t.Errorf("one document whose permissions would not resolve cost the sync %s as well", f.ID(first))
+	}
+}
+
+// A sync of a real corpus takes long enough that it will be interrupted, so
+// resuming from a change's cursor has to pick up everything that came after it.
+//
+// Losing a document here is invisible: the run reports success, the cursor moves
+// on, and the document is missing until somebody searches for it.
+func testResume(t *testing.T, f Fixture) {
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	write(t, f, third, thirdText)
+	write(t, f, fourth, fourthText)
+
+	changes, _ := syncFrom(t, f, connector.Cursor{})
+	if len(changes) < 4 {
+		t.Fatalf("a full sync of four documents emitted %v", ids(changes))
+	}
+
+	at := -1
+	for i := range changes[:len(changes)-1] {
+		if !changes[i].Cursor.IsZero() {
+			at = i
+			break
+		}
+	}
+	if at < 0 {
+		t.Fatal("no change carried a cursor, so a run interrupted part of the way through has to start again from the beginning")
+	}
+
+	rest, _ := syncFrom(t, f, changes[at].Cursor)
+	seen := sorted(rest)
+	for _, ch := range changes[at+1:] {
+		if !slices.Contains(seen, ch.Document.ID) {
+			t.Errorf("resuming from the cursor of %s lost %s, which the same sync emitted after it", changes[at].Document.ID, ch.Document.ID)
+		}
+	}
+}
+
+// An error from emit is the index refusing the document, and a connector that
+// swallowed it would report a successful sync of a corpus that was not stored.
+func testEmitError(t *testing.T, f Fixture) {
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	write(t, f, third, thirdText)
+
+	refused := errors.New("the store would not take it")
+	var n int
+	_, err := f.Connector.Sync(t.Context(), connector.Cursor{}, func(_ context.Context, _ connector.Change) error {
+		n++
+		if n == 2 {
+			return refused
+		}
+		return nil
+	})
+	if !errors.Is(err, refused) {
+		t.Fatalf("sync returned %v, want the error emit returned", err)
+	}
+	if n != 2 {
+		t.Errorf("sync emitted %d changes, want it to stop at the one that was refused", n)
+	}
+}
+
+// A shutdown stops the crawl. A sync that ran to the end after the context was
+// cancelled is one that spends a source's quota on documents nobody is going to
+// store, and on a large corpus it is the difference between a restart taking a
+// second and taking an hour.
+func testCancel(t *testing.T, f Fixture) {
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	write(t, f, third, thirdText)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var n int
+	_, err := f.Connector.Sync(ctx, connector.Cursor{}, func(_ context.Context, _ connector.Change) error {
+		n++
+		cancel()
+		return nil
+	})
+	if err == nil {
+		t.Fatal("a sync cancelled at its first change ran to the end and reported success")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("a cancelled sync returned %v, want context.Canceled", err)
+	}
+	if n >= 3 {
+		t.Errorf("a sync cancelled at its first change went on to emit all %d of them", n)
+	}
+}
+
+// The second sync of a source nothing changed in reads nothing. This is the
+// whole claim of an incremental sync, and the cursor is the only thing holding
+// it up.
+func testIncremental(t *testing.T, f Fixture) {
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	write(t, f, third, thirdText)
+
+	_, cursor := syncFrom(t, f, connector.Cursor{})
+	if cursor.IsZero() {
+		t.Fatal("a full sync came back with no cursor, so there is no incremental path to test")
+	}
+
+	changes, next := syncFrom(t, f, cursor)
+	for _, ch := range changes {
+		if !ch.Deleted && !ch.PermissionsOnly {
+			t.Errorf("a second sync of a source nothing had changed in emitted %s again", ch.Document.ID)
+		}
+	}
+	if next.IsZero() {
+		t.Error("an incremental sync came back with no cursor, so the run after it starts from the beginning")
+	}
+}
+
+// A document written after the last sync is found by the next one. A connector
+// whose cursor has moved too far on is one whose index stops growing, and
+// nothing in the sync says so.
+func testNewDocument(t *testing.T, f Fixture) {
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	_, cursor := syncFrom(t, f, connector.Cursor{})
+
+	write(t, f, third, thirdText)
+	changes, _ := syncFrom(t, f, cursor)
+	ch := find(changes, f.ID(third))
+	if ch == nil {
+		t.Fatalf("a document written after the last sync was not found by the next one, which emitted %v", ids(changes))
+	}
+	if !mentions(ch.Document.Body, "hydraulics") {
+		t.Errorf("%s came back with body %q, which does not contain what was written to it", ch.Document.ID, ch.Document.Body)
+	}
+}
+
+// A document deleted at the source stops being part of it, and the connector has
+// to make that visible one way or the other.
+//
+// Saying so in the sync is the good answer. A source with no change feed cannot,
+// and for one of those the enumeration is what a reconciliation sweep reads, so
+// it has to stop listing the document. A connector that does neither is one
+// whose index can never lose a document, which is how deleted content stays
+// searchable.
+func testDeleted(t *testing.T, f Fixture) {
+	if f.Remove == nil {
+		t.Skip("the fixture cannot delete from the source")
+	}
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	_, cursor := syncFrom(t, f, connector.Cursor{})
+
+	gone := f.ID(second)
+	f.Remove(t, second)
+	changes, _ := syncFrom(t, f, cursor)
+
+	var reported bool
+	for _, ch := range changes {
+		if ch.Document.ID != gone {
+			continue
+		}
+		if ch.Deleted {
+			reported = true
+			continue
+		}
+		t.Errorf("the sync emitted %s as a document after it had been deleted at the source", gone)
+	}
+	if !reported {
+		e, ok := f.Connector.(connector.Enumerator)
+		if !ok {
+			t.Fatalf("%s was deleted at the source, the sync did not say so, and the connector cannot list its source either, so nothing will ever remove it from the index", gone)
+		}
+		if listed := enumerate(t, e); slices.Contains(listed, gone) {
+			t.Errorf("%s was deleted at the source and the enumeration still lists it", gone)
+		}
+	}
+
+	if c, ok := f.Connector.(connector.Fetcher); ok {
+		if _, err := c.Fetch(t.Context(), gone); !errors.Is(err, connector.ErrGone) {
+			t.Errorf("fetching %s after it was deleted returned %v, want connector.ErrGone", gone, err)
+		}
+	}
+}
+
+// A permission change reaches the index without the document being read again.
+//
+// Access at a real source does not live on the document. It lives on the folder,
+// the space or the group above it, and one edit there governs thousands of
+// documents whose content nobody touched. A connector that has to recrawl to
+// notice is a connector where a revocation costs a full sync, which in practice
+// means it waits.
+func testPermissionChange(t *testing.T, f Fixture) {
+	if f.Share == nil {
+		t.Skip("the fixture cannot change who may read a document")
+	}
+	write(t, f, first, firstText)
+	changes, cursor := syncFrom(t, f, connector.Cursor{})
+	was := find(changes, f.ID(first))
+	if was == nil {
+		t.Fatalf("a full sync did not emit %s", f.ID(first))
+	}
+	before := was.Document.Permissions
+
+	f.Share(t, first)
+	changes, _ = syncFrom(t, f, cursor)
+	now := find(changes, f.ID(first))
+	if now == nil {
+		t.Fatalf("who may read %s changed at the source and the next sync emitted %v, so the index is still serving the old answer", f.ID(first), ids(changes))
+	}
+	if samePermissions(now.Document.Permissions, before) {
+		t.Errorf("the sync after a permission change reported the permissions %s already had", f.ID(first))
+	}
+}
+
+// An enumeration and a sync have to agree on what is in the corpus. A sweep
+// built on a listing that says less than the sync does deletes documents that
+// are there, and one that says more refetches documents that are not.
+func testEnumerate(t *testing.T, f Fixture) {
+	e := enumerator(t, f)
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	write(t, f, third, thirdText)
+
+	changes, _ := syncFrom(t, f, connector.Cursor{})
+	if got, want := enumerate(t, e), sorted(changes); !slices.Equal(got, want) {
+		t.Errorf("the enumeration lists %v and the sync emitted %v", got, want)
+	}
+}
+
+// A listing stopped on purpose is not a failed listing. Reporting it as one
+// would make a reconciliation that used an early exit delete the whole index.
+func testEnumerateEarlyStop(t *testing.T, f Fixture) {
+	e := enumerator(t, f)
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	write(t, f, third, thirdText)
+
+	var n int
+	if err := e.Enumerate(t.Context(), func(connector.Item) bool {
+		n++
+		return false
+	}); err != nil {
+		t.Fatalf("an enumeration that was stopped at its first item returned %v, and a sweep reading that as a failure would delete the index", err)
+	}
+	if n != 1 {
+		t.Errorf("the enumeration called back %d times after the first one said stop", n)
+	}
+}
+
+// A repair has to produce the document the sync would have produced, or a sweep
+// that fills a hole fills it with something else.
+func testFetch(t *testing.T, f Fixture) {
+	c := fetcher(t, f)
+	write(t, f, first, firstText)
+
+	changes, _ := syncFrom(t, f, connector.Cursor{})
+	synced := find(changes, f.ID(first))
+	if synced == nil {
+		t.Fatalf("a full sync did not emit %s", f.ID(first))
+	}
+
+	got, err := c.Fetch(t.Context(), f.ID(first))
+	if err != nil {
+		t.Fatalf("fetching %s: %v", f.ID(first), err)
+	}
+	verify(t, f, connector.Change{Document: got})
+	if got.ID != synced.Document.ID {
+		t.Errorf("fetch returned id %q for %q", got.ID, synced.Document.ID)
+	}
+	if got.Body != synced.Document.Body {
+		t.Errorf("fetch returned a different body for %s than the sync did", got.ID)
+	}
+	if got.Title != synced.Document.Title {
+		t.Errorf("fetch returned title %q for %s and the sync returned %q", got.Title, got.ID, synced.Document.Title)
+	}
+	if !samePermissions(got.Permissions, synced.Document.Permissions) {
+		t.Errorf("fetch returned different permissions for %s than the sync did", got.ID)
+	}
+}
+
+// A document the source does not have is an answer rather than a failure. It is
+// how a repair learns that what it was about to refetch should be deleted.
+func testFetchGone(t *testing.T, f Fixture) {
+	c := fetcher(t, f)
+	write(t, f, first, firstText)
+
+	if _, err := c.Fetch(t.Context(), f.ID("never-written.md")); !errors.Is(err, connector.ErrGone) {
+		t.Errorf("fetching a document the source has never had returned %v, want connector.ErrGone", err)
+	}
+}
+
+// The counters are the only checkable statement that an incremental sync is
+// cheap. A local corpus is fast either way, and the same connector with the same
+// bug against a real service costs a hundred thousand requests and a revoked
+// key.
+func testCounters(t *testing.T, f Fixture) {
+	c := counted(t, f)
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	write(t, f, third, thirdText)
+
+	before := c.Counters()
+	_, cursor := syncFrom(t, f, connector.Cursor{})
+	after := c.Counters()
+
+	spent := after.Since(before)
+	if spent.Requests() == 0 {
+		t.Error("a sync that read three documents reported spending nothing at the source")
+	}
+	if spent.Fetches == 0 {
+		t.Error("a sync that read three documents counted no fetches")
+	}
+	if spent.Bytes == 0 {
+		t.Error("a sync that read three documents counted no bytes")
+	}
+	if spent.Lists < 0 || spent.Metadata < 0 || spent.Fetches < 0 || spent.Bytes < 0 {
+		t.Errorf("the counters went backwards over one sync: %+v", spent)
+	}
+
+	syncFrom(t, f, cursor)
+	if idle := c.Counters().Since(after); idle.Fetches != 0 {
+		t.Errorf("a second sync of a source nothing had changed in read %d documents, and the whole point of the cursor is that this is zero", idle.Fetches)
+	}
+}
+
+// Close runs on every path out, including the ones where something else already
+// closed. A second call that failed would turn a clean shutdown into an error in
+// the log every time.
+func testClose(t *testing.T, f Fixture) {
+	if err := f.Connector.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := f.Connector.Close(); err != nil {
+		t.Fatalf("closing a second time: %v", err)
+	}
+}

--- a/connector/connectortest/check.go
+++ b/connector/connectortest/check.go
@@ -1,0 +1,72 @@
+package connectortest
+
+import (
+	"fmt"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+)
+
+// problems reports everything wrong with one change, and nothing at all for a
+// well formed one.
+//
+// It is a plain function over a value rather than something reaching for a
+// [testing.T] so that it can be tested directly, which matters more here than
+// anywhere else in this package. A check that quietly passed everything would
+// look exactly like a suite that everything passes, and the only way to tell
+// those apart is to hand this a broken change and watch it complain.
+func problems(ch connector.Change, source string) []string {
+	var out []string
+	d := ch.Document
+
+	if d.ID == "" {
+		out = append(out, "a change carries no document id, so nothing above the connector can tell which document it is about")
+	}
+	if ch.Deleted && ch.PermissionsOnly {
+		out = append(out, d.ID+" is reported as deleted and as a permission change at the same time, and those ask for opposite things")
+	}
+	if d.Tenant != "" {
+		// The tenant is the pipeline's to set, from the run rather than from the
+		// source. A connector that fills it in is one whose documents land in
+		// whichever tenant it was first written for, and the pipeline overwrites
+		// it anyway, so the only thing the field can do here is mislead whoever
+		// reads the connector next.
+		out = append(out, fmt.Sprintf("%s carries tenant %q, which is set by the pipeline rather than by a connector", d.ID, d.Tenant))
+	}
+	if d.Source != "" && d.Source != source {
+		out = append(out, fmt.Sprintf("%s carries source %q, which is not %q", d.ID, d.Source, source))
+	}
+	if ch.PermissionsOnly && (d.Body != "" || d.Content != nil) {
+		// Nothing above reads content off a permissions only change, so a
+		// connector sending one is either wasting the read or expecting an
+		// update that will not happen.
+		out = append(out, d.ID+" is a permission change and carries content, which will not be stored")
+	}
+
+	if ch.Deleted {
+		// There is nothing left to say about a document that is gone. Asking a
+		// connector to resolve the permissions of a file it can no longer read
+		// would be asking for a guess.
+		return out
+	}
+
+	switch p := d.Permissions; {
+	case p.Source == "":
+		// This is the rule the whole suite exists for. A document indexed
+		// without the access control list that governs it is searchable by
+		// everybody, and no later fix makes it unsearchable by the people who
+		// have already found it. A connector that considered the question and
+		// failed says so with connector.Unresolved and the document is
+		// quarantined instead.
+		out = append(out, fmt.Sprintf("%s arrived without permissions: a connector that cannot work out who may read a document says so with connector.Unresolved(%q) rather than leaving the field empty", d.ID, source))
+	case p.Source != source:
+		out = append(out, fmt.Sprintf("%s has permissions from source %q, and this connector is %q", d.ID, p.Source, source))
+	}
+
+	switch d.Permissions.Mode {
+	case acl.ModeUnknown, acl.ModeACL, acl.ModePublicToTenant:
+	default:
+		out = append(out, fmt.Sprintf("%s reports permission mode %d, which is not one this system has", d.ID, int(d.Permissions.Mode)))
+	}
+	return out
+}

--- a/connector/connectortest/connectortest.go
+++ b/connector/connectortest/connectortest.go
@@ -1,0 +1,299 @@
+// Package connectortest is the conformance suite every connector has to pass.
+//
+// A connector is where the risk in this system concentrates. It is the piece
+// that is written once per source system, usually by whoever needs that source,
+// and it is the piece that decides what gets indexed and who is allowed to read
+// it. Nothing above it can tell a connector that lost half a corpus from a
+// corpus that is half the size, or a connector that never asked about
+// permissions from a source where everything really is readable by everybody.
+// This suite is how that gets told apart.
+//
+// The rules here are the contract in [connector] written down as tests, which
+// makes the suite rather than the interface the definition of a connector: the
+// interface says what compiles, and this says what works.
+//
+// # What is optional and what is not
+//
+// A connector is not required to be able to do everything. Listing a source,
+// fetching one document by id, reporting a deletion, reporting a permission
+// change without the content, and counting what a sync spent are all optional,
+// and a fixture that leaves the matching hook nil skips those cases rather than
+// failing them. What is not optional is that everything a connector does claim
+// to do is right, and the suite is deliberately harder on a connector that
+// claims more.
+//
+// The one rule with no way out is permissions. Every document a connector emits
+// has to say where its access control list came from, and a connector that
+// could not work one out says so with [connector.Unresolved] rather than
+// leaving the field empty. A document that arrives without that is a document
+// nobody can say who may read, and it fails the suite.
+//
+// Usage from a connector's own test file:
+//
+//	func TestConformance(t *testing.T) {
+//		connectortest.Run(t, func(t *testing.T) connectortest.Fixture {
+//			dir := t.TempDir()
+//			src, err := fssource.New(dir, "files", fssource.PublicToTenant("files"))
+//			if err != nil {
+//				t.Fatal(err)
+//			}
+//			return connectortest.Fixture{
+//				Connector: src,
+//				ID:        func(name string) string { return "files:" + name },
+//				Write: func(t *testing.T, name, body string) {
+//					if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+//						t.Fatal(err)
+//					}
+//				},
+//				Remove: func(t *testing.T, name string) {
+//					if err := os.Remove(filepath.Join(dir, name)); err != nil {
+//						t.Fatal(err)
+//					}
+//				},
+//			}
+//		})
+//	}
+package connectortest
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+)
+
+// Fixture is one connector and the handful of things a test has to be able to
+// do to the system behind it.
+//
+// The suite cannot write a file, put an object or post a message, and it should
+// not know which of those it is doing. A fixture is the adapter that turns "put
+// a document called a.md in the source" into whatever that means for one
+// connector, and it is the only part of running the suite that has to be
+// written per source.
+type Fixture struct {
+	// Connector is the connector under test, over a source that holds nothing
+	// yet. It is closed for you when the case ends.
+	Connector connector.Connector
+
+	// ID is the document id the connector will mint for a name that was handed
+	// to Write. It is spelled out by the fixture rather than worked out by the
+	// suite because the shape of an id is the connector's business.
+	ID func(name string) string
+
+	// Write puts a document in the source, replacing one of the same name.
+	//
+	// It has to leave the source in a state a sync can settle on. A source that
+	// keeps time to the second needs its clock moved on afterwards, or a sync
+	// taken immediately after the write records a cursor the write is not yet
+	// behind, and every later sync reads it again. Fixtures for such sources
+	// tick that clock here.
+	Write func(t *testing.T, name, body string)
+
+	// Remove deletes a document from the source. Leave it nil for a source
+	// nothing is ever removed from, which skips the deletion cases.
+	Remove func(t *testing.T, name string)
+
+	// Share changes who may read one document, without touching its content.
+	//
+	// It is what the permission change case is built on, and leaving it nil
+	// skips that case. A connector that cannot report a permission change
+	// without recrawling the document is allowed, and it pays for it on every
+	// access control edit at the source.
+	Share func(t *testing.T, name string)
+
+	// Unresolvable puts one document's access control list beyond working out,
+	// by pointing it at a group that does not resolve or a rule that cannot be
+	// read. Leave it nil for a source where that cannot happen.
+	//
+	// This is the hook behind the rule that matters most: what the suite checks
+	// is that such a document is quarantined and says so, rather than being
+	// indexed with a guess or dropped without a word.
+	Unresolvable func(t *testing.T, name string)
+}
+
+// Factory returns a fresh fixture over an empty source for one test case.
+type Factory func(t *testing.T) Fixture
+
+// Run executes the suite against a connector.
+func Run(t *testing.T, newFixture Factory) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := newFixture(t)
+			switch {
+			case f.Connector == nil:
+				t.Fatal("the fixture has no connector in it")
+			case f.ID == nil:
+				t.Fatal("the fixture does not say what a document id looks like")
+			case f.Write == nil:
+				t.Fatal("the fixture cannot put a document in the source, and every case starts by doing that")
+			}
+			t.Cleanup(func() { _ = f.Connector.Close() })
+			c.run(t, f)
+		})
+	}
+}
+
+type testCase struct {
+	name string
+	run  func(t *testing.T, f Fixture)
+}
+
+var cases = []testCase{
+	{"the source names itself", testSourceName},
+	{"a full sync finds everything the source holds", testFullSync},
+	{"a full sync run twice says the same thing", testFullSyncRepeats},
+	{"every document arrives with permissions", testPermissions},
+	{"a document nobody can resolve is quarantined and says so", testUnresolved},
+	{"a sync resumes from a cursor without losing what came after it", testResume},
+	{"an error from emit stops the sync and comes back unchanged", testEmitError},
+	{"a cancelled sync stops", testCancel},
+	{"a second sync of an unchanged source reads nothing", testIncremental},
+	{"a document written after a sync is found by the next one", testNewDocument},
+	{"a deleted document stops being part of the source", testDeleted},
+	{"a permission change arrives without the content", testPermissionChange},
+	{"enumerate lists what a sync found", testEnumerate},
+	{"enumerate stops when the callback says so", testEnumerateEarlyStop},
+	{"fetch returns the document a sync would have", testFetch},
+	{"fetch of something the source does not have is not a failure", testFetchGone},
+	{"the counters say what a sync spent", testCounters},
+	{"close is repeatable", testClose},
+}
+
+// write puts a document in the source.
+func write(t *testing.T, f Fixture, name, body string) {
+	t.Helper()
+	f.Write(t, name, body)
+}
+
+// syncFrom runs one sync and returns every change it emitted, having checked
+// each one on the way past.
+//
+// Every case goes through here, so the well formedness rules are applied to
+// every change the suite ever sees rather than only to the ones a case thought
+// to look at.
+func syncFrom(t *testing.T, f Fixture, from connector.Cursor) ([]connector.Change, connector.Cursor) {
+	t.Helper()
+	var got []connector.Change
+	next, err := f.Connector.Sync(t.Context(), from, func(_ context.Context, ch connector.Change) error {
+		verify(t, f, ch)
+		got = append(got, ch)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	return got, next
+}
+
+// verify fails the case for a change that breaks a rule every connector has to
+// keep.
+func verify(t *testing.T, f Fixture, ch connector.Change) {
+	t.Helper()
+	for _, p := range problems(ch, f.Connector.Source()) {
+		t.Error(p)
+	}
+}
+
+// ids is the document id of every change, in the order they were emitted.
+func ids(changes []connector.Change) []string {
+	out := make([]string, 0, len(changes))
+	for _, ch := range changes {
+		out = append(out, ch.Document.ID)
+	}
+	return out
+}
+
+// sorted is the ids of a set of changes, in an order two of them can be
+// compared in. The order a connector emits in is its own business.
+func sorted(changes []connector.Change) []string {
+	out := ids(changes)
+	slices.Sort(out)
+	return out
+}
+
+// find returns the change for one document, or nil if there was none.
+func find(changes []connector.Change, id string) *connector.Change {
+	for i := range changes {
+		if changes[i].Document.ID == id {
+			return &changes[i]
+		}
+	}
+	return nil
+}
+
+// enumerate lists the source, and fails the case if the walk does not finish.
+func enumerate(t *testing.T, e connector.Enumerator) []string {
+	t.Helper()
+	var out []string
+	if err := e.Enumerate(t.Context(), func(it connector.Item) bool {
+		if it.ID == "" {
+			t.Error("the enumeration listed an item with no id, which cannot be compared against anything")
+		}
+		out = append(out, it.ID)
+		return true
+	}); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// enumerator returns the connector's listing capability, or skips the case.
+//
+// The capability is optional, so a connector without it is not failing the
+// suite. A connector with it does not get to opt out of the rules about it.
+func enumerator(t *testing.T, f Fixture) connector.Enumerator {
+	t.Helper()
+	e, ok := f.Connector.(connector.Enumerator)
+	if !ok {
+		t.Skip("the connector does not list its source")
+	}
+	return e
+}
+
+// fetcher returns the connector's single document read, or skips the case.
+func fetcher(t *testing.T, f Fixture) connector.Fetcher {
+	t.Helper()
+	c, ok := f.Connector.(connector.Fetcher)
+	if !ok {
+		t.Skip("the connector cannot read one document by id")
+	}
+	return c
+}
+
+// counted returns the connector's counters, or skips the case.
+func counted(t *testing.T, f Fixture) connector.Counted {
+	t.Helper()
+	c, ok := f.Connector.(connector.Counted)
+	if !ok {
+		t.Skip("the connector does not report what it spent")
+	}
+	return c
+}
+
+// mentions reports whether a document's body has a word in it.
+//
+// The suite compares on a marker rather than on the whole body because a
+// connector is allowed to do work on the way past. A source that stores
+// markdown and indexes the text of it is not returning the bytes that went in,
+// and that is the connector doing its job.
+func mentions(body, marker string) bool {
+	return strings.Contains(body, marker)
+}
+
+// samePermissions reports whether two descriptors say the same thing.
+func samePermissions(a, b acl.Permissions) bool {
+	return a.Mode == b.Mode &&
+		a.Source == b.Source &&
+		a.Version == b.Version &&
+		a.Sharing == b.Sharing &&
+		a.Owner == b.Owner &&
+		slices.Equal(a.AllowUsers, b.AllowUsers) &&
+		slices.Equal(a.AllowGroups, b.AllowGroups) &&
+		slices.Equal(a.DenyUsers, b.DenyUsers) &&
+		slices.Equal(a.DenyGroups, b.DenyGroups)
+}

--- a/connector/connectortest/connectortest_test.go
+++ b/connector/connectortest/connectortest_test.go
@@ -1,0 +1,403 @@
+package connectortest
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/doc"
+)
+
+// The suite has to be tested twice over, and the two halves are different
+// questions.
+//
+// The first is whether a connector that does everything right passes, which is
+// what TestTheSuitePassesAConnectorThatWorks answers by running the whole thing
+// against a connector in memory. Without it the suite could be a set of rules
+// no implementation can satisfy and nobody would find out until the second one
+// was written.
+//
+// The second is whether it catches a connector that does not, which is what the
+// checks below answer. A conformance suite that passes everything looks exactly
+// like a conformance suite that everything passes, and the only way to tell
+// those apart is to hand it something broken and watch it complain.
+
+// epoch is where the fake source's clock starts, so that every time in these
+// tests is arithmetic rather than a reading of the machine.
+var epoch = time.Date(2026, time.May, 4, 10, 0, 0, 0, time.UTC)
+
+// memsource is a connector over a map, and the smallest thing that passes the
+// suite.
+//
+// It is here rather than exported because it is not a useful source of
+// documents. What it is useful for is proving that the rules in this package
+// describe something implementable, in a few hundred lines somebody can read in
+// one sitting when they are about to write a real connector.
+type memsource struct {
+	name string
+
+	mu      sync.Mutex
+	seq     int64
+	entries map[string]*entry
+
+	lists    int64
+	metadata int64
+	fetches  int64
+	bytes    int64
+}
+
+// entry is one document in the fake source, with the three clocks a real source
+// keeps: when the content was written, when the access control list was last
+// edited, and when the document was removed.
+type entry struct {
+	body    string
+	written int64
+	perms   acl.Permissions
+	shared  int64
+	removed int64
+}
+
+func newMem(name string) *memsource {
+	return &memsource{name: name, entries: make(map[string]*entry)}
+}
+
+var (
+	_ connector.Connector  = (*memsource)(nil)
+	_ connector.Enumerator = (*memsource)(nil)
+	_ connector.Fetcher    = (*memsource)(nil)
+	_ connector.Counted    = (*memsource)(nil)
+)
+
+func (m *memsource) Source() string { return m.name }
+
+func (m *memsource) Close() error { return nil }
+
+func (m *memsource) id(name string) string { return m.name + ":" + name }
+
+// tick moves the source's clock on and returns the new reading. Everything that
+// happens to a document is filed under one of these, which is what a cursor is
+// then compared against.
+func (m *memsource) tick() int64 {
+	m.seq++
+	return m.seq
+}
+
+func (m *memsource) write(name, body string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e, ok := m.entries[name]
+	if !ok {
+		e = &entry{perms: acl.Permissions{Mode: acl.ModePublicToTenant, Source: m.name}}
+		m.entries[name] = e
+	}
+	e.body = body
+	e.written = m.tick()
+	e.removed = 0
+}
+
+func (m *memsource) remove(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e, ok := m.entries[name]; ok {
+		e.removed = m.tick()
+	}
+}
+
+func (m *memsource) share(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e, ok := m.entries[name]
+	if !ok {
+		return
+	}
+	e.perms = acl.Permissions{
+		Mode:       acl.ModeACL,
+		Source:     m.name,
+		AllowUsers: []acl.Ref{{Source: m.name, Value: "alice"}},
+		Version:    e.perms.Version + 1,
+	}
+	e.shared = m.tick()
+}
+
+func (m *memsource) unresolvable(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e, ok := m.entries[name]; ok {
+		e.perms = connector.Unresolved(m.name)
+		e.shared = m.tick()
+	}
+}
+
+// names is every document in the source, in a fixed order, so that a sync does
+// the same work in the same order twice.
+func (m *memsource) names() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, 0, len(m.entries))
+	for name := range m.entries {
+		out = append(out, name)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func (m *memsource) at(name string) entry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e, ok := m.entries[name]; ok {
+		return *e
+	}
+	return entry{}
+}
+
+func (m *memsource) cursor(seq int64) connector.Cursor {
+	return connector.Cursor{
+		Value: strconv.FormatInt(seq, 10),
+		Time:  epoch.Add(time.Duration(seq) * time.Second),
+	}
+}
+
+func (m *memsource) Sync(ctx context.Context, from connector.Cursor, emit func(context.Context, connector.Change) error) (connector.Cursor, error) {
+	since, err := since(from)
+	if err != nil {
+		return connector.Cursor{}, err
+	}
+	m.mu.Lock()
+	m.lists++
+	m.mu.Unlock()
+
+	for _, name := range m.names() {
+		if err := ctx.Err(); err != nil {
+			return connector.Cursor{}, err
+		}
+		e := m.at(name)
+		switch {
+		case e.removed > since:
+			// A deletion carries no cursor. The document is gone and there is
+			// nothing to resume from that a later run could read again.
+			if since == 0 {
+				continue
+			}
+			if err := emit(ctx, connector.Change{
+				Document: doc.Document{ID: m.id(name)},
+				Deleted:  true,
+			}); err != nil {
+				return connector.Cursor{}, err
+			}
+		case e.removed != 0:
+			continue
+		case e.written > since:
+			m.mu.Lock()
+			m.fetches++
+			m.bytes += int64(len(e.body))
+			m.mu.Unlock()
+			if err := emit(ctx, connector.Change{
+				Document: m.document(name, e),
+				Cursor:   m.cursor(e.written),
+			}); err != nil {
+				return connector.Cursor{}, err
+			}
+		case e.shared > since:
+			// The content did not change, so it is not read again. This is the
+			// cheap half of the whole design and the reason the source keeps two
+			// clocks per document rather than one.
+			m.mu.Lock()
+			m.metadata++
+			m.mu.Unlock()
+			if err := emit(ctx, connector.Change{
+				Document:        doc.Document{ID: m.id(name), Permissions: e.perms},
+				PermissionsOnly: true,
+				Cursor:          m.cursor(e.shared),
+			}); err != nil {
+				return connector.Cursor{}, err
+			}
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cursor(m.seq), nil
+}
+
+func (m *memsource) Enumerate(ctx context.Context, fn func(connector.Item) bool) error {
+	m.mu.Lock()
+	m.lists++
+	m.mu.Unlock()
+	for _, name := range m.names() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		e := m.at(name)
+		if e.removed != 0 {
+			continue
+		}
+		if !fn(connector.Item{ID: m.id(name), Version: strconv.FormatInt(e.written, 10)}) {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (m *memsource) Fetch(ctx context.Context, id string) (doc.Document, error) {
+	if err := ctx.Err(); err != nil {
+		return doc.Document{}, err
+	}
+	name, ok := strings.CutPrefix(id, m.name+":")
+	if !ok {
+		return doc.Document{}, connector.ErrGone
+	}
+	e := m.at(name)
+	if e.written == 0 || e.removed != 0 {
+		return doc.Document{}, connector.ErrGone
+	}
+	m.mu.Lock()
+	m.fetches++
+	m.bytes += int64(len(e.body))
+	m.mu.Unlock()
+	return m.document(name, e), nil
+}
+
+func (m *memsource) Counters() connector.Counters {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return connector.Counters{Lists: m.lists, Metadata: m.metadata, Fetches: m.fetches, Bytes: m.bytes}
+}
+
+func (m *memsource) document(name string, e entry) doc.Document {
+	return doc.Document{
+		ID:           m.id(name),
+		Kind:         doc.KindFile,
+		Title:        name,
+		Body:         e.body,
+		ModifiedAt:   epoch.Add(time.Duration(e.written) * time.Second),
+		SourceUpdate: strconv.FormatInt(e.written, 10),
+		Permissions:  e.perms,
+	}
+}
+
+// since reads the fake source's cursor.
+func since(c connector.Cursor) (int64, error) {
+	if c.Value == "" {
+		return 0, nil
+	}
+	n, err := strconv.ParseInt(c.Value, 10, 64)
+	if err != nil {
+		return 0, errors.New("connectortest: the cursor did not come from this source")
+	}
+	return n, nil
+}
+
+// A connector that does everything the contract asks passes every case,
+// including the optional ones.
+func TestTheSuitePassesAConnectorThatWorks(t *testing.T) {
+	Run(t, func(t *testing.T) Fixture {
+		src := newMem("memory")
+		return Fixture{
+			Connector:    src,
+			ID:           src.id,
+			Write:        func(_ *testing.T, name, body string) { src.write(name, body) },
+			Remove:       func(_ *testing.T, name string) { src.remove(name) },
+			Share:        func(_ *testing.T, name string) { src.share(name) },
+			Unresolvable: func(_ *testing.T, name string) { src.unresolvable(name) },
+		}
+	})
+}
+
+// A well formed change is not complained about, which is the half of the check
+// that stops it being noise.
+func TestNothingIsWrongWithAGoodChange(t *testing.T) {
+	ch := connector.Change{
+		Document: doc.Document{
+			ID:          "memory:a.md",
+			Title:       "a.md",
+			Body:        "something worth reading",
+			Permissions: acl.Permissions{Mode: acl.ModePublicToTenant, Source: "memory"},
+		},
+		Cursor: connector.Cursor{Value: "1"},
+	}
+	if got := problems(ch, "memory"); len(got) != 0 {
+		t.Fatalf("a well formed change was reported as %v", got)
+	}
+}
+
+// The rule the whole suite exists for, and the failures around it. A document
+// indexed without the access control list that governs it is searchable by
+// everybody, and no later fix makes it unsearchable by the people who already
+// found it.
+func TestAChangeThatBreaksARuleIsCaught(t *testing.T) {
+	good := acl.Permissions{Mode: acl.ModePublicToTenant, Source: "memory"}
+	tests := []struct {
+		name   string
+		change connector.Change
+		want   string
+	}{
+		{
+			"a document indexed without permissions",
+			connector.Change{Document: doc.Document{ID: "memory:a.md", Body: "text"}},
+			"arrived without permissions",
+		},
+		{
+			"a document whose permissions came from somewhere else",
+			connector.Change{Document: doc.Document{ID: "memory:a.md", Permissions: acl.Permissions{Mode: acl.ModeACL, Source: "slack"}}},
+			`permissions from source "slack"`,
+		},
+		{
+			"a permission mode this system does not have",
+			connector.Change{Document: doc.Document{ID: "memory:a.md", Permissions: acl.Permissions{Mode: acl.Mode(9), Source: "memory"}}},
+			"permission mode 9",
+		},
+		{
+			"a change with no document id",
+			connector.Change{Document: doc.Document{Permissions: good}},
+			"carries no document id",
+		},
+		{
+			"a connector that filled in the tenant",
+			connector.Change{Document: doc.Document{ID: "memory:a.md", Tenant: "acme", Permissions: good}},
+			"set by the pipeline",
+		},
+		{
+			"a document stamped with another connector's source",
+			connector.Change{Document: doc.Document{ID: "memory:a.md", Source: "slack", Permissions: good}},
+			`carries source "slack"`,
+		},
+		{
+			"a permission change carrying content",
+			connector.Change{Document: doc.Document{ID: "memory:a.md", Body: "text", Permissions: good}, PermissionsOnly: true},
+			"carries content",
+		},
+		{
+			"a change that is both a deletion and a permission change",
+			connector.Change{Document: doc.Document{ID: "memory:a.md"}, Deleted: true, PermissionsOnly: true},
+			"opposite things",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := problems(tt.change, "memory")
+			if len(got) == 0 {
+				t.Fatalf("nothing was reported for %+v", tt.change)
+			}
+			if !slices.ContainsFunc(got, func(p string) bool { return strings.Contains(p, tt.want) }) {
+				t.Errorf("reported %v, want something saying %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A deletion is not asked for permissions. The document is gone and there is
+// nobody left to resolve a rule against, so requiring one would be requiring a
+// guess.
+func TestADeletionIsNotAskedForPermissions(t *testing.T) {
+	ch := connector.Change{Document: doc.Document{ID: "memory:a.md"}, Deleted: true}
+	if got := problems(ch, "memory"); len(got) != 0 {
+		t.Fatalf("a deletion was reported as %v", got)
+	}
+}

--- a/connector/fssource/conformance_test.go
+++ b/connector/fssource/conformance_test.go
@@ -1,0 +1,142 @@
+package fssource_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/connectortest"
+	"github.com/tamnd/genba/connector/fssource"
+)
+
+// TestConformance runs the connector conformance suite against this connector.
+//
+// This is the reference run. fssource is the connector the interface was
+// written against, so a rule the suite checks that this cannot pass is a rule
+// about somebody's idea of a source rather than about connectors, and belongs
+// in neither place.
+func TestConformance(t *testing.T) {
+	connectortest.Run(t, func(t *testing.T) connectortest.Fixture {
+		root := t.TempDir()
+		policy := newFixturePolicy("files")
+		src, err := fssource.New(root, "files", policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return connectortest.Fixture{
+			Connector: src,
+			ID:        func(name string) string { return "files:" + name },
+			Write: func(t *testing.T, name, body string) {
+				t.Helper()
+				full := filepath.Join(root, filepath.FromSlash(name))
+				if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				// A modification time is as coarse as the platform says it is,
+				// and two files written inside one test land on the same one on
+				// more platforms than not. Stamping each write from a clock the
+				// fixture keeps makes the order a sync sees the order the test
+				// wrote in, everywhere, and it is the same thing a fixture over
+				// a service with a one second clock has to do.
+				at := policy.tick()
+				if err := os.Chtimes(full, at, at); err != nil {
+					t.Fatal(err)
+				}
+			},
+			Remove: func(t *testing.T, name string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(root, filepath.FromSlash(name))); err != nil {
+					t.Fatal(err)
+				}
+			},
+			Share:        func(_ *testing.T, name string) { policy.share(name) },
+			Unresolvable: func(_ *testing.T, name string) { policy.fail(name) },
+		}
+	})
+}
+
+// fixturePolicy is a policy whose answers a test can change.
+//
+// It stands in for the OWNERS file or the group export a real deployment plugs
+// in here, and it keeps a clock of its own so that a permission edit is always
+// filed after the last file was written. That is what a sync compares against
+// when it decides whether an access control list moved since the last run.
+type fixturePolicy struct {
+	source string
+
+	mu      sync.Mutex
+	at      time.Time
+	perms   map[string]acl.Permissions
+	changed map[string]time.Time
+	broken  map[string]bool
+}
+
+func newFixturePolicy(source string) *fixturePolicy {
+	return &fixturePolicy{
+		source:  source,
+		at:      time.Date(2026, time.May, 4, 10, 0, 0, 0, time.UTC),
+		perms:   make(map[string]acl.Permissions),
+		changed: make(map[string]time.Time),
+		broken:  make(map[string]bool),
+	}
+}
+
+var (
+	_ fssource.Policy    = (*fixturePolicy)(nil)
+	_ fssource.Versioned = (*fixturePolicy)(nil)
+)
+
+// tick moves the fixture's clock on and returns the new reading.
+func (p *fixturePolicy) tick() time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.at = p.at.Add(time.Second)
+	return p.at
+}
+
+func (p *fixturePolicy) Permissions(_ context.Context, rel string) (acl.Permissions, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.broken[rel] {
+		return acl.Permissions{}, errors.New("the group this file is shared with does not resolve")
+	}
+	if perm, ok := p.perms[rel]; ok {
+		return perm, nil
+	}
+	return acl.Permissions{Mode: acl.ModePublicToTenant, Source: p.source}, nil
+}
+
+func (p *fixturePolicy) ChangedAt(_ context.Context, rel string) (time.Time, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.changed[rel], nil
+}
+
+// share narrows one file to one person, which is the edit a real deployment
+// makes in the file above it rather than on the file itself.
+func (p *fixturePolicy) share(rel string) {
+	at := p.tick()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.perms[rel] = acl.Permissions{
+		Mode:       acl.ModeACL,
+		Source:     p.source,
+		AllowUsers: []acl.Ref{{Source: "unix", Value: "alice"}},
+		Version:    p.perms[rel].Version + 1,
+	}
+	p.changed[rel] = at
+}
+
+// fail puts one file's access control list beyond working out.
+func (p *fixturePolicy) fail(rel string) {
+	at := p.tick()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.broken[rel] = true
+	p.changed[rel] = at
+}

--- a/connector/objectsource/conformance_test.go
+++ b/connector/objectsource/conformance_test.go
@@ -1,0 +1,129 @@
+package objectsource_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/connectortest"
+	"github.com/tamnd/genba/connector/objectsource"
+)
+
+// TestConformance runs the connector conformance suite against this connector.
+//
+// It runs against the fake service for the same reason the rest of this
+// package's tests do. What the suite is checking is the connector's behaviour,
+// which a real bucket would answer the same way and would also make this need a
+// network and an account.
+func TestConformance(t *testing.T) {
+	connectortest.Run(t, func(t *testing.T) connectortest.Fixture {
+		store := newStore(t)
+		policy := newFixturePolicy("objects")
+		src, err := objectsource.New(store.client(t), "objects", policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return connectortest.Fixture{
+			Connector: src,
+			ID:        func(name string) string { return "objects:" + name },
+			Write: func(_ *testing.T, name, body string) {
+				store.put(name, body)
+				// Object storage keeps one modification time per object, to the
+				// second, and this connector holds its cursor a second behind
+				// the service's own clock so that an object written later in the
+				// same second is not filed under a time the cursor has passed.
+				// Moving the service's clock on after a write is what leaves a
+				// sync something to settle on, and it is what a real bucket does
+				// by itself while nobody is looking.
+				store.tick(2 * time.Second)
+			},
+			Remove:       func(_ *testing.T, name string) { store.remove(name) },
+			Share:        func(_ *testing.T, name string) { policy.share(name) },
+			Unresolvable: func(_ *testing.T, name string) { policy.fail(name) },
+		}
+	})
+}
+
+// fixturePolicy is a policy whose answers a test can change.
+//
+// The bucket and object policies in this package read a real access control
+// list and are tested against one elsewhere. What the suite needs is something
+// that can be made to change its mind on demand, and to fail for one object
+// without failing for the rest.
+type fixturePolicy struct {
+	source string
+
+	mu      sync.Mutex
+	at      time.Time
+	perms   map[string]acl.Permissions
+	changed map[string]time.Time
+	broken  map[string]bool
+}
+
+func newFixturePolicy(source string) *fixturePolicy {
+	return &fixturePolicy{
+		source:  source,
+		at:      time.Date(2026, time.May, 4, 10, 0, 0, 0, time.UTC),
+		perms:   make(map[string]acl.Permissions),
+		changed: make(map[string]time.Time),
+		broken:  make(map[string]bool),
+	}
+}
+
+var (
+	_ objectsource.Policy    = (*fixturePolicy)(nil)
+	_ objectsource.Versioned = (*fixturePolicy)(nil)
+)
+
+// tick moves the fixture's clock on and returns the new reading, so that a
+// permission edit is always filed after the object was written.
+func (p *fixturePolicy) tick() time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.at = p.at.Add(time.Second)
+	return p.at
+}
+
+func (p *fixturePolicy) Permissions(_ context.Context, key string) (acl.Permissions, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.broken[key] {
+		return acl.Permissions{}, errors.New("the account this object is shared with does not resolve")
+	}
+	if perm, ok := p.perms[key]; ok {
+		return perm, nil
+	}
+	return acl.Permissions{Mode: acl.ModePublicToTenant, Source: p.source}, nil
+}
+
+func (p *fixturePolicy) ChangedAt(_ context.Context, key string) (time.Time, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.changed[key], nil
+}
+
+// share narrows one object to one person, without the object being touched.
+func (p *fixturePolicy) share(key string) {
+	at := p.tick()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.perms[key] = acl.Permissions{
+		Mode:       acl.ModeACL,
+		Source:     p.source,
+		AllowUsers: []acl.Ref{{Source: "email", Value: "alice@example.com"}},
+		Version:    p.perms[key].Version + 1,
+	}
+	p.changed[key] = at
+}
+
+// fail puts one object's access control list beyond working out.
+func (p *fixturePolicy) fail(key string) {
+	at := p.tick()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.broken[key] = true
+	p.changed[key] = at
+}

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -375,3 +375,48 @@ Everything else is optional, and each piece buys one thing.
 `connector/fssource` implements every one of them and is the one to read before writing another.
 `connector/objectsource` implements all but the deletion, over a network service, and is the one to read for the parts a local source never has to deal with: signing, paging, and a listing whose order has nothing to do with what changed.
 A bucket listing is the same shape of problem as a walk, and an object that is no longer in it is found by the sweep for the same reason.
+
+### The conformance suite is the definition
+
+`connector/connectortest` is what a connector has to pass, and it rather than the interface is the definition of one.
+The interface says what compiles.
+The suite says what works, because most of what a connector has to get right is not expressible as a method signature: that a full sync finds everything, that resuming from a cursor loses nothing, that a second sync of a source nothing changed in reads nothing, and that every document says who may read it.
+
+Running it takes a fixture, which is the adapter between the suite and one source.
+The suite cannot write a file, put an object or post a message, and it should not know which of those it is doing, so a fixture is a connector plus a handful of functions that do those things to the system behind it.
+
+```go
+func TestConformance(t *testing.T) {
+	connectortest.Run(t, func(t *testing.T) connectortest.Fixture {
+		dir := t.TempDir()
+		src, err := fssource.New(dir, "files", fssource.PublicToTenant("files"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return connectortest.Fixture{
+			Connector: src,
+			ID:        func(name string) string { return "files:" + name },
+			Write:     func(t *testing.T, name, body string) { /* put it in the source */ },
+			Remove:    func(t *testing.T, name string) { /* take it out again */ },
+		}
+	})
+}
+```
+
+`Remove`, `Share` and `Unresolvable` are optional and a fixture that leaves one nil skips the cases that need it, which is how a source nothing is ever deleted from is not failed for a deletion it cannot do.
+The optional capabilities work the same way: a connector that does not implement `Enumerator` skips the listing cases, and one that does gets held to them.
+The suite is deliberately harder on a connector that claims more.
+
+`Write` has one responsibility worth knowing about before writing a fixture.
+It has to leave the source in a state a sync can settle on, which for a source that keeps time to the second means moving that clock on afterwards.
+Without it a sync taken straight after a write records a cursor the write is not yet behind, and every later sync reads the same document again, which the suite reports as an incremental sync that is not incremental.
+The fixture over object storage ticks the fake service's clock and the one over the filesystem stamps each file, and both are doing the same thing for the same reason.
+
+The one rule with no way out is permissions.
+Every document a connector emits has to say where its access control list came from, and a connector that could not work one out says so with `connector.Unresolved` rather than leaving the field empty.
+Both produce `acl.ModeUnknown` and both quarantine the document, and the difference is that one of them says at the call site that the question was considered.
+A change that arrives with an empty `Permissions.Source` is a connector that forgot, and it fails the suite.
+
+Running the suite is not optional either.
+`TestEveryConnectorRunsTheConformanceSuite` at the root of the module looks for the packages that declare a connector and fails for any of them whose tests do not call `connectortest.Run`.
+A conformance suite nobody runs is documentation, and documentation about permissions is the first thing skipped when a connector is written in a hurry against a source somebody needs indexed by Friday.


### PR DESCRIPTION
A connector is where the risk in this system concentrates.
It is written once per source system, usually by whoever needs that source indexed, and it decides both what gets indexed and who is allowed to read it.
Nothing above it can tell a connector that lost half a corpus from a corpus that is half the size, or a connector that never asked about permissions from a source where everything really is readable by everybody.

This adds `connector/connectortest`, the suite that tells those apart.
It is the contract in `connector` written down as tests, which makes the suite rather than the interface the definition of a connector: the interface says what compiles, and this says what works.

## What it checks

Eighteen cases, run against a fixture.

- The source names itself, and keeps the same name across calls, because that name is what a resume point is filed under.
- A full sync finds everything the source holds, and two full syncs say the same thing.
- Every document arrives with permissions.
- A document whose access control list would not resolve is quarantined and says so, and the rest of the sync carries on.
- A sync resumes from a change's cursor without losing anything that was emitted after it.
- An error from `emit` stops the sync and comes back unchanged.
- A cancelled sync stops.
- A second sync of a source nothing changed in reads nothing, and a document written after a sync is found by the next one.
- A deleted document stops being part of the source, either because the sync says so or because the enumeration stops listing it.
- A permission change reaches the index without the content being read again.
- An enumeration lists what a sync found, and a listing stopped on purpose is not a failed listing.
- A fetch returns the document a sync would have, and a fetch of something the source does not have is `ErrGone` rather than an error.
- The counters say what a sync spent, and the second sync of an unchanged source spends no fetches.
- Close is repeatable.

## What is optional

A connector is not required to be able to do everything.
`Remove`, `Share` and `Unresolvable` on the fixture are optional and leaving one nil skips the cases that need it, so a source nothing is ever deleted from is not failed for a deletion it cannot do.
The optional capabilities work the same way: a connector that does not implement `Enumerator` skips the listing cases, and one that does gets held to them.
The suite is deliberately harder on a connector that claims more.

The one rule with no way out is permissions.
Every document a connector emits has to say where its access control list came from, and a connector that could not work one out says so with `connector.Unresolved` rather than leaving the field empty.
Both produce `acl.ModeUnknown` and both quarantine the document, and the difference is that one of them says at the call site that the question was considered.
A change that arrives with an empty `Permissions.Source` is a connector that forgot, and it fails.

## Testing the suite

The checks on a single change are a plain function over a value rather than something reaching for a `testing.T`, so the package's own tests hand it broken changes and watch it complain.
A conformance suite that passes everything looks exactly like a conformance suite that everything passes, and that is the only way to tell those apart.

The same test file carries a connector over a map, which runs the whole suite.
It is there to prove the rules describe something implementable, in a few hundred lines somebody can read in one sitting before writing a real one.

## The two connectors

Both pass unchanged, which is the answer I wanted from writing the rules out of the interface documentation rather than out of either implementation.

Their fixtures are worth reading before writing a third, because both have to stamp a write with a clock of their own.
A filesystem modification time is as coarse as the platform says it is and two files written inside one test land on the same one on more platforms than not, and object storage keeps one second and this connector holds its cursor a second behind the service's clock on purpose.
A sync taken straight after a write would otherwise record a cursor the write is not yet behind, and every later sync would read the same document again, which the suite reports as an incremental sync that is not incremental.

## Running it is not optional

`TestEveryConnectorRunsTheConformanceSuite` at the root of the module finds the packages that declare a connector and fails any of them whose tests do not call `connectortest.Run`.
It reads the files rather than the types, because the thing being checked is that a test exists, and a reflective check would need the test to be running to find out that the test is not there.
It also fails if it finds no connectors at all, so a change in how they are written cannot make it quietly stop checking anything.

A conformance suite nobody runs is documentation, and documentation about permissions is the first thing skipped when a connector is written in a hurry against a source somebody needs indexed by Friday.

Closes #17.