### PR TITLE
connector/recorded: record HTTP exchanges once and replay them from a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ func main() {
 | `connector/objectsource` | an S3 compatible bucket, signed and paged, [docs/ingestion.md](docs/ingestion.md) |
 | `connector/thread` | a conversation and its replies assembled into one document |
 | `connector/limit` | the rate limit, backoff and circuit breaker every connector shares, as a round tripper |
+| `connector/recorded` | HTTP exchanges captured from a real service and replayed from a directory, so tests need no account |
 | `extract` | text and structure out of PDF, Word, PowerPoint, Excel, HTML and Markdown, [docs/extraction.md](docs/extraction.md) |
 | `ingest` | the pipeline that runs a connector into a store |
 | `config` | runtime configuration and the rules for loading it |

--- a/arch_test.go
+++ b/arch_test.go
@@ -149,6 +149,12 @@ var allowed = map[string][]string{
 	// that difference is allowed to show up as a dependency: an S3 client of our
 	// own is a file in the package rather than a layer under it.
 	"connector/objectsource": {"acl", "connector", "connector/aclmap", "doc", "extract"},
+	// recorded imports nothing of ours either. It is a round tripper over a
+	// directory of files, it deals in requests and responses, and it has never
+	// heard of a document or a connector. Keeping it that way is what lets it be
+	// used by a connector's tests without the tests of this package needing a
+	// connector to exercise it.
+	"connector/recorded": nil,
 	// limit imports nothing of ours at all. It is a round tripper and a token
 	// bucket, and the only thing it knows about a crawl is that requests go out
 	// on an http.Client. A rate limiter that imported connector would be one that

--- a/connector/recorded/cassette.go
+++ b/connector/recorded/cassette.go
@@ -1,0 +1,183 @@
+package recorded
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// A recording is a directory of numbered files rather than one file holding
+// everything.
+//
+// One file per exchange is what makes the set reviewable. A connector's crawl
+// is twenty or thirty requests, a change to one of them should be a change to
+// one file, and a person looking for what the source says when a channel is
+// private should be able to find it by reading the file names. A single large
+// file would put every refresh of the fixtures into one diff hunk and would
+// make the interesting response the four hundredth line of it.
+//
+// The number in front is the order the requests were made in, which is the
+// other half of what a reader needs: a crawl is a sequence, and a listing that
+// sorted alphabetically would put the second page of results before the first.
+const nameFormat = "%04d-%s.json"
+
+// written matches the files Save writes, and is what tells them apart from
+// anything else somebody has put in the directory.
+var written = regexp.MustCompile(`^\d{4}-.*\.json$`)
+
+// Load reads the exchanges recorded in a directory, in the order they were
+// made.
+func Load(dir string) ([]Exchange, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("recorded: reading %s: %w", dir, err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
+			names = append(names, e.Name())
+		}
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("recorded: %s holds no recordings", dir)
+	}
+	slices.Sort(names)
+
+	out := make([]Exchange, 0, len(names))
+	for _, name := range names {
+		raw, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return nil, fmt.Errorf("recorded: %w", err)
+		}
+		var e Exchange
+		if err := json.Unmarshal(raw, &e); err != nil {
+			return nil, fmt.Errorf("recorded: %s: %w", name, err)
+		}
+		if e.Request.URL == "" {
+			return nil, fmt.Errorf("recorded: %s records no request", name)
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// Save writes what has been recorded into a directory, creating it if it is not
+// there.
+//
+// Files left over from an earlier recording are removed, so that refreshing a
+// fixture set against a service that no longer has an endpoint leaves the
+// directory describing the crawl as it is now. Only the files Save itself
+// writes are touched: a README next to them stays where it is.
+func (t *Transport) Save(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("recorded: %w", err)
+	}
+	if err := removeSaved(dir); err != nil {
+		return err
+	}
+
+	for i, e := range t.Exchanges() {
+		raw, err := json.MarshalIndent(e, "", "  ")
+		if err != nil {
+			return fmt.Errorf("recorded: %w", err)
+		}
+		name := fmt.Sprintf(nameFormat, i+1, slug(e.Request))
+		if err := os.WriteFile(filepath.Join(dir, name), append(raw, '\n'), 0o644); err != nil {
+			return fmt.Errorf("recorded: %w", err)
+		}
+	}
+	return nil
+}
+
+// removeSaved removes the files a previous Save wrote.
+func removeSaved(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("recorded: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !written.MatchString(e.Name()) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, e.Name())); err != nil {
+			return fmt.Errorf("recorded: %w", err)
+		}
+	}
+	return nil
+}
+
+// slug is the readable half of a file name: enough of the request to find the
+// file by eye, and nothing that would make the name depend on the machine it
+// was recorded on.
+func slug(r Request) string {
+	u, err := url.Parse(r.URL)
+	if err != nil {
+		return "request"
+	}
+
+	parts := []string{strings.ToLower(r.Method)}
+	for _, seg := range strings.Split(path.Clean(u.Path), "/") {
+		if seg == "" || seg == "." {
+			continue
+		}
+		parts = append(parts, seg)
+	}
+
+	// A path of identifiers is a path where every file would otherwise be
+	// called the same thing, so the query is what tells two pages of the same
+	// listing apart.
+	if q := u.Query(); len(q) > 0 {
+		keys := make([]string, 0, len(q))
+		for k := range q {
+			keys = append(keys, k)
+		}
+		slices.Sort(keys)
+		for _, k := range keys {
+			parts = append(parts, k+"-"+q.Get(k))
+		}
+	}
+
+	out := clean(strings.Join(parts, "-"))
+	if out == "" {
+		return "request"
+	}
+	return trim(out, 80)
+}
+
+// clean reduces a string to the characters that are the same on every operating
+// system a test might run on.
+func clean(s string) string {
+	var b strings.Builder
+	var dash bool
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.':
+			b.WriteRune(r)
+			dash = false
+		case b.Len() > 0 && !dash:
+			b.WriteByte('-')
+			dash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// trim shortens a name without cutting it in the middle of a word where it can
+// help it.
+func trim(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	s = s[:n]
+	if i := strings.LastIndex(s, "-"); i > n/2 {
+		s = s[:i]
+	}
+	return strings.Trim(s, "-")
+}

--- a/connector/recorded/recorded.go
+++ b/connector/recorded/recorded.go
@@ -1,0 +1,547 @@
+// Package recorded replays HTTP exchanges that were captured from a real
+// service, so that a connector's tests do not need an account at one.
+//
+// A connector for somebody else's product is mostly a reading of that product's
+// API, and the tests that matter are the ones that say what happens when it
+// answers the way it really does. There are three ways to get that and two of
+// them are bad. Hand written JSON says what somebody thought the API returns,
+// which is how a connector ends up parsing a field that was renamed two years
+// ago. A live account makes the test suite depend on a network, a token, a
+// workspace somebody has to keep populated, and a rate limit, and the test then
+// fails for four reasons that have nothing to do with the change under review.
+//
+// The third way is to talk to the real service once, write down exactly what it
+// said, and run the tests against that. The recording is a file in the
+// repository, so it is reviewed like code, it is diffed when it is refreshed,
+// and the day the service changes a field the diff is the notice. Nothing in
+// the test suite needs a token, and everything in it is checking against bytes
+// a real service produced.
+//
+// # Recording
+//
+// Recording is a round tripper wrapped around a real one.
+//
+//	rec := recorded.Record(http.DefaultTransport)
+//	src := chat.New(rec.Client(), token)
+//	// ... drive the connector against the live service ...
+//	if err := rec.Save("testdata/chat"); err != nil {
+//		t.Fatal(err)
+//	}
+//
+// Secrets never reach the file. The headers and query parameters that carry
+// credentials are replaced before anything is written, and a [Scrubber] handles
+// the ones that are in a body instead. This matters more than it sounds:
+// a recording is committed, and a token committed once is a token leaked
+// permanently, whatever the next commit does.
+//
+// # Replaying
+//
+// Replaying is the same round tripper with a directory behind it instead of a
+// network.
+//
+//	rt, err := recorded.Replay("testdata/chat")
+//
+// A request nothing was recorded for is an error naming what was asked and what
+// the recording holds, rather than an empty response the connector then fails
+// to parse fifty lines away from the cause.
+package recorded
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode/utf8"
+)
+
+// Redacted is what replaces a credential in a recording.
+//
+// It is a visible string rather than an empty one so that a reader of the file
+// can tell a header that was removed from a header the service never sent, and
+// so that a connector replaying against the recording still gets a header of
+// the right shape.
+const Redacted = "REDACTED"
+
+// DefaultRedactedHeaders are the request and response headers that carry a
+// credential often enough to be worth removing without being asked.
+var DefaultRedactedHeaders = []string{
+	"Authorization",
+	"Cookie",
+	"Proxy-Authorization",
+	"Set-Cookie",
+	"X-Api-Key",
+	"X-Auth-Token",
+}
+
+// DefaultRedactedParams are the query parameters that carry a credential.
+//
+// They are removed from the file and from the key an exchange is matched on,
+// which is the part that is easy to miss: a recording made with one token has
+// to replay for a test that has no token at all.
+var DefaultRedactedParams = []string{
+	"access_token",
+	"api_key",
+	"key",
+	"sig",
+	"signature",
+	"token",
+	"x-amz-credential",
+	"x-amz-signature",
+}
+
+// Scrubber removes whatever a body carries that must not be committed. It is
+// handed the payload and returns what to write in its place.
+type Scrubber func(body []byte) []byte
+
+// Transport is an [http.RoundTripper] that either records what a real service
+// said or replays what it said last time.
+//
+// It is safe for concurrent use, because a connector that fetches in parallel
+// is a connector whose tests have to be able to.
+type Transport struct {
+	base    http.RoundTripper
+	headers []string
+	params  []string
+	scrub   Scrubber
+
+	mu        sync.Mutex
+	recording bool
+	exchanges []Exchange
+	served    []int
+	used      map[string]int
+}
+
+// Option configures a transport.
+type Option func(*Transport)
+
+// WithRedactedHeaders adds to the headers removed from a recording.
+func WithRedactedHeaders(names ...string) Option {
+	return func(t *Transport) { t.headers = append(t.headers, names...) }
+}
+
+// WithRedactedParams adds to the query parameters removed from a recording and
+// from the key an exchange is matched on.
+func WithRedactedParams(names ...string) Option {
+	return func(t *Transport) { t.params = append(t.params, names...) }
+}
+
+// WithScrubber installs a function that removes secrets from a body.
+//
+// The default does nothing, because what is secret in a body is a fact about
+// one product's API rather than about HTTP. A workspace that returns its own
+// invite links or a signed download URL in a listing needs one of these.
+func WithScrubber(s Scrubber) Option {
+	return func(t *Transport) {
+		if s != nil {
+			t.scrub = s
+		}
+	}
+}
+
+// Record returns a transport that sends requests through base and remembers
+// both sides of every one of them.
+func Record(base http.RoundTripper, opts ...Option) *Transport {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	t := newTransport(opts)
+	t.base = base
+	t.recording = true
+	return t
+}
+
+// Replay returns a transport that answers out of the exchanges recorded in dir.
+func Replay(dir string, opts ...Option) (*Transport, error) {
+	exchanges, err := Load(dir)
+	if err != nil {
+		return nil, err
+	}
+	t := newTransport(opts)
+	t.exchanges = exchanges
+	return t, nil
+}
+
+// From returns a transport that answers out of exchanges held in memory, which
+// is what a test that builds its own fixture rather than reading one wants.
+func From(exchanges []Exchange, opts ...Option) *Transport {
+	t := newTransport(opts)
+	t.exchanges = slices.Clone(exchanges)
+	return t
+}
+
+func newTransport(opts []Option) *Transport {
+	t := &Transport{
+		headers: slices.Clone(DefaultRedactedHeaders),
+		params:  slices.Clone(DefaultRedactedParams),
+		scrub:   func(b []byte) []byte { return b },
+		used:    make(map[string]int),
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+var _ http.RoundTripper = (*Transport)(nil)
+
+// Client returns an HTTP client using this transport.
+func (t *Transport) Client() *http.Client { return &http.Client{Transport: t} }
+
+// ErrNoRecording is returned for a request the recording has no answer for.
+var ErrNoRecording = errors.New("recorded: nothing was recorded for this request")
+
+// RoundTrip answers a request from the recording, or makes it and records the
+// answer.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := take(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	if t.recording {
+		return t.capture(req, body)
+	}
+	return t.replay(req, body)
+}
+
+// replay finds the recorded answer to a request.
+func (t *Transport) replay(req *http.Request, body []byte) (*http.Response, error) {
+	k := t.key(req.Method, req.URL, body)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	var found []int
+	for i, e := range t.exchanges {
+		u, err := url.Parse(e.Request.URL)
+		if err != nil {
+			continue
+		}
+		if t.key(e.Request.Method, u, e.Request.Body.Bytes()) == k {
+			found = append(found, i)
+		}
+	}
+	if len(found) == 0 {
+		return nil, fmt.Errorf("%w: %s\nthe recording holds:\n%s", ErrNoRecording, k, t.summary())
+	}
+
+	// Several recordings of the same request are answered in the order they
+	// were made, and the last one answers for ever after. A source asked the
+	// same question twice usually gets the same answer, and a fixture set that
+	// ran out after one would make every test that syncs twice brittle for no
+	// reason a reader could see.
+	n := min(t.used[k], len(found)-1)
+	t.used[k]++
+	t.served = append(t.served, found[n])
+	return t.exchanges[found[n]].response(req), nil
+}
+
+// capture makes the request for real and writes down what came back.
+func (t *Transport) capture(req *http.Request, body []byte) (*http.Response, error) {
+	if body != nil {
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	answer, err := take(resp.Body)
+	if err != nil {
+		resp.Body.Close()
+		return nil, err
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(answer))
+
+	e := Exchange{
+		Request: Request{
+			Method:  req.Method,
+			URL:     t.cleanURL(req.URL),
+			Headers: t.cleanHeaders(req.Header),
+			Body:    payload(t.scrub(body)),
+		},
+		Response: Response{
+			Status:  resp.StatusCode,
+			Headers: t.cleanHeaders(resp.Header),
+			Body:    payload(t.scrub(answer)),
+		},
+	}
+
+	t.mu.Lock()
+	t.exchanges = append(t.exchanges, e)
+	t.mu.Unlock()
+	return resp, nil
+}
+
+// Exchanges returns what has been recorded so far.
+func (t *Transport) Exchanges() []Exchange {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return slices.Clone(t.exchanges)
+}
+
+// Unused returns the recorded requests nothing asked for.
+//
+// A fixture set drifts the same way a comment does. A connector that stopped
+// calling an endpoint leaves the recording of it behind, and the next person to
+// read the directory takes it for a description of what the connector does.
+// This is how a test says so.
+func (t *Transport) Unused() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var out []string
+	for i, e := range t.exchanges {
+		if slices.Contains(t.served, i) {
+			continue
+		}
+		u, err := url.Parse(e.Request.URL)
+		if err != nil {
+			out = append(out, e.Request.Method+" "+e.Request.URL)
+			continue
+		}
+		out = append(out, t.key(e.Request.Method, u, e.Request.Body.Bytes()))
+	}
+	return out
+}
+
+// summary is what the recording holds, for the error a missing one produces.
+func (t *Transport) summary() string {
+	seen := make(map[string]bool, len(t.exchanges))
+	var keys []string
+	for _, e := range t.exchanges {
+		u, err := url.Parse(e.Request.URL)
+		if err != nil {
+			continue
+		}
+		k := t.key(e.Request.Method, u, e.Request.Body.Bytes())
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, "  "+k)
+		}
+	}
+	if len(keys) == 0 {
+		return "  nothing at all"
+	}
+	slices.Sort(keys)
+	return strings.Join(keys, "\n")
+}
+
+// key is what two requests have to agree on to be the same request.
+//
+// The scheme and the host are left out, and that is deliberate. A recording is
+// a description of an API rather than of the workspace it was taken from, and
+// requiring a test to point its client at the hostname somebody happened to
+// record against would make every fixture set carry a company's subdomain
+// around with it.
+//
+// The redacted parameters are left out for the same reason one step further in:
+// a recording made with a token has to answer a test that has none.
+func (t *Transport) key(method string, u *url.URL, body []byte) string {
+	var b strings.Builder
+	b.WriteString(strings.ToUpper(method))
+	b.WriteByte(' ')
+	b.WriteString(u.EscapedPath())
+	if q := t.cleanQuery(u.Query()); len(q) > 0 {
+		b.WriteByte('?')
+		b.WriteString(q.Encode())
+	}
+	if len(body) > 0 {
+		// A body is part of the question for the sources that ask with a form
+		// post rather than a query string, and several of them do.
+		b.WriteByte(' ')
+		b.WriteString(canonicalBody(body))
+	}
+	return b.String()
+}
+
+// cleanURL is a URL with its credentials taken out, for writing down.
+func (t *Transport) cleanURL(u *url.URL) string {
+	clean := *u
+	clean.User = nil
+	if q := t.cleanQuery(u.Query()); len(q) > 0 {
+		clean.RawQuery = q.Encode()
+	} else {
+		clean.RawQuery = ""
+	}
+	return clean.String()
+}
+
+func (t *Transport) cleanQuery(q url.Values) url.Values {
+	for name := range q {
+		if t.redactedParam(name) {
+			q.Del(name)
+		}
+	}
+	return q
+}
+
+func (t *Transport) redactedParam(name string) bool {
+	for _, p := range t.params {
+		if strings.EqualFold(p, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// cleanHeaders is a header set with the credentials replaced.
+func (t *Transport) cleanHeaders(h http.Header) map[string][]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(h))
+	for name, values := range h {
+		if t.redactedHeader(name) {
+			out[http.CanonicalHeaderKey(name)] = []string{Redacted}
+			continue
+		}
+		out[http.CanonicalHeaderKey(name)] = slices.Clone(values)
+	}
+	return out
+}
+
+func (t *Transport) redactedHeader(name string) bool {
+	for _, h := range t.headers {
+		if strings.EqualFold(h, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// canonicalBody is a body reduced to something two identical requests agree on.
+//
+// A form post is compared field by field rather than byte by byte, because the
+// order a client writes its fields in is not part of what it asked. Anything
+// else is compared as it stands.
+func canonicalBody(body []byte) string {
+	if v, err := url.ParseQuery(string(body)); err == nil && looksLikeForm(body) {
+		return v.Encode()
+	}
+	return strings.Join(strings.Fields(string(body)), " ")
+}
+
+// looksLikeForm reports whether a body is a URL encoded form.
+//
+// url.ParseQuery accepts almost anything, including a line of prose, so the
+// shape has to be checked rather than the parse.
+func looksLikeForm(body []byte) bool {
+	s := string(body)
+	return strings.Contains(s, "=") && !strings.ContainsAny(s, "{}\n\r")
+}
+
+// take reads a body and closes it, and returns nil for one that was not there.
+func take(r io.ReadCloser) ([]byte, error) {
+	if r == nil || r == http.NoBody {
+		return nil, nil
+	}
+	defer r.Close()
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	return b, nil
+}
+
+// Exchange is one request and the answer it got.
+type Exchange struct {
+	Request  Request  `json:"request"`
+	Response Response `json:"response"`
+}
+
+// Request is what was asked.
+type Request struct {
+	Method string `json:"method"`
+	URL    string `json:"url"`
+
+	// Headers are kept for the reader rather than for the matching. Nothing is
+	// compared against them, because a client library that adds an Accept
+	// header this year and not last year has not changed the question it is
+	// asking.
+	Headers map[string][]string `json:"headers,omitempty"`
+
+	Body Payload `json:"body,omitzero"`
+}
+
+// Response is what came back.
+type Response struct {
+	Status  int                 `json:"status"`
+	Headers map[string][]string `json:"headers,omitempty"`
+	Body    Payload             `json:"body,omitzero"`
+}
+
+// response turns a recorded answer back into one a client can read.
+func (e Exchange) response(req *http.Request) *http.Response {
+	body := e.Response.Body.Bytes()
+	header := make(http.Header, len(e.Response.Headers))
+	for name, values := range e.Response.Headers {
+		header[http.CanonicalHeaderKey(name)] = slices.Clone(values)
+	}
+	status := e.Response.Status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		Status:        strconv.Itoa(status) + " " + http.StatusText(status),
+		StatusCode:    status,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
+}
+
+// Payload is the body of a request or a response, written down in whichever of
+// three forms keeps the file readable.
+//
+// A recording is reviewed, and a review of a wall of base64 is not a review.
+// A JSON body is nested into the file as JSON, so a change to one field of one
+// response shows up in a diff as a change to one line. Text that is not JSON is
+// a string. Anything that is neither is bytes, and only then.
+type Payload struct {
+	JSON   json.RawMessage `json:"json,omitempty"`
+	Text   string          `json:"text,omitempty"`
+	Binary []byte          `json:"binary,omitempty"`
+}
+
+// Bytes is the payload as it went over the wire.
+func (p Payload) Bytes() []byte {
+	switch {
+	case len(p.JSON) > 0:
+		return p.JSON
+	case p.Text != "":
+		return []byte(p.Text)
+	default:
+		return p.Binary
+	}
+}
+
+// payload picks the form to write a body down in.
+func payload(body []byte) Payload {
+	switch {
+	case len(body) == 0:
+		return Payload{}
+	case json.Valid(body):
+		// The file is written with indentation, which reformats this along with
+		// everything around it. That changes the bytes a replay hands back and
+		// it is worth saying out loud: what is being recorded is the document
+		// the service sent rather than its whitespace, and the alternative is a
+		// wall of one line responses that no diff can be read against.
+		return Payload{JSON: body}
+	case utf8.Valid(body):
+		return Payload{Text: string(body)}
+	default:
+		return Payload{Binary: body}
+	}
+}

--- a/connector/recorded/recorded_test.go
+++ b/connector/recorded/recorded_test.go
@@ -1,0 +1,570 @@
+package recorded_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/connector/recorded"
+)
+
+// service is a stand in for the product a connector talks to. Everything in
+// this file records against it and then replays without it, which is the whole
+// claim the package makes.
+func service(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// answer is a response that has already been read and closed, which is what
+// every helper here hands back so that no test has to remember to.
+type answer struct {
+	status int
+	header http.Header
+	body   string
+}
+
+// do makes a request and reads all of the answer to it. The error is returned
+// rather than fatal, because a request the recording has nothing for is the
+// point of several of these tests.
+func do(t *testing.T, c *http.Client, req *http.Request) (answer, error) {
+	t.Helper()
+	resp, err := c.Do(req)
+	if err != nil {
+		return answer{}, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return answer{status: resp.StatusCode, header: resp.Header, body: string(body)}, nil
+}
+
+// get asks with a credential on it, the way a connector does.
+func get(t *testing.T, c *http.Client, rawurl string) answer {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, rawurl, http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer xoxb-a-real-token")
+	got, err := do(t, c, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+// post asks with a form, the way several of these products want to be asked.
+func post(t *testing.T, c *http.Client, rawurl string, form url.Values) answer {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, rawurl, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	got, err := do(t, c, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func TestWhatWasRecordedIsWhatComesBack(t *testing.T) {
+	srv := service(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Rate-Limit-Remaining", "48")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = io.WriteString(w, `{"ok":true,"channels":[{"id":"C1","name":"maintenance"}]}`)
+	})
+
+	rec := recorded.Record(http.DefaultTransport)
+	live := get(t, rec.Client(), srv.URL+"/api/conversations.list?limit=200")
+
+	dir := t.TempDir()
+	if err := rec.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	rt, err := recorded.Replay(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.Close()
+
+	replayed := get(t, rt.Client(), srv.URL+"/api/conversations.list?limit=200")
+	// The same document rather than the same bytes. A JSON body is nested into
+	// the file as JSON so that a diff can be read, which reindents it, and what
+	// is being recorded is what the service said rather than its whitespace.
+	sameJSON(t, replayed.body, live.body)
+	if replayed.status != live.status {
+		t.Errorf("status is %d, want %d", replayed.status, live.status)
+	}
+	// The rate limit headers are the ones a connector's backoff reads, so a
+	// recording that dropped them could not be used to test the thing most
+	// likely to be wrong.
+	if got := replayed.header.Get("X-Rate-Limit-Remaining"); got != "48" {
+		t.Errorf("the rate limit header came back as %q", got)
+	}
+	if got := replayed.header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("content type is %q", got)
+	}
+}
+
+// A recording is committed. A token committed once is a token leaked
+// permanently, whatever the next commit does.
+func TestNoCredentialReachesTheFile(t *testing.T) {
+	srv := service(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"ok":true,"webhook":"https://hooks.example.com/T1/B2/xoxb-secret-hook"}`)
+	})
+
+	rec := recorded.Record(http.DefaultTransport, recorded.WithScrubber(func(b []byte) []byte {
+		return []byte(strings.ReplaceAll(string(b), "xoxb-secret-hook", recorded.Redacted))
+	}))
+	get(t, rec.Client(), srv.URL+"/api/auth.test?token=xoxb-a-real-token&limit=1")
+
+	dir := t.TempDir()
+	if err := rec.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, secret := range []string{"xoxb-a-real-token", "xoxb-secret-hook"} {
+		if found := grep(t, dir, secret); found != "" {
+			t.Errorf("%s carries %q:\n%s", found, secret, read(t, filepath.Join(dir, found)))
+		}
+	}
+	// What is left has to still say a token was there, or a reader cannot tell
+	// a header that was removed from one the service never sent.
+	if !strings.Contains(read(t, filepath.Join(dir, only(t, dir))), recorded.Redacted) {
+		t.Error("the recording does not say anything was removed")
+	}
+}
+
+// A recording made with a token has to answer a test that has none, or the
+// fixture set is only usable by whoever recorded it.
+func TestARecordingMadeWithATokenReplaysWithoutOne(t *testing.T) {
+	srv := service(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+
+	rec := recorded.Record(http.DefaultTransport)
+	get(t, rec.Client(), srv.URL+"/api/auth.test?token=xoxb-a-real-token")
+
+	dir := t.TempDir()
+	if err := rec.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+	rt, err := recorded.Replay(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/auth.test", http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := do(t, rt.Client(), req); err != nil {
+		t.Fatalf("a request with no token found nothing: %v", err)
+	}
+}
+
+// A recording is a description of an API rather than of the workspace it was
+// taken from, so a test does not have to point its client at whichever
+// hostname somebody happened to record against.
+func TestTheHostIsNotPartOfTheQuestion(t *testing.T) {
+	rt := recorded.From([]recorded.Exchange{{
+		Request:  recorded.Request{Method: "GET", URL: "https://acme.example.com/api/conversations.list?limit=200"},
+		Response: recorded.Response{Status: 200, Body: recorded.Payload{Text: "ok"}},
+	}})
+
+	if got := get(t, rt.Client(), "https://somewhere-else.invalid/api/conversations.list?limit=200"); got.body != "ok" {
+		t.Errorf("body is %q", got.body)
+	}
+}
+
+func TestTheOrderOfTheQueryDoesNotMatter(t *testing.T) {
+	rt := recorded.From([]recorded.Exchange{{
+		Request:  recorded.Request{Method: "GET", URL: "https://x/api/list?cursor=abc&limit=200&types=public"},
+		Response: recorded.Response{Status: 200, Body: recorded.Payload{Text: "ok"}},
+	}})
+
+	if got := get(t, rt.Client(), "https://x/api/list?types=public&limit=200&cursor=abc"); got.body != "ok" {
+		t.Errorf("body is %q", got.body)
+	}
+}
+
+// Several of these products ask with a form post rather than a query string,
+// and the order a client writes its fields in is not part of what it asked.
+func TestAFormPostIsComparedFieldByField(t *testing.T) {
+	srv := service(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"ok":true,"messages":[]}`)
+	})
+
+	rec := recorded.Record(http.DefaultTransport)
+	post(t, rec.Client(), srv.URL+"/api/conversations.replies", url.Values{
+		"channel": {"C1"}, "ts": {"1714816800.000100"}, "limit": {"200"},
+	})
+
+	dir := t.TempDir()
+	if err := rec.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+	rt, err := recorded.Replay(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.Close()
+
+	got := post(t, rt.Client(), srv.URL+"/api/conversations.replies", url.Values{
+		"ts": {"1714816800.000100"}, "limit": {"200"}, "channel": {"C1"},
+	})
+	sameJSON(t, got.body, `{"ok":true,"messages":[]}`)
+}
+
+func TestADifferentFormPostIsADifferentQuestion(t *testing.T) {
+	rt := recorded.From([]recorded.Exchange{{
+		Request: recorded.Request{
+			Method: "POST",
+			URL:    "https://x/api/conversations.replies",
+			Body:   recorded.Payload{Text: "channel=C1&ts=1"},
+		},
+		Response: recorded.Response{Status: 200, Body: recorded.Payload{Text: "ok"}},
+	}})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		"https://x/api/conversations.replies", strings.NewReader("channel=C2&ts=1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := do(t, rt.Client(), req); err == nil {
+		t.Fatal("a request for another channel was answered from the recording for C1")
+	}
+}
+
+// A crawl that pages asks the same question twice with different answers, and a
+// sync run twice asks it again and should get the last one rather than an
+// error.
+func TestRepeatedRequestsAreAnsweredInOrderAndThenRepeat(t *testing.T) {
+	page := func(body string) recorded.Exchange {
+		return recorded.Exchange{
+			Request:  recorded.Request{Method: "GET", URL: "https://x/api/list"},
+			Response: recorded.Response{Status: 200, Body: recorded.Payload{Text: body}},
+		}
+	}
+	rt := recorded.From([]recorded.Exchange{page("first"), page("second")})
+
+	want := []string{"first", "second", "second", "second"}
+	for i, w := range want {
+		if got := get(t, rt.Client(), "https://x/api/list"); got.body != w {
+			t.Errorf("request %d got %q, want %q", i+1, got.body, w)
+		}
+	}
+}
+
+// A request nothing was recorded for is an error naming what was asked and what
+// the recording holds, rather than an empty response the connector then fails
+// to parse fifty lines away from the cause.
+func TestAnUnrecordedRequestSaysWhatItAskedAndWhatIsThere(t *testing.T) {
+	rt := recorded.From([]recorded.Exchange{{
+		Request:  recorded.Request{Method: "GET", URL: "https://x/api/conversations.list"},
+		Response: recorded.Response{Status: 200, Body: recorded.Payload{Text: "ok"}},
+	}})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://x/api/users.list", http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = do(t, rt.Client(), req)
+	if err == nil {
+		t.Fatal("a request nothing was recorded for was answered")
+	}
+	if !errors.Is(err, recorded.ErrNoRecording) {
+		t.Errorf("error is %v, want one that says nothing was recorded", err)
+	}
+	if !strings.Contains(err.Error(), "/api/users.list") {
+		t.Errorf("the error does not say what was asked: %v", err)
+	}
+	if !strings.Contains(err.Error(), "/api/conversations.list") {
+		t.Errorf("the error does not say what the recording holds: %v", err)
+	}
+}
+
+// A fixture set drifts the same way a comment does. A connector that stopped
+// calling an endpoint leaves the recording of it behind, and the next person to
+// read the directory takes it for a description of what the connector does.
+func TestUnusedReportsWhatNothingAskedFor(t *testing.T) {
+	rt := recorded.From([]recorded.Exchange{
+		{
+			Request:  recorded.Request{Method: "GET", URL: "https://x/api/conversations.list"},
+			Response: recorded.Response{Status: 200, Body: recorded.Payload{Text: "ok"}},
+		},
+		{
+			Request:  recorded.Request{Method: "GET", URL: "https://x/api/users.list"},
+			Response: recorded.Response{Status: 200, Body: recorded.Payload{Text: "ok"}},
+		},
+	})
+
+	if got := rt.Unused(); len(got) != 2 {
+		t.Fatalf("before anything was asked, Unused is %v", got)
+	}
+	get(t, rt.Client(), "https://x/api/conversations.list")
+
+	got := rt.Unused()
+	if len(got) != 1 || !strings.Contains(got[0], "users.list") {
+		t.Errorf("Unused is %v, want the one nothing asked for", got)
+	}
+}
+
+// A recording is reviewed, and a review of a wall of base64 is not a review.
+func TestAJsonBodyIsWrittenAsJsonSoThatADiffCanBeRead(t *testing.T) {
+	srv := service(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"ok":true,"channels":[{"id":"C1","name":"maintenance","is_private":false}]}`)
+	})
+
+	rec := recorded.Record(http.DefaultTransport)
+	get(t, rec.Client(), srv.URL+"/api/conversations.list")
+
+	dir := t.TempDir()
+	if err := rec.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	file := read(t, filepath.Join(dir, only(t, dir)))
+	if !strings.Contains(file, `"name": "maintenance"`) {
+		t.Errorf("the response was not written out as readable json:\n%s", file)
+	}
+	if strings.Contains(file, "base64") || strings.Contains(file, `\"`) {
+		t.Errorf("the response was escaped into a string:\n%s", file)
+	}
+}
+
+func TestABodyThatIsNotTextRoundTrips(t *testing.T) {
+	want := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe}
+	srv := service(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(want)
+	})
+
+	rec := recorded.Record(http.DefaultTransport)
+	get(t, rec.Client(), srv.URL+"/files/logo.png")
+
+	dir := t.TempDir()
+	if err := rec.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+	rt, err := recorded.Replay(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.Close()
+
+	if got := get(t, rt.Client(), srv.URL+"/files/logo.png"); got.body != string(want) {
+		t.Errorf("the bytes came back as %q, want %q", got.body, want)
+	}
+}
+
+// Refreshing a fixture set against a service that no longer has an endpoint has
+// to leave the directory describing the crawl as it is now, and has to leave
+// alone whatever else is in there.
+func TestSavingAgainReplacesTheOldRecordingAndNothingElse(t *testing.T) {
+	srv := service(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+	dir := t.TempDir()
+
+	first := recorded.Record(http.DefaultTransport)
+	get(t, first.Client(), srv.URL+"/api/one")
+	get(t, first.Client(), srv.URL+"/api/two")
+	get(t, first.Client(), srv.URL+"/api/three")
+	if err := first.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("how this was taken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	second := recorded.Record(http.DefaultTransport)
+	get(t, second.Client(), srv.URL+"/api/one")
+	if err := second.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	names := files(t, dir)
+	if len(names) != 2 {
+		t.Fatalf("the directory holds %v", names)
+	}
+	if !contains(names, "README.md") {
+		t.Errorf("the note beside the recordings was removed: %v", names)
+	}
+	for _, name := range names {
+		if strings.Contains(name, "two") || strings.Contains(name, "three") {
+			t.Errorf("%s survived a refresh that no longer makes that request", name)
+		}
+	}
+}
+
+// The number in front is the order the requests were made in, because a crawl
+// is a sequence and a listing sorted alphabetically would put the second page
+// of results before the first.
+func TestTheFilesAreNamedForWhatWasAskedInTheOrderItWasAsked(t *testing.T) {
+	srv := service(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	})
+
+	rec := recorded.Record(http.DefaultTransport)
+	get(t, rec.Client(), srv.URL+"/api/conversations.list?limit=200")
+	get(t, rec.Client(), srv.URL+"/api/conversations.history?channel=C1")
+
+	dir := t.TempDir()
+	if err := rec.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	names := files(t, dir)
+	if len(names) != 2 {
+		t.Fatalf("the directory holds %v", names)
+	}
+	if !strings.HasPrefix(names[0], "0001-") || !strings.Contains(names[0], "conversations.list") {
+		t.Errorf("the first file is %q", names[0])
+	}
+	if !strings.HasPrefix(names[1], "0002-") || !strings.Contains(names[1], "conversations.history") {
+		t.Errorf("the second file is %q", names[1])
+	}
+	if strings.ContainsAny(strings.Join(names, ""), `/\:?*"<>|`) {
+		t.Errorf("a name holds something a filesystem somewhere will refuse: %v", names)
+	}
+}
+
+func TestReplayingSomethingThatIsNotThereSaysSo(t *testing.T) {
+	if _, err := recorded.Replay(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Error("replaying a directory that is not there succeeded")
+	}
+	if _, err := recorded.Replay(t.TempDir()); err == nil {
+		t.Error("replaying an empty directory succeeded")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "0001-broken.json"), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := recorded.Replay(dir)
+	if err == nil {
+		t.Fatal("replaying a recording that does not parse succeeded")
+	}
+	if !strings.Contains(err.Error(), "0001-broken.json") {
+		t.Errorf("the error does not say which file: %v", err)
+	}
+}
+
+// A connector that fetches in parallel is a connector whose tests have to be
+// able to. Run with -race this is the whole of the claim.
+func TestATransportIsSafeToShareBetweenGoroutines(t *testing.T) {
+	rt := recorded.From([]recorded.Exchange{{
+		Request:  recorded.Request{Method: "GET", URL: "https://x/api/list"},
+		Response: recorded.Response{Status: 200, Body: recorded.Payload{Text: "ok"}},
+	}})
+
+	c := rt.Client()
+	done := make(chan string, 8)
+	for range cap(done) {
+		go func() {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/api/list", http.NoBody)
+			if err != nil {
+				done <- err.Error()
+				return
+			}
+			resp, err := c.Do(req)
+			if err != nil {
+				done <- err.Error()
+				return
+			}
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			done <- string(body)
+		}()
+	}
+	for range cap(done) {
+		if got := <-done; got != "ok" {
+			t.Errorf("a concurrent request got %q", got)
+		}
+	}
+}
+
+// sameJSON reports the two bodies as the same document, whatever the
+// whitespace between the fields is.
+func sameJSON(t *testing.T, got, want string) {
+	t.Helper()
+	var a, b any
+	if err := json.Unmarshal([]byte(got), &a); err != nil {
+		t.Fatalf("the body that came back is not json: %v\n%s", err, got)
+	}
+	if err := json.Unmarshal([]byte(want), &b); err != nil {
+		t.Fatalf("the body wanted is not json: %v\n%s", err, want)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("the body is\n%s\nand should have been\n%s", got, want)
+	}
+}
+
+func read(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func files(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	return out
+}
+
+func only(t *testing.T, dir string) string {
+	t.Helper()
+	names := files(t, dir)
+	if len(names) != 1 {
+		t.Fatalf("the directory holds %v, want one recording", names)
+	}
+	return names[0]
+}
+
+// grep returns the name of the first file in dir holding a string, or empty.
+func grep(t *testing.T, dir, want string) string {
+	t.Helper()
+	for _, name := range files(t, dir) {
+		if strings.Contains(read(t, filepath.Join(dir, name)), want) {
+			return name
+		}
+	}
+	return ""
+}
+
+func contains(names []string, want string) bool {
+	for _, name := range names {
+		if name == want {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -461,3 +461,41 @@ A change that arrives with an empty `Permissions.Source` is a connector that for
 Running the suite is not optional either.
 `TestEveryConnectorRunsTheConformanceSuite` at the root of the module looks for the packages that declare a connector and fails for any of them whose tests do not call `connectortest.Run`.
 A conformance suite nobody runs is documentation, and documentation about permissions is the first thing skipped when a connector is written in a hurry against a source somebody needs indexed by Friday.
+
+### Testing against a recording of the real service
+
+A connector for somebody else's product is mostly a reading of that product's API, and the tests that matter are the ones that say what happens when it answers the way it really does.
+There are three ways to get that and two of them are bad.
+Hand written JSON says what somebody thought the API returns, which is how a connector ends up parsing a field that was renamed two years ago.
+A live account makes the suite depend on a network, a token, a workspace somebody has to keep populated and a rate limit, and the test then fails for four reasons that have nothing to do with the change under review.
+
+The third way is `connector/recorded`.
+It is an `http.RoundTripper` that talks to the real service once, writes down exactly what it said, and answers out of that afterwards.
+
+```go
+rec := recorded.Record(http.DefaultTransport)
+// ... drive the connector against the live service once ...
+if err := rec.Save("testdata/chat"); err != nil {
+	t.Fatal(err)
+}
+
+// ... and from then on, with no account and no network:
+rt, err := recorded.Replay("testdata/chat")
+```
+
+A recording is one JSON file per exchange in a numbered directory, because a crawl is twenty or thirty requests and a change to one of them should be a change to one file.
+A JSON body is nested into the file as JSON rather than escaped into a string, so the day the service renames a field the diff is one line and the review is the notice.
+The number in front is the order the requests were made in, since a listing sorted alphabetically would put the second page of results before the first.
+
+Two decisions in the matching are worth knowing about before recording anything.
+The scheme and the host are not part of what a request asked, so a fixture set describes an API rather than the workspace it was captured from and a test does not have to point its client at somebody's subdomain.
+The parameters that carry credentials are not part of it either, which is what lets a recording made with a token answer a test that has none.
+A form post is compared field by field for the same reason, because the order a client writes its fields in is not part of the question.
+
+Secrets never reach the file.
+The usual headers and query parameters are replaced with `REDACTED` before anything is written, and `recorded.WithScrubber` handles the ones that are in a body instead, such as a signed download URL or an invite link that comes back in a listing.
+This matters more than it sounds.
+A recording is committed, and a token committed once is a token leaked permanently, whatever the next commit does.
+
+A request nothing was recorded for is an error naming what was asked and what the recording holds, rather than an empty response the connector fails to parse fifty lines away from the cause.
+`Unused` reports the other direction, the recorded requests nothing asked for, which is how a fixture set left behind by a connector that stopped calling an endpoint gets noticed instead of being read as a description of what the connector does.


### PR DESCRIPTION
The chat, ticket and wiki connectors are next, and all three read somebody else's API.
The tests that matter for one of those are the ones that say what happens when the service answers the way it really does, and there are three ways to get that.

Hand written JSON says what somebody thought the API returns, which is how a connector ends up parsing a field that was renamed two years ago.
A live account makes the suite depend on a network, a token, a workspace somebody has to keep populated and a rate limit, so the test fails for four reasons that have nothing to do with the change under review.

This is the third way.
`connector/recorded` is an `http.RoundTripper` that talks to the real service once, writes down exactly what it said, and answers out of that afterwards.

```go
rec := recorded.Record(http.DefaultTransport)
// ... drive the connector against the live service once ...
if err := rec.Save("testdata/chat"); err != nil {
	t.Fatal(err)
}

// ... and from then on, with no account and no network:
rt, err := recorded.Replay("testdata/chat")
```

## What is in the file

One JSON file per exchange in a numbered directory.
A crawl is twenty or thirty requests, a change to one of them should be a change to one file, and the number in front is the order the requests were made in because a listing sorted alphabetically would put the second page of results before the first.

A JSON body is nested into the file as JSON rather than escaped into a string or turned into base64.
A recording is reviewed, a review of a wall of base64 is not a review, and the day the service renames a field the diff is one line.
Text that is not JSON is a string, and anything that is neither is bytes, only then.

## What two requests have to agree on

The scheme and the host are left out of the matching on purpose.
A recording is a description of an API rather than of the workspace it was taken from, and requiring a test to point its client at whichever hostname somebody happened to record against would make every fixture set carry a company subdomain around with it.

The parameters that carry credentials are left out for the same reason one step further in, so a recording made with a token answers a test that has none.
A form post is compared field by field rather than byte by byte, because the order a client writes its fields in is not part of the question it asked, and several of these products ask with a form post rather than a query string.

Several recordings of the same request are answered in the order they were made and the last one answers from then on, which is what a paging crawl needs on the way out and what a test that syncs twice needs on the way back.

## Secrets

A recording is committed, and a token committed once is a token leaked permanently whatever the next commit does.
The usual headers and query parameters are replaced with `REDACTED` before anything is written, and `WithScrubber` handles the ones that are in a body instead, such as a signed download URL or an invite link that comes back in a listing.
The replacement is a visible string rather than an empty one so a reader can tell a header that was removed from one the service never sent.

## Errors that say something

A request nothing was recorded for is an error naming what was asked and what the recording holds, rather than an empty response the connector then fails to parse fifty lines away from the cause.
`Unused` reports the other direction, the recorded requests nothing asked for, which is how a fixture left behind by a connector that stopped calling an endpoint gets noticed instead of being read as a description of what the connector still does.

`Save` removes only the files it wrote itself, so refreshing a fixture set leaves the directory describing the crawl as it is now and leaves a README next to it alone.

## Tests

Twenty tests, no network beyond `httptest`, and they run with `-race` because a connector that fetches in parallel is one whose tests have to be able to.
They cover the round trip of status, headers and body, that no credential reaches the file, that a recording made with a token replays without one, query order, form field order, repeated requests, the missing recording error, `Unused`, readable JSON in the file, a body that is not text, a refresh that removes stale files and keeps the rest, the file names, and the three ways `Load` can fail.

Part of #15.