### PR TITLE
connector/thread: assemble a conversation into one document

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ func main() {
 | `connector/connectortest` | the conformance suite that defines what a connector is |
 | `connector/fssource` | the reference connector, a directory tree with OWNERS files, walked or watched |
 | `connector/objectsource` | an S3 compatible bucket, signed and paged, [docs/ingestion.md](docs/ingestion.md) |
+| `connector/thread` | a conversation and its replies assembled into one document |
 | `connector/limit` | the rate limit, backoff and circuit breaker every connector shares, as a round tripper |
 | `extract` | text and structure out of PDF, Word, PowerPoint, Excel, HTML and Markdown, [docs/extraction.md](docs/extraction.md) |
 | `ingest` | the pipeline that runs a connector into a store |
@@ -429,6 +430,12 @@ Everything after the first sync is incremental.
 A second run over an unchanged tree reads no files at all, an OWNERS edit costs one write per document rather than a recrawl of the subtree, and a reconciliation sweep after every sync catches what a change feed cannot report, starting with the file somebody deleted.
 The same holds over a network: a second sync of an unchanged bucket fetches no objects and reads no bytes, and rewriting the bucket's access control list costs one write per object rather than a fetch of the whole bucket.
 [docs/ingestion.md](docs/ingestion.md) has the details, including the optional capabilities a connector implements to get each of those and the rule that stops a timed out enumeration from emptying a working index.
+
+Chat, ticket trackers and wikis all keep the same shape underneath the vocabulary, and `connector/thread` is the one place it is assembled.
+Something is said and then people say things about it: a message and its replies, an issue and its comments, a page and the discussion at the bottom of it.
+An index that copies the source's row per message shape answers badly, because a question about a cancelled order returns fourteen rows from the same conversation and none of them is the answer on its own, while the reply that holds the answer scores nothing for the word in the question because that word was in the message above it.
+So a conversation is one document that ranks as a whole, the author of each message goes into the body in front of what they said, a repeated message is kept once because a paged reply listing repeats the parent on every page, and a thread too long to fit keeps its beginning and its end and says how many messages it left out.
+Nothing is written in place of what was left out, because a marker in a body is a phrase in the index that nobody at the source ever typed.
 
 What a connector is gets decided by `connector/connectortest` rather than by the interface.
 The interface says what compiles, and the suite says what works: that a full sync finds everything, that resuming from a cursor loses nothing that came after it, that a second sync of a source nothing changed in reads nothing, that a deleted document stops being part of the source one way or the other, and that every document says who may read it.

--- a/arch_test.go
+++ b/arch_test.go
@@ -136,7 +136,14 @@ var allowed = map[string][]string{
 	// suite that could only be run by packages allowed to import it, and would
 	// slowly turn into a description of that one connector.
 	"connector/connectortest": {"acl", "connector", "doc"},
-	"connector/fssource":      {"acl", "connector", "connector/aclmap", "doc", "extract"},
+	// thread is the assembly of a conversation into one document, and it names
+	// acl and doc because a document and the rule that governs it are what it
+	// produces. It does not name connector, which is the point of it being a
+	// separate package: assembling a thread is a transformation of values with
+	// no cursor, no source and nothing to close, and keeping it out of reach of
+	// the connector interface is what keeps it testable as arithmetic.
+	"connector/thread":   {"acl", "doc"},
+	"connector/fssource": {"acl", "connector", "connector/aclmap", "doc", "extract"},
 	// objectsource sits at the same level as fssource and names the same five
 	// packages. It talks to a network service and fssource does not, and none of
 	// that difference is allowed to show up as a dependency: an S3 client of our

--- a/connector/thread/thread.go
+++ b/connector/thread/thread.go
@@ -1,0 +1,462 @@
+// Package thread turns a conversation into one document.
+//
+// Chat, ticket trackers and wikis all keep the same shape underneath the
+// vocabulary. Something is said, and then people say things about it: a message
+// and its replies, an issue and its comments, a page and the discussion at the
+// bottom of it. The source stores those as separate rows because that is how
+// they were written, one at a time, by different people on different days.
+//
+// An index that copies that shape is an index that answers badly. Ask it why
+// the gearbox order was cancelled and it returns fourteen rows from the same
+// conversation, ranked against each other, none of which is the answer on its
+// own. The reply that says "supplier could not meet the date" scores nothing at
+// all for the word gearbox, because the word gearbox was in the message above
+// it and was never repeated. Worse, the fourteen rows crowd out the thirteen
+// other conversations that should have been on the page.
+//
+// So a conversation is one document. It is one result, it ranks as a whole,
+// and every word anybody said in it is a word that can find it.
+//
+// # What this package does not do
+//
+// It does not talk to anything. A connector fetches the messages, resolves who
+// wrote them and works out who may read the result, and hands the pieces here.
+// That is what makes this the one place the assembly is defined rather than the
+// same assembly written three times with three sets of small differences
+// nobody meant.
+//
+// It does not decide permissions either, and [Conversation.Document] takes them
+// rather than filling them in. A conversation is assembled out of messages from
+// a container whose access rules the connector had to read anyway, and a
+// signature that lets the caller forget the answer is a signature that invites
+// a thread being indexed without one.
+package thread
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+)
+
+// DefaultMaxBody is how much of a conversation goes into a document body.
+//
+// It is generous because a conversation is the one thing in a corpus that has
+// no natural size: a thread runs for as long as people keep replying, and the
+// long ones are usually the ones worth finding. Past this the body stops
+// growing and the document says so.
+const DefaultMaxBody = 128 << 10
+
+// TitleLimit is how long a title derived from the first message may get.
+//
+// Chat has no titles. A thread's title has to be made out of what somebody
+// typed first, and what somebody typed first is sometimes four paragraphs.
+const TitleLimit = 80
+
+// Message is one thing somebody said.
+type Message struct {
+	// ID is the source's own identifier for the message. It has to be unique
+	// within the conversation and stable across reads, because it is what
+	// deduplicates a paged reply listing.
+	ID string
+
+	// Author is who wrote it, resolved as far as the connector managed. A
+	// message whose author could not be resolved at all is still worth
+	// indexing: the text is the part somebody is searching for.
+	Author doc.Person
+
+	// At is when it was written.
+	At time.Time
+
+	// Edited is when it was last changed, and is zero for a message nobody went
+	// back to. It matters more than it looks: a message edited in place changes
+	// what the document says without any reply being added, and a version
+	// derived only from reply times would leave the index serving the old text
+	// until somebody happened to answer.
+	Edited time.Time
+
+	// Text is what was said, as plain text. Turning a source's own markup into
+	// this is the connector's job, because every one of them has a different
+	// one.
+	Text string
+}
+
+// last is when this message last changed.
+func (m Message) last() time.Time {
+	if m.Edited.After(m.At) {
+		return m.Edited
+	}
+	return m.At
+}
+
+// Conversation is a root message and everything said in reply to it.
+type Conversation struct {
+	// ID is the document id, already in whatever form the connector files
+	// documents under. This package does not build it, because the shape of an
+	// id is the connector's business and every one of them prefixes its own
+	// name.
+	ID string
+
+	// Kind is the document kind, and defaults to [doc.KindMessage].
+	Kind doc.Kind
+
+	// Title is the source's own title, for the sources that have one. An issue
+	// has a summary and a wiki page has a heading. Chat has neither, and a
+	// conversation with no title gets one made out of its first message.
+	Title string
+
+	// Container is the channel, project or space the conversation lives in.
+	Container string
+
+	// URL links to the conversation at the source.
+	URL string
+
+	// Root is the message the conversation is about.
+	Root Message
+
+	// Replies is everything said after it, in any order. Duplicates are
+	// dropped, which is not a nicety: a paged reply listing at more than one
+	// source repeats the parent message on every page, so a connector that
+	// concatenates the pages hands over the root three times.
+	Replies []Message
+
+	// Revision is the source's own version of the conversation, for a source
+	// that keeps one. A source that does not leaves it empty and gets a version
+	// derived from when the conversation last changed.
+	Revision string
+
+	// Properties are the source specific fields worth faceting on, such as a
+	// ticket status. They are copied into the document and anything this
+	// package sets is only set if the caller did not.
+	Properties map[string]string
+}
+
+// Option adjusts how a conversation is turned into a document.
+type Option func(*options)
+
+type options struct {
+	maxBody int
+}
+
+// WithMaxBody sets how much of a conversation goes into the body. A value below
+// one selects [DefaultMaxBody].
+func WithMaxBody(n int) Option {
+	return func(o *options) {
+		if n > 0 {
+			o.maxBody = n
+		}
+	}
+}
+
+// Document assembles the conversation into one document that perm governs.
+//
+// Everything the conversation knows is filled in. The tenant and the source
+// name are not, because those belong to the run and to the connector rather
+// than to the conversation.
+func (c Conversation) Document(perm acl.Permissions, opts ...Option) doc.Document {
+	o := options{maxBody: DefaultMaxBody}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	msgs, rooted := c.ordered()
+	body, omitted := assemble(msgs, o.maxBody)
+
+	replies := len(msgs)
+	if rooted {
+		replies--
+	}
+
+	kind := c.Kind
+	if kind == "" {
+		kind = doc.KindMessage
+	}
+
+	props := make(map[string]string, len(c.Properties)+5)
+	for k, v := range c.Properties {
+		props[k] = v
+	}
+	setIfAbsent(props, doc.MediaType, "text/plain")
+	setIfAbsent(props, "messages", strconv.Itoa(len(msgs)))
+	setIfAbsent(props, "replies", strconv.Itoa(replies))
+	setIfAbsent(props, "participants", strconv.Itoa(participants(msgs)))
+	if omitted > 0 {
+		// The body is part of the conversation rather than the whole of it. A
+		// reader that cannot tell the difference will report a thread as
+		// missing a sentence that is in it.
+		setIfAbsent(props, "truncated", "true")
+		setIfAbsent(props, "omitted_messages", strconv.Itoa(omitted))
+	}
+
+	created, modified := span(msgs)
+	revision := c.Revision
+	if revision == "" && !modified.IsZero() {
+		// A conversation whose source keeps no version of its own still needs
+		// one, or an incremental sync has no way to tell a thread that gained a
+		// reply from one that did not. When the last thing in it happened is
+		// the honest answer and it moves for an edit as well as for a reply.
+		revision = modified.UTC().Format(time.RFC3339Nano)
+	}
+
+	return doc.Document{
+		ID:           c.ID,
+		Kind:         kind,
+		Title:        c.title(),
+		Body:         body,
+		URL:          c.URL,
+		Author:       c.Root.Author,
+		Container:    c.Container,
+		CreatedAt:    created,
+		ModifiedAt:   modified,
+		SourceUpdate: revision,
+		Permissions:  perm,
+		Properties:   props,
+	}
+}
+
+// ordered is every message in the conversation, root first and replies in the
+// order they were written.
+//
+// The root is pinned to the front rather than sorted with the rest because it
+// is the front whatever its timestamp says. Sources do move it: a ticket
+// description edited after the first comment carries a later time than the
+// comment, and an imported conversation carries whatever time the import wrote.
+func (c Conversation) ordered() (msgs []Message, rooted bool) {
+	out := make([]Message, 0, len(c.Replies)+1)
+	seen := make(map[string]bool, len(c.Replies)+1)
+
+	rooted = !c.Root.empty()
+	if rooted {
+		out = append(out, c.Root)
+		seen[c.Root.ID] = true
+	}
+	for _, m := range c.Replies {
+		if m.empty() {
+			continue
+		}
+		// A message with no id cannot be deduplicated and is kept, because
+		// dropping it would lose content over a field the source did not fill
+		// in. A message with one is kept once.
+		if m.ID != "" {
+			if seen[m.ID] {
+				continue
+			}
+			seen[m.ID] = true
+		}
+		out = append(out, m)
+	}
+
+	replies := out
+	if rooted {
+		replies = out[1:]
+	}
+	slices.SortStableFunc(replies, func(a, b Message) int {
+		if !a.At.Equal(b.At) {
+			return a.At.Compare(b.At)
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
+	return out, rooted
+}
+
+// empty reports whether a message carries nothing worth keeping.
+func (m Message) empty() bool {
+	return strings.TrimSpace(m.Text) == "" && m.ID == "" && m.At.IsZero()
+}
+
+// assemble renders the messages into a body, and reports how many of them did
+// not fit.
+//
+// What gets dropped is the middle. The root stays because it is what the
+// conversation is about, and the end stays because that is where the answer is:
+// a thread long enough to be cut is usually one that was cut because it took a
+// while to work something out, and the working out is at the bottom. Nothing is
+// written in place of what was left out, because a marker in a body is a phrase
+// in the index that nobody at the source ever typed.
+func assemble(msgs []Message, maxBody int) (body string, omitted int) {
+	rendered := make([]string, len(msgs))
+	var have int
+	for i, m := range msgs {
+		rendered[i] = render(m)
+		if rendered[i] != "" {
+			have++
+		}
+	}
+
+	keep := make([]bool, len(msgs))
+	var size int
+	if len(rendered) > 0 && rendered[0] != "" {
+		keep[0] = true
+		size = len(rendered[0])
+	}
+	for i := len(rendered) - 1; i > 0; i-- {
+		if rendered[i] == "" {
+			continue
+		}
+		// Two for the blank line between messages.
+		next := size + len(rendered[i]) + 2
+		if next > maxBody {
+			break
+		}
+		keep[i] = true
+		size = next
+	}
+
+	parts := make([]string, 0, have)
+	var kept int
+	for i, r := range rendered {
+		if r == "" || !keep[i] {
+			continue
+		}
+		parts = append(parts, r)
+		kept++
+	}
+
+	body = strings.Join(parts, "\n\n")
+	if len(body) > maxBody {
+		// The first message on its own is over the limit, which the loop above
+		// cannot do anything about because a conversation with no body at all
+		// is worse than a conversation with a long first message.
+		body = cut(body, maxBody)
+	}
+	return body, have - kept
+}
+
+// render is one message as a line of body text.
+//
+// The author's name goes in front of what they said, which puts it in the index
+// as well as on the screen. That is the difference between being able to search
+// for what Mei said about the gearbox and only being able to search for the
+// gearbox.
+func render(m Message) string {
+	text := strings.TrimSpace(m.Text)
+	if text == "" {
+		return ""
+	}
+	if who := display(m.Author); who != "" {
+		return who + ": " + text
+	}
+	return text
+}
+
+// display is what to call somebody, in the order of how much it means to a
+// person reading a result.
+func display(p doc.Person) string {
+	switch {
+	case p.Name != "":
+		return p.Name
+	case p.Email != "":
+		return p.Email
+	default:
+		return p.Identity.Value
+	}
+}
+
+// title is the conversation's own title, or one made out of what was said
+// first.
+func (c Conversation) title() string {
+	if t := strings.TrimSpace(c.Title); t != "" {
+		return t
+	}
+	if t := summarise(c.Root.Text); t != "" {
+		return t
+	}
+	// A conversation with no title and nothing readable in its first message is
+	// usually one that opened with a file or an image. The container is a
+	// worse title than the thread deserves and it is a great deal better than
+	// an empty row.
+	return c.Container
+}
+
+// summarise makes a title out of the first thing somebody typed.
+func summarise(text string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(text), "\n")
+	line = strings.Join(strings.Fields(line), " ")
+	if utf8.RuneCountInString(line) <= TitleLimit {
+		return line
+	}
+
+	short := cutRunes(line, TitleLimit)
+	// Cutting at the last space keeps the title from ending in half a word.
+	// A first line with no space in it at all is a URL or a stack trace, and
+	// there is nowhere better to cut it than where the room ran out.
+	if i := strings.LastIndex(short, " "); i > TitleLimit/2 {
+		short = short[:i]
+	}
+	return strings.TrimRight(short, " ,.;:") + "..."
+}
+
+// span is when the conversation started and when it last changed.
+func span(msgs []Message) (created, modified time.Time) {
+	for _, m := range msgs {
+		if m.At.IsZero() {
+			continue
+		}
+		if created.IsZero() || m.At.Before(created) {
+			created = m.At
+		}
+		if last := m.last(); last.After(modified) {
+			modified = last
+		}
+	}
+	return created, modified
+}
+
+// participants is how many distinct people said something.
+func participants(msgs []Message) int {
+	seen := make(map[string]bool, len(msgs))
+	for _, m := range msgs {
+		if who := key(m.Author); who != "" {
+			seen[who] = true
+		}
+	}
+	return len(seen)
+}
+
+// key identifies a person for counting, preferring the identifiers a source
+// keeps stable over the name somebody can change.
+func key(p doc.Person) string {
+	switch {
+	case p.Subject != "":
+		return "subject:" + p.Subject
+	case p.Identity.Value != "":
+		return "identity:" + p.Identity.Source + ":" + p.Identity.Value
+	case p.Email != "":
+		return "email:" + strings.ToLower(p.Email)
+	default:
+		return p.Name
+	}
+}
+
+// cut truncates a string to n bytes without splitting a rune.
+func cut(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
+}
+
+// cutRunes truncates a string to n runes.
+func cutRunes(s string, n int) string {
+	var count int
+	for i := range s {
+		if count == n {
+			return s[:i]
+		}
+		count++
+	}
+	return s
+}
+
+func setIfAbsent(m map[string]string, k, v string) {
+	if _, ok := m[k]; !ok {
+		m[k] = v
+	}
+}

--- a/connector/thread/thread_test.go
+++ b/connector/thread/thread_test.go
@@ -1,0 +1,520 @@
+package thread_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/thread"
+	"github.com/tamnd/genba/doc"
+)
+
+// epoch is where every conversation in these tests starts, so that the times
+// are arithmetic rather than a reading of the machine.
+var epoch = time.Date(2026, time.May, 4, 10, 0, 0, 0, time.UTC)
+
+func at(minutes int) time.Time { return epoch.Add(time.Duration(minutes) * time.Minute) }
+
+func person(name string) doc.Person {
+	return doc.Person{
+		Name:     name,
+		Identity: acl.Identity{Source: "chat", Value: strings.ToLower(name)},
+	}
+}
+
+func perms() acl.Permissions {
+	return acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "chat",
+		AllowGroups: []acl.Ref{{Source: "chat", Value: "C-maintenance"}},
+	}
+}
+
+// sample is the conversation most of these tests work on: somebody asks a
+// question, two people answer, and the answer is at the bottom.
+func sample() thread.Conversation {
+	return thread.Conversation{
+		ID:        "chat:C-maintenance:1714816800",
+		Container: "maintenance",
+		URL:       "https://chat.example.com/maintenance/p1714816800",
+		Root: thread.Message{
+			ID:     "m1",
+			Author: person("Mei"),
+			At:     at(0),
+			Text:   "the gearbox on line two is making a noise again",
+		},
+		Replies: []thread.Message{
+			{ID: "m2", Author: person("Ade"), At: at(5), Text: "did anybody check the oil level"},
+			{ID: "m3", Author: person("Mei"), At: at(9), Text: "oil is fine, it is the bearing"},
+		},
+	}
+}
+
+// The whole point of the package. A conversation is one document, and every
+// word anybody said in it is a word that can find it.
+func TestAConversationIsOneDocumentThatHoldsEveryReply(t *testing.T) {
+	got := sample().Document(perms())
+
+	if got.ID != "chat:C-maintenance:1714816800" {
+		t.Errorf("id is %q", got.ID)
+	}
+	for _, want := range []string{"gearbox", "oil level", "it is the bearing"} {
+		if !strings.Contains(got.Body, want) {
+			t.Errorf("the body does not contain %q:\n%s", want, got.Body)
+		}
+	}
+	if got.Kind != doc.KindMessage {
+		t.Errorf("kind is %q, want a message", got.Kind)
+	}
+	if got.Container != "maintenance" {
+		t.Errorf("container is %q", got.Container)
+	}
+	if got.URL == "" {
+		t.Error("the document does not link back to the conversation")
+	}
+}
+
+// The author of a message is in the body in front of what they said, which is
+// the difference between searching for what Mei said about the gearbox and only
+// being able to search for the gearbox.
+func TestEachMessageIsAttributedInTheBody(t *testing.T) {
+	got := sample().Document(perms())
+	want := "Mei: the gearbox on line two is making a noise again\n\n" +
+		"Ade: did anybody check the oil level\n\n" +
+		"Mei: oil is fine, it is the bearing"
+	if got.Body != want {
+		t.Errorf("body is\n%s\nwant\n%s", got.Body, want)
+	}
+}
+
+func TestAMessageWithNoNameToPutOnItIsStillIndexed(t *testing.T) {
+	c := sample()
+	c.Replies = append(c.Replies, thread.Message{ID: "m4", At: at(12), Text: "replacement ordered"})
+
+	got := c.Document(perms())
+	if !strings.HasSuffix(got.Body, "\n\nreplacement ordered") {
+		t.Errorf("the message was dropped or was given an empty name:\n%s", got.Body)
+	}
+}
+
+func TestTheNameFallsBackToWhateverTheSourceKnew(t *testing.T) {
+	tests := []struct {
+		name   string
+		author doc.Person
+		want   string
+	}{
+		{"a display name", doc.Person{Name: "Mei Chen", Email: "mei@example.com"}, "Mei Chen: hello"},
+		{"an email address", doc.Person{Email: "mei@example.com"}, "mei@example.com: hello"},
+		{"a source identifier", doc.Person{Identity: acl.Identity{Source: "chat", Value: "U04AB"}}, "U04AB: hello"},
+		{"nothing at all", doc.Person{}, "hello"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := thread.Conversation{
+				ID:   "chat:x",
+				Root: thread.Message{ID: "m1", Author: tt.author, At: at(0), Text: "hello"},
+			}
+			if got := c.Document(perms()).Body; got != tt.want {
+				t.Errorf("body is %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A paged reply listing at more than one source repeats the parent message on
+// every page, so a connector that concatenates the pages hands the root over
+// three times. Saying it three times in the body would also treble its weight
+// in the ranking.
+func TestARepeatedMessageIsKeptOnce(t *testing.T) {
+	c := sample()
+	c.Replies = append([]thread.Message{c.Root, c.Replies[0], c.Root}, c.Replies...)
+
+	got := c.Document(perms())
+	if n := strings.Count(got.Body, "the gearbox on line two"); n != 1 {
+		t.Errorf("the root appears %d times:\n%s", n, got.Body)
+	}
+	if n := strings.Count(got.Body, "did anybody check the oil"); n != 1 {
+		t.Errorf("a reply appears %d times:\n%s", n, got.Body)
+	}
+	if got.Properties["messages"] != "3" {
+		t.Errorf("the document counts %s messages, want 3", got.Properties["messages"])
+	}
+}
+
+func TestRepliesAreOrderedByWhenTheyWereWritten(t *testing.T) {
+	c := sample()
+	c.Replies = []thread.Message{c.Replies[1], c.Replies[0]}
+
+	body := c.Document(perms()).Body
+	if i, j := strings.Index(body, "oil level"), strings.Index(body, "it is the bearing"); i > j {
+		t.Errorf("the replies came out in the wrong order:\n%s", body)
+	}
+}
+
+// A ticket description edited after the first comment carries a later time than
+// the comment, and an imported conversation carries whatever time the import
+// wrote. The root is still what the conversation is about.
+func TestTheRootStaysFirstWhateverItsTimestampSays(t *testing.T) {
+	c := sample()
+	c.Root.At = at(30)
+
+	body := c.Document(perms()).Body
+	if !strings.HasPrefix(body, "Mei: the gearbox") {
+		t.Errorf("the root is not first:\n%s", body)
+	}
+}
+
+func TestTwoMessagesWrittenInTheSameInstantComeOutInTheSameOrderTwice(t *testing.T) {
+	c := sample()
+	c.Replies = []thread.Message{
+		{ID: "m9", Author: person("Zo"), At: at(5), Text: "last"},
+		{ID: "m2", Author: person("Ade"), At: at(5), Text: "first"},
+	}
+	first := c.Document(perms()).Body
+	for range 5 {
+		if got := c.Document(perms()).Body; got != first {
+			t.Fatalf("the body changed between runs:\n%s\n%s", first, got)
+		}
+	}
+	if strings.Index(first, "first") > strings.Index(first, "last") {
+		t.Errorf("the tie was broken by something other than the message id:\n%s", first)
+	}
+}
+
+func TestTheConversationSpansFromTheFirstMessageToTheLast(t *testing.T) {
+	got := sample().Document(perms())
+	if !got.CreatedAt.Equal(at(0)) {
+		t.Errorf("created at %v, want %v", got.CreatedAt, at(0))
+	}
+	if !got.ModifiedAt.Equal(at(9)) {
+		t.Errorf("modified at %v, want %v", got.ModifiedAt, at(9))
+	}
+}
+
+// A message edited in place changes what the document says without any reply
+// being added. A version derived only from reply times would leave the index
+// serving the old text until somebody happened to answer.
+func TestAnEditMovesTheVersionWithoutAnyReply(t *testing.T) {
+	before := sample().Document(perms())
+
+	c := sample()
+	c.Replies[0].Edited = at(40)
+	after := c.Document(perms())
+
+	if after.SourceUpdate == before.SourceUpdate {
+		t.Errorf("the version is still %q after a message was edited", after.SourceUpdate)
+	}
+	if !after.ModifiedAt.Equal(at(40)) {
+		t.Errorf("modified at %v, want the time of the edit", after.ModifiedAt)
+	}
+	if !after.CreatedAt.Equal(at(0)) {
+		t.Errorf("the edit moved the creation time to %v", after.CreatedAt)
+	}
+}
+
+func TestASourceThatKeepsItsOwnVersionKeepsIt(t *testing.T) {
+	c := sample()
+	c.Revision = "17"
+	if got := c.Document(perms()).SourceUpdate; got != "17" {
+		t.Errorf("version is %q, want the source's own", got)
+	}
+}
+
+func TestAConversationWithNoTimesHasNoVersionToOffer(t *testing.T) {
+	c := thread.Conversation{ID: "chat:x", Root: thread.Message{ID: "m1", Text: "hello"}}
+	if got := c.Document(perms()).SourceUpdate; got != "" {
+		t.Errorf("version is %q, want nothing rather than the zero time", got)
+	}
+}
+
+func TestTheTitleComesFromTheFirstMessageWhenTheSourceHasNone(t *testing.T) {
+	if got := sample().Document(perms()).Title; got != "the gearbox on line two is making a noise again" {
+		t.Errorf("title is %q", got)
+	}
+}
+
+func TestASourceWithItsOwnTitleKeepsIt(t *testing.T) {
+	c := sample()
+	c.Title = "Line two gearbox noise"
+	if got := c.Document(perms()).Title; got != "Line two gearbox noise" {
+		t.Errorf("title is %q", got)
+	}
+}
+
+func TestALongFirstMessageIsElidedIntoATitle(t *testing.T) {
+	c := sample()
+	c.Root.Text = strings.Repeat("the gearbox is making a noise and ", 20)
+
+	got := c.Document(perms()).Title
+	switch {
+	case len([]rune(got)) > thread.TitleLimit+3:
+		t.Errorf("title is %d runes: %q", len([]rune(got)), got)
+	case !strings.HasSuffix(got, "..."):
+		t.Errorf("title %q does not say it was cut", got)
+	case strings.HasSuffix(strings.TrimSuffix(got, "..."), " "):
+		t.Errorf("title %q was cut in the middle of the space", got)
+	}
+}
+
+func TestOnlyTheFirstLineOfAMessageBecomesATitle(t *testing.T) {
+	c := sample()
+	c.Root.Text = "gearbox noise\n\nit started on Tuesday and it is worse under load"
+
+	if got := c.Document(perms()).Title; got != "gearbox noise" {
+		t.Errorf("title is %q", got)
+	}
+}
+
+// A conversation that opened with a file or an image has nothing readable in
+// its first message. The container is a worse title than the thread deserves
+// and a great deal better than an empty result row.
+func TestAConversationWithNothingToNameItselfAfterUsesItsContainer(t *testing.T) {
+	c := thread.Conversation{
+		ID:        "chat:x",
+		Container: "maintenance",
+		Root:      thread.Message{ID: "m1", At: at(0)},
+		Replies:   []thread.Message{{ID: "m2", At: at(1), Text: "thanks"}},
+	}
+	if got := c.Document(perms()).Title; got != "maintenance" {
+		t.Errorf("title is %q", got)
+	}
+}
+
+func TestTheCountsAreOnTheDocument(t *testing.T) {
+	got := sample().Document(perms())
+	want := map[string]string{
+		"messages":     "3",
+		"replies":      "2",
+		"participants": "2",
+	}
+	for k, v := range want {
+		if got.Properties[k] != v {
+			t.Errorf("%s is %q, want %q", k, got.Properties[k], v)
+		}
+	}
+	if got.Properties[doc.MediaType] != "text/plain" {
+		t.Errorf("media type is %q", got.Properties[doc.MediaType])
+	}
+}
+
+func TestTheConnectorsOwnPropertiesSurvive(t *testing.T) {
+	c := sample()
+	c.Properties = map[string]string{"status": "open", doc.MediaType: "text/markdown"}
+
+	got := c.Document(perms()).Properties
+	if got["status"] != "open" {
+		t.Errorf("the connector's own property is %q", got["status"])
+	}
+	if got[doc.MediaType] != "text/markdown" {
+		t.Errorf("media type is %q, want the one the connector set", got[doc.MediaType])
+	}
+	if got["messages"] != "3" {
+		t.Errorf("the counts were not added alongside")
+	}
+}
+
+func TestTheCallersPropertyMapIsNotWrittenTo(t *testing.T) {
+	c := sample()
+	c.Properties = map[string]string{"status": "open"}
+
+	c.Document(perms())
+	if len(c.Properties) != 1 {
+		t.Errorf("the caller's map grew to %v", c.Properties)
+	}
+}
+
+// The middle is what gets dropped. The root stays because it is what the
+// conversation is about, and the end stays because a thread long enough to be
+// cut is usually one that took a while to work something out, and the working
+// out is at the bottom.
+func TestALongConversationKeepsItsBeginningAndItsEnd(t *testing.T) {
+	c := thread.Conversation{
+		ID:   "chat:long",
+		Root: thread.Message{ID: "m0", Author: person("Mei"), At: at(0), Text: "why was the gearbox order cancelled"},
+	}
+	for i := 1; i <= 200; i++ {
+		c.Replies = append(c.Replies, thread.Message{
+			ID:     "m" + strconv.Itoa(i),
+			Author: person("Ade"),
+			At:     at(i),
+			Text:   "message number " + strconv.Itoa(i) + " " + strings.Repeat("filler ", 20),
+		})
+	}
+	c.Replies = append(c.Replies, thread.Message{
+		ID:     "m201",
+		Author: person("Mei"),
+		At:     at(201),
+		Text:   "the supplier could not meet the date",
+	})
+
+	got := c.Document(perms(), thread.WithMaxBody(4096))
+	if len(got.Body) > 4096 {
+		t.Fatalf("the body is %d bytes, over the limit", len(got.Body))
+	}
+	if !strings.Contains(got.Body, "why was the gearbox order cancelled") {
+		t.Error("the root was dropped")
+	}
+	if !strings.Contains(got.Body, "the supplier could not meet the date") {
+		t.Error("the answer at the bottom was dropped")
+	}
+	if strings.Contains(got.Body, "message number 100 ") {
+		t.Error("nothing was dropped, so the limit did nothing")
+	}
+	if got.Properties["truncated"] != "true" {
+		t.Error("the document does not say it holds part of the conversation")
+	}
+	if got.Properties["omitted_messages"] == "" || got.Properties["omitted_messages"] == "0" {
+		t.Errorf("omitted_messages is %q", got.Properties["omitted_messages"])
+	}
+}
+
+// Nothing is written in place of what was left out. A marker in a body is a
+// phrase in the index that nobody at the source ever typed, and it turns up in
+// snippets.
+func TestNothingIsWrittenInPlaceOfWhatWasDropped(t *testing.T) {
+	c := thread.Conversation{
+		ID:   "chat:long",
+		Root: thread.Message{ID: "m0", Author: person("Mei"), At: at(0), Text: "start"},
+	}
+	for i := 1; i <= 50; i++ {
+		c.Replies = append(c.Replies, thread.Message{
+			ID: "m" + strconv.Itoa(i), Author: person("Ade"), At: at(i),
+			Text: strings.Repeat("filler ", 20),
+		})
+	}
+	body := c.Document(perms(), thread.WithMaxBody(512)).Body
+	for _, marker := range []string{"[", "…", "...", "omitted", "truncated", "snip"} {
+		if strings.Contains(body, marker) {
+			t.Errorf("the body carries %q, which nobody typed:\n%s", marker, body)
+		}
+	}
+}
+
+// A conversation with a very long first message and nothing else still has to
+// produce a body, and it still has to respect the limit.
+func TestAFirstMessageOverTheLimitIsCutRatherThanDropped(t *testing.T) {
+	c := thread.Conversation{
+		ID:   "chat:x",
+		Root: thread.Message{ID: "m1", Author: person("Mei"), At: at(0), Text: strings.Repeat("a", 4000)},
+	}
+	got := c.Document(perms(), thread.WithMaxBody(100))
+	if got.Body == "" {
+		t.Fatal("the body is empty")
+	}
+	if len(got.Body) > 100 {
+		t.Errorf("the body is %d bytes, over the limit", len(got.Body))
+	}
+}
+
+func TestCuttingABodyDoesNotSplitARune(t *testing.T) {
+	c := thread.Conversation{
+		ID:   "chat:x",
+		Root: thread.Message{ID: "m1", At: at(0), Text: strings.Repeat("\u00e9", 200)},
+	}
+	body := c.Document(perms(), thread.WithMaxBody(101)).Body
+	if strings.ContainsRune(body, '\ufffd') {
+		t.Errorf("the body was cut in the middle of a rune: %q", body)
+	}
+}
+
+func TestAConversationThatFitsIsNotMarkedAsCut(t *testing.T) {
+	got := sample().Document(perms())
+	if _, ok := got.Properties["truncated"]; ok {
+		t.Error("a conversation that fits was marked as cut")
+	}
+	if _, ok := got.Properties["omitted_messages"]; ok {
+		t.Error("a conversation that fits reported omitted messages")
+	}
+}
+
+func TestAMessageWithNoTextIsNotARunOfBlankLines(t *testing.T) {
+	c := sample()
+	c.Replies = append(c.Replies, thread.Message{ID: "m4", Author: person("Zo"), At: at(11), Text: "   "})
+
+	got := c.Document(perms())
+	if strings.Contains(got.Body, "\n\n\n") {
+		t.Errorf("an empty message left a hole in the body:\n%q", got.Body)
+	}
+	if strings.Contains(got.Body, "Zo:") {
+		t.Errorf("an empty message was attributed:\n%q", got.Body)
+	}
+	// It is still a message somebody sent, and it still counts.
+	if got.Properties["messages"] != "4" {
+		t.Errorf("the document counts %s messages, want 4", got.Properties["messages"])
+	}
+}
+
+// The permissions are an argument rather than a field, so that a connector
+// cannot assemble a thread and forget to say who may read it.
+func TestThePermissionsAreWhateverTheConnectorPassed(t *testing.T) {
+	got := sample().Document(perms())
+	if got.Permissions.Mode != acl.ModeACL || got.Permissions.Source != "chat" {
+		t.Errorf("permissions are %+v", got.Permissions)
+	}
+	if len(got.Permissions.AllowGroups) != 1 {
+		t.Errorf("the allow list is %v", got.Permissions.AllowGroups)
+	}
+}
+
+// The tenant is the pipeline's to set and the source name is the connector's.
+// Neither belongs to a conversation, and filling either in here would put a
+// value somewhere the layer above overwrites.
+func TestTheTenantAndTheSourceAreLeftToTheLayersThatOwnThem(t *testing.T) {
+	got := sample().Document(perms())
+	if got.Tenant != "" {
+		t.Errorf("tenant is %q", got.Tenant)
+	}
+	if got.Source != "" {
+		t.Errorf("source is %q", got.Source)
+	}
+}
+
+func TestTheKindTheConnectorAskedForIsKept(t *testing.T) {
+	c := sample()
+	c.Kind = doc.KindTicket
+	if got := c.Document(perms()).Kind; got != doc.KindTicket {
+		t.Errorf("kind is %q", got)
+	}
+}
+
+func TestTheAuthorIsWhoeverStartedIt(t *testing.T) {
+	got := sample().Document(perms())
+	if got.Author.Name != "Mei" {
+		t.Errorf("author is %+v", got.Author)
+	}
+}
+
+// Two people with the same display name are two people if the source gave them
+// different identifiers, and one person if it did not.
+func TestParticipantsAreCountedByIdentityRatherThanByName(t *testing.T) {
+	c := thread.Conversation{
+		ID:   "chat:x",
+		Root: thread.Message{ID: "m1", At: at(0), Text: "one", Author: doc.Person{Name: "Alex", Identity: acl.Identity{Source: "chat", Value: "U1"}}},
+		Replies: []thread.Message{
+			{ID: "m2", At: at(1), Text: "two", Author: doc.Person{Name: "Alex", Identity: acl.Identity{Source: "chat", Value: "U2"}}},
+			{ID: "m3", At: at(2), Text: "three", Author: doc.Person{Name: "Alex", Identity: acl.Identity{Source: "chat", Value: "U1"}}},
+		},
+	}
+	if got := c.Document(perms()).Properties["participants"]; got != "2" {
+		t.Errorf("participants is %q, want 2", got)
+	}
+}
+
+func TestAnEmptyConversationProducesAnEmptyBodyRatherThanPanicking(t *testing.T) {
+	got := thread.Conversation{ID: "chat:x"}.Document(perms())
+	if got.Body != "" {
+		t.Errorf("body is %q", got.Body)
+	}
+	if got.Properties["messages"] != "0" {
+		t.Errorf("messages is %q", got.Properties["messages"])
+	}
+}
+
+func TestAMaxBodyBelowOneSelectsTheDefault(t *testing.T) {
+	got := sample().Document(perms(), thread.WithMaxBody(0), thread.WithMaxBody(-1))
+	if !strings.Contains(got.Body, "it is the bearing") {
+		t.Errorf("a limit of zero cut the body:\n%s", got.Body)
+	}
+}

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -376,6 +376,47 @@ Everything else is optional, and each piece buys one thing.
 `connector/objectsource` implements all but the deletion, over a network service, and is the one to read for the parts a local source never has to deal with: signing, paging, and a listing whose order has nothing to do with what changed.
 A bucket listing is the same shape of problem as a walk, and an object that is no longer in it is found by the sweep for the same reason.
 
+### A conversation is one document
+
+Chat, ticket trackers and wikis keep the same shape underneath their vocabulary.
+Something is said, and then people say things about it: a message and its replies, an issue and its comments, a page and the discussion at the bottom of it.
+The source stores those as separate rows because that is how they were written, one at a time, by different people on different days.
+
+An index that copies that shape answers badly.
+Ask it why the gearbox order was cancelled and it returns fourteen rows from the same conversation, ranked against each other, none of which is the answer on its own.
+The reply that says the supplier could not meet the date scores nothing at all for the word gearbox, because the word gearbox was in the message above it and was never repeated.
+The fourteen rows also crowd out the thirteen other conversations that should have been on the page.
+
+So a conversation is one document, and `connector/thread` is where it is assembled.
+It talks to nothing.
+A connector fetches the messages, resolves who wrote them and works out who may read the result, and hands the pieces over.
+
+```go
+d := thread.Conversation{
+	ID:        "chat:" + channel + ":" + ts,
+	Container: channel,
+	Root:      thread.Message{ID: ts, Author: author, At: when, Text: text},
+	Replies:   replies,
+}.Document(perms)
+```
+
+The permissions are an argument rather than a field, for the reason the rest of this document keeps coming back to: a signature that lets a caller forget the answer is a signature that invites a thread being indexed without one.
+
+Four decisions in there are worth knowing about.
+
+The author of each message goes into the body in front of what they said, which puts the name in the index as well as on the screen.
+That is the difference between being able to search for what Mei said about the gearbox and only being able to search for the gearbox.
+
+A repeated message is kept once.
+A paged reply listing at more than one source repeats the parent message on every page, so a connector that concatenates the pages hands the root over three times, and saying it three times in the body trebles its weight in the ranking as well.
+
+An edit moves the version.
+A message edited in place changes what the document says without any reply being added, so a version derived only from reply times leaves the index serving the old text until somebody happens to answer.
+
+A conversation too long for the body limit keeps its beginning and its end.
+The root stays because it is what the conversation is about, and the end stays because a thread long enough to be cut is usually one that took a while to work something out, and the working out is at the bottom.
+The document records how many messages were left out, and nothing is written in place of them, because a marker in a body is a phrase in the index that nobody at the source ever typed and it turns up in snippets.
+
 ### The conformance suite is the definition
 
 `connector/connectortest` is what a connector has to pass, and it rather than the interface is the definition of one.


### PR DESCRIPTION
Groundwork for #15, the chat, ticket and wiki connectors.

Chat, ticket trackers and wikis all keep the same shape underneath the vocabulary.
Something is said, and then people say things about it: a message and its replies, an issue and its comments, a page and the discussion at the bottom of it.
The source stores those as separate rows because that is how they were written, one at a time, by different people on different days.

An index that copies that shape answers badly.
Ask it why the gearbox order was cancelled and it returns fourteen rows from the same conversation, ranked against each other, none of which is the answer on its own.
The reply that says the supplier could not meet the date scores nothing at all for the word gearbox, because the word gearbox was in the message above it and was never repeated.
The fourteen rows also crowd out the thirteen other conversations that should have been on the page.

So a conversation is one document, and this is the package that assembles it.

## What is in it

`thread.Conversation` is a root message, its replies, and the few things the source knows about the pair.
`Document` turns that into a `doc.Document`.

```go
d := thread.Conversation{
	ID:        "chat:" + channel + ":" + ts,
	Container: channel,
	Root:      thread.Message{ID: ts, Author: author, At: when, Text: text},
	Replies:   replies,
}.Document(perms)
```

The package talks to nothing and imports `acl` and `doc` and nothing else of ours.
A connector fetches the messages, resolves who wrote them and works out who may read the result, and hands the pieces over.
That is what makes the assembly one thing rather than the same assembly written three times with three sets of small differences nobody meant, and it is also what makes it testable as arithmetic.

The permissions are an argument rather than a field.
A conversation is assembled out of messages from a container whose access rules the connector had to read anyway, and a signature that lets the caller forget the answer is a signature that invites a thread being indexed without one.

## The decisions worth arguing about

**The author of each message goes into the body in front of what they said.**
That puts the name in the index as well as on the screen, which is the difference between being able to search for what Mei said about the gearbox and only being able to search for the gearbox.

**A repeated message is kept once.**
A paged reply listing at more than one source repeats the parent message on every page, so a connector that concatenates the pages hands the root over three times.
Saying it three times in the body trebles its weight in the ranking as well as reading badly.

**The root stays first whatever its timestamp says.**
A ticket description edited after the first comment carries a later time than the comment, and an imported conversation carries whatever time the import wrote.

**An edit moves the version.**
A message edited in place changes what the document says without any reply being added, and a version derived only from reply times would leave the index serving the old text until somebody happened to answer.

**A conversation too long for the limit keeps its beginning and its end.**
The root stays because it is what the conversation is about, and the end stays because a thread long enough to be cut is usually one that took a while to work something out, and the working out is at the bottom.
The document records how many messages it left out, and nothing is written in place of them, because a marker in a body is a phrase in the index that nobody at the source ever typed and it turns up in snippets.

**Chat has no titles**, so a conversation with none gets one made out of the first line of its first message, elided at a word boundary.
One that opened with a file and has no readable first message falls back to its container, which is a worse title than the thread deserves and a great deal better than an empty result row.

## Tests

Thirty tests, all of them arithmetic over a fixed clock, covering the assembly, the ordering and its tie break, the deduplication, the counts, the times, the version and what moves it, the title and its fallbacks, the truncation from both ends, the rune boundary a cut body must not split, and the properties a connector sets being left alone.

There is also a test that the caller's property map is not written to, which is the sort of thing that is free to get right now and expensive to find later.