### PR TITLE
Add the crawl chat, tickets and wikis share

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ func main() {
 | `connector/fssource` | the reference connector, a directory tree with OWNERS files, walked or watched |
 | `connector/objectsource` | an S3 compatible bucket, signed and paged, [docs/ingestion.md](docs/ingestion.md) |
 | `connector/thread` | a conversation and its replies assembled into one document |
+| `connector/threadsource` | the crawl, cursor and permission refresh chat, ticket trackers and wikis share, [docs/ingestion.md](docs/ingestion.md) |
 | `connector/limit` | the rate limit, backoff and circuit breaker every connector shares, as a round tripper |
 | `connector/recorded` | HTTP exchanges captured from a real service and replayed from a directory, so tests need no account |
 | `extract` | text and structure out of PDF, Word, PowerPoint, Excel, HTML and Markdown, [docs/extraction.md](docs/extraction.md) |
@@ -437,6 +438,11 @@ Something is said and then people say things about it: a message and its replies
 An index that copies the source's row per message shape answers badly, because a question about a cancelled order returns fourteen rows from the same conversation and none of them is the answer on its own, while the reply that holds the answer scores nothing for the word in the question because that word was in the message above it.
 So a conversation is one document that ranks as a whole, the author of each message goes into the body in front of what they said, a repeated message is kept once because a paged reply listing repeats the parent on every page, and a thread too long to fit keeps its beginning and its end and says how many messages it left out.
 Nothing is written in place of what was left out, because a marker in a body is a phrase in the index that nobody at the source ever typed.
+
+Assembling one conversation is the easy half.
+`connector/threadsource` is the other half, and it is written once for all three products: the crawl over containers, the cursor that survives an interrupted run, the sweep that finds what a change feed never reports, and the permission refresh that runs when a channel is made private without a message in it being touched.
+A product adapter answers four questions about its API and gets a connector, which is why a channel somebody restricted this morning costs one write per thread in it rather than a recrawl, and why a thread and a channel that changed in the same second are both emitted exactly once.
+The rule comes from the container, a conversation may override it the way a ticket with a security level on it does, and a container nobody has said anything about quarantines what is in it rather than defaulting to readable.
 
 What a connector is gets decided by `connector/connectortest` rather than by the interface.
 The interface says what compiles, and the suite says what works: that a full sync finds everything, that resuming from a cursor loses nothing that came after it, that a second sync of a source nothing changed in reads nothing, that a deleted document stops being part of the source one way or the other, and that every document says who may read it.

--- a/arch_test.go
+++ b/arch_test.go
@@ -149,6 +149,13 @@ var allowed = map[string][]string{
 	// that difference is allowed to show up as a dependency: an S3 client of our
 	// own is a file in the package rather than a layer under it.
 	"connector/objectsource": {"acl", "connector", "connector/aclmap", "doc", "extract"},
+	// threadsource is the same level again, and it names thread rather than
+	// extract because a conversation arrives as messages instead of as bytes:
+	// there is nothing to pull text out of, only a shape to assemble. It does not
+	// name aclmap either, because the rule on a conversation comes from the
+	// container the product already told us about rather than from a file we were
+	// handed alongside it.
+	"connector/threadsource": {"acl", "connector", "connector/thread", "doc"},
 	// recorded imports nothing of ours either. It is a round tripper over a
 	// directory of files, it deals in requests and responses, and it has never
 	// heard of a document or a connector. Keeping it that way is what lets it be

--- a/connector/threadsource/fake_test.go
+++ b/connector/threadsource/fake_test.go
@@ -1,0 +1,330 @@
+package threadsource_test
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/connectortest"
+	"github.com/tamnd/genba/connector/thread"
+	"github.com/tamnd/genba/connector/threadsource"
+	"github.com/tamnd/genba/doc"
+)
+
+// The fake is a chat tool with the parts that matter and none of the parts that
+// do not. It has rooms with a rule on each, threads with replies, a clock that
+// only moves when something happens to it, and the ability to be told to fail.
+//
+// It stands in for three products rather than one. What a real adapter adds is
+// paging, signing, a rate limit and a vocabulary, and every one of those is
+// beneath the interface this exercises.
+
+const source = "chat"
+
+// epoch is when everything in these tests happens. A fixed clock is what makes
+// a cursor comparable, and a source whose times came from time.Now would make
+// every one of these tests a race against the second boundary.
+var epoch = time.Date(2026, time.June, 2, 9, 0, 0, 0, time.UTC)
+
+type fake struct {
+	mu    sync.Mutex
+	clock time.Time
+	rooms map[string]*room
+	order []string
+
+	// asked records the containers Threads was called for, which is how a test
+	// says that a resumed run did not walk a channel it had already finished.
+	asked  []string
+	listed []string
+	reads  int
+	closes int
+
+	failContainers error
+	failThreads    error
+	failList       error
+	failRead       error
+}
+
+type room struct {
+	id       string
+	name     string
+	access   acl.Permissions
+	accessAt time.Time
+	convs    map[string]*conv
+}
+
+type conv struct {
+	id      string
+	room    string
+	title   string
+	body    string
+	author  string
+	created time.Time
+	updated time.Time
+	replies []thread.Message
+	access  acl.Permissions
+	gone    bool
+}
+
+func newFake() *fake {
+	f := &fake{clock: epoch, rooms: make(map[string]*room)}
+	f.addRoom("r1", "maintenance")
+	return f
+}
+
+// addRoom adds a channel everybody in the tenant may read.
+func (f *fake) addRoom(id, name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rooms[id] = &room{
+		id:     id,
+		name:   name,
+		access: acl.Permissions{Mode: acl.ModePublicToTenant, Source: source},
+		convs:  make(map[string]*conv),
+	}
+	f.order = append(f.order, id)
+}
+
+// write starts a thread, or edits the one that is already there, and moves the
+// clock on afterwards the way a real source's does.
+func (f *fake) write(roomID, id, body string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r := f.rooms[roomID]
+	c, ok := r.convs[id]
+	if !ok {
+		c = &conv{id: id, room: roomID, title: strings.ToUpper(id[:1]) + id[1:], author: "mei", created: f.clock}
+		r.convs[id] = c
+	}
+	c.body = body
+	c.updated = f.clock
+	c.gone = false
+	f.clock = f.clock.Add(time.Second)
+}
+
+// writeAt starts a thread stamped with a time of the caller's choosing and
+// leaves the clock where it was, which is how two conversations end up sharing
+// an instant.
+func (f *fake) writeAt(roomID, id, body string, at time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r := f.rooms[roomID]
+	r.convs[id] = &conv{
+		id: id, room: roomID, title: strings.ToUpper(id[:1]) + id[1:],
+		author: "mei", body: body, created: at, updated: at,
+	}
+}
+
+// reply adds a message to a thread, which is a change to the thread rather than
+// a document of its own.
+func (f *fake) reply(roomID, id, author, text string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c := f.rooms[roomID].convs[id]
+	c.replies = append(c.replies, thread.Message{
+		ID:     id + "-r" + string(rune('1'+len(c.replies))),
+		Author: person(author),
+		At:     f.clock,
+		Text:   text,
+	})
+	c.updated = f.clock
+	f.clock = f.clock.Add(time.Second)
+}
+
+// remove deletes a thread. Nothing in this source's change feed reports it,
+// which is the point: the only way it ever reaches the index is the sweep.
+func (f *fake) remove(roomID, id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.rooms[roomID].convs, id)
+	f.clock = f.clock.Add(time.Second)
+}
+
+// share makes a room private, which changes who may read everything in it
+// without touching a single message.
+func (f *fake) share(roomID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r := f.rooms[roomID]
+	r.access = acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      source,
+		AllowGroups: []acl.Ref{{Source: source, Value: r.id}},
+		Version:     r.access.Version + 1,
+	}
+	r.accessAt = f.clock
+	f.clock = f.clock.Add(time.Second)
+}
+
+// restrict gives one thread a rule of its own, the way a ticket with a security
+// level on it has one.
+func (f *fake) restrict(roomID, id string, p acl.Permissions) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rooms[roomID].convs[id].access = p
+}
+
+// quarantine puts one thread's rule beyond working out.
+func (f *fake) quarantine(roomID, id string) {
+	f.restrict(roomID, id, connector.Unresolved(source))
+}
+
+// unruled takes the rule off a room entirely, which is the state a source
+// built without a policy is in.
+func (f *fake) unruled(roomID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rooms[roomID].access = acl.Permissions{}
+}
+
+func (f *fake) Containers(context.Context) ([]threadsource.Container, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failContainers != nil {
+		return nil, f.failContainers
+	}
+	out := make([]threadsource.Container, 0, len(f.order))
+	for _, id := range f.order {
+		r := f.rooms[id]
+		out = append(out, threadsource.Container{
+			ID:       r.id,
+			Name:     r.name,
+			Access:   r.access,
+			AccessAt: r.accessAt,
+		})
+	}
+	// The order a product lists its channels in is not something anybody
+	// promised, so this one hands them back in the least helpful order it can.
+	slices.Reverse(out)
+	return out, nil
+}
+
+func (f *fake) Threads(ctx context.Context, c threadsource.Container, since time.Time, fn func(context.Context, threadsource.Thread) error) error {
+	f.mu.Lock()
+	if f.failThreads != nil {
+		err := f.failThreads
+		f.mu.Unlock()
+		return err
+	}
+	f.asked = append(f.asked, c.ID)
+	var changed []*conv
+	for _, cv := range f.rooms[c.ID].convs {
+		// At or after, which is what the interface asks for and what leaves the
+		// duplicate at the boundary to be dealt with above.
+		if since.IsZero() || !cv.updated.Before(since) {
+			changed = append(changed, cv)
+		}
+	}
+	f.mu.Unlock()
+
+	slices.SortFunc(changed, func(a, b *conv) int {
+		if d := a.updated.Compare(b.updated); d != 0 {
+			return d
+		}
+		return strings.Compare(a.id, b.id)
+	})
+	for _, cv := range changed {
+		if err := fn(ctx, cv.thread()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fake) List(_ context.Context, c threadsource.Container, fn func(connector.Item) bool) error {
+	f.mu.Lock()
+	if f.failList != nil {
+		err := f.failList
+		f.mu.Unlock()
+		return err
+	}
+	f.listed = append(f.listed, c.ID)
+	var items []connector.Item
+	for _, cv := range f.rooms[c.ID].convs {
+		items = append(items, connector.Item{ID: cv.id, Version: cv.updated.UTC().Format(time.RFC3339Nano)})
+	}
+	f.mu.Unlock()
+
+	slices.SortFunc(items, func(a, b connector.Item) int { return strings.Compare(a.ID, b.ID) })
+	for _, item := range items {
+		if !fn(item) {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (f *fake) Read(_ context.Context, id string) (threadsource.Thread, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failRead != nil {
+		return threadsource.Thread{}, f.failRead
+	}
+	f.reads++
+	for _, r := range f.rooms {
+		if cv, ok := r.convs[id]; ok && !cv.gone {
+			return cv.thread(), nil
+		}
+	}
+	return threadsource.Thread{}, connector.ErrGone
+}
+
+func (f *fake) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closes++
+	return nil
+}
+
+// thread is one conversation the way an adapter hands it over.
+func (c *conv) thread() threadsource.Thread {
+	return threadsource.Thread{
+		Conversation: thread.Conversation{
+			ID:        c.id,
+			Kind:      "message",
+			Title:     c.title,
+			Container: "",
+			URL:       "https://chat.example.com/" + c.room + "/" + c.id,
+			Root: thread.Message{
+				ID:     c.id,
+				Author: person(c.author),
+				At:     c.created,
+				Text:   c.body,
+			},
+			Replies: slices.Clone(c.replies),
+		},
+		Container: c.room,
+		Access:    c.access,
+		Updated:   c.updated,
+	}
+}
+
+func person(name string) doc.Person {
+	return doc.Person{Name: name, Email: name + "@acme.com", Identity: acl.Identity{Source: source, Value: name}}
+}
+
+// The conformance suite is what decides whether this is a connector. Everything
+// else in this package's tests is about the parts that are specific to a
+// conversation, and none of it would matter if this failed.
+func TestConformance(t *testing.T) {
+	connectortest.Run(t, func(t *testing.T) connectortest.Fixture {
+		f := newFake()
+		src, err := threadsource.New(f, source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return connectortest.Fixture{
+			Connector:    src,
+			ID:           func(name string) string { return source + ":" + name },
+			Write:        func(_ *testing.T, name, body string) { f.write("r1", name, body) },
+			Remove:       func(_ *testing.T, name string) { f.remove("r1", name) },
+			Share:        func(_ *testing.T, _ string) { f.share("r1") },
+			Unresolvable: func(_ *testing.T, name string) { f.quarantine("r1", name) },
+		}
+	})
+}

--- a/connector/threadsource/threadsource.go
+++ b/connector/threadsource/threadsource.go
@@ -308,6 +308,12 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 		highest = start.Since
 		edge    = slices.Clone(start.Edge)
 		latest  = start.Perms
+
+		// A full sync has nothing to refresh. Every conversation it emits
+		// carries the rule the container has right now, so emitting a
+		// permission change alongside it would be saying the same thing twice
+		// and doubling the size of the first sync of a workspace.
+		full = from.IsZero()
 	)
 	for _, c := range containers {
 		if err := ctx.Err(); err != nil {
@@ -333,7 +339,7 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 			since = start.At
 		}
 
-		if c.AccessAt.After(start.Perms) {
+		if !full && c.AccessAt.After(start.Perms) {
 			if err := s.refresh(ctx, c, start, emit); err != nil {
 				return connector.Cursor{}, err
 			}

--- a/connector/threadsource/threadsource.go
+++ b/connector/threadsource/threadsource.go
@@ -1,0 +1,662 @@
+// Package threadsource is the connector chat, ticket trackers and wikis share.
+//
+// Three products that look nothing alike keep the same shape underneath the
+// vocabulary. There are containers, which a chat tool calls channels, a tracker
+// calls projects and a wiki calls spaces, and the container is where the access
+// rule lives. Inside a container there are conversations, which are a thread, an
+// issue with its comments, or a page with its comments, and a conversation is a
+// first message and the replies to it. Everything else is naming.
+//
+// Writing that three times produces three connectors that drift apart, and the
+// part they drift on is the part that must not drift. So the crawl, the cursor,
+// the resume and the permission refresh are here, and a product adapter is left
+// with the only thing that is genuinely different: how to ask its API.
+//
+// # What an adapter provides
+//
+// A [Service] is four questions a product's API has to be able to answer. List
+// the containers and say who may read each one, walk the conversations in a
+// container that changed since a time, list the conversation ids a container
+// holds, and read one conversation by id.
+//
+// The four are all required, and the last two are the ones worth arguing about.
+// Listing is what reconciliation is built on, and none of these products has a
+// change feed that reports a deletion: a message removed, an issue deleted and
+// a page archived all leave the index holding a document nothing will ever take
+// away. Reading one conversation by id is what turns the sweep from a report
+// into a repair.
+//
+// # Permissions come from the container
+//
+// A conversation inherits the rule that governs the container it is in, which is
+// how every one of these products actually works. A private channel is private
+// because of the channel, and a page in a restricted space is restricted because
+// of the space.
+//
+// A conversation may override it, and that is not an edge case: a ticket with a
+// security level on it is readable by that level's members and by nobody else,
+// whatever the project says, and a page with restrictions on it is the same. An
+// adapter says so by filling in [Thread.Access].
+//
+// There is no permissive default. A container whose rule is the zero value
+// quarantines everything in it, which is loud and safe, rather than publishing a
+// private channel to the tenant, which is quiet and not.
+//
+// # Incremental sync
+//
+// The cursor is the newest change time the last completed run saw, and a later
+// run asks each container for what changed at or after it. Asking for at or
+// after rather than strictly after is deliberate, because the alternative loses
+// a conversation that changed in the same instant as the cursor, and the ids
+// already emitted at that instant are carried in the cursor so that nothing is
+// emitted twice for it.
+//
+// An interrupted run resumes at the container it reached rather than at the
+// beginning. Containers are walked in a fixed order and the cursor a change
+// carries names the container and how far into it the run had got, so a crawl
+// killed two hours in does not start again from the first channel.
+//
+// A container's rule can be rewritten without a single conversation in it being
+// touched, and nothing in a listing of changes says so. An adapter that can say
+// when the rule last changed turns that into a permission change carrying no
+// body, which is how a revocation reaches the index without the channel being
+// read again.
+package threadsource
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/thread"
+	"github.com/tamnd/genba/doc"
+)
+
+// Container is a channel, a project or a space: the thing conversations are in
+// and the thing the access rule is usually on.
+type Container struct {
+	// ID is the source's own identifier, and it is what the cursor records.
+	// It has to be stable, because a container whose id changes is a container
+	// a resuming run will walk again.
+	ID string
+
+	// Name is what a person calls it, and it lands in
+	// [doc.Document.Container] for every conversation inside it.
+	Name string
+
+	// Access is who may read everything in it. The zero value quarantines the
+	// container's contents rather than publishing them.
+	Access acl.Permissions
+
+	// AccessAt is when the rule last changed, and the zero time means the
+	// product cannot say.
+	//
+	// It is what a permission change without a recrawl is built on. A product
+	// that cannot answer it is not broken and pays for it in the obvious way:
+	// a revocation reaches the index when the conversations under it are next
+	// read for some other reason.
+	AccessAt time.Time
+}
+
+// Thread is one conversation as an adapter hands it over.
+type Thread struct {
+	// Conversation is the content, assembled into one document by
+	// [thread.Conversation.Document].
+	Conversation thread.Conversation
+
+	// Container is the id of the container it is in, which is where its access
+	// rule comes from when it has none of its own.
+	Container string
+
+	// Access overrides the container's rule for this conversation alone. The
+	// zero value means the conversation inherits, and an adapter that
+	// considered the question and failed says so with [connector.Unresolved]
+	// rather than leaving this empty.
+	Access acl.Permissions
+
+	// Updated is when the source says the conversation last changed, and is
+	// what the cursor is made of. Leaving it zero is allowed and the last
+	// message in the conversation is used instead, which is right for a chat
+	// thread and wrong for a ticket whose fields changed without a comment.
+	Updated time.Time
+}
+
+// Service is what a product's API has to be able to answer.
+//
+// An implementation talks to one product and is where every difference between
+// them is allowed to live: the paging, the signing, the rate limit, the shape
+// of an id and the vocabulary. None of that reaches this package, and nothing
+// in this package reaches a network.
+type Service interface {
+	// Containers returns the channels, projects or spaces this source covers,
+	// with the rule that governs each.
+	//
+	// It is called once per sync and once per enumeration, so an adapter that
+	// pages is expected to page here rather than to hand back a first page.
+	Containers(ctx context.Context) ([]Container, error)
+
+	// Threads calls fn for every conversation in a container that changed at
+	// or after since, oldest change first.
+	//
+	// A zero since means everything the container holds. At or after rather
+	// than strictly after is what keeps a conversation that changed in the
+	// same instant as the cursor from being lost, and the duplicate that
+	// causes is dealt with here rather than by the adapter.
+	//
+	// An error from fn is returned to the caller unchanged and stops the walk,
+	// the same rule [connector.Connector.Sync] follows, because it is the same
+	// error travelling up.
+	Threads(ctx context.Context, c Container, since time.Time, fn func(context.Context, Thread) error) error
+
+	// List calls fn for every conversation the container currently holds, and
+	// stops early if fn returns false.
+	//
+	// It has to be complete or it has to fail. A listing that quietly returns
+	// part of a channel reads, to the sweep above it, as a channel the rest of
+	// which was deleted.
+	List(ctx context.Context, c Container, fn func(connector.Item) bool) error
+
+	// Read returns one conversation by the source's own id, which is the
+	// document id with the source name taken off the front.
+	//
+	// It returns [connector.ErrGone] if the source no longer has it, which is
+	// not a failure: it is the answer, and it is how a repair learns that what
+	// it was about to refetch should be deleted instead.
+	Read(ctx context.Context, id string) (Thread, error)
+}
+
+// Source is a connector over one [Service].
+type Source struct {
+	service Service
+	name    string
+	maxBody int
+	skipped func(id string, reason error)
+
+	lists    atomic.Int64
+	metadata atomic.Int64
+	fetches  atomic.Int64
+	bytes    atomic.Int64
+
+	once     sync.Once
+	closeErr error
+}
+
+// Option configures a source.
+type Option func(*Source)
+
+// WithMaxBody sets the largest conversation body that is indexed. A value below
+// one selects [thread.DefaultMaxBody].
+func WithMaxBody(n int) Option {
+	return func(s *Source) {
+		if n > 0 {
+			s.maxBody = n
+		}
+	}
+}
+
+// WithSkipped installs a callback for conversations the sync passed over.
+//
+// A sync does not abandon a workspace because one conversation in it could not
+// be turned into a document. What it must not be is silent: an index quietly
+// missing everything nobody could read looks exactly like an index that is
+// complete, and the difference only shows up when somebody cannot find a thread
+// they remember. The default does nothing.
+func WithSkipped(f func(id string, reason error)) Option {
+	return func(s *Source) {
+		if f != nil {
+			s.skipped = f
+		}
+	}
+}
+
+// New returns a source reading svc and naming itself name.
+func New(svc Service, name string, opts ...Option) (*Source, error) {
+	if svc == nil {
+		return nil, errors.New("threadsource: nil service")
+	}
+	if name == "" {
+		return nil, errors.New("threadsource: empty source name")
+	}
+	s := &Source{
+		service: svc,
+		name:    name,
+		maxBody: thread.DefaultMaxBody,
+		skipped: func(string, error) {},
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s, nil
+}
+
+var (
+	_ connector.Connector  = (*Source)(nil)
+	_ connector.Enumerator = (*Source)(nil)
+	_ connector.Fetcher    = (*Source)(nil)
+	_ connector.Counted    = (*Source)(nil)
+)
+
+// Source returns the connector's name.
+func (s *Source) Source() string { return s.name }
+
+// Close closes the service if it is something that can be closed, and is safe
+// to call more than once.
+//
+// Most adapters hold an HTTP client that outlives them and have nothing to
+// release, which is why this is an interface check rather than a method on
+// [Service]: requiring every adapter to write an empty Close would make the one
+// that does need to release something look like all the ones that do not.
+func (s *Source) Close() error {
+	s.once.Do(func() {
+		if c, ok := s.service.(interface{ Close() error }); ok {
+			s.closeErr = c.Close()
+		}
+	})
+	return s.closeErr
+}
+
+// edgeLimit is how many ids the cursor carries for the instant it stopped at.
+//
+// The list exists so that a conversation changed in the same instant as the
+// cursor is neither lost nor emitted twice, and one instant normally holds one
+// conversation. A bulk import that stamps ten thousand of them with the same
+// time is the case this bound is for, and what going over it costs is a handful
+// of documents indexed again on the next run, which is the harmless direction.
+const edgeLimit = 256
+
+// syncPoint is what this connector puts in a cursor.
+//
+// Since is how far the last completed run got, and Edge is the conversations
+// emitted at exactly that instant. Container and At are only set on the cursors
+// carried by individual changes: they say which container an interrupted run
+// had reached and how far into it, so a cursor with a container in it is
+// exactly the record of a run that did not finish.
+//
+// Perms is the same high water mark for access rules, and it is separate
+// because the two move for different reasons. A rule rewritten at midnight
+// governs conversations nobody has touched for a year, and folding the two
+// together would mean either re-reading the year or missing the rewrite.
+type syncPoint struct {
+	Since     time.Time `json:"since"`
+	Edge      []string  `json:"edge,omitempty"`
+	Perms     time.Time `json:"perms,omitempty"`
+	Container string    `json:"container,omitempty"`
+	At        time.Time `json:"at,omitempty"`
+}
+
+// Sync walks every container and emits the conversations that changed.
+func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(context.Context, connector.Change) error) (connector.Cursor, error) {
+	start, err := parseCursor(from)
+	if err != nil {
+		return connector.Cursor{}, err
+	}
+
+	containers, err := s.containers(ctx)
+	if err != nil {
+		return connector.Cursor{}, err
+	}
+
+	var (
+		highest = start.Since
+		edge    = slices.Clone(start.Edge)
+		latest  = start.Perms
+	)
+	for _, c := range containers {
+		if err := ctx.Err(); err != nil {
+			return connector.Cursor{}, err
+		}
+
+		// The high water mark for rules covers every container whether or not
+		// this run walked it, because the next run compares against it and a
+		// container skipped here was walked by the run this one is resuming.
+		if c.AccessAt.After(latest) {
+			latest = c.AccessAt
+		}
+
+		// A container the interrupted run had already finished is one whose
+		// changes were emitted with the cursor this one started from, so
+		// walking it again would cost a full listing to emit nothing.
+		if start.Container != "" && c.ID < start.Container {
+			continue
+		}
+
+		since := start.Since
+		if c.ID == start.Container && start.At.After(since) {
+			since = start.At
+		}
+
+		if c.AccessAt.After(start.Perms) {
+			if err := s.refresh(ctx, c, start, emit); err != nil {
+				return connector.Cursor{}, err
+			}
+		}
+
+		err := s.service.Threads(ctx, c, since, func(ctx context.Context, th Thread) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			at := changedAt(th)
+			if !s.wanted(th, at, start, since) {
+				return nil
+			}
+
+			document, err := s.document(th, c)
+			if err != nil {
+				s.skipped(th.Conversation.ID, err)
+				return nil
+			}
+			if err := emit(ctx, connector.Change{
+				Document: document,
+				Cursor:   resume(start, c.ID, at),
+			}); err != nil {
+				return err
+			}
+
+			switch {
+			case at.After(highest):
+				// The instant moved on, so what was emitted at the old one is
+				// no longer what a resuming run has to skip.
+				highest, edge = at, append(edge[:0], th.Conversation.ID)
+			case at.Equal(highest) && len(edge) < edgeLimit:
+				edge = append(edge, th.Conversation.ID)
+			}
+			return nil
+		})
+		if err != nil {
+			return connector.Cursor{}, err
+		}
+	}
+
+	if highest.IsZero() && latest.IsZero() {
+		return from, nil
+	}
+	return cursorAt(syncPoint{Since: highest, Edge: edge, Perms: latest}, highest), nil
+}
+
+// wanted decides whether a conversation the service handed over is one this run
+// should emit.
+//
+// Two of the three reasons to say no are about the boundary the cursor sits on.
+// A service is asked for what changed at or after a time so that nothing in
+// that instant is lost, which means it hands back what was already emitted at
+// that instant, and the cursor carries those ids so that they are not emitted
+// twice.
+func (s *Source) wanted(th Thread, at time.Time, start syncPoint, since time.Time) bool {
+	switch {
+	case th.Conversation.ID == "":
+		s.skipped("", errors.New("the conversation has no id, so there is nothing to file it under"))
+		return false
+	case at.IsZero():
+		// Nothing about it says when it changed, so every run will emit it
+		// again. That is the safe direction and it is worth saying out loud
+		// rather than dropping the conversation.
+		return true
+	case !since.IsZero() && at.Before(since):
+		return false
+	case at.Equal(start.Since) && slices.Contains(start.Edge, th.Conversation.ID):
+		return false
+	default:
+		return true
+	}
+}
+
+// refresh emits a permission change for every conversation in a container whose
+// rule was rewritten, without reading any of them.
+//
+// This is the whole of "a revocation takes effect without a resync". Somebody
+// makes a channel private and nothing inside it is touched, so a sync that only
+// asked what changed would find nothing at all and the index would keep
+// answering with the old rule.
+func (s *Source) refresh(ctx context.Context, c Container, start syncPoint, emit func(context.Context, connector.Change) error) error {
+	perms := s.access(Thread{}, c)
+	cursor := resume(start, c.ID, start.At)
+
+	var failed error
+	s.lists.Add(1)
+	err := s.service.List(ctx, c, func(item connector.Item) bool {
+		if item.ID == "" {
+			return true
+		}
+		s.metadata.Add(1)
+		failed = emit(ctx, connector.Change{
+			Document:        doc.Document{ID: s.id(item.ID), Source: s.name, Permissions: perms},
+			PermissionsOnly: true,
+			Cursor:          cursor,
+		})
+		return failed == nil
+	})
+	if failed != nil {
+		return failed
+	}
+	return err
+}
+
+// Enumerate lists every conversation the source currently holds.
+//
+// It is what the reconciliation sweep runs on, and for these products it is the
+// only thing that ever removes anything. A message deleted, an issue deleted and
+// a page archived are all changes no change feed reports, so without this the
+// index would keep serving a thread the source no longer has.
+func (s *Source) Enumerate(ctx context.Context, fn func(connector.Item) bool) error {
+	containers, err := s.containers(ctx)
+	if err != nil {
+		return err
+	}
+	for _, c := range containers {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		stopped := false
+		s.lists.Add(1)
+		err := s.service.List(ctx, c, func(item connector.Item) bool {
+			if item.ID == "" {
+				return true
+			}
+			item.ID = s.id(item.ID)
+			if !fn(item) {
+				stopped = true
+				return false
+			}
+			return true
+		})
+		if err != nil {
+			return err
+		}
+		if stopped {
+			// A listing stopped on purpose is not a failed listing, and the
+			// caller that stopped it is not asking for the next container.
+			return nil
+		}
+	}
+	return nil
+}
+
+// Fetch reads one conversation by document id, with its permissions resolved
+// the way a sync would resolve them.
+func (s *Source) Fetch(ctx context.Context, id string) (doc.Document, error) {
+	raw, ok := strings.CutPrefix(id, s.name+":")
+	if !ok || raw == "" {
+		return doc.Document{}, fmt.Errorf("threadsource: %q is not an id from %s", id, s.name)
+	}
+
+	th, err := s.service.Read(ctx, raw)
+	if err != nil {
+		return doc.Document{}, err
+	}
+
+	// The container is where the rule lives, and a fetch arrives with nothing
+	// but an id. An adapter that filled the conversation's own access in has
+	// answered the question already and this costs nothing.
+	var c Container
+	if !resolved(th.Access) && th.Container != "" {
+		containers, err := s.containers(ctx)
+		if err != nil {
+			return doc.Document{}, err
+		}
+		if i := slices.IndexFunc(containers, func(x Container) bool { return x.ID == th.Container }); i >= 0 {
+			c = containers[i]
+		}
+	}
+	return s.document(th, c)
+}
+
+// Counters returns what this connector has spent at the source.
+//
+// They are counted in conversations rather than in requests, because how many
+// requests a conversation costs is the adapter's business and changes with
+// every page size. What matters above here is the shape: a second sync of a
+// workspace nothing changed in fetches nothing.
+func (s *Source) Counters() connector.Counters {
+	return connector.Counters{
+		Lists:    s.lists.Load(),
+		Metadata: s.metadata.Load(),
+		Fetches:  s.fetches.Load(),
+		Bytes:    s.bytes.Load(),
+	}
+}
+
+// containers lists the containers in a fixed order.
+//
+// The order is the resume point. A cursor says which container an interrupted
+// run reached and the next run skips the ones before it, which is only sound if
+// the two runs walk them in the same order, and the order a product's API
+// happens to list channels in is not something to rely on.
+func (s *Source) containers(ctx context.Context) ([]Container, error) {
+	s.lists.Add(1)
+	containers, err := s.service.Containers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Container, 0, len(containers))
+	for _, c := range containers {
+		if c.ID != "" {
+			out = append(out, c)
+		}
+	}
+	slices.SortFunc(out, func(a, b Container) int { return strings.Compare(a.ID, b.ID) })
+	return out, nil
+}
+
+// document turns one conversation into one document.
+func (s *Source) document(th Thread, c Container) (doc.Document, error) {
+	if th.Conversation.ID == "" {
+		return doc.Document{}, errors.New("the conversation has no id, so there is nothing to file it under")
+	}
+
+	d := th.Conversation.Document(s.access(th, c), thread.WithMaxBody(s.maxBody))
+	d.ID = s.id(th.Conversation.ID)
+	d.Source = s.name
+	if d.Container == "" {
+		d.Container = c.Name
+	}
+
+	s.fetches.Add(1)
+	s.bytes.Add(int64(len(d.Body)))
+	return d, nil
+}
+
+// access is the rule that governs one conversation.
+//
+// The conversation's own answer wins, because a ticket with a security level on
+// it is readable by that level's members whatever the project says. Otherwise it
+// inherits the container, and a container with no rule at all quarantines what
+// is in it rather than publishing it.
+func (s *Source) access(th Thread, c Container) acl.Permissions {
+	switch {
+	case resolved(th.Access):
+		return th.Access
+	case resolved(c.Access):
+		return c.Access
+	default:
+		return connector.Unresolved(s.name)
+	}
+}
+
+// resolved reports whether a descriptor is one somebody filled in.
+//
+// A descriptor naming its source is one a connector produced, including the one
+// [connector.Unresolved] produces, which says the question was considered and
+// could not be answered. The zero value is the other thing entirely: nobody
+// said anything, and that is what inheriting is for.
+func resolved(p acl.Permissions) bool { return p.Source != "" || p.Mode != acl.ModeUnknown }
+
+// id is the document id for one conversation.
+func (s *Source) id(raw string) string { return s.name + ":" + raw }
+
+// changedAt is when a conversation last changed.
+//
+// The source's own answer is used when there is one, because a ticket whose
+// priority was raised changed without anybody writing a word and only the source
+// knows that. Otherwise the last thing anybody said in it is the honest answer.
+func changedAt(th Thread) time.Time {
+	if !th.Updated.IsZero() {
+		return th.Updated
+	}
+	last := latestOf(th.Conversation.Root, time.Time{})
+	for _, m := range th.Conversation.Replies {
+		last = latestOf(m, last)
+	}
+	return last
+}
+
+func latestOf(m thread.Message, so time.Time) time.Time {
+	for _, at := range []time.Time{m.At, m.Edited} {
+		if at.After(so) {
+			so = at
+		}
+	}
+	return so
+}
+
+// parseCursor reads back what this connector wrote.
+func parseCursor(c connector.Cursor) (syncPoint, error) {
+	if c.IsZero() {
+		return syncPoint{}, nil
+	}
+	var p syncPoint
+	if err := json.Unmarshal([]byte(c.Value), &p); err != nil {
+		// A cursor this connector cannot read was written by a different
+		// version or a different connector. Refusing is better than silently
+		// resyncing a workspace, which on a large one is hours of somebody
+		// else's rate limit.
+		return syncPoint{}, fmt.Errorf("threadsource: unreadable cursor %q: %w", c.Value, err)
+	}
+	return p, nil
+}
+
+func cursorAt(p syncPoint, at time.Time) connector.Cursor {
+	// The only way this fails is a time that cannot be formatted, and there is
+	// no such time. An empty value would be read back as no cursor at all,
+	// which resyncs the workspace rather than losing anything.
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return connector.Cursor{}
+	}
+	return connector.Cursor{Value: string(raw), Time: at}
+}
+
+// resume is the cursor carried by one change, and is where an interrupted run
+// picks up.
+//
+// It keeps the completed run's Since rather than moving it on, and records the
+// progress separately. Moving it on would be wrong in a way that is invisible:
+// the containers this run has not reached yet still have to be asked from the
+// old point, and a cursor that had advanced past them would skip everything in
+// them that changed in between.
+func resume(start syncPoint, container string, at time.Time) connector.Cursor {
+	return cursorAt(syncPoint{
+		Since:     start.Since,
+		Edge:      start.Edge,
+		Perms:     start.Perms,
+		Container: container,
+		At:        at,
+	}, start.Since)
+}

--- a/connector/threadsource/threadsource_test.go
+++ b/connector/threadsource/threadsource_test.go
@@ -1,0 +1,616 @@
+package threadsource_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/thread"
+	"github.com/tamnd/genba/connector/threadsource"
+	"github.com/tamnd/genba/doc"
+)
+
+func newSource(t *testing.T, f *fake, opts ...threadsource.Option) *threadsource.Source {
+	t.Helper()
+	src, err := threadsource.New(f, source, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+	return src
+}
+
+// sync runs one sync and hands back everything it emitted.
+func run(t *testing.T, src *threadsource.Source, from connector.Cursor) ([]connector.Change, connector.Cursor) {
+	t.Helper()
+	var got []connector.Change
+	next, err := src.Sync(t.Context(), from, func(_ context.Context, ch connector.Change) error {
+		got = append(got, ch)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	return got, next
+}
+
+// find returns the change for one document id.
+func find(changes []connector.Change, id string) *connector.Change {
+	for i := range changes {
+		if changes[i].Document.ID == id {
+			return &changes[i]
+		}
+	}
+	return nil
+}
+
+func ids(changes []connector.Change) []string {
+	out := make([]string, 0, len(changes))
+	for _, ch := range changes {
+		out = append(out, ch.Document.ID)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// A thread is one result with its replies, which is the whole reason this
+// connector assembles rather than emitting a row per message.
+func TestAThreadAndItsRepliesAreOneDocument(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.reply("r1", "gearbox", "sam", "Bearing, I think.")
+	f.reply("r1", "gearbox", "mei", "Replacement ordered.")
+	src := newSource(t, f)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 1 {
+		t.Fatalf("a thread of three messages produced %d documents: %v", len(changes), ids(changes))
+	}
+
+	got := changes[0].Document
+	for _, want := range []string{"making a noise", "Bearing, I think", "Replacement ordered"} {
+		if !strings.Contains(got.Body, want) {
+			t.Errorf("the body does not hold %q:\n%s", want, got.Body)
+		}
+	}
+	if got.Properties["messages"] != "3" || got.Properties["replies"] != "2" {
+		t.Errorf("the counts are messages=%q replies=%q", got.Properties["messages"], got.Properties["replies"])
+	}
+}
+
+func TestADocumentSaysWhereItCameFromAndNotWhoItIsFor(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	src := newSource(t, f)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := changes[0].Document
+	if got.ID != "chat:gearbox" {
+		t.Errorf("the id is %q, want the source name in front of the conversation's own id", got.ID)
+	}
+	if got.Source != source {
+		t.Errorf("the document says it came from %q", got.Source)
+	}
+	// The tenant is the pipeline's to set, from the run rather than from the
+	// source, and a connector that fills it in is one whose documents land in
+	// whichever tenant it was first written for.
+	if got.Tenant != "" {
+		t.Errorf("the document carries tenant %q", got.Tenant)
+	}
+	// The channel is what a person reading a result row wants to see, and the
+	// conversation itself said nothing about it.
+	if got.Container != "maintenance" {
+		t.Errorf("the container is %q, want the channel's name", got.Container)
+	}
+}
+
+// A conversation inherits the rule on the container, because that is how every
+// one of these products actually works.
+func TestAConversationInheritsTheChannelsRule(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.share("r1")
+	src := newSource(t, f)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "chat:gearbox")
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if got.Document.Permissions.Mode != acl.ModeACL {
+		t.Fatalf("the document is %v, want the private channel's rule", got.Document.Permissions.Mode)
+	}
+	if len(got.Document.Permissions.AllowGroups) != 1 {
+		t.Errorf("the rule allows %v", got.Document.Permissions.AllowGroups)
+	}
+}
+
+// A ticket with a security level on it is readable by that level's members and
+// by nobody else, whatever the project says.
+func TestAConversationWithARuleOfItsOwnKeepsIt(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r1", "payroll", "Payroll is late again.")
+	f.restrict("r1", "payroll", acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      source,
+		AllowGroups: []acl.Ref{{Source: source, Value: "finance"}},
+	})
+	src := newSource(t, f)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	open := find(changes, "chat:gearbox")
+	closed := find(changes, "chat:payroll")
+	if open == nil || closed == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if open.Document.Permissions.Mode != acl.ModePublicToTenant {
+		t.Errorf("the unrestricted thread is %v", open.Document.Permissions.Mode)
+	}
+	if got := closed.Document.Permissions.AllowGroups; len(got) != 1 || got[0].Value != "finance" {
+		t.Errorf("the restricted thread allows %v, want the group named on it rather than the channel's", got)
+	}
+}
+
+// There is no permissive default. A channel nobody has said anything about is
+// quarantined, which is loud and safe, rather than published to the tenant.
+func TestAChannelWithNoRuleQuarantinesWhatIsInIt(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.unruled("r1")
+	src := newSource(t, f)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "chat:gearbox")
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if got.Document.Permissions.Mode != acl.ModeUnknown {
+		t.Errorf("a thread in a channel with no rule is %v", got.Document.Permissions.Mode)
+	}
+	if got.Document.Permissions.Source != source {
+		t.Errorf("the descriptor says it came from %q, and a connector that could not answer still says who was asked", got.Document.Permissions.Source)
+	}
+	if got.Document.Queryable() {
+		t.Error("a thread nobody can say who may read is queryable")
+	}
+}
+
+// Somebody makes a channel private and nothing inside it is touched. A sync
+// that only asked what changed would find nothing at all, and the index would
+// keep answering with the old rule.
+func TestMakingAChannelPrivateReachesTheIndexWithoutReadingIt(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r1", "coolant", "Coolant pump replaced.")
+	src := newSource(t, f)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	before := src.Counters()
+
+	f.share("r1")
+	changes, next := run(t, src, cursor)
+
+	if len(changes) != 2 {
+		t.Fatalf("making the channel private emitted %v, want both threads in it", ids(changes))
+	}
+	for _, ch := range changes {
+		if !ch.PermissionsOnly {
+			t.Errorf("%s came back as a content change, and nothing in it changed", ch.Document.ID)
+		}
+		if ch.Document.Body != "" {
+			t.Errorf("%s carries content on a permission change, which will not be stored", ch.Document.ID)
+		}
+		if ch.Document.Permissions.Mode != acl.ModeACL {
+			t.Errorf("%s reports %v, which is the rule it already had", ch.Document.ID, ch.Document.Permissions.Mode)
+		}
+	}
+	if spent := src.Counters().Since(before); spent.Fetches != 0 {
+		t.Errorf("a permission change read %d threads, and the point of it is that it reads none", spent.Fetches)
+	}
+
+	// And the run after it says nothing, because the rule has not changed
+	// again. A connector that re-emitted here would rewrite the permissions of
+	// every document in the workspace on every sync for ever.
+	if again, _ := run(t, src, next); len(again) != 0 {
+		t.Errorf("the sync after the permission change emitted %v", ids(again))
+	}
+}
+
+func TestASecondSyncOfAWorkspaceNothingChangedInEmitsNothing(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r1", "coolant", "Coolant pump replaced.")
+	src := newSource(t, f)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	before := src.Counters()
+
+	changes, _ := run(t, src, cursor)
+	if len(changes) != 0 {
+		t.Errorf("a second sync emitted %v", ids(changes))
+	}
+	if spent := src.Counters().Since(before); spent.Fetches != 0 || spent.Bytes != 0 {
+		t.Errorf("a second sync read %d threads and %d bytes", spent.Fetches, spent.Bytes)
+	}
+}
+
+// A reply is a change to the thread rather than a document of its own, so the
+// next sync emits that thread again and the rest of the channel not at all.
+func TestAReplyBringsTheWholeThreadBack(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r1", "coolant", "Coolant pump replaced.")
+	src := newSource(t, f)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	f.reply("r1", "gearbox", "sam", "Bearing, I think.")
+
+	changes, _ := run(t, src, cursor)
+	if got := ids(changes); !slices.Equal(got, []string{"chat:gearbox"}) {
+		t.Fatalf("the sync after one reply emitted %v", got)
+	}
+	if !strings.Contains(changes[0].Document.Body, "Bearing, I think") {
+		t.Errorf("the reply is not in the body:\n%s", changes[0].Document.Body)
+	}
+}
+
+// Two conversations changed in the same instant is the case a cursor made of a
+// timestamp gets wrong. Asking for what changed strictly after the cursor loses
+// the second one for ever, and asking for what changed at or after it emits both
+// again on every run until something else happens in the channel.
+func TestTwoThreadsInOneInstantAreEmittedOnceEach(t *testing.T) {
+	f := newFake()
+	at := epoch.Add(time.Hour)
+	f.writeAt("r1", "gearbox", "The gearbox on line two is making a noise.", at)
+	f.writeAt("r1", "coolant", "Coolant pump replaced.", at)
+	src := newSource(t, f)
+
+	changes, cursor := run(t, src, connector.Cursor{})
+	if got := ids(changes); !slices.Equal(got, []string{"chat:coolant", "chat:gearbox"}) {
+		t.Fatalf("the first sync emitted %v", got)
+	}
+
+	if again, next := run(t, src, cursor); len(again) != 0 {
+		t.Errorf("the second sync emitted %v again", ids(again))
+	} else if next.IsZero() {
+		t.Error("the second sync came back with no cursor")
+	}
+
+	// And a third conversation in that same instant, written after the sync
+	// that recorded it, is still found. This is the half that a connector
+	// comparing strictly after the cursor loses without a word.
+	f.writeAt("r1", "belt", "Belt tension checked.", at)
+	changes, _ = run(t, src, cursor)
+	if got := ids(changes); !slices.Equal(got, []string{"chat:belt"}) {
+		t.Errorf("a thread written in the same instant as the cursor came back as %v", got)
+	}
+}
+
+// A crawl of a real workspace takes long enough that it will be interrupted,
+// and the cursor a change carries is what makes the next run cheap.
+func TestAnInterruptedRunDoesNotWalkTheChannelsItFinished(t *testing.T) {
+	f := newFake()
+	f.addRoom("r2", "incidents")
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r2", "outage", "The payments queue backed up.")
+	src := newSource(t, f)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	stopped := find(changes, "chat:outage")
+	if stopped == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+
+	f.asked = nil
+	run(t, src, stopped.Cursor)
+	if !slices.Equal(f.asked, []string{"r2"}) {
+		t.Errorf("resuming inside r2 walked %v, and r1 was finished before the run died", f.asked)
+	}
+}
+
+// Resuming has to pick up everything that came after the cursor, in the
+// channels the run had reached and in the ones it had not.
+func TestResumingLosesNothingInEitherDirection(t *testing.T) {
+	f := newFake()
+	f.addRoom("r2", "incidents")
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r2", "outage", "The payments queue backed up.")
+	src := newSource(t, f)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	from := find(changes, "chat:gearbox")
+	if from == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+
+	f.write("r1", "coolant", "Coolant pump replaced.")
+	f.write("r2", "network", "Switch firmware rolled back.")
+
+	got, _ := run(t, src, from.Cursor)
+	for _, want := range []string{"chat:coolant", "chat:network", "chat:outage"} {
+		if find(got, want) == nil {
+			t.Errorf("resuming from a change in r1 did not emit %s, and it emitted %v", want, ids(got))
+		}
+	}
+}
+
+// A cursor this connector cannot read was written by a different version or a
+// different connector, and resyncing a workspace on the strength of that is
+// hours of somebody else's rate limit.
+func TestAnUnreadableCursorIsRefusedRatherThanIgnored(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	src := newSource(t, f)
+
+	_, err := src.Sync(t.Context(), connector.Cursor{Value: "not a cursor this connector wrote"}, func(context.Context, connector.Change) error {
+		t.Error("a sync from an unreadable cursor emitted a document")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("a sync from an unreadable cursor succeeded")
+	}
+	if !strings.Contains(err.Error(), "cursor") {
+		t.Errorf("the error does not say what was wrong: %v", err)
+	}
+}
+
+// The sweep is the only thing that ever removes a thread, because none of these
+// products reports a deletion in a change feed.
+func TestEnumerateListsEveryChannel(t *testing.T) {
+	f := newFake()
+	f.addRoom("r2", "incidents")
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r2", "outage", "The payments queue backed up.")
+	src := newSource(t, f)
+
+	var got []string
+	if err := src.Enumerate(t.Context(), func(item connector.Item) bool {
+		if item.Version == "" {
+			t.Errorf("%s was listed without a version, so it can be found missing but never stale", item.ID)
+		}
+		got = append(got, item.ID)
+		return true
+	}); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	slices.Sort(got)
+	if want := []string{"chat:gearbox", "chat:outage"}; !slices.Equal(got, want) {
+		t.Errorf("the enumeration lists %v, want %v", got, want)
+	}
+}
+
+// A listing stopped on purpose is not a failed listing. Reporting it as one
+// would make a reconciliation that used an early exit delete the whole index.
+func TestEnumerateStopsWhenTheCallerSaysSo(t *testing.T) {
+	f := newFake()
+	f.addRoom("r2", "incidents")
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r2", "outage", "The payments queue backed up.")
+	src := newSource(t, f)
+
+	var seen int
+	if err := src.Enumerate(t.Context(), func(connector.Item) bool {
+		seen++
+		return false
+	}); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if seen != 1 {
+		t.Errorf("the listing carried on for %d items after being told to stop", seen)
+	}
+}
+
+func TestFetchReturnsWhatASyncWouldHave(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.reply("r1", "gearbox", "sam", "Bearing, I think.")
+	src := newSource(t, f)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	want := changes[0].Document
+
+	got, err := src.Fetch(t.Context(), "chat:gearbox")
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got.ID != want.ID || got.Body != want.Body || got.Title != want.Title {
+		t.Errorf("fetch returned %+v, and the sync emitted %+v", got, want)
+	}
+	// A fetch arrives with nothing but an id, so the rule has to be worked out
+	// from the channel the conversation says it is in.
+	if got.Permissions.Mode != want.Permissions.Mode || got.Permissions.Source != source {
+		t.Errorf("fetch resolved %v and the sync resolved %v", got.Permissions, want.Permissions)
+	}
+}
+
+func TestFetchOfSomethingTheSourceNoLongerHasIsNotAFailure(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	src := newSource(t, f)
+
+	f.remove("r1", "gearbox")
+	if _, err := src.Fetch(t.Context(), "chat:gearbox"); !errors.Is(err, connector.ErrGone) {
+		t.Errorf("fetching a deleted thread gave %v, want the answer that it is gone", err)
+	}
+}
+
+func TestFetchOfAnIdFromSomewhereElseSaysSo(t *testing.T) {
+	f := newFake()
+	src := newSource(t, f)
+
+	_, err := src.Fetch(t.Context(), "wiki:gearbox")
+	if err == nil {
+		t.Fatal("fetching an id from another source succeeded")
+	}
+	if errors.Is(err, connector.ErrGone) {
+		t.Error("an id from another source came back as a document this source used to have")
+	}
+	if !strings.Contains(err.Error(), "wiki:gearbox") {
+		t.Errorf("the error does not say what was asked for: %v", err)
+	}
+}
+
+func TestTheCountersSayWhatASyncSpent(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r1", "coolant", "Coolant pump replaced.")
+	src := newSource(t, f)
+
+	run(t, src, connector.Cursor{})
+	got := src.Counters()
+	if got.Fetches != 2 {
+		t.Errorf("a sync of two threads counted %d fetches", got.Fetches)
+	}
+	if got.Lists == 0 {
+		t.Error("a sync that listed the channels and their threads counted no listings")
+	}
+	if got.Bytes == 0 {
+		t.Error("a sync that read two threads counted no bytes")
+	}
+}
+
+// A conversation too long to index whole keeps its beginning and its end, and
+// the document says it was cut.
+func TestALongThreadIsCutRatherThanDropped(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", strings.Repeat("the gearbox is still making a noise. ", 200))
+	f.reply("r1", "gearbox", "sam", "Bearing, I think.")
+	src := newSource(t, f, threadsource.WithMaxBody(256))
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := changes[0].Document
+	if len(got.Body) > 256 {
+		t.Errorf("the body is %d bytes with a limit of 256", len(got.Body))
+	}
+	if got.Properties["truncated"] != "true" {
+		t.Error("the document does not say it was cut, so a reader will report it as missing a sentence that is in it")
+	}
+}
+
+func TestClosingClosesTheServiceOnceAndIsRepeatable(t *testing.T) {
+	f := newFake()
+	src, err := threadsource.New(f, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatalf("closing a second time: %v", err)
+	}
+	if f.closes != 1 {
+		t.Errorf("the service was closed %d times", f.closes)
+	}
+}
+
+func TestASourceWithNothingBehindItIsRefused(t *testing.T) {
+	if _, err := threadsource.New(nil, source); err == nil {
+		t.Error("a source with no service behind it was built")
+	}
+	if _, err := threadsource.New(newFake(), ""); err == nil {
+		t.Error("a source with no name was built, and the name is what its cursor is filed under")
+	}
+}
+
+// An error from the service is the caller's to see. A sync that swallowed one
+// would report success and move the cursor past documents it never read.
+func TestAnErrorFromTheServiceComesBackUnchanged(t *testing.T) {
+	failed := errors.New("the workspace is rate limiting us")
+
+	for _, tc := range []struct {
+		name string
+		set  func(f *fake)
+	}{
+		{"listing the channels", func(f *fake) { f.failContainers = failed }},
+		{"walking a channel", func(f *fake) { f.failThreads = failed }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFake()
+			f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+			tc.set(f)
+			src := newSource(t, f)
+
+			_, err := src.Sync(t.Context(), connector.Cursor{}, func(context.Context, connector.Change) error { return nil })
+			if !errors.Is(err, failed) {
+				t.Errorf("the sync returned %v, want the error the service gave it", err)
+			}
+		})
+	}
+}
+
+// nameless is an adapter with a bug in it: a conversation with no id, which is
+// the one thing that leaves nothing to file a document under.
+type nameless struct{}
+
+func (nameless) Containers(context.Context) ([]threadsource.Container, error) {
+	return []threadsource.Container{{
+		ID:     "r1",
+		Name:   "maintenance",
+		Access: acl.Permissions{Mode: acl.ModePublicToTenant, Source: source},
+	}}, nil
+}
+
+func (nameless) Threads(ctx context.Context, _ threadsource.Container, _ time.Time, fn func(context.Context, threadsource.Thread) error) error {
+	return fn(ctx, threadsource.Thread{
+		Conversation: thread.Conversation{Title: "a thread with no identity"},
+		Container:    "r1",
+		Updated:      epoch,
+	})
+}
+
+func (nameless) List(context.Context, threadsource.Container, func(connector.Item) bool) error {
+	return nil
+}
+
+func (nameless) Read(context.Context, string) (threadsource.Thread, error) {
+	return threadsource.Thread{}, connector.ErrGone
+}
+
+// An index quietly missing what nobody could read looks exactly like an index
+// that is complete, and the difference only shows up when somebody cannot find
+// a thread they remember.
+func TestAConversationThatCannotBeIndexedIsReported(t *testing.T) {
+	var skipped []error
+	src, err := threadsource.New(nameless{}, source, threadsource.WithSkipped(func(_ string, reason error) {
+		skipped = append(skipped, reason)
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 0 {
+		t.Errorf("a conversation with no id was emitted as %v", ids(changes))
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("the sync passed over a conversation and said %v", skipped)
+	}
+	if !strings.Contains(skipped[0].Error(), "id") {
+		t.Errorf("the reason given was %q", skipped[0])
+	}
+}
+
+// A document with an author on it is what makes a result row say who to ask,
+// and the author of a thread is whoever started it.
+func TestTheAuthorIsWhoeverStartedTheThread(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.reply("r1", "gearbox", "sam", "Bearing, I think.")
+	src := newSource(t, f)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if got := changes[0].Document.Author; got.Name != "mei" {
+		t.Errorf("the author is %+v, want whoever wrote the first message", got)
+	}
+	if got := changes[0].Document.Kind; got != doc.KindMessage {
+		t.Errorf("the kind is %q", got)
+	}
+}

--- a/connector/threadsource/threadsource_test.go
+++ b/connector/threadsource/threadsource_test.go
@@ -222,6 +222,34 @@ func TestMakingAChannelPrivateReachesTheIndexWithoutReadingIt(t *testing.T) {
 	}
 }
 
+// A full sync already emits every conversation with the rule its container has
+// right now, so emitting a permission change alongside each one would be saying
+// the same thing twice and doubling the first sync of a workspace.
+func TestAFullSyncDoesNotRefreshWhatItIsAlreadyEmitting(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r1", "coolant", "Coolant pump replaced.")
+	// The room's rule was rewritten before anything ever read it, which is the
+	// ordinary state of a source being indexed for the first time.
+	f.share("r1")
+	src := newSource(t, f)
+
+	changes, next := run(t, src, connector.Cursor{})
+	if got := ids(changes); !slices.Equal(got, []string{"chat:coolant", "chat:gearbox"}) {
+		t.Fatalf("a first sync of two threads emitted %v", got)
+	}
+	for _, ch := range changes {
+		if ch.PermissionsOnly {
+			t.Errorf("%s was emitted as a permission change by the sync that first indexed it", ch.Document.ID)
+		}
+	}
+	// And the run after it says nothing, so the rule the first sync used was
+	// recorded rather than skipped.
+	if again, _ := run(t, src, next); len(again) != 0 {
+		t.Errorf("the sync after the first one emitted %v", ids(again))
+	}
+}
+
 func TestASecondSyncOfAWorkspaceNothingChangedInEmitsNothing(t *testing.T) {
 	f := newFake()
 	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -447,6 +447,7 @@ A container nobody has said anything about quarantines everything in it rather t
 Making a channel private touches no message in it, so a sync that only asked what changed would find nothing and the index would keep answering with the old rule.
 An adapter reports when the rule changed, and when that is newer than the cursor the source lists the container and emits a permission change per conversation in it, carrying the new rule and no body.
 That costs one write per thread rather than a refetch of the channel, and the run after it says nothing, because the rule has not changed again.
+A full sync refreshes nothing, because every conversation it emits already carries the rule its container has right now, and emitting a permission change alongside each one would double the first sync of a workspace to say the same thing twice.
 
 The cursor is a time plus an edge set, and the edge set is what makes it correct.
 Two conversations that changed in the same instant is the case a bare timestamp gets wrong in both directions: asking for what changed strictly after the cursor loses the second one for ever, and asking for what changed at or after it emits both again on every run until something else happens.

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -417,6 +417,52 @@ A conversation too long for the body limit keeps its beginning and its end.
 The root stays because it is what the conversation is about, and the end stays because a thread long enough to be cut is usually one that took a while to work something out, and the working out is at the bottom.
 The document records how many messages were left out, and nothing is written in place of them, because a marker in a body is a phrase in the index that nobody at the source ever typed and it turns up in snippets.
 
+### The crawl the three of them share
+
+Assembling one conversation is the easy half.
+The other half is the crawl around it, and writing that three times produces three connectors that drift apart on exactly the parts that must not drift: the cursor, the resume, the sweep and the permission refresh.
+So it is written once, in `connector/threadsource`, and a product adapter is left with the only thing that is genuinely different, which is how to ask its API.
+
+An adapter answers four questions.
+
+```go
+type Service interface {
+	Containers(ctx context.Context) ([]Container, error)
+	Threads(ctx context.Context, c Container, since time.Time, fn func(context.Context, Thread) error) error
+	List(ctx context.Context, c Container, fn func(connector.Item) bool) error
+	Read(ctx context.Context, id string) (Thread, error)
+}
+```
+
+A container is a channel, a project or a space, and it carries the access rule and the time that rule last changed.
+A thread is a `thread.Conversation` plus the container it is in, an optional rule of its own and the time it last changed.
+All four questions are required, and the last two are the ones worth arguing about: none of these products reports a deletion in a change feed, so a message removed, an issue deleted and a page archived all leave the index holding a document that nothing will ever take away, and the sweep is the only thing that removes it.
+`List` is what the sweep reads and `Read` is what turns it from a report into a repair.
+
+The rule comes from the container, because that is how all three products actually work.
+A private channel is private because of the channel, and a page in a restricted space is restricted because of the space.
+A conversation may override it, which is not an edge case: a ticket with a security level on it is readable by that level's members and nobody else, whatever the project says.
+A container nobody has said anything about quarantines everything in it rather than defaulting to readable, which is the same rule the rest of this document keeps coming back to.
+
+Making a channel private touches no message in it, so a sync that only asked what changed would find nothing and the index would keep answering with the old rule.
+An adapter reports when the rule changed, and when that is newer than the cursor the source lists the container and emits a permission change per conversation in it, carrying the new rule and no body.
+That costs one write per thread rather than a refetch of the channel, and the run after it says nothing, because the rule has not changed again.
+
+The cursor is a time plus an edge set, and the edge set is what makes it correct.
+Two conversations that changed in the same instant is the case a bare timestamp gets wrong in both directions: asking for what changed strictly after the cursor loses the second one for ever, and asking for what changed at or after it emits both again on every run until something else happens.
+So the cursor asks for at or after and carries the ids already emitted at exactly that instant, capped at a few hundred, and a workspace busy enough to overflow the cap re-emits rather than loses.
+
+The cursor a change carries also records how far the run had got, as a container and a time inside it, while keeping the last completed run's boundary.
+That is what makes an interrupted crawl cheap to resume: the next run skips the containers it had already finished and picks up inside the one it was in.
+The boundary itself does not move mid-run, because advancing it would skip changes in the containers the run had not reached yet.
+
+```go
+src, err := threadsource.New(svc, "chat", threadsource.WithMaxBody(64<<10))
+```
+
+`WithSkipped` is told about a conversation the source could not index, which so far means one that arrived with no id.
+An index quietly missing what nobody could read looks exactly like an index that is complete, and the difference only shows up when somebody cannot find a thread they remember.
+
 ### The conformance suite is the definition
 
 `connector/connectortest` is what a connector has to pass, and it rather than the interface is the definition of one.


### PR DESCRIPTION
`connector/thread` assembles one conversation into one document.
The crawl around it was still going to be written three times, once for chat, once for a ticket tracker and once for a wiki, and the parts it would have been written three times for are the parts that must not drift: the cursor, the resume, the sweep and the permission refresh.

`connector/threadsource` is that crawl, written once.
A product adapter answers four questions about its API and gets a connector that passes the conformance suite.

```go
type Service interface {
	Containers(ctx context.Context) ([]Container, error)
	Threads(ctx context.Context, c Container, since time.Time, fn func(context.Context, Thread) error) error
	List(ctx context.Context, c Container, fn func(connector.Item) bool) error
	Read(ctx context.Context, id string) (Thread, error)
}
```

A container is a channel, a project or a space.
A thread is a `thread.Conversation` plus the container it is in, an optional rule of its own and the time it last changed.
What a real adapter adds on top is paging, signing, a rate limit and a vocabulary, and none of those is a difference in the crawl.

## Permissions come from the container

That is how all three products actually work.
A private channel is private because of the channel, and a page in a restricted space is restricted because of the space.

A conversation may override it, which is not an edge case: a ticket with a security level on it is readable by that level's members and by nobody else, whatever the project says.
A container nobody has said anything about quarantines everything in it rather than defaulting to readable, which is the same rule the rest of the ingestion path already follows.

Making a channel private touches no message in it, so a sync that only asked what changed would find nothing and the index would keep answering with the old rule.
When an adapter reports a rule that changed after the cursor, the source lists the container and emits one permission change per conversation in it, carrying the new rule and no body.
That costs one write per thread rather than a refetch of the channel, and the test asserts the fetch counter did not move.
The run after it says nothing, because a source that re-emitted here would rewrite the permissions of every document in the workspace on every sync for ever.

## The cursor is a time plus an edge set

Two conversations that changed in the same instant is the case a bare timestamp gets wrong in both directions.
Asking for what changed strictly after the cursor loses the second one for ever, and asking for what changed at or after it emits both again on every run until something else happens in the channel.

So the cursor asks for at or after and carries the ids already emitted at exactly that instant, capped at 256, and a workspace busy enough to overflow the cap re-emits rather than loses.
`objectsource` solves the same problem by holding its cursor a second behind the store's clock, which works because a bucket has a clock to read in a response header.
A `Service` has no such thing, so the ids are carried instead.

Each change also carries how far the run had got, as a container and a time inside it, while keeping the last completed run's boundary.
An interrupted crawl resumes inside the container it was in and skips the ones it finished, and a test asserts which containers the second run asked about.
The boundary itself does not move mid-run, because advancing it would skip changes in the containers the run had not reached yet.
Containers are walked in id order for the same reason, and the fake deliberately hands them back reversed so that the sort is doing the work rather than the fake's map order.

## List and Read are required

None of these products reports a deletion in a change feed.
A message removed, an issue deleted and a page archived all leave the index holding a document that nothing will ever take away, so the reconciliation sweep is the only thing that removes one, and a source that could not list would have no sweep.
`Read` is what turns the sweep from a report into a repair, and it is also what a preview and a reindex of one document go through.

## Tests

The conformance suite runs against a fake chat tool with rooms, threads, replies, a clock that only moves when something happens to it, and the ability to be told to fail.
On top of it: a thread of three messages is one document with the counts on it, ids are prefixed and the tenant is left for the pipeline, a conversation inherits the room's rule and a restricted one keeps its own, a room with no rule quarantines what is in it, a room made private emits permission changes and reads nothing, a reply brings back that thread and nothing else, two threads written in the same instant are emitted once each and a third written into that instant afterwards is still found, a resumed run does not walk a room it finished, an unreadable cursor is refused rather than treated as empty, an early stop in the enumeration is not an error, `Fetch` returns what the sync emitted and resolves the rule from the room, a long thread is cut rather than dropped and says so, and a conversation with no id is reported through `WithSkipped` rather than passed over in silence.

Part of #15.