### PR TITLE
Add the Slack connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ func main() {
 | `connector/objectsource` | an S3 compatible bucket, signed and paged, [docs/ingestion.md](docs/ingestion.md) |
 | `connector/thread` | a conversation and its replies assembled into one document |
 | `connector/threadsource` | the crawl, cursor and permission refresh chat, ticket trackers and wikis share, [docs/ingestion.md](docs/ingestion.md) |
+| `connector/slacksource` | Slack, a thread at a time, with per method rate limits and a recorded workspace to test against |
 | `connector/limit` | the rate limit, backoff and circuit breaker every connector shares, as a round tripper |
 | `connector/recorded` | HTTP exchanges captured from a real service and replayed from a directory, so tests need no account |
 | `extract` | text and structure out of PDF, Word, PowerPoint, Excel, HTML and Markdown, [docs/extraction.md](docs/extraction.md) |
@@ -443,6 +444,13 @@ Assembling one conversation is the easy half.
 `connector/threadsource` is the other half, and it is written once for all three products: the crawl over containers, the cursor that survives an interrupted run, the sweep that finds what a change feed never reports, and the permission refresh that runs when a channel is made private without a message in it being touched.
 A product adapter answers four questions about its API and gets a connector, which is why a channel somebody restricted this morning costs one write per thread in it rather than a recrawl, and why a thread and a channel that changed in the same second are both emitted exactly once.
 The rule comes from the container, a conversation may override it the way a ticket with a security level on it does, and a container nobody has said anything about quarantines what is in it rather than defaulting to readable.
+
+`connector/slacksource` is the first product on it, and most of what it does is deal with the things Slack does not tell you.
+There is no endpoint for what changed since a time, so a sync reads history back to the cursor and to a reply window as well, because a reply moves nothing but the parent's latest reply and a parent older than the cursor would otherwise never be looked at again.
+A reply older than the window is missed on purpose, and the version in the listing is what makes the sweep repair it, which is the honest version of a source with no change feed.
+Nothing reports that somebody was removed from a private channel either, so membership is reapplied on a schedule as well as when Slack says the channel changed, because a revocation that lands whenever somebody next posts is not a revocation.
+Slack publishes a rate limit per method rather than per token and the published rates differ by a hundred times across the methods one crawl uses, so each tier gets its own bucket and a request is routed by the method it names.
+Direct messages are never asked for rather than asked for and filtered, joins and leaves and topic changes are not documents, and the whole thing is tested twice over: against a fake workspace for behaviour, and against a committed recording of a crawl for the wire format, so nobody needs an account to run the tests.
 
 What a connector is gets decided by `connector/connectortest` rather than by the interface.
 The interface says what compiles, and the suite says what works: that a full sync finds everything, that resuming from a cursor loses nothing that came after it, that a second sync of a source nothing changed in reads nothing, that a deleted document stops being part of the source one way or the other, and that every document says who may read it.

--- a/arch_test.go
+++ b/arch_test.go
@@ -156,6 +156,14 @@ var allowed = map[string][]string{
 	// container the product already told us about rather than from a file we were
 	// handed alongside it.
 	"connector/threadsource": {"acl", "connector", "connector/thread", "doc"},
+	// slacksource is a product adapter and sits one level below the crawl it
+	// plugs into, so it names threadsource. It also names limit, because Slack
+	// publishes a different rate per method and a client that respects that is
+	// part of the adapter rather than something a caller assembles. It does not
+	// name extract, ingest or store: what an adapter knows is one product, and
+	// an adapter that knew where its documents were going would be a second
+	// place the pipeline is described.
+	"connector/slacksource": {"acl", "connector", "connector/limit", "connector/thread", "connector/threadsource", "doc"},
 	// recorded imports nothing of ours either. It is a round tripper over a
 	// directory of files, it deals in requests and responses, and it has never
 	// heard of a document or a connector. Keeping it that way is what lets it be

--- a/connector/slacksource/api.go
+++ b/connector/slacksource/api.go
@@ -1,0 +1,284 @@
+package slacksource
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+)
+
+// envelope is what every Slack method wraps its answer in.
+//
+// A refusal is a 200 with ok false far more often than it is a status code, so
+// the body is what decides whether a call worked. A client that only looked at
+// the status would treat "you are not in that channel" as an empty channel.
+type envelope struct {
+	OK       bool   `json:"ok"`
+	Error    string `json:"error"`
+	Metadata struct {
+		NextCursor string `json:"next_cursor"`
+	} `json:"response_metadata"`
+}
+
+// channel is one entry of conversations.list.
+type channel struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	IsPrivate  bool   `json:"is_private"`
+	IsArchived bool   `json:"is_archived"`
+	IsIM       bool   `json:"is_im"`
+	IsMPIM     bool   `json:"is_mpim"`
+
+	// Updated is when the channel's own settings last changed, in
+	// milliseconds. A rename, an archive and a conversion between public and
+	// private all move it. Somebody being removed from a private channel does
+	// not, which is dealt with elsewhere and is the reason this comment exists.
+	Updated int64 `json:"updated"`
+}
+
+// message is one entry of conversations.history or conversations.replies.
+type message struct {
+	Type       string `json:"type"`
+	Subtype    string `json:"subtype"`
+	User       string `json:"user"`
+	BotID      string `json:"bot_id"`
+	Username   string `json:"username"`
+	Text       string `json:"text"`
+	TS         string `json:"ts"`
+	ThreadTS   string `json:"thread_ts"`
+	ReplyCount int    `json:"reply_count"`
+	// LatestReply is the timestamp of the newest reply, and it is the only
+	// thing about a parent message that moves when somebody answers it.
+	LatestReply string `json:"latest_reply"`
+	Edited      *struct {
+		TS   string `json:"ts"`
+		User string `json:"user"`
+	} `json:"edited"`
+}
+
+// user is what users.info returns.
+type user struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	RealName string `json:"real_name"`
+	Deleted  bool   `json:"deleted"`
+	IsBot    bool   `json:"is_bot"`
+	Profile  struct {
+		RealName string `json:"real_name"`
+		Email    string `json:"email"`
+	} `json:"profile"`
+}
+
+// call asks Slack one question and decodes the answer into out.
+//
+// It is a GET even though half of Slack's examples are POSTs, and the reason is
+// retrying. A request carrying a body cannot be replayed by a transport that
+// has already handed the body away, so [limit] will not retry one, and being
+// throttled is not an unusual event on this API: it is the normal way Slack
+// tells a crawler to slow down. Every method used here is a read, every read
+// method accepts its parameters in the query string, and a GET is what makes
+// the retry, the backoff and the circuit breaker apply to all of them.
+//
+// out is decoded from the same bytes as the envelope rather than from a second
+// read, because a Slack response is small and reading it twice is a second
+// allocation for no benefit.
+func (s *Service) call(ctx context.Context, name string, form url.Values, out any) (next string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.base+"/"+name+"?"+form.Encode(), http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("slacksource: building the %s request: %w", name, err)
+	}
+
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("slacksource: %s: %w", name, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// A megabyte is far more than any of these methods returns at the page
+	// sizes this adapter asks for, and a bound is what keeps a source that has
+	// started answering with something else from being a memory problem.
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("slacksource: reading the %s response: %w", name, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("slacksource: %s: %s", name, resp.Status)
+	}
+
+	var env envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return "", fmt.Errorf("slacksource: decoding the %s response: %w", name, err)
+	}
+	if !env.OK {
+		code := env.Error
+		if code == "" {
+			code = "no reason given"
+		}
+		return "", &Error{Method: name, Code: code}
+	}
+	if out != nil {
+		if err := json.Unmarshal(raw, out); err != nil {
+			return "", fmt.Errorf("slacksource: decoding the %s response: %w", name, err)
+		}
+	}
+	return env.Metadata.NextCursor, nil
+}
+
+// pages walks a cursor paged method, decoding each page and handing it to fn.
+//
+// fn returns false to stop, which is not an error: a listing the caller ended on
+// purpose is not a failed listing, and reporting it as one is how a
+// reconciliation sweep ends up emptying an index.
+//
+// The page is a fresh value on every turn of the loop, and that is not tidiness.
+// Decoding JSON into a slice that already has elements in it reuses those
+// elements and only overwrites the fields the new document mentions, so a second
+// page decoded into the first page's slice inherits every field the second page
+// left out. A message with no subtype landing where a channel_join used to be
+// becomes a channel_join, and the thread it starts silently stops being indexed.
+func pages[T any](ctx context.Context, s *Service, name string, form url.Values, fn func(T) bool) error {
+	// The form is copied because a caller reusing it for a second channel would
+	// otherwise inherit the cursor of the first, and what that causes is a
+	// channel silently starting halfway through.
+	q := url.Values{}
+	for k, v := range form {
+		q[k] = append([]string(nil), v...)
+	}
+	for {
+		var page T
+		next, err := s.call(ctx, name, q, &page)
+		if err != nil {
+			return err
+		}
+		if !fn(page) {
+			return nil
+		}
+		if next == "" {
+			return nil
+		}
+		q.Set("cursor", next)
+	}
+}
+
+// people resolves Slack user ids to the person a document says wrote it.
+//
+// It is a cache because a busy channel is a few dozen people saying thousands
+// of things, and a lookup per message would spend the whole rate limit on
+// names. It never expires: a display name that changed mid crawl is not worth a
+// second request, and the next full sync picks it up.
+type people struct {
+	svc *Service
+
+	mu sync.Mutex
+	by map[string]doc.Person
+}
+
+func newPeople(s *Service) *people {
+	return &people{svc: s, by: make(map[string]doc.Person)}
+}
+
+// person returns who a message is from.
+//
+// A message with no user is from an application, and the name it posted under
+// is the best there is. A lookup that fails still produces a person, with the
+// identity filled in and the name missing, because the alternative is failing a
+// whole channel over a display name.
+func (p *people) person(ctx context.Context, m message) doc.Person {
+	if m.User == "" {
+		name := m.Username
+		if name == "" {
+			name = m.BotID
+		}
+		if name == "" {
+			return doc.Person{}
+		}
+		return doc.Person{
+			Name:     name,
+			Identity: acl.Identity{Source: p.svc.name, Value: name},
+		}
+	}
+
+	p.mu.Lock()
+	got, ok := p.by[m.User]
+	p.mu.Unlock()
+	if ok {
+		return got
+	}
+
+	id := acl.Identity{Source: p.svc.name, Value: m.User}
+	found := doc.Person{Subject: m.User, Identity: id, Name: m.User}
+
+	var out struct {
+		User user `json:"user"`
+	}
+	if _, err := p.svc.call(ctx, "users.info", url.Values{"user": {m.User}}, &out); err != nil {
+		p.svc.skip(m.User, fmt.Errorf("looking up who wrote a message: %w", err))
+	} else {
+		name := out.User.Profile.RealName
+		if name == "" {
+			name = out.User.RealName
+		}
+		if name == "" {
+			name = out.User.Name
+		}
+		found = doc.Person{
+			Subject:  out.User.ID,
+			Identity: id,
+			Name:     name,
+			Email:    out.User.Profile.Email,
+		}
+	}
+
+	p.mu.Lock()
+	p.by[m.User] = found
+	p.mu.Unlock()
+	return found
+}
+
+// stamp turns a Slack timestamp into a time.
+//
+// A Slack timestamp is seconds with six decimal places, as a string, and it is
+// also the message's identifier. Parsing it as a float loses the last digits at
+// the far end of the range, so the two halves are parsed separately.
+func stamp(ts string) time.Time {
+	if ts == "" {
+		return time.Time{}
+	}
+	whole, frac, _ := strings.Cut(ts, ".")
+	sec, err := strconv.ParseInt(whole, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	var micros int64
+	if frac != "" {
+		// Slack pads to six digits. Anything else is padded here rather than
+		// rejected, because a shorter fraction is still a time.
+		for len(frac) < 6 {
+			frac += "0"
+		}
+		micros, _ = strconv.ParseInt(frac[:6], 10, 64)
+	}
+	return time.Unix(sec, micros*int64(time.Microsecond)).UTC()
+}
+
+// slackTime turns a time back into the string Slack's oldest parameter wants.
+func slackTime(t time.Time) string {
+	if t.IsZero() {
+		return "0"
+	}
+	return fmt.Sprintf("%d.%06d", t.Unix(), t.Nanosecond()/int(time.Microsecond))
+}
+
+// errBadID is what an id that this source could never have produced comes back
+// as, which is different from an id it produced and no longer has.
+var errBadID = errors.New("slacksource: not an id from this workspace")

--- a/connector/slacksource/fake_test.go
+++ b/connector/slacksource/fake_test.go
@@ -1,0 +1,536 @@
+package slacksource_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A Slack workspace with the parts that matter and none of the parts that do
+// not. It has public and private channels, threads with replies, users with
+// names, cursor paging, a clock that only moves when something happens to it,
+// and the ability to be told to refuse.
+//
+// It exists so that these tests do not need an account, and it is also what the
+// committed recording under testdata was made from. Everything asserted against
+// the recording is asserted against this first, so the two cannot drift without
+// a test going red.
+
+// epoch is when everything in these tests happens, as Slack counts time.
+const epoch = 1780000000.0
+
+type workspace struct {
+	mu       sync.Mutex
+	clock    float64
+	channels []*chanel
+	users    map[string]person
+	calls    map[string]int
+
+	// fail makes one method refuse with a Slack error code, and notIn makes the
+	// token behave like a bot that is in the workspace but not in a channel.
+	fail  map[string]string
+	notIn map[string]bool
+
+	// throttle is how many more times the next request is answered with 429
+	// before it is answered properly.
+	throttle int
+
+	// page is how many items go in one page, which is small on purpose so that
+	// the paging is exercised by an ordinary sync rather than by one test.
+	page int
+
+	// types records every kind of conversation any listing has asked for.
+	types []string
+}
+
+type chanel struct {
+	id, name string
+	private  bool
+	archived bool
+	updated  int64 // milliseconds, the way Slack reports it
+	members  []string
+	msgs     []*msg
+}
+
+type msg struct {
+	ts      string
+	user    string
+	text    string
+	subtype string
+	edited  string
+	replies []*msg
+}
+
+type person struct {
+	id, name, real, email string
+}
+
+func newWorkspace() *workspace {
+	w := &workspace{
+		clock: epoch,
+		users: map[string]person{
+			"U_MEI": {"U_MEI", "mei", "Mei Tanaka", "mei@acme.com"},
+			"U_SAM": {"U_SAM", "sam", "Sam Okafor", "sam@acme.com"},
+			"U_LEE": {"U_LEE", "lee", "Lee Berger", "lee@acme.com"},
+		},
+		calls: make(map[string]int),
+		fail:  make(map[string]string),
+		notIn: make(map[string]bool),
+		page:  2,
+	}
+	w.addChannel("C_GENERAL", "general", false)
+	return w
+}
+
+// now is the workspace's clock as a time, which is what the adapter measures
+// its reply window against.
+func (w *workspace) now() time.Time {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return stampOf(w.clock)
+}
+
+func stampOf(f float64) time.Time {
+	sec := int64(f)
+	micro := int64((f - float64(sec)) * 1e6)
+	return time.Unix(sec, micro*int64(time.Microsecond)).UTC()
+}
+
+func (w *workspace) addChannel(id, name string, private bool) *chanel {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	c := &chanel{id: id, name: name, private: private, updated: int64(w.clock) * 1000}
+	if private {
+		c.members = []string{"U_MEI", "U_SAM"}
+	}
+	w.channels = append(w.channels, c)
+	w.clock++
+	return c
+}
+
+func (w *workspace) find(id string) *chanel {
+	for _, c := range w.channels {
+		if c.id == id {
+			return c
+		}
+	}
+	return nil
+}
+
+// tick hands out the next Slack timestamp.
+func (w *workspace) tick() string {
+	ts := fmt.Sprintf("%.6f", w.clock)
+	w.clock++
+	return ts
+}
+
+// post starts a thread, or replaces the text of the one already filed under
+// that name, and returns its timestamp.
+func (w *workspace) post(channelID, name, text string) string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	c := w.find(channelID)
+	for _, m := range c.msgs {
+		if m.text == name || strings.HasPrefix(m.text, name+"\n") {
+			m.text = name + "\n" + text
+			m.edited = w.tick()
+			return m.ts
+		}
+	}
+	m := &msg{ts: w.tick(), user: "U_MEI", text: name + "\n" + text}
+	c.msgs = append(c.msgs, m)
+	return m.ts
+}
+
+// tsOf is the timestamp a name was filed under, which is what turns the
+// conformance suite's document names into ids this adapter would produce.
+func (w *workspace) tsOf(channelID, name string) string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	c := w.find(channelID)
+	for _, m := range c.msgs {
+		if m.text == name || strings.HasPrefix(m.text, name+"\n") {
+			return m.ts
+		}
+	}
+	// A name nothing was ever written under still has to produce an id, because
+	// a test asking for a document that is not there is a test about what
+	// happens when it is not there.
+	return "0.000000"
+}
+
+// reply answers a thread, which moves the thread and nothing else.
+func (w *workspace) reply(channelID, name, user, text string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	c := w.find(channelID)
+	for _, m := range c.msgs {
+		if m.text == name || strings.HasPrefix(m.text, name+"\n") {
+			m.replies = append(m.replies, &msg{ts: w.tick(), user: user, text: text})
+			return
+		}
+	}
+}
+
+// system posts one of the things Slack writes about the channel itself rather
+// than about anything anybody wanted to say.
+func (w *workspace) system(channelID, subtype, text string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	c := w.find(channelID)
+	c.msgs = append(c.msgs, &msg{ts: w.tick(), user: "U_SAM", text: text, subtype: subtype})
+}
+
+// remove deletes a thread. Nothing in Slack's history reports that it was ever
+// there, which is why the sweep exists.
+func (w *workspace) remove(channelID, name string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	c := w.find(channelID)
+	c.msgs = slices.DeleteFunc(c.msgs, func(m *msg) bool {
+		return m.text == name || strings.HasPrefix(m.text, name+"\n")
+	})
+	w.clock++
+}
+
+// makePrivate converts a channel, which changes who may read everything in it
+// without touching a single message.
+func (w *workspace) makePrivate(channelID string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	c := w.find(channelID)
+	c.private = true
+	c.members = []string{"U_MEI", "U_SAM"}
+	w.clock++
+	c.updated = int64(w.clock) * 1000
+}
+
+// removeMember takes somebody out of a private channel, which is the change
+// Slack does not report anywhere.
+func (w *workspace) removeMember(channelID, user string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	c := w.find(channelID)
+	c.members = slices.DeleteFunc(c.members, func(m string) bool { return m == user })
+	w.clock++
+}
+
+// askedFor reports whether any conversations.list call asked for a kind of
+// conversation, which is how a test says that direct messages were never
+// requested rather than requested and then filtered.
+func (w *workspace) askedFor(kind string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return slices.Contains(w.types, kind)
+}
+
+func (w *workspace) counted(method string) int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.calls[method]
+}
+
+func (w *workspace) resetCounts() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.calls = make(map[string]int)
+}
+
+// server starts the workspace on a listener and returns its API base.
+func (w *workspace) server(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(w.handle))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/api"
+}
+
+func (w *workspace) handle(rw http.ResponseWriter, req *http.Request) {
+	method := strings.TrimPrefix(req.URL.Path, "/api/")
+
+	if err := req.ParseForm(); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.mu.Lock()
+	w.calls[method]++
+	if w.throttle > 0 {
+		w.throttle--
+		w.mu.Unlock()
+		// Slack names its own delay, and a crawl that ignored it would be told
+		// off again immediately.
+		rw.Header().Set("Retry-After", "0")
+		rw.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+	if code, ok := w.fail[method]; ok {
+		w.mu.Unlock()
+		w.deny(rw, code)
+		return
+	}
+	w.mu.Unlock()
+
+	// Every call carries the token as a header rather than as a form field, so
+	// that a recording of one does not have the token in the file name.
+	if !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
+		w.deny(rw, "not_authed")
+		return
+	}
+
+	switch method {
+	case "conversations.list":
+		w.list(rw, req)
+	case "conversations.members":
+		w.membersOf(rw, req)
+	case "conversations.history":
+		w.history(rw, req)
+	case "conversations.replies":
+		w.thread(rw, req)
+	case "users.info":
+		w.user(rw, req)
+	default:
+		w.deny(rw, "unknown_method")
+	}
+}
+
+func (w *workspace) deny(rw http.ResponseWriter, code string) {
+	// A Slack refusal is a 200 with ok false, which is the whole reason the
+	// adapter reads the body before it looks at the status.
+	w.send(rw, map[string]any{"ok": false, "error": code})
+}
+
+func (w *workspace) send(rw http.ResponseWriter, body map[string]any) {
+	rw.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(rw)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(body)
+}
+
+// paged cuts a slice at the cursor and returns the page and the next cursor.
+func paged[T any](items []T, cursor string, size int) (page []T, next string) {
+	from := 0
+	if cursor != "" {
+		from, _ = strconv.Atoi(cursor)
+	}
+	if from > len(items) {
+		from = len(items)
+	}
+	to := min(from+size, len(items))
+	if to < len(items) {
+		next = strconv.Itoa(to)
+	}
+	return items[from:to], next
+}
+
+func (w *workspace) list(rw http.ResponseWriter, req *http.Request) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	types := req.Form.Get("types")
+	for _, kind := range strings.Split(types, ",") {
+		kind = strings.TrimSuffix(strings.TrimSpace(kind), "_channel")
+		if kind != "" && !slices.Contains(w.types, kind) {
+			w.types = append(w.types, kind)
+		}
+	}
+
+	var want []map[string]any
+	for _, c := range w.channels {
+		if c.private && !strings.Contains(types, "private_channel") {
+			continue
+		}
+		if !c.private && !strings.Contains(types, "public_channel") {
+			continue
+		}
+		if c.archived && req.Form.Get("exclude_archived") == "true" {
+			continue
+		}
+		want = append(want, map[string]any{
+			"id":          c.id,
+			"name":        c.name,
+			"is_private":  c.private,
+			"is_archived": c.archived,
+			"is_channel":  true,
+			"updated":     c.updated,
+		})
+	}
+
+	page, next := paged(want, req.Form.Get("cursor"), w.page)
+	w.send(rw, map[string]any{
+		"ok":                true,
+		"channels":          page,
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+func (w *workspace) membersOf(rw http.ResponseWriter, req *http.Request) {
+	w.mu.Lock()
+	id := req.Form.Get("channel")
+	c := w.find(id)
+	notIn := w.notIn[id]
+	var members []string
+	if c != nil {
+		members = slices.Clone(c.members)
+	}
+	size := w.page
+	w.mu.Unlock()
+
+	switch {
+	case c == nil:
+		w.deny(rw, "channel_not_found")
+		return
+	case notIn:
+		w.deny(rw, "not_in_channel")
+		return
+	}
+
+	// Slack does not promise an order, so this one hands them back in the least
+	// helpful order it can.
+	slices.Reverse(members)
+	page, next := paged(members, req.Form.Get("cursor"), size)
+	w.send(rw, map[string]any{
+		"ok":                true,
+		"members":           page,
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+func (w *workspace) history(rw http.ResponseWriter, req *http.Request) {
+	w.mu.Lock()
+	id := req.Form.Get("channel")
+	c := w.find(id)
+	notIn := w.notIn[id]
+	size := w.page
+
+	var rows []map[string]any
+	if c != nil {
+		oldest, _ := strconv.ParseFloat(req.Form.Get("oldest"), 64)
+		// Slack returns history newest first, and a walk that assumed otherwise
+		// would be one that worked here and failed on the real thing.
+		for i := len(c.msgs) - 1; i >= 0; i-- {
+			m := c.msgs[i]
+			at, _ := strconv.ParseFloat(m.ts, 64)
+			if at < oldest {
+				continue
+			}
+			rows = append(rows, w.row(m, true))
+		}
+	}
+	w.mu.Unlock()
+
+	switch {
+	case c == nil:
+		w.deny(rw, "channel_not_found")
+		return
+	case notIn:
+		w.deny(rw, "not_in_channel")
+		return
+	}
+
+	page, next := paged(rows, req.Form.Get("cursor"), size)
+	w.send(rw, map[string]any{
+		"ok":                true,
+		"messages":          page,
+		"has_more":          next != "",
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+func (w *workspace) thread(rw http.ResponseWriter, req *http.Request) {
+	w.mu.Lock()
+	c := w.find(req.Form.Get("channel"))
+	ts := req.Form.Get("ts")
+	var parent *msg
+	if c != nil {
+		for _, m := range c.msgs {
+			if m.ts == ts {
+				parent = m
+				break
+			}
+		}
+	}
+	var rows []map[string]any
+	if parent != nil {
+		rows = append(rows, w.row(parent, true))
+		for _, r := range parent.replies {
+			row := w.row(r, false)
+			row["thread_ts"] = parent.ts
+			rows = append(rows, row)
+		}
+	}
+	size := w.page
+	w.mu.Unlock()
+
+	switch {
+	case c == nil:
+		w.deny(rw, "channel_not_found")
+		return
+	case parent == nil:
+		w.deny(rw, "thread_not_found")
+		return
+	}
+
+	page, next := paged(rows, req.Form.Get("cursor"), size)
+	if req.Form.Get("cursor") != "" {
+		// A paged reply listing repeats the parent on every page, which is the
+		// behaviour that makes a naive adapter index the first message three
+		// times.
+		page = append([]map[string]any{w.row(parent, true)}, page...)
+	}
+	w.send(rw, map[string]any{
+		"ok":                true,
+		"messages":          page,
+		"has_more":          next != "",
+		"response_metadata": map[string]any{"next_cursor": next},
+	})
+}
+
+// row is one message the way Slack reports it. The reply count and the latest
+// reply are only on a parent read from history, which is exactly the asymmetry
+// the adapter has to cope with.
+func (w *workspace) row(m *msg, asParent bool) map[string]any {
+	row := map[string]any{
+		"type": "message",
+		"user": m.user,
+		"text": m.text,
+		"ts":   m.ts,
+	}
+	if m.subtype != "" {
+		row["subtype"] = m.subtype
+	}
+	if m.edited != "" {
+		row["edited"] = map[string]any{"ts": m.edited, "user": m.user}
+	}
+	if asParent && len(m.replies) > 0 {
+		row["thread_ts"] = m.ts
+		row["reply_count"] = len(m.replies)
+		row["latest_reply"] = m.replies[len(m.replies)-1].ts
+	}
+	return row
+}
+
+func (w *workspace) user(rw http.ResponseWriter, req *http.Request) {
+	w.mu.Lock()
+	p, ok := w.users[req.Form.Get("user")]
+	w.mu.Unlock()
+	if !ok {
+		w.deny(rw, "user_not_found")
+		return
+	}
+	w.send(rw, map[string]any{
+		"ok": true,
+		"user": map[string]any{
+			"id":        p.id,
+			"name":      p.name,
+			"real_name": p.real,
+			"profile":   map[string]any{"real_name": p.real, "email": p.email},
+		},
+	})
+}

--- a/connector/slacksource/recording_test.go
+++ b/connector/slacksource/recording_test.go
@@ -1,0 +1,287 @@
+package slacksource_test
+
+import (
+	"flag"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/recorded"
+	"github.com/tamnd/genba/connector/slacksource"
+	"github.com/tamnd/genba/connector/threadsource"
+)
+
+// The fixture set is a crawl of a small workspace written down once and read
+// back by the test below, so that the adapter is exercised against the bytes a
+// Slack workspace actually sends without anybody needing an account or a token
+// to run the tests.
+//
+// The fake next to this file is the other half of the story and neither
+// replaces the other. The fake is where behaviour is written: it can be made to
+// throttle, to refuse a channel, to lose a message between two syncs. The
+// recording is where the wire format is pinned: it is the answer to "did we
+// change what we send" and it is the thing that would have to be refreshed if
+// Slack changed a field name.
+const fixtures = "testdata/workspace"
+
+// The ids the recorded workspace produces. They are written down rather than
+// worked out because a fixture set is a fixed corpus, and a test that derived
+// them from the fake would pass just as happily against a recording of
+// something else entirely.
+const (
+	welcomeID = "slack:C_GENERAL:1780000001.000000"
+	gearboxID = "slack:C_LINE_TWO:1780000003.000000"
+	guardID   = "slack:C_SAFETY:1780000008.000000"
+)
+
+// pinned is what the clock says while the fixtures are being read back. A full
+// sync reads all of history and asks for nothing that depends on the time, so
+// this only has to be steady rather than right.
+var pinned = func() time.Time { return time.Unix(1780000009, 0).UTC() }
+
+var update = flag.Bool("update", false, "record the Slack fixtures in testdata again")
+
+// recordingWorkspace is the workspace the fixtures are a crawl of.
+//
+// It is small on purpose and every part of it is there for a reason: two public
+// channels so that the listing is more than one entry, a thread with two
+// replies from two different people so that assembly and the name lookups are
+// in the recording, a join message so that the thing we refuse to index is in
+// there too, and a private channel so that a membership listing is as well.
+func recordingWorkspace() *workspace {
+	w := newWorkspace()
+	w.post("C_GENERAL", "welcome", "Morning all. Line two is down until the gearbox is looked at.")
+
+	w.addChannel("C_LINE_TWO", "line-two", false)
+	w.post("C_LINE_TWO", "gearbox", "The gearbox on line two is making a noise under load.")
+	w.reply("C_LINE_TWO", "gearbox", "U_SAM", "Sounds like the outboard bearing to me.")
+	w.reply("C_LINE_TWO", "gearbox", "U_LEE", "I changed that one on Tuesday, so it should not be.")
+	w.system("C_LINE_TWO", "channel_join", "<@U_LEE> has joined the channel")
+
+	w.addChannel("C_SAFETY", "safety", true)
+	w.post("C_SAFETY", "guard", "The guard on the press is being replaced on Friday morning.")
+	return w
+}
+
+// authed puts the token on the way the adapter does, so that what is recorded
+// is a real authenticated crawl rather than one made against a service that was
+// not asking.
+type authed struct{ base http.RoundTripper }
+
+func (a authed) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+token)
+	return a.base.RoundTrip(req)
+}
+
+// TestRecordTheFixtures writes the fixture set again. It is skipped unless the
+// flag is given, because a recording that refreshed itself on every run would
+// never fail: the thing it is there to catch is a change to what we send, and a
+// fixture regenerated alongside the change agrees with it by construction.
+func TestRecordTheFixtures(t *testing.T) {
+	if !*update {
+		t.Skip("run with -update to record the fixtures again")
+	}
+
+	w := recordingWorkspace()
+	if got := "slack:C_LINE_TWO:" + w.tsOf("C_LINE_TWO", "gearbox"); got != gearboxID {
+		t.Fatalf("the workspace filed the gearbox thread under %s, and the tests below look for %s", got, gearboxID)
+	}
+
+	rec := recorded.Record(authed{http.DefaultTransport},
+		recorded.WithRedactedHeaders("Authorization"),
+		recorded.WithRedactedParams("token"),
+	)
+	src, err := slacksource.New(token,
+		slacksource.WithBaseURL(w.server(t)),
+		slacksource.WithHTTPClient(rec.Client()),
+		slacksource.WithClock(pinned),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = src.Close() }()
+
+	crawl(t, src)
+
+	// A crawl asks the same listing question more than once: the sync, the
+	// sweep and a fetch each need to know what the channels are and who may
+	// read them. Writing the answer down three times is three files to review
+	// and no more coverage, so the repeats are dropped and what is left is one
+	// file per distinct question.
+	var (
+		seen = map[string]bool{}
+		once []recorded.Exchange
+	)
+	for _, e := range rec.Exchanges() {
+		k := e.Request.Method + " " + e.Request.URL
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		once = append(once, settle(e))
+	}
+
+	if err := recorded.From(once).Save(fixtures); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %d of %d exchanges to %s", len(once), len(rec.Exchanges()), fixtures)
+}
+
+// settle takes the run out of a recorded exchange.
+//
+// Two things in one differ every time it is made: the address the test server
+// was given, and the date the answer came back on. Neither is matched against
+// and neither means anything, and leaving them in would make every refresh of
+// the fixtures a diff on all eleven files with the real change somewhere in it.
+// The host is written as Slack's for the same reason: a reader opening one of
+// these files should see the request that would have gone to Slack.
+func settle(e recorded.Exchange) recorded.Exchange {
+	if u, err := url.Parse(e.Request.URL); err == nil {
+		slack, err := url.Parse(slacksource.DefaultBaseURL)
+		if err != nil {
+			panic(err)
+		}
+		u.Scheme, u.Host = slack.Scheme, slack.Host
+		e.Request.URL = u.String()
+	}
+	delete(e.Response.Headers, "Date")
+	delete(e.Response.Headers, "Content-Length")
+	return e
+}
+
+// crawl is everything the fixture set has to answer, and it is shared so that
+// what is recorded and what is replayed cannot drift apart.
+func crawl(t *testing.T, src *threadsource.Source) []connector.Change {
+	t.Helper()
+
+	changes, _ := run(t, src, connector.Cursor{})
+
+	var listed []connector.Item
+	if err := src.Enumerate(t.Context(), func(item connector.Item) bool {
+		listed = append(listed, item)
+		return true
+	}); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(listed) == 0 {
+		t.Fatal("the listing found nothing")
+	}
+
+	if _, err := src.Fetch(t.Context(), gearboxID); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	return changes
+}
+
+// TestTheRecordedWorkspaceCrawlsWithoutAnAccount is the point of the fixture
+// set: the whole adapter, the real paging and the real decoding, against bytes
+// that came off a workspace and are now a file.
+func TestTheRecordedWorkspaceCrawlsWithoutAnAccount(t *testing.T) {
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src, err := slacksource.New(token,
+		// The base URL is the real one. Nothing reaches it, and using it is what
+		// keeps the recording keyed on the path Slack serves rather than on the
+		// port a test server happened to be given.
+		slacksource.WithBaseURL(slacksource.DefaultBaseURL),
+		slacksource.WithHTTPClient(rt.Client()),
+		slacksource.WithClock(pinned),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = src.Close() }()
+
+	changes := crawl(t, src)
+
+	want := []string{welcomeID, gearboxID, guardID}
+	if got := ids(changes); !slices.Equal(got, want) {
+		t.Fatalf("the recorded workspace crawled to %v, want %v", got, want)
+	}
+
+	gearbox := find(changes, gearboxID)
+	if gearbox == nil {
+		t.Fatal("the thread with the replies on it is not in the crawl")
+	}
+	for _, phrase := range []string{
+		"making a noise under load",
+		"outboard bearing",
+		"changed that one on Tuesday",
+	} {
+		if !strings.Contains(gearbox.Document.Body, phrase) {
+			t.Errorf("the thread is missing %q:\n%s", phrase, gearbox.Document.Body)
+		}
+	}
+	if got := gearbox.Document.Title; !strings.Contains(got, "gearbox") {
+		t.Errorf("the thread is titled %q", got)
+	}
+
+	// Names came out of the recording too, which is the part a crawl without an
+	// account usually cannot show.
+	if got := gearbox.Document.Author.Name; got != "Mei Tanaka" {
+		t.Errorf("the thread is attributed to %q, want the name the recording holds", got)
+	}
+}
+
+// TestTheRecordingHoldsNothingItIsNotAskedFor keeps the fixture set from
+// growing a tail of responses nothing reads.
+//
+// A recording is a thing people add to and rarely take away from, and one that
+// has drifted is worse than none: a reviewer reading a file next to the test
+// reasonably assumes the test depends on it.
+func TestTheRecordingHoldsNothingItIsNotAskedFor(t *testing.T) {
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := slacksource.New(token,
+		slacksource.WithBaseURL(slacksource.DefaultBaseURL),
+		slacksource.WithHTTPClient(rt.Client()),
+		slacksource.WithClock(pinned),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = src.Close() }()
+
+	crawl(t, src)
+
+	if left := rt.Unused(); len(left) != 0 {
+		t.Errorf("the fixture set answers %d requests the crawl never makes:\n%s", len(left), strings.Join(left, "\n"))
+	}
+}
+
+// TestTheRecordingCarriesNoCredentials is the reason a fixture set is safe to
+// commit at all. It is a check on the recording rather than on the code, and it
+// is here because the file is here.
+func TestTheRecordingCarriesNoCredentials(t *testing.T) {
+	entries, err := os.ReadDir(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(fixtures, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(raw), token) {
+			t.Errorf("%s holds the token it was recorded with", e.Name())
+		}
+		if strings.Contains(string(raw), "xoxb-") || strings.Contains(string(raw), "xoxp-") {
+			t.Errorf("%s holds something shaped like a Slack token", e.Name())
+		}
+	}
+}

--- a/connector/slacksource/service.go
+++ b/connector/slacksource/service.go
@@ -1,0 +1,522 @@
+package slacksource
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/thread"
+	"github.com/tamnd/genba/connector/threadsource"
+	"github.com/tamnd/genba/doc"
+)
+
+// DefaultACLRefresh is how often a private channel's membership is reapplied to
+// the documents in it even though nothing said it had changed.
+//
+// Slack moves a channel's updated field when the channel is renamed, archived
+// or converted between public and private, and leaves it alone when somebody is
+// removed from a private one. That last case is the one that matters, because
+// it is a revocation, and a revocation that reaches the index whenever somebody
+// happens to post is not a revocation.
+//
+// So the rule is reapplied on a schedule as well. A day is the default: it
+// bounds how long a removed member keeps seeing a private channel's threads in
+// their results, and it costs one write per thread in the private channels once
+// a day rather than a read of any of them.
+const DefaultACLRefresh = 24 * time.Hour
+
+// WithACLRefresh sets how often a private channel's membership is reapplied.
+// Zero selects [DefaultACLRefresh].
+func WithACLRefresh(d time.Duration) Option {
+	return func(s *Service) { s.aclRefresh = d }
+}
+
+// Containers lists the channels this token can see, public and private, with
+// who may read each.
+//
+// Direct messages and group messages are not asked for. There is no rule that
+// makes one safe to put in a shared index, and skipping them at the request is
+// better than filtering them afterwards, because a filter is a thing that can
+// be got wrong once and then be wrong for ever.
+func (s *Service) Containers(ctx context.Context) ([]threadsource.Container, error) {
+	form := url.Values{
+		"types":            {"public_channel,private_channel"},
+		"exclude_archived": {"true"},
+		"limit":            {strconv.Itoa(s.page)},
+	}
+
+	type listing struct {
+		Channels []channel `json:"channels"`
+	}
+	var found []channel
+	if err := pages(ctx, s, "conversations.list", form, func(page listing) bool {
+		found = append(found, page.Channels...)
+		return true
+	}); err != nil {
+		return nil, err
+	}
+
+	containers := make([]threadsource.Container, 0, len(found))
+	for _, ch := range found {
+		if ch.IsIM || ch.IsMPIM || ch.IsArchived {
+			continue
+		}
+		access, at, err := s.access(ctx, ch)
+		if err != nil {
+			return nil, err
+		}
+		containers = append(containers, threadsource.Container{
+			ID:       ch.ID,
+			Name:     ch.Name,
+			Access:   access,
+			AccessAt: at,
+		})
+	}
+	return containers, nil
+}
+
+// access works out who may read a channel, and when that answer last moved.
+func (s *Service) access(ctx context.Context, ch channel) (acl.Permissions, time.Time, error) {
+	// Slack reports the channel's own last change in milliseconds, and a
+	// channel that has never been touched since it was made reports nothing.
+	var at time.Time
+	if ch.Updated > 0 {
+		at = time.UnixMilli(ch.Updated).UTC()
+	}
+
+	if !ch.IsPrivate {
+		// Everybody in the workspace may read a public channel whether or not
+		// they are in it, which is the definition of one.
+		return acl.Permissions{
+			Mode:    acl.ModePublicToTenant,
+			Source:  s.name,
+			Version: uint64(ch.Updated),
+		}, at, nil
+	}
+
+	members, err := s.members(ctx, ch.ID)
+	switch {
+	case err == nil:
+	case refused(err, "not_in_channel"), refused(err, "channel_not_found"):
+		// The token can see that the channel exists and cannot see who is in
+		// it, so there is no answer to give. Quarantining is the only safe
+		// thing and staying quiet about it is the only unsafe one.
+		s.skip(ch.ID, fmt.Errorf("who may read #%s: %w", ch.Name, err))
+		// No schedule is applied here. Reapplying a rule means listing the
+		// channel, this token cannot list it, and there is nothing in the index
+		// from it to reapply anything to: the same refusal keeps its
+		// conversations out in the first place.
+		return connector.Unresolved(s.name), at, nil
+	default:
+		return acl.Permissions{}, time.Time{}, err
+	}
+
+	allow := make([]acl.Ref, 0, len(members))
+	for _, m := range members {
+		allow = append(allow, acl.Ref{Source: s.name, Value: m})
+	}
+	return acl.Permissions{
+		Mode:       acl.ModeACL,
+		Source:     s.name,
+		AllowUsers: allow,
+		Version:    uint64(ch.Updated),
+	}, s.aclTick(at), nil
+}
+
+// aclTick raises a private channel's rule time to the start of the current
+// refresh interval, which is what makes the schedule in [DefaultACLRefresh]
+// happen.
+//
+// The interval is quantised rather than measured from the last sync so that the
+// answer does not depend on when the syncs happened to run. Two servers reading
+// the same workspace an hour apart agree about whether the rule has moved, and
+// a sync every five minutes still only reapplies it once.
+func (s *Service) aclTick(at time.Time) time.Time {
+	every := s.aclRefresh
+	if every <= 0 {
+		every = DefaultACLRefresh
+	}
+	tick := s.now().UTC().Truncate(every)
+	if tick.After(at) {
+		return tick
+	}
+	return at
+}
+
+// members lists the people in a private channel.
+func (s *Service) members(ctx context.Context, id string) ([]string, error) {
+	form := url.Values{"channel": {id}, "limit": {strconv.Itoa(s.page)}}
+	type listing struct {
+		Members []string `json:"members"`
+	}
+	var all []string
+	if err := pages(ctx, s, "conversations.members", form, func(page listing) bool {
+		all = append(all, page.Members...)
+		return true
+	}); err != nil {
+		return nil, err
+	}
+	// The order Slack lists members in is not something anybody promised, and a
+	// list that reorders itself between syncs is a permission change that never
+	// happened, written to every document in the channel.
+	slices.Sort(all)
+	return slices.Compact(all), nil
+}
+
+// Threads walks the conversations in a channel that changed at or after since.
+//
+// Slack has no endpoint for that. History is ordered by when a message was
+// posted, and a reply to an old thread moves nothing but that thread's
+// latest_reply, so the history is read back to the older of since and the reply
+// window and each thread is judged on its newest message. What that misses is
+// the reply to a thread older than the window, and the sweep is what catches it.
+func (s *Service) Threads(ctx context.Context, c threadsource.Container, since time.Time, fn func(context.Context, threadsource.Thread) error) error {
+	parents, err := s.history(ctx, c.ID, s.oldest(since))
+	switch {
+	case err == nil:
+	case refused(err, "not_in_channel"), refused(err, "channel_not_found"):
+		// A bot that is in the workspace but not in the channel. There is
+		// nothing to index and nothing that went wrong with the run, and the
+		// only thing worse than not indexing it is not saying so.
+		s.skip(c.ID, fmt.Errorf("reading #%s: %w", c.Name, err))
+		return nil
+	default:
+		return err
+	}
+
+	changed := make([]message, 0, len(parents))
+	for _, m := range parents {
+		if !changedAt(m).Before(since) {
+			changed = append(changed, m)
+		}
+	}
+	// Oldest change first, which is what the cursor above this is built on: a
+	// run that stopped halfway has to have emitted everything before the point
+	// it reached.
+	slices.SortFunc(changed, func(a, b message) int {
+		if d := changedAt(a).Compare(changedAt(b)); d != 0 {
+			return d
+		}
+		return strings.Compare(a.TS, b.TS)
+	})
+
+	for _, m := range changed {
+		th, err := s.assemble(ctx, c.ID, m)
+		if err != nil {
+			if refused(err, "thread_not_found") || refused(err, "message_not_found") {
+				// Deleted between the listing and the read, which is a race
+				// every crawl has and not a reason to fail the channel. The
+				// sweep removes it from the index.
+				s.skip(s.threadID(c.ID, m.TS), err)
+				continue
+			}
+			return err
+		}
+		if err := fn(ctx, th); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// oldest is how far back a sync reads.
+//
+// A first sync reads everything. Any other one reads back to the reply window
+// as well as to the cursor, because a thread whose parent is inside the window
+// may have been replied to since the cursor without moving.
+func (s *Service) oldest(since time.Time) time.Time {
+	if since.IsZero() {
+		return time.Time{}
+	}
+	window := s.now().UTC().Add(-s.window)
+	if window.Before(since) {
+		return window
+	}
+	return since
+}
+
+// List reports every thread the channel currently holds, with a version derived
+// from its newest message.
+//
+// This is the only thing that ever removes a deleted thread from the index, and
+// the version is what repairs a thread whose late reply the change feed could
+// not see.
+func (s *Service) List(ctx context.Context, c threadsource.Container, fn func(connector.Item) bool) error {
+	parents, err := s.history(ctx, c.ID, time.Time{})
+	switch {
+	case err == nil:
+	case refused(err, "not_in_channel"), refused(err, "channel_not_found"):
+		// Listing nothing here would be a claim that the channel is empty, and
+		// the sweep above treats an empty channel as a channel whose documents
+		// should all be deleted. So this is an error rather than a silence.
+		return fmt.Errorf("slacksource: listing #%s: %w", c.Name, err)
+	default:
+		return err
+	}
+	for _, m := range parents {
+		if !fn(connector.Item{
+			ID:      s.threadID(c.ID, m.TS),
+			Version: version(m),
+		}) {
+			return nil
+		}
+	}
+	return nil
+}
+
+// Read fetches one thread by the id this adapter made for it.
+func (s *Service) Read(ctx context.Context, id string) (threadsource.Thread, error) {
+	ch, ts, ok := strings.Cut(id, ":")
+	if !ok || ch == "" || ts == "" {
+		return threadsource.Thread{}, fmt.Errorf("%w: %q", errBadID, id)
+	}
+
+	replies, err := s.replies(ctx, ch, ts)
+	switch {
+	case err == nil:
+	case refused(err, "thread_not_found"), refused(err, "message_not_found"), refused(err, "channel_not_found"):
+		return threadsource.Thread{}, connector.ErrGone
+	default:
+		return threadsource.Thread{}, err
+	}
+	if len(replies) == 0 {
+		return threadsource.Thread{}, connector.ErrGone
+	}
+
+	th, err := s.build(ctx, ch, replies[0], replies[1:])
+	if err != nil {
+		return threadsource.Thread{}, err
+	}
+	return th, nil
+}
+
+// history reads a channel's top level messages back to oldest, newest first,
+// which is the order Slack returns them in.
+func (s *Service) history(ctx context.Context, id string, oldest time.Time) ([]message, error) {
+	form := url.Values{
+		"channel": {id},
+		"limit":   {strconv.Itoa(s.page)},
+		// Inclusive matters for the same reason the interface above asks for at
+		// or after: a message posted in exactly the second the cursor names is
+		// one an exclusive read loses for ever.
+		"inclusive": {"true"},
+		"oldest":    {slackTime(oldest)},
+	}
+
+	type listing struct {
+		Messages []message `json:"messages"`
+	}
+	var found []message
+	if err := pages(ctx, s, "conversations.history", form, func(page listing) bool {
+		for _, m := range page.Messages {
+			if top(m) {
+				found = append(found, m)
+			}
+		}
+		return true
+	}); err != nil {
+		return nil, err
+	}
+	return found, nil
+}
+
+// replies reads a whole thread, parent first.
+func (s *Service) replies(ctx context.Context, ch, ts string) ([]message, error) {
+	form := url.Values{
+		"channel": {ch},
+		"ts":      {ts},
+		"limit":   {strconv.Itoa(s.page)},
+	}
+
+	type listing struct {
+		Messages []message `json:"messages"`
+	}
+	var found []message
+	if err := pages(ctx, s, "conversations.replies", form, func(page listing) bool {
+		found = append(found, page.Messages...)
+		return true
+	}); err != nil {
+		return nil, err
+	}
+	// A paged reply listing repeats the parent on every page, and concatenating
+	// the pages is how the root message ends up in the body three times.
+	// [thread.Conversation] drops the repeat, and dropping it here as well
+	// keeps the reply count in the document honest.
+	return dedupe(found), nil
+}
+
+// assemble reads the replies to a parent message and builds the thread.
+//
+// A message with no replies is already whole, and asking Slack for the replies
+// to it would be one request per message in the workspace to be told what we
+// were already holding.
+func (s *Service) assemble(ctx context.Context, ch string, parent message) (threadsource.Thread, error) {
+	if parent.ReplyCount == 0 {
+		return s.build(ctx, ch, parent, nil)
+	}
+	all, err := s.replies(ctx, ch, parent.TS)
+	if err != nil {
+		return threadsource.Thread{}, err
+	}
+	if len(all) == 0 {
+		return s.build(ctx, ch, parent, nil)
+	}
+	return s.build(ctx, ch, all[0], all[1:])
+}
+
+// build turns a parent and its replies into what the crawl above wants.
+func (s *Service) build(ctx context.Context, ch string, parent message, replies []message) (threadsource.Thread, error) {
+	msgs := make([]thread.Message, 0, len(replies))
+	for _, m := range replies {
+		msgs = append(msgs, s.message(ctx, m))
+	}
+
+	// The replies in hand are counted as well as the parent's own account of
+	// them. Both agree on a healthy workspace, and when they do not it is
+	// because the parent arrived without its thread fields, which is a thread
+	// that would otherwise report itself as older than a reply this run is
+	// holding and be dropped for being before the cursor.
+	at := changedAt(parent)
+	for _, m := range replies {
+		if r := stamp(m.TS); r.After(at) {
+			at = r
+		}
+	}
+	if len(replies) > parent.ReplyCount {
+		parent.ReplyCount = len(replies)
+	}
+
+	conv := thread.Conversation{
+		ID:       s.threadID(ch, parent.TS),
+		Kind:     doc.KindMessage,
+		Title:    title(parent.Text),
+		URL:      s.permalink(ch, parent.TS),
+		Root:     s.message(ctx, parent),
+		Replies:  msgs,
+		Revision: revision(at, parent.ReplyCount),
+	}
+
+	return threadsource.Thread{
+		Conversation: conv,
+		Container:    ch,
+		Updated:      at,
+	}, nil
+}
+
+// message turns one Slack message into one line of a conversation.
+func (s *Service) message(ctx context.Context, m message) thread.Message {
+	out := thread.Message{
+		ID:     m.TS,
+		Author: s.users.person(ctx, m),
+		At:     stamp(m.TS),
+		Text:   m.Text,
+	}
+	if m.Edited != nil {
+		out.Edited = stamp(m.Edited.TS)
+	}
+	return out
+}
+
+// threadID is the id a thread is filed under, which has to name the channel
+// because reading a thread back needs one.
+func (s *Service) threadID(ch, ts string) string { return ch + ":" + ts }
+
+// permalink is where a person goes to read the thread at the source.
+//
+// It is built rather than asked for. chat.getPermalink is a request per thread
+// for a string with no information in it that we do not already have, and the
+// shape of a Slack archive link has not changed in a decade.
+func (s *Service) permalink(ch, ts string) string {
+	return fmt.Sprintf("https://slack.com/archives/%s/p%s", ch, strings.ReplaceAll(ts, ".", ""))
+}
+
+// top reports whether a message is the start of a thread rather than part of
+// one.
+//
+// The two that are not are a reply, which has a thread_ts pointing at somebody
+// else, and the noise Slack posts about the channel itself: joins, leaves,
+// renames and pinned messages. Indexing "Mei has joined the channel" as a
+// document is how a search for a person's name returns four hundred results
+// they did not write.
+func top(m message) bool {
+	if m.Type != "" && m.Type != "message" {
+		return false
+	}
+	if m.ThreadTS != "" && m.ThreadTS != m.TS {
+		return false
+	}
+	switch m.Subtype {
+	case "", "bot_message", "me_message", "file_share":
+		return strings.TrimSpace(m.Text) != ""
+	default:
+		return false
+	}
+}
+
+// changedAt is when a thread last changed, which is the newest of the parent
+// being posted, the parent being edited and the last reply arriving.
+func changedAt(m message) time.Time {
+	at := stamp(m.TS)
+	if m.Edited != nil {
+		if e := stamp(m.Edited.TS); e.After(at) {
+			at = e
+		}
+	}
+	if r := stamp(m.LatestReply); r.After(at) {
+		at = r
+	}
+	return at
+}
+
+// version is the source's own idea of a revision, and it is what the sweep
+// compares. It has to move when anything in the thread moves, which is why it
+// is not simply the parent's timestamp.
+func version(m message) string {
+	return revision(changedAt(m), m.ReplyCount)
+}
+
+// revision is the same string built from a time and a count that have already
+// been worked out, so that a listing and a read of the same thread agree.
+func revision(at time.Time, replies int) string {
+	return fmt.Sprintf("%s/%d", slackTime(at), replies)
+}
+
+// title is the first line of the first message, shortened.
+//
+// A Slack thread has no title, and a document with none is a search result with
+// nothing on it but a snippet.
+func title(text string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(text), "\n")
+	line = strings.TrimSpace(line)
+	const most = 80
+	if len(line) <= most {
+		return line
+	}
+	// Cut at a word so that the title does not end mid word, and only if there
+	// is a word boundary anywhere near the end.
+	cut := strings.LastIndex(line[:most], " ")
+	if cut < most/2 {
+		cut = most
+	}
+	return strings.TrimSpace(line[:cut])
+}
+
+// dedupe drops the repeats a paged listing produces, keeping the first of each.
+func dedupe(msgs []message) []message {
+	seen := make(map[string]struct{}, len(msgs))
+	out := msgs[:0]
+	for _, m := range msgs {
+		if _, ok := seen[m.TS]; ok {
+			continue
+		}
+		seen[m.TS] = struct{}{}
+		out = append(out, m)
+	}
+	return out
+}

--- a/connector/slacksource/slacksource.go
+++ b/connector/slacksource/slacksource.go
@@ -1,0 +1,251 @@
+// Package slacksource indexes a Slack workspace.
+//
+// It is an adapter and nothing more. The crawl, the cursor, the resume, the
+// reconciliation sweep and the permission refresh are all in
+// [threadsource], and what is here is the four questions that package asks,
+// answered against the Slack Web API: list the channels and say who may read
+// each one, walk the threads in a channel that changed since a time, list the
+// thread ids a channel holds, and read one thread by its id.
+//
+// # A thread is the document
+//
+// Slack stores a conversation as a parent message and a list of replies, and a
+// reply is not a document. It is a sentence in one. So a thread is fetched
+// whole, assembled by [thread.Conversation.Document], and indexed as a single
+// result that ranks as a whole.
+//
+// # Permissions
+//
+// A public channel is readable by everybody in the workspace, so it maps to
+// [acl.ModePublicToTenant]. A private channel is readable by its members and by
+// nobody else, so it maps to an access control list naming them, which is one
+// extra request per private channel per sync rather than per thread.
+//
+// A direct message conversation is not indexed at all. There is no rule that
+// makes one safe to put in a shared index: the members are two people, the
+// content is theirs, and a product that indexed them would be one nobody could
+// deploy. They are skipped by not asking for them.
+//
+// A channel this token cannot see is a channel that is not listed, which is the
+// end of it. The interesting case is the channel that is listed and then refuses
+// to be read, which happens when a bot is in the workspace but not in the
+// channel. That is reported rather than guessed at.
+//
+// # What incremental means here
+//
+// Slack has no "what changed since" endpoint. `conversations.history` is ordered
+// by the time a message was posted, and a reply to a two year old thread does
+// not move that thread anywhere: the parent keeps its original timestamp and
+// only its latest_reply moves.
+//
+// So a sync reads the history of each channel back to the older of the cursor
+// and the reply window, and emits a thread whose newest change is at or after
+// the cursor. A late reply to a thread older than the window is not in the
+// change feed at all, and is found by the reconciliation sweep instead: the
+// listing reports each thread with a version derived from its newest message,
+// and a version that differs from the stored one is a document the pipeline
+// refetches. That is the honest arrangement. Widening the window costs history
+// pages on every sync, and narrowing it moves work onto a sweep that runs less
+// often, and neither of them loses anything.
+//
+// # Rate limits
+//
+// Slack limits per method rather than per token, in tiers, and a crawl that
+// treated them as one number would either be throttled at the speed of its
+// slowest method or be refused at the speed of its fastest. Each tier gets its
+// own bucket, requests are routed to one by the method they name, and a 429 is
+// obeyed by the tier that earned it. All of that is [limit] doing the work: the
+// retries, the backoff, the Retry-After header and the circuit breaker are the
+// same ones every connector in this repository uses.
+package slacksource
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/connector/limit"
+	"github.com/tamnd/genba/connector/threadsource"
+)
+
+// DefaultName is the source name a document's id is prefixed with when the
+// caller does not choose one.
+const DefaultName = "slack"
+
+// DefaultBaseURL is the Slack Web API. It is an option so that a test can point
+// the adapter at a recording or at a server of its own.
+const DefaultBaseURL = "https://slack.com/api"
+
+// DefaultReplyWindow is how far back a sync reads history looking for threads
+// that were replied to since the cursor.
+//
+// A week is chosen because it is roughly how long a Slack thread stays alive.
+// A reply after it is not lost, it is found by the sweep instead.
+const DefaultReplyWindow = 7 * 24 * time.Hour
+
+// DefaultPageSize is how many items are asked for per page. Slack accepts up to
+// a thousand and recommends far less, and two hundred is what its own
+// documentation suggests for the listing endpoints.
+const DefaultPageSize = 200
+
+// Service answers [threadsource.Service] against a Slack workspace.
+type Service struct {
+	http       *http.Client
+	base       string
+	token      string
+	name       string
+	page       int
+	window     time.Duration
+	aclRefresh time.Duration
+	now        func() time.Time
+	users      *people
+	skipped    func(id string, reason error)
+}
+
+var _ threadsource.Service = (*Service)(nil)
+
+// Option configures a [Service].
+type Option func(*Service)
+
+// WithName sets the source name, which is what every document id from this
+// workspace is prefixed with. A deployment indexing two workspaces needs two
+// names, because the ids from them would otherwise collide.
+func WithName(name string) Option {
+	return func(s *Service) { s.name = name }
+}
+
+// WithBaseURL points the adapter somewhere other than Slack, which is what a
+// test against a recording does.
+func WithBaseURL(u string) Option {
+	return func(s *Service) { s.base = strings.TrimSuffix(u, "/") }
+}
+
+// WithHTTPClient replaces the client entirely, rate limiting included.
+//
+// A caller who passes one is taking on the limits themselves, which is right
+// for a test replaying a recording and wrong for anything talking to Slack.
+func WithHTTPClient(c *http.Client) Option {
+	return func(s *Service) { s.http = c }
+}
+
+// WithLimits changes what the workspace is allowed to cost.
+//
+// The rates are per tier and this scales all of them, so a workspace that has
+// asked us to go slower is one number rather than four.
+func WithLimits(l limit.Limits) Option {
+	return func(s *Service) { s.http = tiered(s.token, l) }
+}
+
+// WithReplyWindow sets how far back each sync reads history looking for threads
+// that were replied to. Zero selects [DefaultReplyWindow].
+func WithReplyWindow(d time.Duration) Option {
+	return func(s *Service) { s.window = d }
+}
+
+// WithPageSize sets how many items are asked for per page. Zero selects
+// [DefaultPageSize].
+func WithPageSize(n int) Option {
+	return func(s *Service) { s.page = n }
+}
+
+// WithSkipped is told about a channel or a thread that could not be indexed,
+// with the reason.
+//
+// The case worth having it for is a bot that is in the workspace but not in a
+// channel: the channel is listed and then refuses to be read, and an index
+// quietly missing it looks exactly like an index that is complete.
+func WithSkipped(f func(id string, reason error)) Option {
+	return func(s *Service) { s.skipped = f }
+}
+
+// WithClock replaces the clock the reply window and the permission refresh
+// schedule are measured against.
+//
+// It is here for tests, which need those two to be measured against a time they
+// chose rather than against a real one, and it is exported rather than smuggled
+// in through a build tag because a test in another package needs it too.
+func WithClock(now func() time.Time) Option {
+	return func(s *Service) { s.now = now }
+}
+
+// NewService builds the adapter on its own, which is what a caller wanting to
+// wrap it or test it against a recording needs.
+func NewService(token string, opts ...Option) (*Service, error) {
+	if token == "" {
+		return nil, errors.New("slacksource: a token is required")
+	}
+	s := &Service{
+		base:   DefaultBaseURL,
+		token:  token,
+		name:   DefaultName,
+		page:   DefaultPageSize,
+		window: DefaultReplyWindow,
+		now:    time.Now,
+	}
+	s.http = tiered(token, limit.Limits{})
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.name == "" {
+		return nil, errors.New("slacksource: the source name cannot be empty")
+	}
+	if s.base == "" {
+		return nil, errors.New("slacksource: the base URL cannot be empty")
+	}
+	if s.page < 1 {
+		s.page = DefaultPageSize
+	}
+	if s.window <= 0 {
+		s.window = DefaultReplyWindow
+	}
+	if s.now == nil {
+		s.now = time.Now
+	}
+	s.users = newPeople(s)
+	return s, nil
+}
+
+// New builds a connector over a Slack workspace, ready to be handed to the
+// ingestion pipeline.
+func New(token string, opts ...Option) (*threadsource.Source, error) {
+	svc, err := NewService(token, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var wrapped []threadsource.Option
+	if svc.skipped != nil {
+		wrapped = append(wrapped, threadsource.WithSkipped(svc.skipped))
+	}
+	return threadsource.New(svc, svc.name, wrapped...)
+}
+
+// Name is the source name documents from this workspace are filed under.
+func (s *Service) Name() string { return s.name }
+
+// skip reports something that could not be indexed, if anybody asked to hear
+// about it.
+func (s *Service) skip(id string, reason error) {
+	if s.skipped != nil {
+		s.skipped(id, reason)
+	}
+}
+
+// Error is what Slack says when it refuses. The string is the machine readable
+// one from the body rather than the status, because a Slack refusal is a 200
+// with ok false far more often than it is a status code.
+type Error struct {
+	Method string
+	Code   string
+}
+
+func (e *Error) Error() string { return fmt.Sprintf("slack: %s: %s", e.Method, e.Code) }
+
+// refused reports whether an error is Slack saying no with this particular
+// code, which is how a caller tells "not in that channel" from "the network
+// went away".
+func refused(err error, code string) bool {
+	var se *Error
+	return errors.As(err, &se) && se.Code == code
+}

--- a/connector/slacksource/slacksource_test.go
+++ b/connector/slacksource/slacksource_test.go
@@ -1,0 +1,636 @@
+package slacksource_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/connectortest"
+	"github.com/tamnd/genba/connector/limit"
+	"github.com/tamnd/genba/connector/slacksource"
+	"github.com/tamnd/genba/connector/threadsource"
+	"github.com/tamnd/genba/doc"
+)
+
+const token = "xoxb-a-real-looking-token"
+
+// quick is a rate limit that does not slow a test down while still being the
+// real limiter, retries, backoff, circuit breaker and all.
+var quick = limit.Limits{Rate: 10000, Burst: 50, MinBackoff: time.Millisecond, MaxBackoff: 5 * time.Millisecond}
+
+func newSource(t *testing.T, w *workspace, opts ...slacksource.Option) *threadsource.Source {
+	t.Helper()
+	all := append([]slacksource.Option{
+		slacksource.WithBaseURL(w.server(t)),
+		slacksource.WithLimits(quick),
+		slacksource.WithClock(w.now),
+	}, opts...)
+	src, err := slacksource.New(token, all...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+	return src
+}
+
+func run(t *testing.T, src *threadsource.Source, from connector.Cursor) ([]connector.Change, connector.Cursor) {
+	t.Helper()
+	var got []connector.Change
+	next, err := src.Sync(t.Context(), from, func(_ context.Context, ch connector.Change) error {
+		got = append(got, ch)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	return got, next
+}
+
+func ids(changes []connector.Change) []string {
+	out := make([]string, 0, len(changes))
+	for _, ch := range changes {
+		out = append(out, ch.Document.ID)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func find(changes []connector.Change, id string) *connector.Change {
+	for i := range changes {
+		if changes[i].Document.ID == id {
+			return &changes[i]
+		}
+	}
+	return nil
+}
+
+// The conformance suite is what decides whether this is a connector, and
+// everything else in this file is about the parts that are specific to Slack.
+//
+// Unresolvable is left out because Slack has no per message rule to make
+// unresolvable. A thread is readable exactly when its channel is, and the case
+// where that cannot be worked out is a whole channel at a time, which is its own
+// test below.
+func TestConformance(t *testing.T) {
+	connectortest.Run(t, func(t *testing.T) connectortest.Fixture {
+		w := newWorkspace()
+		src, err := slacksource.New(token,
+			slacksource.WithBaseURL(w.server(t)),
+			slacksource.WithLimits(quick),
+			slacksource.WithClock(w.now),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return connectortest.Fixture{
+			Connector: src,
+			ID:        func(name string) string { return "slack:C_GENERAL:" + w.tsOf("C_GENERAL", name) },
+			Write:     func(_ *testing.T, name, body string) { w.post("C_GENERAL", name, body) },
+			Remove:    func(_ *testing.T, name string) { w.remove("C_GENERAL", name) },
+			Share:     func(_ *testing.T, _ string) { w.makePrivate("C_GENERAL") },
+		}
+	})
+}
+
+// A reply is a sentence in a document rather than a document, which is the one
+// thing this connector exists to get right.
+func TestAThreadAndItsRepliesAreOneDocument(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.reply("C_GENERAL", "gearbox", "U_SAM", "Bearing, I think.")
+	w.reply("C_GENERAL", "gearbox", "U_LEE", "Replacement ordered, arrives Thursday.")
+	w.post("C_GENERAL", "coolant", "Coolant pump replaced.")
+	src := newSource(t, w)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 2 {
+		t.Fatalf("a channel with two threads and three replies produced %d documents: %v", len(changes), ids(changes))
+	}
+
+	got := find(changes, "slack:C_GENERAL:"+w.tsOf("C_GENERAL", "gearbox"))
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	for _, want := range []string{"making a noise", "Bearing, I think", "arrives Thursday"} {
+		if !strings.Contains(got.Document.Body, want) {
+			t.Errorf("the body does not hold %q:\n%s", want, got.Document.Body)
+		}
+	}
+	// The name of whoever said each thing goes into the body, which is the
+	// difference between searching for what Mei said about the gearbox and only
+	// being able to search for the gearbox.
+	for _, want := range []string{"Mei Tanaka", "Sam Okafor", "Lee Berger"} {
+		if !strings.Contains(got.Document.Body, want) {
+			t.Errorf("the body does not name %q:\n%s", want, got.Document.Body)
+		}
+	}
+	if got.Document.Properties["replies"] != "2" {
+		t.Errorf("the document reports %q replies", got.Document.Properties["replies"])
+	}
+	if got.Document.Kind != doc.KindMessage {
+		t.Errorf("the kind is %q", got.Document.Kind)
+	}
+	if !strings.Contains(got.Document.URL, "/archives/C_GENERAL/p") {
+		t.Errorf("the link is %q, and it has to be one a person can open", got.Document.URL)
+	}
+}
+
+// The noise Slack posts about the channel itself is not a document. Indexing
+// "Mei has joined the channel" is how a search for somebody's name returns four
+// hundred results they did not write.
+func TestJoinsAndLeavesAreNotDocuments(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.system("C_GENERAL", "channel_join", "<@U_SAM> has joined the channel")
+	w.system("C_GENERAL", "channel_leave", "<@U_LEE> has left the channel")
+	w.system("C_GENERAL", "channel_topic", "<@U_MEI> set the channel topic: line two")
+	src := newSource(t, w)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if got := ids(changes); len(got) != 1 {
+		t.Fatalf("a channel with one thread and three pieces of housekeeping emitted %v", got)
+	}
+	if !strings.Contains(changes[0].Document.Body, "making a noise") {
+		t.Errorf("the one document is not the thread:\n%s", changes[0].Document.Body)
+	}
+}
+
+// A message whose text is empty has nothing to index. A file share with no
+// comment is the common one, and it arrives as a message with an attachment and
+// no words in it.
+func TestAMessageWithNothingInItIsNotADocument(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.system("C_GENERAL", "file_share", "   ")
+	src := newSource(t, w)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 1 {
+		t.Errorf("a message with no text in it was indexed: %v", ids(changes))
+	}
+}
+
+// A public channel is readable by the whole workspace, which is what makes it
+// public, and a private one is readable by its members and nobody else.
+func TestAPrivateChannelIsInvisibleToAnybodyNotInIt(t *testing.T) {
+	w := newWorkspace()
+	w.addChannel("C_LEAD", "leadership", true)
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.post("C_LEAD", "restructure", "The reorganisation goes out on Monday.")
+	src := newSource(t, w)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	open := find(changes, "slack:C_GENERAL:"+w.tsOf("C_GENERAL", "gearbox"))
+	closed := find(changes, "slack:C_LEAD:"+w.tsOf("C_LEAD", "restructure"))
+	if open == nil || closed == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+
+	if open.Document.Permissions.Mode != acl.ModePublicToTenant {
+		t.Errorf("a thread in a public channel is %v", open.Document.Permissions.Mode)
+	}
+	if closed.Document.Permissions.Mode != acl.ModeACL {
+		t.Fatalf("a thread in a private channel is %v", closed.Document.Permissions.Mode)
+	}
+	if got := closed.Document.Permissions.AllowUsers; len(got) != 2 {
+		t.Fatalf("the private thread allows %v, want the two members of the channel", got)
+	}
+
+	// A person who is not in the channel is not on the list, and the list is
+	// the whole of the rule: there is no group and no fallback that would let
+	// them through.
+	lee := acl.Principal{Tenant: "acme", Subject: "U_LEE", Identities: []acl.Identity{{Source: "slack", Value: "U_LEE"}}}
+	if closed.Document.Permissions.Allows(&lee) {
+		t.Error("somebody who is not in the private channel may read a thread from it")
+	}
+	mei := acl.Principal{Tenant: "acme", Subject: "U_MEI", Identities: []acl.Identity{{Source: "slack", Value: "U_MEI"}}}
+	if !closed.Document.Permissions.Allows(&mei) {
+		t.Error("a member of the private channel may not read a thread from it")
+	}
+}
+
+// The member list is not ordered by anything, and a list that reorders itself
+// between syncs would be a revocation that never happened, written to every
+// document in the channel.
+func TestTheMemberListIsPutInOrder(t *testing.T) {
+	w := newWorkspace()
+	w.addChannel("C_LEAD", "leadership", true)
+	w.post("C_LEAD", "restructure", "The reorganisation goes out on Monday.")
+	src := newSource(t, w)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := changes[0].Document.Permissions.AllowUsers
+	if !slices.IsSortedFunc(got, func(a, b acl.Ref) int { return strings.Compare(a.Value, b.Value) }) {
+		t.Errorf("the rule lists %v, and the fake hands them back in the least helpful order it can", got)
+	}
+}
+
+// Direct messages have no rule that makes them safe to put in a shared index,
+// so they are not asked for at all.
+func TestDirectMessagesAreNotIndexed(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	src := newSource(t, w)
+
+	if _, err := src.Sync(t.Context(), connector.Cursor{}, func(context.Context, connector.Change) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	// The fake refuses anything it was not asked for by returning nothing, so
+	// the assertion is on the request: nothing ever asked for im or mpim.
+	if w.askedFor("im") || w.askedFor("mpim") {
+		t.Error("the crawl asked Slack for direct messages")
+	}
+}
+
+// A bot that is in the workspace but not in a channel is the case that quietly
+// produces an incomplete index, so it is quarantined and reported rather than
+// guessed at.
+func TestAChannelTheTokenCannotReadIsQuarantinedAndReported(t *testing.T) {
+	w := newWorkspace()
+	w.addChannel("C_LEAD", "leadership", true)
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.post("C_LEAD", "restructure", "The reorganisation goes out on Monday.")
+	w.notIn["C_LEAD"] = true
+
+	var skipped []string
+	src := newSource(t, w, slacksource.WithSkipped(func(id string, _ error) {
+		skipped = append(skipped, id)
+	}))
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if !slices.Contains(skipped, "C_LEAD") {
+		t.Errorf("the run said nothing about a channel it could not read, it said %v", skipped)
+	}
+	for _, ch := range changes {
+		if strings.HasPrefix(ch.Document.ID, "slack:C_LEAD:") {
+			t.Errorf("%s was emitted from a channel the token cannot read", ch.Document.ID)
+		}
+	}
+	if find(changes, "slack:C_GENERAL:"+w.tsOf("C_GENERAL", "gearbox")) == nil {
+		t.Errorf("one unreadable channel emptied the whole sync, which emitted %v", ids(changes))
+	}
+}
+
+// A listing that reported an unreadable channel as empty would be a claim that
+// its documents should all be deleted, so it is an error instead.
+func TestListingAChannelTheTokenCannotReadIsAnError(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	src := newSource(t, w)
+	w.notIn["C_GENERAL"] = true
+
+	err := src.Enumerate(t.Context(), func(connector.Item) bool { return true })
+	if err == nil {
+		t.Fatal("listing a channel the token cannot read succeeded, and the sweep would then delete everything in it")
+	}
+	if !strings.Contains(err.Error(), "general") {
+		t.Errorf("the error does not say which channel: %v", err)
+	}
+}
+
+// Making a channel private changes who may read everything in it without
+// touching a single message.
+func TestMakingAChannelPrivateReachesTheIndexWithoutReadingIt(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.post("C_GENERAL", "coolant", "Coolant pump replaced.")
+	src := newSource(t, w)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	before := src.Counters()
+
+	w.makePrivate("C_GENERAL")
+	changes, next := run(t, src, cursor)
+
+	if len(changes) != 2 {
+		t.Fatalf("making the channel private emitted %v, want both threads in it", ids(changes))
+	}
+	for _, ch := range changes {
+		if !ch.PermissionsOnly {
+			t.Errorf("%s came back as a content change and nothing in it changed", ch.Document.ID)
+		}
+		if ch.Document.Permissions.Mode != acl.ModeACL {
+			t.Errorf("%s reports %v", ch.Document.ID, ch.Document.Permissions.Mode)
+		}
+	}
+	if spent := src.Counters().Since(before); spent.Fetches != 0 {
+		t.Errorf("a permission change read %d threads, and the point of it is that it reads none", spent.Fetches)
+	}
+	if again, _ := run(t, src, next); len(again) != 0 {
+		t.Errorf("the sync after the permission change emitted %v", ids(again))
+	}
+}
+
+// Slack does not report that somebody was removed from a private channel
+// anywhere, and a revocation that reaches the index whenever somebody happens
+// to post is not a revocation. So the rule is reapplied on a schedule.
+func TestARemovedMemberIsAppliedOnTheSchedule(t *testing.T) {
+	w := newWorkspace()
+	w.addChannel("C_LEAD", "leadership", true)
+	w.post("C_LEAD", "restructure", "The reorganisation goes out on Monday.")
+
+	// The clock is the workspace's, so the test moves it rather than waiting.
+	now := w.now()
+	src := newSource(t, w,
+		slacksource.WithACLRefresh(time.Hour),
+		slacksource.WithClock(func() time.Time { return now }),
+	)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	if changes, _ := run(t, src, cursor); len(changes) != 0 {
+		t.Fatalf("a second sync in the same interval emitted %v", ids(changes))
+	}
+
+	w.removeMember("C_LEAD", "U_SAM")
+	// Still inside the same interval, so Slack has told us nothing and neither
+	// has the schedule.
+	if changes, _ := run(t, src, cursor); len(changes) != 0 {
+		t.Fatalf("the removal was applied before the schedule said to, which means every sync applies it: %v", ids(changes))
+	}
+
+	now = now.Add(time.Hour)
+	changes, _ := run(t, src, cursor)
+	if len(changes) != 1 {
+		t.Fatalf("the interval passed and the sync emitted %v", ids(changes))
+	}
+	if !changes[0].PermissionsOnly {
+		t.Error("reapplying a rule read the thread again")
+	}
+	if got := changes[0].Document.Permissions.AllowUsers; len(got) != 1 || got[0].Value != "U_MEI" {
+		t.Errorf("the rule now allows %v, want only the member who is still in the channel", got)
+	}
+}
+
+// The reply window is the honest part of a source with no change feed. A reply
+// inside it is in the sync, and a reply outside it is in the sweep.
+func TestAReplyInsideTheWindowIsFoundByTheSync(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.post("C_GENERAL", "coolant", "Coolant pump replaced.")
+	src := newSource(t, w, slacksource.WithReplyWindow(time.Hour))
+
+	_, cursor := run(t, src, connector.Cursor{})
+	w.reply("C_GENERAL", "gearbox", "U_SAM", "Bearing, I think.")
+
+	changes, _ := run(t, src, cursor)
+	want := "slack:C_GENERAL:" + w.tsOf("C_GENERAL", "gearbox")
+	if got := ids(changes); !slices.Equal(got, []string{want}) {
+		t.Fatalf("the sync after one reply emitted %v, want just %s", got, want)
+	}
+	if !strings.Contains(changes[0].Document.Body, "Bearing, I think") {
+		t.Errorf("the reply is not in the body:\n%s", changes[0].Document.Body)
+	}
+}
+
+// A reply to a thread older than the window does not move that thread anywhere
+// Slack will report, so the change feed cannot see it. The version in the
+// listing is what makes the sweep find it instead.
+func TestAReplyOutsideTheWindowIsFoundByTheListing(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	// Something newer, so that the cursor lands past the gearbox thread and a
+	// window of nothing leaves it out of reach of the next sync.
+	w.post("C_GENERAL", "coolant", "Coolant pump replaced.")
+	src := newSource(t, w, slacksource.WithReplyWindow(time.Nanosecond))
+
+	_, cursor := run(t, src, connector.Cursor{})
+	id := "slack:C_GENERAL:" + w.tsOf("C_GENERAL", "gearbox")
+	was := versionOf(t, src, id)
+
+	w.reply("C_GENERAL", "gearbox", "U_SAM", "Bearing, I think.")
+
+	// The sync cannot see it, and that is the documented cost rather than a bug.
+	if again, _ := run(t, src, cursor); len(again) != 0 {
+		t.Errorf("the sync saw a reply outside the window after all, which would be better: %v", ids(again))
+	}
+	// The listing can, because the version is derived from the newest message.
+	if now := versionOf(t, src, id); now == was {
+		t.Fatalf("the listing reports version %q both before and after a reply, so the sweep can never repair it", now)
+	}
+	// And the repair is a real fetch of the thread with the reply in it.
+	got, err := src.Fetch(t.Context(), id)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if !strings.Contains(got.Body, "Bearing, I think") {
+		t.Errorf("the repaired document does not hold the reply:\n%s", got.Body)
+	}
+}
+
+// versionOf reads what the listing says about one document.
+func versionOf(t *testing.T, src *threadsource.Source, id string) string {
+	t.Helper()
+	var got string
+	if err := src.Enumerate(t.Context(), func(item connector.Item) bool {
+		if item.ID == id {
+			got = item.Version
+			return false
+		}
+		return true
+	}); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if got == "" {
+		t.Fatalf("the listing does not hold %s", id)
+	}
+	return got
+}
+
+// An edit changes what a document says without any reply being added, and a
+// version derived only from reply times would leave the index serving the old
+// text until somebody happened to answer.
+func TestAnEditMovesTheVersion(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	src := newSource(t, w)
+
+	changes, cursor := run(t, src, connector.Cursor{})
+	id := changes[0].Document.ID
+	was := versionOf(t, src, id)
+
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two has stopped.")
+
+	if now := versionOf(t, src, id); now == was {
+		t.Errorf("an edit left the version at %q", now)
+	}
+	got, _ := run(t, src, cursor)
+	if len(got) != 1 || !strings.Contains(got[0].Document.Body, "has stopped") {
+		t.Errorf("the sync after an edit emitted %v", ids(got))
+	}
+}
+
+// A paged reply listing repeats the parent message on every page, so an adapter
+// that concatenated the pages would say the first thing three times and treble
+// its weight in the ranking.
+func TestTheParentIsNotCountedOncePerPage(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	for _, text := range []string{"Bearing, I think.", "Replacement ordered.", "It arrived.", "Fitted and quiet."} {
+		w.reply("C_GENERAL", "gearbox", "U_SAM", text)
+	}
+	src := newSource(t, w)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if got := changes[0].Document.Properties["replies"]; got != "4" {
+		t.Errorf("the document reports %q replies over three pages, want 4", got)
+	}
+	if n := strings.Count(changes[0].Document.Body, "making a noise"); n != 1 {
+		t.Errorf("the first message is in the body %d times", n)
+	}
+}
+
+// A source that gave up on the first refusal would fail a run over a rate limit
+// that Slack expects every client to hit.
+func TestBeingThrottledDoesNotFailTheRun(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	src := newSource(t, w)
+
+	w.throttle = 3
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 1 {
+		t.Fatalf("a run that was throttled three times emitted %v", ids(changes))
+	}
+	if w.throttle != 0 {
+		t.Errorf("%d refusals were never retried", w.throttle)
+	}
+}
+
+// Slack limits per method in tiers, and the crawl uses methods from three of
+// them. Sharing one bucket would either be refused at the speed of the fastest
+// or crawl at the speed of the slowest.
+func TestEachMethodDrawsOnItsOwnLimit(t *testing.T) {
+	w := newWorkspace()
+	w.addChannel("C_LEAD", "leadership", true)
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.post("C_LEAD", "restructure", "The reorganisation goes out on Monday.")
+
+	svc, err := slacksource.NewService(token,
+		slacksource.WithBaseURL(w.server(t)),
+		slacksource.WithLimits(quick),
+		slacksource.WithClock(w.now),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := threadsource.New(svc, svc.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+
+	run(t, src, connector.Cursor{})
+	if got := svc.Stats().Requests; got == 0 {
+		t.Fatal("the run went through no limiter at all")
+	}
+	for _, method := range []string{"conversations.list", "conversations.members", "conversations.history", "users.info"} {
+		if w.counted(method) == 0 {
+			t.Errorf("the crawl never called %s, so this test is not measuring what it says it is", method)
+		}
+	}
+}
+
+// A name looked up once is a name looked up once, however many messages the
+// person wrote.
+func TestAPersonIsLookedUpOnce(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.post("C_GENERAL", "coolant", "Coolant pump replaced.")
+	w.reply("C_GENERAL", "gearbox", "U_MEI", "Still noisy.")
+	src := newSource(t, w)
+
+	w.resetCounts()
+	run(t, src, connector.Cursor{})
+	if got := w.counted("users.info"); got != 1 {
+		t.Errorf("one person who wrote three messages was looked up %d times", got)
+	}
+}
+
+// A lookup that fails is a display name, and failing a whole channel over one
+// is worse than indexing the thread with the id in place of the name.
+func TestAFailedNameLookupDoesNotFailTheChannel(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.fail["users.info"] = "user_not_found"
+
+	var skipped []string
+	src := newSource(t, w, slacksource.WithSkipped(func(id string, _ error) { skipped = append(skipped, id) }))
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 1 {
+		t.Fatalf("a failed name lookup emitted %v", ids(changes))
+	}
+	if got := changes[0].Document.Author.Identity.Value; got != "U_MEI" {
+		t.Errorf("the author's identity is %q, and that much was known without asking", got)
+	}
+	if !slices.Contains(skipped, "U_MEI") {
+		t.Errorf("nothing was said about the failed lookup, only %v", skipped)
+	}
+}
+
+// An error that is not a refusal is the caller's to see. A sync that swallowed
+// one would report success and move the cursor past threads it never read.
+func TestARealErrorComesBack(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	w.fail["conversations.list"] = "invalid_auth"
+	src := newSource(t, w)
+
+	_, err := src.Sync(t.Context(), connector.Cursor{}, func(context.Context, connector.Change) error { return nil })
+	if err == nil {
+		t.Fatal("a sync with an invalid token succeeded")
+	}
+	if !strings.Contains(err.Error(), "invalid_auth") {
+		t.Errorf("the error does not say what Slack said: %v", err)
+	}
+}
+
+func TestFetchOfSomethingNoLongerThere(t *testing.T) {
+	w := newWorkspace()
+	w.post("C_GENERAL", "gearbox", "The gearbox on line two is making a noise.")
+	src := newSource(t, w)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	id := changes[0].Document.ID
+	w.remove("C_GENERAL", "gearbox")
+
+	if _, err := src.Fetch(t.Context(), id); !errors.Is(err, connector.ErrGone) {
+		t.Errorf("fetching a deleted thread gave %v, want the answer that it is gone", err)
+	}
+}
+
+func TestFetchOfAnIdThisWorkspaceCouldNotHaveMade(t *testing.T) {
+	w := newWorkspace()
+	src := newSource(t, w)
+
+	_, err := src.Fetch(t.Context(), "slack:nonsense")
+	if err == nil {
+		t.Fatal("fetching a malformed id succeeded")
+	}
+	if errors.Is(err, connector.ErrGone) {
+		t.Error("a malformed id came back as a thread this workspace used to have")
+	}
+}
+
+func TestBuildingTheAdapterRejectsWhatCannotWork(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts []slacksource.Option
+		tok  string
+	}{
+		{name: "no token"},
+		{name: "no source name", tok: token, opts: []slacksource.Option{slacksource.WithName("")}},
+		{name: "no base URL", tok: token, opts: []slacksource.Option{slacksource.WithBaseURL("")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := slacksource.New(tc.tok, tc.opts...); err == nil {
+				t.Error("it was built anyway")
+			}
+		})
+	}
+}

--- a/connector/slacksource/testdata/workspace/0001-get-api-conversations.list-exclude-archived-true-limit-200-types-public-channel.json
+++ b/connector/slacksource/testdata/workspace/0001-get-api-conversations.list-exclude-archived-true-limit-200-types-public-channel.json
@@ -1,0 +1,40 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/conversations.list?exclude_archived=true\u0026limit=200\u0026types=public_channel%2Cprivate_channel"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "channels": [
+          {
+            "id": "C_GENERAL",
+            "is_archived": false,
+            "is_channel": true,
+            "is_private": false,
+            "name": "general",
+            "updated": 1780000000000
+          },
+          {
+            "id": "C_LINE_TWO",
+            "is_archived": false,
+            "is_channel": true,
+            "is_private": false,
+            "name": "line-two",
+            "updated": 1780000002000
+          }
+        ],
+        "ok": true,
+        "response_metadata": {
+          "next_cursor": "2"
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/0002-get-api-conversations.list-cursor-2-exclude-archived-true-limit-200-types.json
+++ b/connector/slacksource/testdata/workspace/0002-get-api-conversations.list-cursor-2-exclude-archived-true-limit-200-types.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/conversations.list?cursor=2\u0026exclude_archived=true\u0026limit=200\u0026types=public_channel%2Cprivate_channel"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "channels": [
+          {
+            "id": "C_SAFETY",
+            "is_archived": false,
+            "is_channel": true,
+            "is_private": true,
+            "name": "safety",
+            "updated": 1780000007000
+          }
+        ],
+        "ok": true,
+        "response_metadata": {
+          "next_cursor": ""
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/0003-get-api-conversations.members-channel-c-safety-limit-200.json
+++ b/connector/slacksource/testdata/workspace/0003-get-api-conversations.members-channel-c-safety-limit-200.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/conversations.members?channel=C_SAFETY\u0026limit=200"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "members": [
+          "U_SAM",
+          "U_MEI"
+        ],
+        "ok": true,
+        "response_metadata": {
+          "next_cursor": ""
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/0004-get-api-conversations.history-channel-c-general-inclusive-true-limit-200-oldest.json
+++ b/connector/slacksource/testdata/workspace/0004-get-api-conversations.history-channel-c-general-inclusive-true-limit-200-oldest.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/conversations.history?channel=C_GENERAL\u0026inclusive=true\u0026limit=200\u0026oldest=0"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "has_more": false,
+        "messages": [
+          {
+            "text": "welcome\nMorning all. Line two is down until the gearbox is looked at.",
+            "ts": "1780000001.000000",
+            "type": "message",
+            "user": "U_MEI"
+          }
+        ],
+        "ok": true,
+        "response_metadata": {
+          "next_cursor": ""
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/0005-get-api-users.info-user-u-mei.json
+++ b/connector/slacksource/testdata/workspace/0005-get-api-users.info-user-u-mei.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/users.info?user=U_MEI"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "ok": true,
+        "user": {
+          "id": "U_MEI",
+          "name": "mei",
+          "profile": {
+            "email": "mei@acme.com",
+            "real_name": "Mei Tanaka"
+          },
+          "real_name": "Mei Tanaka"
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/0006-get-api-conversations.history-channel-c-line-two-inclusive-true-limit-200.json
+++ b/connector/slacksource/testdata/workspace/0006-get-api-conversations.history-channel-c-line-two-inclusive-true-limit-200.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/conversations.history?channel=C_LINE_TWO\u0026inclusive=true\u0026limit=200\u0026oldest=0"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "has_more": false,
+        "messages": [
+          {
+            "subtype": "channel_join",
+            "text": "\u003c@U_LEE\u003e has joined the channel",
+            "ts": "1780000006.000000",
+            "type": "message",
+            "user": "U_SAM"
+          },
+          {
+            "latest_reply": "1780000005.000000",
+            "reply_count": 2,
+            "text": "gearbox\nThe gearbox on line two is making a noise under load.",
+            "thread_ts": "1780000003.000000",
+            "ts": "1780000003.000000",
+            "type": "message",
+            "user": "U_MEI"
+          }
+        ],
+        "ok": true,
+        "response_metadata": {
+          "next_cursor": ""
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/0007-get-api-conversations.replies-channel-c-line-two-limit-200-ts-1780000003.000000.json
+++ b/connector/slacksource/testdata/workspace/0007-get-api-conversations.replies-channel-c-line-two-limit-200-ts-1780000003.000000.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/conversations.replies?channel=C_LINE_TWO\u0026limit=200\u0026ts=1780000003.000000"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "has_more": true,
+        "messages": [
+          {
+            "latest_reply": "1780000005.000000",
+            "reply_count": 2,
+            "text": "gearbox\nThe gearbox on line two is making a noise under load.",
+            "thread_ts": "1780000003.000000",
+            "ts": "1780000003.000000",
+            "type": "message",
+            "user": "U_MEI"
+          },
+          {
+            "text": "Sounds like the outboard bearing to me.",
+            "thread_ts": "1780000003.000000",
+            "ts": "1780000004.000000",
+            "type": "message",
+            "user": "U_SAM"
+          }
+        ],
+        "ok": true,
+        "response_metadata": {
+          "next_cursor": "2"
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/0008-get-api-conversations.replies-channel-c-line-two-cursor-2-limit-200-ts.json
+++ b/connector/slacksource/testdata/workspace/0008-get-api-conversations.replies-channel-c-line-two-cursor-2-limit-200-ts.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/conversations.replies?channel=C_LINE_TWO\u0026cursor=2\u0026limit=200\u0026ts=1780000003.000000"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "has_more": false,
+        "messages": [
+          {
+            "latest_reply": "1780000005.000000",
+            "reply_count": 2,
+            "text": "gearbox\nThe gearbox on line two is making a noise under load.",
+            "thread_ts": "1780000003.000000",
+            "ts": "1780000003.000000",
+            "type": "message",
+            "user": "U_MEI"
+          },
+          {
+            "text": "I changed that one on Tuesday, so it should not be.",
+            "thread_ts": "1780000003.000000",
+            "ts": "1780000005.000000",
+            "type": "message",
+            "user": "U_LEE"
+          }
+        ],
+        "ok": true,
+        "response_metadata": {
+          "next_cursor": ""
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/0009-get-api-users.info-user-u-sam.json
+++ b/connector/slacksource/testdata/workspace/0009-get-api-users.info-user-u-sam.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/users.info?user=U_SAM"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "ok": true,
+        "user": {
+          "id": "U_SAM",
+          "name": "sam",
+          "profile": {
+            "email": "sam@acme.com",
+            "real_name": "Sam Okafor"
+          },
+          "real_name": "Sam Okafor"
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/0010-get-api-users.info-user-u-lee.json
+++ b/connector/slacksource/testdata/workspace/0010-get-api-users.info-user-u-lee.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/users.info?user=U_LEE"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "ok": true,
+        "user": {
+          "id": "U_LEE",
+          "name": "lee",
+          "profile": {
+            "email": "lee@acme.com",
+            "real_name": "Lee Berger"
+          },
+          "real_name": "Lee Berger"
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/0011-get-api-conversations.history-channel-c-safety-inclusive-true-limit-200-oldest-0.json
+++ b/connector/slacksource/testdata/workspace/0011-get-api-conversations.history-channel-c-safety-inclusive-true-limit-200-oldest-0.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://slack.com/api/conversations.history?channel=C_SAFETY\u0026inclusive=true\u0026limit=200\u0026oldest=0"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "has_more": false,
+        "messages": [
+          {
+            "text": "guard\nThe guard on the press is being replaced on Friday morning.",
+            "ts": "1780000008.000000",
+            "type": "message",
+            "user": "U_MEI"
+          }
+        ],
+        "ok": true,
+        "response_metadata": {
+          "next_cursor": ""
+        }
+      }
+    }
+  }
+}

--- a/connector/slacksource/testdata/workspace/README.md
+++ b/connector/slacksource/testdata/workspace/README.md
@@ -1,0 +1,43 @@
+# A recorded Slack workspace
+
+These files are one crawl of a small Slack workspace, written down so the tests
+next to them can exercise the whole adapter without an account, a token or a
+network.
+Each file is one request and the answer it got, numbered in the order the crawl
+made them.
+
+The workspace has three channels.
+`general` holds one message, `line-two` holds a thread with two replies on it
+and a join notice we refuse to index, and `safety` is private with two members.
+Between them they cover the listing, the paging, the thread assembly, the name
+lookups and the membership read.
+
+## Refreshing them
+
+    go test ./connector/slacksource/ -run TestRecordTheFixtures -update
+
+That runs the crawl again against the fake workspace in `fake_test.go` and
+rewrites every numbered file here.
+It does not touch this README.
+
+Two things are taken out before the files are written: the address the fake was
+listening on, which is replaced with Slack's, and the response headers that say
+how long the body was and what time it was.
+All three change on every run and none of them is matched against, so leaving
+them in would turn every refresh into a diff on all eleven files.
+
+The repeated requests are dropped as well.
+A crawl asks what the channels are three times, once for the sync, once for the
+sweep and once for a fetch, and three copies of the same answer is three files
+to review and no more coverage.
+
+## What is not in here
+
+No credentials.
+The token is sent as a bearer header and the header is redacted before anything
+is written, and there is a test that reads these files back and fails if
+anything shaped like a Slack token is in them.
+
+Nothing real either.
+The people, the channels and the messages are made up, and the workspace they
+came from is the fake in `fake_test.go` rather than anybody's Slack.

--- a/connector/slacksource/tiers.go
+++ b/connector/slacksource/tiers.go
@@ -1,0 +1,124 @@
+package slacksource
+
+import (
+	"net/http"
+	"path"
+
+	"github.com/tamnd/genba/connector/limit"
+)
+
+// Slack publishes a rate limit per method rather than per token, and sorts the
+// methods into tiers. The numbers below are the documented sustained rates in
+// requests per minute, and they differ by a factor of a hundred across the
+// methods one crawl uses.
+//
+// One bucket for all of them has to be set to the slowest tier or it is set too
+// fast for it, and neither is acceptable: the first spends a crawl's whole
+// budget waiting to list users, and the second is refused. So each tier gets a
+// bucket, and a request is routed to one by the method it names.
+const (
+	tier1 = 1.0 / 60
+	tier2 = 20.0 / 60
+	tier3 = 50.0 / 60
+	tier4 = 100.0 / 60
+)
+
+// method is the last path segment of a Slack API URL, which is the method name.
+func method(u string) string { return path.Base(u) }
+
+// tierOf says which bucket a method draws from. An unknown method is treated as
+// the slowest useful tier rather than the fastest, because being wrong in that
+// direction costs time and being wrong in the other costs a refusal.
+func tierOf(m string) float64 {
+	switch m {
+	case "conversations.history", "conversations.replies", "conversations.info":
+		return tier3
+	case "users.info", "users.list":
+		return tier4
+	case "conversations.list", "conversations.members":
+		return tier2
+	default:
+		return tier2
+	}
+}
+
+// tiers routes each request to the limiter for the tier its method is in.
+//
+// It is a round tripper rather than four clients because the alternative is
+// making every call site pick a client, and a call site that picks the wrong one
+// is a bug that only shows up as throttling on somebody else's workspace.
+type tiers struct {
+	token string
+	byURL map[float64]http.RoundTripper
+}
+
+var _ http.RoundTripper = (*tiers)(nil)
+
+// tiered builds a client whose requests are rate limited per Slack tier and
+// authenticated with the token.
+//
+// The limits given are scaled: the rate is treated as a multiplier on each
+// tier's published rate, so a caller who has been asked to halve their traffic
+// says so once. A zero rate leaves the published rates alone.
+func tiered(token string, l limit.Limits) *http.Client {
+	scale := l.Rate
+	if scale <= 0 {
+		scale = 1
+	}
+	t := &tiers{token: token, byURL: make(map[float64]http.RoundTripper, 4)}
+	for _, rate := range []float64{tier1, tier2, tier3, tier4} {
+		per := l
+		per.Rate = rate * scale
+		if per.Burst == 0 {
+			// A page of a listing followed immediately by the threads on it is
+			// a burst, and a limiter with no burst would space them out for no
+			// reason. Slack's own guidance is that a short burst is fine and a
+			// sustained one is not.
+			per.Burst = 5
+		}
+		t.byURL[rate] = limit.NewTransport(per)
+	}
+	return &http.Client{Transport: t}
+}
+
+func (t *tiers) RoundTrip(req *http.Request) (*http.Response, error) {
+	// The token goes on here rather than at the call sites so that there is one
+	// place it can be forgotten, and it is a bearer header rather than a form
+	// field because a form field ends up in a recording.
+	if req.Header.Get("Authorization") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	return t.byURL[tierOf(method(req.URL.Path))].RoundTrip(req)
+}
+
+// stats reports what every tier has spent, which is what an operator watches
+// when a workspace starts taking longer than it did yesterday.
+func (t *tiers) stats() limit.TransportStats {
+	var out limit.TransportStats
+	for _, rt := range t.byURL {
+		tr, ok := rt.(*limit.Transport)
+		if !ok {
+			continue
+		}
+		s := tr.Stats()
+		out.Requests += s.Requests
+		out.Retries += s.Retries
+		out.Trips += s.Trips
+		out.Open = out.Open || s.Open
+		out.Limiter.Waits += s.Limiter.Waits
+		out.Limiter.Waited += s.Limiter.Waited
+		out.Limiter.Pauses += s.Limiter.Pauses
+	}
+	return out
+}
+
+// Stats reports what this workspace has cost in requests, retries and waiting.
+// A client the caller supplied has no limiter in it and reports nothing.
+func (s *Service) Stats() limit.TransportStats {
+	t, ok := s.http.Transport.(*tiers)
+	if !ok {
+		return limit.TransportStats{}
+	}
+	return t.stats()
+}

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -464,6 +464,33 @@ src, err := threadsource.New(svc, "chat", threadsource.WithMaxBody(64<<10))
 `WithSkipped` is told about a conversation the source could not index, which so far means one that arrived with no id.
 An index quietly missing what nobody could read looks exactly like an index that is complete, and the difference only shows up when somebody cannot find a thread they remember.
 
+### Slack, and what a product does not tell you
+
+`connector/slacksource` is the first adapter on that interface, and what is interesting about it is not the four methods.
+It is everything Slack declines to report, because each of those gaps turns into a decision that has to be made somewhere.
+
+Slack has no "what changed since" endpoint.
+History is ordered by when a message was posted, and a reply to a thread moves nothing in the listing except that thread's `latest_reply`, so a thread posted last month and answered this morning is still in last month's position.
+So a sync reads history back to the older of the cursor and a reply window, and judges each thread on its newest message.
+A week is the default window and it is the whole of the tradeoff: a reply to a thread older than that is not something the sync can see, the version in the listing moves anyway because it is derived from the newest message in the thread, and the sweep is what repairs it.
+That is worse than a change feed and it is better than pretending, which would be reading all of history on every sync or claiming a reply is a new document.
+
+Slack does not report that somebody was removed from a private channel.
+A channel's `updated` field moves when it is renamed, archived or converted, and stays exactly where it was when a member is taken out, which is the one case that matters because it is a revocation.
+So membership is reapplied on a schedule as well, once a day by default, and the schedule is quantised to the interval rather than measured from the last sync so that two servers reading the same workspace an hour apart agree about whether the rule moved.
+That bounds how long a removed member keeps seeing a private channel's threads, and it costs one write per thread in the private channels once a day rather than a read of any of them.
+A channel this token cannot read at all is quarantined and reported through `WithSkipped`, and it is deliberately left off the schedule: reapplying a rule means listing the channel, this token cannot list it, and there is nothing in the index from it to reapply anything to.
+
+Slack publishes a rate limit per method rather than per token, and the published rates across the methods one crawl uses differ by a factor of a hundred.
+One bucket for all of them is either set to the slowest tier, in which case the crawl spends its budget waiting to look up display names, or set too fast for the slowest, in which case it is refused.
+So each tier gets a bucket and a request is routed to one by the method it names, all four wrapping `connector/limit` so the retries, the backoff and the circuit breaker are the ones every other connector uses.
+Every call is a GET rather than a POST for the same reason: a request carrying a body cannot be replayed by a transport that has already handed the body away, so a POST is never retried, and being throttled is not an unusual event on this API but the normal way Slack asks a crawler to slow down.
+
+The rest is about what is not a document.
+Direct messages and group messages are not asked for rather than asked for and filtered, because a filter is a thing that can be got wrong once and then be wrong for ever.
+Joins, leaves, topic changes and pinned messages are not documents either, since indexing "somebody has joined the channel" is how a search for a person's name returns four hundred results they never wrote.
+Display names are looked up once per person per crawl and cached, and a lookup that fails still produces an author with the identity filled in and the name missing, because failing a whole channel over a display name is the wrong trade.
+
 ### The conformance suite is the definition
 
 `connector/connectortest` is what a connector has to pass, and it rather than the interface is the definition of one.
@@ -546,3 +573,10 @@ A recording is committed, and a token committed once is a token leaked permanent
 
 A request nothing was recorded for is an error naming what was asked and what the recording holds, rather than an empty response the connector fails to parse fifty lines away from the cause.
 `Unused` reports the other direction, the recorded requests nothing asked for, which is how a fixture set left behind by a connector that stopped calling an endpoint gets noticed instead of being read as a description of what the connector does.
+
+`connector/slacksource/testdata/workspace` is what one looks like in practice, and it is worth reading before writing the next one.
+It is eleven files, refreshed with `go test ./connector/slacksource/ -run TestRecordTheFixtures -update`, and the recording and the fake sit side by side rather than one replacing the other.
+The fake is where behaviour is written, because it can be told to throttle, to refuse a channel or to lose a message between two syncs, and none of that is a thing a recording can be asked to do.
+The recording is where the wire format is pinned, and it is the test that would go red the day Slack renamed a field.
+Two of its rules are worth copying: the repeated requests are dropped, since a crawl asks what the channels are once for the sync, once for the sweep and once for a fetch and three copies of the same answer is three files to review and no more coverage, and everything that differs per run is taken out, which means the address the fake was listening on and the headers saying how long the body was and what time it is.
+Leaving those in makes every refresh a diff on every file with the real change somewhere inside it.


### PR DESCRIPTION
The first product adapter on `connector/threadsource`.
Most of what is interesting about it is not the four methods it answers, it is everything Slack declines to report, because each of those gaps turns into a decision that has to be made somewhere.

## No change feed

Slack has no endpoint for what changed since a time.
History is ordered by when a message was posted, and a reply to a thread moves nothing in the listing except that thread's `latest_reply`, so a thread posted last month and answered this morning is still sitting in last month's position.

So a sync reads history back to the older of the cursor and a reply window, and judges each thread on its newest message.
A week is the default window and it is the whole of the tradeoff.
A reply to a thread older than that is not something the sync can see, the version in the listing moves anyway because it is derived from the newest message in the thread, and the sweep is what repairs it.
That is worse than a change feed and it is better than pretending, which would mean either reading all of history on every sync or claiming a reply is a new document.

## No revocation feed

Slack does not report that somebody was removed from a private channel.
A channel's `updated` field moves when it is renamed, archived or converted, and stays exactly where it was when a member is taken out, which is the one case that matters because it is a revocation.

So membership is reapplied on a schedule as well, once a day by default.
The schedule is quantised to the interval rather than measured from the last sync, so two servers reading the same workspace an hour apart agree about whether the rule moved, and a sync every five minutes still only reapplies it once.
That bounds how long a removed member keeps seeing a private channel's threads and it costs one write per thread in the private channels once a day rather than a read of any of them.

A channel this token cannot read at all is quarantined and reported through `WithSkipped`, and it is deliberately left off the schedule.
Reapplying a rule means listing the channel, this token cannot list it, and there is nothing in the index from it to reapply anything to.

## Rate limits per method, not per token

Slack publishes a rate limit per method, and the published rates across the methods one crawl uses differ by a factor of a hundred.
One bucket for all of them is either set to the slowest tier, in which case the crawl spends its budget waiting to look up display names, or set too fast for the slowest, in which case it is refused.
So each tier gets a bucket and a request is routed to one by the method it names, all four wrapping `connector/limit` so the retries, the backoff and the circuit breaker are the ones every other connector uses.

Every call is a GET rather than a POST for the same reason.
A request carrying a body cannot be replayed by a transport that has already handed the body away, so a POST is never retried, and being throttled is not an unusual event on this API but the normal way Slack asks a crawler to slow down.

## What is not a document

Direct messages and group messages are not asked for rather than asked for and filtered, because a filter is a thing that can be got wrong once and then be wrong for ever.
Joins, leaves, topic changes and pinned messages are not documents either, since indexing "somebody has joined the channel" is how a search for a person's name returns four hundred results they never wrote.
Display names are looked up once per person per crawl and cached, and a lookup that fails still produces an author with the identity filled in and the name missing, because failing a whole channel over a display name is the wrong trade.

## Tested twice over

A fake workspace in `fake_test.go` for behaviour, since it can be told to throttle, to refuse a channel or to lose a message between two syncs, and none of that is a thing a recording can be asked to do.
A committed recording under `testdata/workspace` for the wire format, which is the test that would go red the day Slack renamed a field.
Neither replaces the other, and the tests need no account, no token and no network.

The recording is eleven files, refreshed with `go test ./connector/slacksource/ -run TestRecordTheFixtures -update`.
The repeated requests are dropped, because a crawl asks what the channels are once for the sync, once for the sweep and once for a fetch, and three copies of the same answer is three files to review and no more coverage.
Everything that differs per run is taken out as well, which means the address the fake was listening on and the headers saying how long the body was and what time it is, since leaving those in makes every refresh a diff on every file with the real change somewhere inside it.
There is a test that reads the files back and fails if anything shaped like a Slack token is in them.

## One thing worth writing down

The paging helper had a bug that only showed up once there was a real API behind it.
Decoding JSON into a slice that already has elements in it reuses those elements and only overwrites the fields the new document mentions, so a second page decoded into the first page's slice inherits every field the second page left out.
A message with no subtype landing where a `channel_join` used to be becomes a `channel_join`, and the thread it starts silently stops being indexed.
Each page now decodes into a fresh value, and the reason is written down next to it so nobody puts the reuse back for the allocation.

`go build`, `go vet`, `golangci-lint run` and `go test -race ./...` are clean.

Part of #15.
