### PR TITLE
acl: add Mode.Valid and use it in the conformance check

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -114,6 +114,26 @@ const (
 	ModeOwnerOnly
 )
 
+// Valid reports whether m is one of the modes above.
+//
+// A mode is a small integer and it arrives from places the compiler does not
+// check: a connector written against an older version of this package, a row
+// read back out of a store, a value decoded from a cursor. An unrecognised one
+// is not a mode this system knows how to apply, and the only safe reading of it
+// is that the descriptor did not resolve.
+//
+// The switch has no default clause on purpose. That is what makes the linter
+// fail here when a mode is added, which is a great deal better than the
+// alternative, where a new mode is quietly reported as not existing by every
+// check that was written before it.
+func (m Mode) Valid() bool {
+	switch m {
+	case ModeUnknown, ModeACL, ModePublicToTenant, ModeOwnerOnly:
+		return true
+	}
+	return false
+}
+
 // Sharing records how far a source said a document travels, beyond the people
 // its lists name.
 //

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -147,6 +147,22 @@ func TestAllowsNilPrincipal(t *testing.T) {
 	}
 }
 
+func TestModeValid(t *testing.T) {
+	for _, mode := range []acl.Mode{acl.ModeUnknown, acl.ModeACL, acl.ModePublicToTenant, acl.ModeOwnerOnly} {
+		if !mode.Valid() {
+			t.Errorf("mode %d is one of ours and Valid said it is not", int(mode))
+		}
+	}
+	// Anything past the last mode is a number somebody made up, or a mode from
+	// a version of this package that is not the one this binary was built
+	// against. Neither is a rule this system knows how to apply.
+	for _, mode := range []acl.Mode{acl.Mode(4), acl.Mode(9), acl.Mode(255)} {
+		if mode.Valid() {
+			t.Errorf("mode %d is not one of ours and Valid said it is", int(mode))
+		}
+	}
+}
+
 func TestResolve(t *testing.T) {
 	perms := []acl.Permissions{
 		0: {Mode: acl.ModePublicToTenant},

--- a/connector/connectortest/check.go
+++ b/connector/connectortest/check.go
@@ -3,7 +3,6 @@ package connectortest
 import (
 	"fmt"
 
-	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/connector"
 )
 
@@ -63,9 +62,7 @@ func problems(ch connector.Change, source string) []string {
 		out = append(out, fmt.Sprintf("%s has permissions from source %q, and this connector is %q", d.ID, p.Source, source))
 	}
 
-	switch d.Permissions.Mode {
-	case acl.ModeUnknown, acl.ModeACL, acl.ModePublicToTenant:
-	default:
+	if !d.Permissions.Mode.Valid() {
 		out = append(out, fmt.Sprintf("%s reports permission mode %d, which is not one this system has", d.ID, int(d.Permissions.Mode)))
 	}
 	return out

--- a/connector/connectortest/connectortest_test.go
+++ b/connector/connectortest/connectortest_test.go
@@ -392,6 +392,28 @@ func TestAChangeThatBreaksARuleIsCaught(t *testing.T) {
 	}
 }
 
+// TestEveryModeThePermissionModelHasIsAccepted is the other half of the mode
+// check, and it is the half that gets left out.
+//
+// The check exists to catch a connector that invented a number, and a check
+// written from a list somebody typed catches a connector using a mode that was
+// added after the list. That failure is worse than the one it was guarding
+// against: the connector is right, the descriptor is right, and the suite says
+// the mode does not exist. Ranging over the modes rather than naming them here
+// is what keeps the two lists from being two lists.
+func TestEveryModeThePermissionModelHasIsAccepted(t *testing.T) {
+	modes := []acl.Mode{acl.ModeUnknown, acl.ModeACL, acl.ModePublicToTenant, acl.ModeOwnerOnly}
+	for _, mode := range modes {
+		ch := connector.Change{Document: doc.Document{
+			ID:          "memory:a.md",
+			Permissions: acl.Permissions{Mode: mode, Source: "memory"},
+		}}
+		if got := problems(ch, "memory"); len(got) != 0 {
+			t.Errorf("mode %d was reported as %v", int(mode), got)
+		}
+	}
+}
+
 // A deletion is not asked for permissions. The document is gone and there is
 // nobody left to resolve a rule against, so requiring one would be requiring a
 // guess.


### PR DESCRIPTION
The conformance suite added last week checks that a change carries a permission mode this system actually has, and it did that by listing the modes by hand.
The list was missing `ModeOwnerOnly`, so a connector reporting the mode a private file actually has would have been told, in as many words, that the mode does not exist.

The filesystem connector produces that mode today for a file only its owner can read.
The suite passed it because the conformance fixture builds its permissions from a policy that never returns that mode, which is exactly the shape of bug where the test and the code are both wrong in the same direction.

## What changed

`acl.Mode` gets a `Valid` method and the check calls it.

The method belongs in `acl` because which modes exist is a fact about the permission model rather than about the test suite, and a list of them kept anywhere else is a second list to forget to update.
Its switch has no default clause on purpose.
The lint configuration sets `default-signifies-exhaustive`, which is why the original switch compiled and passed with a case missing, so leaving the default off is what makes the linter fail here the next time a mode is added.

## Tests

`TestModeValid` covers the four modes and three numbers that are not modes.

`TestEveryModeThePermissionModelHasIsAccepted` is the one that would have caught the original bug.
It runs every mode through the checker and requires all of them to be accepted, which is the half of a mode check that normally gets left out.