### PR TITLE
Add the Jira connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ func main() {
 | `connector/thread` | a conversation and its replies assembled into one document |
 | `connector/threadsource` | the crawl, cursor and permission refresh chat, ticket trackers and wikis share, [docs/ingestion.md](docs/ingestion.md) |
 | `connector/slacksource` | Slack, a thread at a time, with per method rate limits and a recorded workspace to test against |
+| `connector/jirasource` | Jira, an issue and its comments as one document, with security levels and a recorded site to test against |
 | `connector/limit` | the rate limit, backoff and circuit breaker every connector shares, as a round tripper |
 | `connector/recorded` | HTTP exchanges captured from a real service and replayed from a directory, so tests need no account |
 | `extract` | text and structure out of PDF, Word, PowerPoint, Excel, HTML and Markdown, [docs/extraction.md](docs/extraction.md) |
@@ -451,6 +452,13 @@ A reply older than the window is missed on purpose, and the version in the listi
 Nothing reports that somebody was removed from a private channel either, so membership is reapplied on a schedule as well as when Slack says the channel changed, because a revocation that lands whenever somebody next posts is not a revocation.
 Slack publishes a rate limit per method rather than per token and the published rates differ by a hundred times across the methods one crawl uses, so each tier gets its own bucket and a request is routed by the method it names.
 Direct messages are never asked for rather than asked for and filtered, joins and leaves and topic changes are not documents, and the whole thing is tested twice over: against a fake workspace for behaviour, and against a committed recording of a crawl for the wire format, so nobody needs an account to run the tests.
+
+`connector/jirasource` is the second product on the same interface, and it is interesting for the opposite reason.
+Jira has a real change feed, because an issue's `updated` field moves when anything about it moves and JQL will filter and order by it, so a sync is one query per project with no window to widen and nothing to guess at, and a ticket moved from one column to another with nobody writing a word is found the same way a comment is.
+The sweep is still there and it is only for deletion, because nothing in JQL reports an issue that was deleted or moved somewhere this token cannot follow.
+Permissions are the hard half instead: browse comes from the project's permission scheme, which grants it to some mixture of groups, named accounts and project roles, and a role is resolved to the people in it rather than left as the name of a thing.
+An issue security level replaces the project's answer rather than adding to it, which is the concrete case a conversation is allowed to override its container for, and a level this token cannot resolve quarantines the ticket instead of falling back to the project, because a security level is the one thing somebody set on purpose to keep other people out.
+A description is not text but a document tree, so it is rendered as Markdown rather than flattened, which keeps the stack trace in a code block and the table of readings a table, since a search result that shows somebody a flattened version of the thing they were looking for has answered the query and failed the person.
 
 What a connector is gets decided by `connector/connectortest` rather than by the interface.
 The interface says what compiles, and the suite says what works: that a full sync finds everything, that resuming from a cursor loses nothing that came after it, that a second sync of a source nothing changed in reads nothing, that a deleted document stops being part of the source one way or the other, and that every document says who may read it.

--- a/arch_test.go
+++ b/arch_test.go
@@ -164,6 +164,11 @@ var allowed = map[string][]string{
 	// an adapter that knew where its documents were going would be a second
 	// place the pipeline is described.
 	"connector/slacksource": {"acl", "connector", "connector/limit", "connector/thread", "connector/threadsource", "doc"},
+	// jirasource is the same shape for tickets, and the list is the same list.
+	// The one thing it has that the chat adapter does not is a rule on a single
+	// document rather than on the container, which is what an issue security
+	// level is, and that is still acl and threadsource rather than anything new.
+	"connector/jirasource": {"acl", "connector", "connector/limit", "connector/thread", "connector/threadsource", "doc"},
 	// recorded imports nothing of ours either. It is a round tripper over a
 	// directory of files, it deals in requests and responses, and it has never
 	// heard of a document or a connector. Keeping it that way is what lets it be

--- a/connector/jirasource/adf.go
+++ b/connector/jirasource/adf.go
@@ -1,0 +1,408 @@
+package jirasource
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// A Jira description is not text. It is a document tree, and turning it back
+// into something a person and an index can both read is most of what this file
+// does.
+//
+// Two ways of getting it wrong are worth naming, because both are common.
+//
+// Concatenating every text node is the first. It produces a wall with the
+// heading run into the paragraph and the three bullet points run into each
+// other, and an index built on it cannot tell a phrase somebody wrote from a
+// phrase made by two unrelated lines meeting. Structure is not decoration.
+//
+// Throwing the structure away is the second, and it is worse. A ticket's
+// description is very often a stack trace, a snippet of configuration or a
+// table of what was tried, and a search result that shows the reader a
+// flattened version of the thing they were looking for has answered the query
+// and failed the person. So this renders Markdown: headings stay headings,
+// code blocks keep their fences and their language, lists stay lists and tables
+// stay tables. The index reads it as text and the interface renders it as what
+// it is.
+
+// node is one element of an Atlassian document.
+type node struct {
+	Type    string          `json:"type"`
+	Text    string          `json:"text"`
+	Attrs   map[string]any  `json:"attrs"`
+	Marks   []mark          `json:"marks"`
+	Content json.RawMessage `json:"content"`
+}
+
+// mark is the formatting on a text node, which arrives beside the text rather
+// than around it.
+type mark struct {
+	Type  string         `json:"type"`
+	Attrs map[string]any `json:"attrs"`
+}
+
+// maxDepth is how far into a document this will walk.
+//
+// A description is nested a handful of levels deep and nothing legitimate is
+// near this. It is here because the input is somebody else's JSON and the walk
+// is recursive, and a document that nests itself a hundred thousand deep should
+// be a truncated description rather than a crashed indexer.
+const maxDepth = 32
+
+// text renders an Atlassian document as Markdown.
+//
+// Anything that will not parse comes back empty rather than as an error. A
+// description this adapter cannot read is a ticket with a summary, a reporter,
+// a status and a comment thread, all of which are worth indexing, and refusing
+// the whole issue over the shape of one field would be losing more than it
+// saves.
+func text(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	// A site on the older API, or a field somebody set through a script, holds
+	// a plain string here rather than a tree.
+	var plain string
+	if json.Unmarshal(raw, &plain) == nil {
+		return strings.TrimSpace(plain)
+	}
+
+	var doc node
+	if json.Unmarshal(raw, &doc) != nil {
+		return ""
+	}
+
+	var b strings.Builder
+	block(&b, doc, 0, "")
+	return strings.TrimSpace(collapse(b.String()))
+}
+
+// children decodes the content of a node, which is held raw so that a document
+// is only walked as deep as it is read.
+func children(n node) []node {
+	if len(n.Content) == 0 {
+		return nil
+	}
+	var out []node
+	if json.Unmarshal(n.Content, &out) != nil {
+		return nil
+	}
+	return out
+}
+
+// block renders a node that stands on its own, at the given nesting depth and
+// with prefix in front of every line it produces.
+//
+// The prefix is what makes a list inside a quote inside a list come out right:
+// each level adds to it rather than tracking where it is.
+func block(b *strings.Builder, n node, depth int, prefix string) {
+	if depth > maxDepth {
+		return
+	}
+
+	switch n.Type {
+	case "doc":
+		blocks(b, children(n), depth+1, prefix)
+
+	case "paragraph":
+		line(b, prefix, inline(children(n), depth+1))
+
+	case "heading":
+		level := 1
+		if got, ok := number(n.Attrs, "level"); ok && got >= 1 && got <= 6 {
+			level = got
+		}
+		line(b, prefix, strings.Repeat("#", level)+" "+inline(children(n), depth+1))
+
+	case "blockquote":
+		blocks(b, children(n), depth+1, prefix+"> ")
+
+	case "bulletList", "orderedList":
+		list(b, n, depth+1, prefix)
+
+	case "codeBlock":
+		lang, _ := str(n.Attrs, "language")
+		line(b, prefix, "```"+lang)
+		for _, l := range strings.Split(inline(children(n), depth+1), "\n") {
+			line(b, prefix, l)
+		}
+		line(b, prefix, "```")
+
+	case "rule":
+		line(b, prefix, "---")
+
+	case "panel":
+		// A panel is a coloured box with a note in it. The colour is the whole
+		// of what it adds and a quote is the closest thing Markdown has.
+		blocks(b, children(n), depth+1, prefix+"> ")
+
+	case "table":
+		table(b, n, depth+1, prefix)
+
+	case "taskList":
+		for _, item := range children(n) {
+			state, _ := str(item.Attrs, "state")
+			box := "[ ] "
+			if strings.EqualFold(state, "DONE") {
+				box = "[x] "
+			}
+			line(b, prefix, "- "+box+inline(children(item), depth+2))
+		}
+
+	case "mediaGroup", "mediaSingle":
+		for _, m := range children(n) {
+			block(b, m, depth+1, prefix)
+		}
+
+	case "media":
+		// An attachment is a file the index does not hold, and what is worth
+		// saying about it is that it is there and what it is called. A link to
+		// it would be a link that stops working the day the token does.
+		name, _ := str(n.Attrs, "alt")
+		if name == "" {
+			name, _ = str(n.Attrs, "id")
+		}
+		if name != "" {
+			line(b, prefix, "(attachment: "+name+")")
+		}
+
+	case "expand", "nestedExpand":
+		if title, ok := str(n.Attrs, "title"); ok && title != "" {
+			line(b, prefix, "**"+title+"**")
+		}
+		blocks(b, children(n), depth+1, prefix)
+
+	default:
+		// An unknown block is still rendered rather than dropped. The format
+		// gains node types and a description written with next year's editor
+		// should be a ticket with its text in the index rather than a ticket
+		// that mysteriously has none.
+		kids := children(n)
+		if len(kids) == 0 {
+			line(b, prefix, inlineOne(n, depth+1))
+			return
+		}
+		blocks(b, kids, depth+1, prefix)
+	}
+}
+
+// blocks renders a run of nodes with a blank line between them.
+func blocks(b *strings.Builder, nodes []node, depth int, prefix string) {
+	for i, n := range nodes {
+		if i > 0 {
+			line(b, strings.TrimRight(prefix, " "), "")
+		}
+		block(b, n, depth, prefix)
+	}
+}
+
+// list renders a bulleted or numbered list, including the lists inside it.
+func list(b *strings.Builder, n node, depth int, prefix string) {
+	ordered := n.Type == "orderedList"
+	start := 1
+	if got, ok := number(n.Attrs, "order"); ok && got > 0 {
+		start = got
+	}
+
+	for i, item := range children(n) {
+		bullet := "- "
+		if ordered {
+			bullet = strconv.Itoa(start+i) + ". "
+		}
+		// Everything under the first line of an item is indented to sit under
+		// it, which is what keeps a paragraph belonging to its bullet instead
+		// of ending the list.
+		inner := prefix + strings.Repeat(" ", len(bullet))
+		var body strings.Builder
+		blocks(&body, children(item), depth+1, "")
+
+		lines := strings.Split(strings.TrimRight(body.String(), "\n"), "\n")
+		for j, l := range lines {
+			switch {
+			case j == 0:
+				line(b, prefix, bullet+l)
+			case strings.TrimSpace(l) == "":
+				line(b, "", "")
+			default:
+				line(b, inner, l)
+			}
+		}
+	}
+}
+
+// table renders a table as a Markdown one.
+//
+// The first row is treated as the header whether or not its cells say they are,
+// because Markdown has no way to write a table without one and a table whose
+// first row is data reads better as a header than as nothing.
+func table(b *strings.Builder, n node, depth int, prefix string) {
+	rows := children(n)
+	if len(rows) == 0 {
+		return
+	}
+	for i, row := range rows {
+		cells := children(row)
+		out := make([]string, 0, len(cells))
+		for _, c := range cells {
+			var cell strings.Builder
+			blocks(&cell, children(c), depth+1, "")
+			// A newline inside a cell would end the table, so what was several
+			// paragraphs becomes one line.
+			out = append(out, strings.Join(strings.Fields(cell.String()), " "))
+		}
+		line(b, prefix, "| "+strings.Join(out, " | ")+" |")
+		if i == 0 {
+			line(b, prefix, "|"+strings.Repeat(" --- |", len(out)))
+		}
+	}
+}
+
+// inline renders a run of nodes that sit inside a line.
+func inline(nodes []node, depth int) string {
+	if depth > maxDepth {
+		return ""
+	}
+	var b strings.Builder
+	for _, n := range nodes {
+		b.WriteString(inlineOne(n, depth))
+	}
+	return b.String()
+}
+
+// inlineOne renders one node that sits inside a line.
+func inlineOne(n node, depth int) string {
+	switch n.Type {
+	case "text":
+		return marked(n)
+
+	case "hardBreak":
+		return "\n"
+
+	case "mention":
+		// The text a mention carries already has the at sign on it. Where it
+		// does not, the id is better than nothing, because a ticket that says
+		// "assigning this to" and then stops is a ticket that lost its point.
+		if t, ok := str(n.Attrs, "text"); ok && t != "" {
+			return t
+		}
+		if id, ok := str(n.Attrs, "id"); ok {
+			return "@" + id
+		}
+		return ""
+
+	case "emoji":
+		if t, ok := str(n.Attrs, "text"); ok && t != "" {
+			return t
+		}
+		s, _ := str(n.Attrs, "shortName")
+		return s
+
+	case "date":
+		// A date node holds milliseconds since the epoch, which is not
+		// something to show anybody, and there is nothing else in the node.
+		if ts, ok := str(n.Attrs, "timestamp"); ok {
+			if ms, err := strconv.ParseInt(ts, 10, 64); err == nil {
+				return stampMillis(ms)
+			}
+		}
+		return ""
+
+	case "status":
+		if t, ok := str(n.Attrs, "text"); ok {
+			return t
+		}
+		return ""
+
+	case "inlineCard", "blockCard", "embedCard":
+		u, _ := str(n.Attrs, "url")
+		return u
+
+	default:
+		return inline(children(n), depth+1)
+	}
+}
+
+// marked applies a text node's formatting.
+//
+// A link is the one that earns its place. The text of a link and where it goes
+// are different things and both are worth having: somebody searching for a
+// runbook by name should find the ticket that linked to it, and somebody
+// reading the ticket should be able to follow it.
+func marked(n node) string {
+	out := n.Text
+	if out == "" {
+		return ""
+	}
+
+	var href string
+	for _, m := range n.Marks {
+		switch m.Type {
+		case "code":
+			out = "`" + out + "`"
+		case "strong":
+			out = "**" + out + "**"
+		case "em":
+			out = "*" + out + "*"
+		case "strike":
+			out = "~~" + out + "~~"
+		case "link":
+			href, _ = str(m.Attrs, "href")
+		}
+	}
+	if href != "" && href != out {
+		out = "[" + out + "](" + href + ")"
+	}
+	return out
+}
+
+// line writes one line with its prefix, leaving no trailing space on a line
+// that has nothing else on it.
+func line(b *strings.Builder, prefix, s string) {
+	b.WriteString(strings.TrimRight(prefix+s, " "))
+	b.WriteByte('\n')
+}
+
+// collapse turns any run of blank lines into one.
+//
+// A document that nests quotes inside lists inside panels produces a blank line
+// per level on the way out, and six of them in a row is not a paragraph break,
+// it is the renderer showing through.
+func collapse(s string) string {
+	var (
+		b     strings.Builder
+		blank bool
+	)
+	for _, l := range strings.Split(s, "\n") {
+		empty := strings.TrimSpace(strings.TrimLeft(l, ">| ")) == ""
+		if empty && blank {
+			continue
+		}
+		blank = empty
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// str reads a string attribute, which arrives as any because the attribute set
+// of a node is not a fixed shape.
+func str(attrs map[string]any, name string) (string, bool) {
+	v, ok := attrs[name].(string)
+	return v, ok
+}
+
+// number reads a numeric attribute. JSON numbers decode as float64, and a
+// heading level that arrived as 2.0 is a heading level of two.
+func number(attrs map[string]any, name string) (int, bool) {
+	switch v := attrs[name].(type) {
+	case float64:
+		return int(v), true
+	case string:
+		n, err := strconv.Atoi(v)
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}

--- a/connector/jirasource/api.go
+++ b/connector/jirasource/api.go
@@ -1,0 +1,318 @@
+package jirasource
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/tamnd/genba/connector/limit"
+)
+
+// limited builds the client every request goes out on.
+//
+// One bucket rather than the per method tiers a source with published rates
+// gets, because Jira publishes none: it bills by the cost of what was asked
+// for, and the way a client is told it has spent too much is a 429 with a
+// Retry-After on it. Obeying that header is [limit]'s job and it is the same
+// code every other connector here uses.
+func limited(email, token string, l limit.Limits) *http.Client {
+	if l.Burst == 0 {
+		// A page of a search followed immediately by the comments on what was on
+		// it is a burst, and spacing those out would be slower for no benefit to
+		// anybody. A sustained burst is what a rate limit is for and that is
+		// still limited.
+		l.Burst = 10
+	}
+	return &http.Client{Transport: &basic{
+		auth: "Basic " + base64.StdEncoding.EncodeToString([]byte(email+":"+token)),
+		base: limit.NewTransport(l),
+	}}
+}
+
+// basic puts the credentials on every request.
+//
+// Jira Cloud authenticates an API token with basic authentication over the
+// account's email address, which is a header rather than a query parameter, and
+// that is the half of it worth being deliberate about: a token in a query
+// string ends up in a server log, in a recording and in a bug report.
+type basic struct {
+	auth string
+	base http.RoundTripper
+}
+
+var _ http.RoundTripper = (*basic)(nil)
+
+func (b *basic) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("Authorization") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", b.auth)
+	}
+	return b.base.RoundTrip(req)
+}
+
+// Stats reports what this site has cost in requests, retries and waiting. A
+// client the caller supplied has no limiter in it and reports nothing.
+func (s *Service) Stats() limit.TransportStats {
+	b, ok := s.http.Transport.(*basic)
+	if !ok {
+		return limit.TransportStats{}
+	}
+	t, ok := b.base.(*limit.Transport)
+	if !ok {
+		return limit.TransportStats{}
+	}
+	return t.Stats()
+}
+
+// failure is the shape Jira refuses in.
+type failure struct {
+	Messages []string          `json:"errorMessages"`
+	Errors   map[string]string `json:"errors"`
+}
+
+// call asks the site one question and decodes the answer into out.
+//
+// Every call is a GET. Two of the endpoints used here have a POST form that
+// takes a larger request, and neither is worth it: a request carrying a body
+// cannot be replayed by a transport that has already handed the body away, so
+// [limit] will not retry one, and a 429 is the normal way this API asks a
+// crawler to slow down rather than an unusual event.
+func (s *Service) call(ctx context.Context, path string, form url.Values, out any) error {
+	u := s.base + path
+	if len(form) > 0 {
+		u += "?" + form.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("jirasource: building the %s request: %w", path, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("jirasource: %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Four megabytes is far more than any of these endpoints returns at the page
+	// sizes this adapter asks for, and a bound is what keeps a site that has
+	// started answering with something else from being a memory problem. It is
+	// larger than the one the chat adapter uses because a page of issues carries
+	// a hundred descriptions and a chat page carries two hundred sentences.
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return fmt.Errorf("jirasource: reading the %s response: %w", path, err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		e := &Error{Path: path, Status: resp.StatusCode}
+		var f failure
+		if json.Unmarshal(raw, &f) == nil {
+			e.Messages = append(e.Messages, f.Messages...)
+			for field, why := range f.Errors {
+				e.Messages = append(e.Messages, field+": "+why)
+			}
+		}
+		return e
+	}
+
+	if out != nil {
+		if err := json.Unmarshal(raw, out); err != nil {
+			return fmt.Errorf("jirasource: decoding the %s response: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// window is what every offset paged Jira listing carries alongside its items.
+//
+// Three endpoints report the end of a listing three different ways: a total to
+// compare against, an isLast flag, or nothing at all. All three are handled
+// rather than one of them, because a crawl that guessed wrong either stops
+// early and quietly indexes half a project or loops for ever.
+type window struct {
+	StartAt    int  `json:"startAt"`
+	MaxResults int  `json:"maxResults"`
+	Total      int  `json:"total"`
+	IsLast     bool `json:"isLast"`
+}
+
+func (w window) page() window { return w }
+
+// windowed is anything with a [window] embedded in it, which is every listing
+// this adapter reads.
+type windowed interface{ page() window }
+
+// pages walks an offset paged endpoint, decoding each page and handing it to
+// fn, which reports how many items were on it and whether to carry on.
+//
+// The page is a fresh value on every turn of the loop, and that is not
+// tidiness. Decoding JSON into a slice that already has elements in it reuses
+// those elements and only overwrites the fields the new document mentions, so a
+// second page decoded into the first page's slice inherits every field the
+// second page left out.
+func pages[T windowed](ctx context.Context, s *Service, path string, form url.Values, fn func(T) (count int, more bool)) error {
+	at := 0
+	for {
+		q := url.Values{}
+		for k, v := range form {
+			q[k] = append([]string(nil), v...)
+		}
+		q.Set("startAt", strconv.Itoa(at))
+		q.Set("maxResults", strconv.Itoa(s.page))
+
+		var page T
+		if err := s.call(ctx, path, q, &page); err != nil {
+			return err
+		}
+
+		got, more := fn(page)
+		w := page.page()
+
+		// What was asked for is not what was granted. Every one of these
+		// endpoints caps the page size at whatever the site is configured to
+		// allow and says so in maxResults, and a crawl that compared a fifty
+		// item page against the hundred it asked for would decide the listing
+		// had ended and index half a project.
+		size := s.page
+		if w.MaxResults > 0 && w.MaxResults < size {
+			size = w.MaxResults
+		}
+
+		switch {
+		case !more, got == 0, w.IsLast:
+			return nil
+		case w.Total > 0 && at+got >= w.Total:
+			return nil
+		case got < size:
+			// A short page is the end of the listing on the endpoints that
+			// report neither a total nor a flag, and it is the end on the others
+			// too. Asking again would be a request for nothing.
+			return nil
+		}
+		at += got
+	}
+}
+
+// project is one entry of the project listing.
+type project struct {
+	ID   string `json:"id"`
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+
+// account is a person, as Jira reports one.
+//
+// The account id is the identifier and the display name is a label. They are
+// not the same thing and the difference matters: a display name is chosen by
+// its owner, two people may have the same one, and a permission rule written
+// against one would be a permission rule anybody could grant themselves.
+type account struct {
+	AccountID   string `json:"accountId"`
+	DisplayName string `json:"displayName"`
+	Email       string `json:"emailAddress"`
+	Active      bool   `json:"active"`
+}
+
+// issue is one ticket, with the fields this adapter asks for.
+type issue struct {
+	ID     string `json:"id"`
+	Key    string `json:"key"`
+	Fields struct {
+		Summary     string          `json:"summary"`
+		Description json.RawMessage `json:"description"`
+		Created     string          `json:"created"`
+		Updated     string          `json:"updated"`
+		Reporter    *account        `json:"reporter"`
+		Creator     *account        `json:"creator"`
+		Assignee    *account        `json:"assignee"`
+		Status      *struct {
+			Name string `json:"name"`
+		} `json:"status"`
+		IssueType *struct {
+			Name string `json:"name"`
+		} `json:"issuetype"`
+		Priority *struct {
+			Name string `json:"name"`
+		} `json:"priority"`
+		Labels []string `json:"labels"`
+
+		// Security is the issue security level, and it is the field that makes
+		// this connector interesting. An issue that has one is readable by that
+		// level's members and by nobody else, whatever the project says.
+		Security *struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"security"`
+
+		Comment *comments `json:"comment"`
+	} `json:"fields"`
+}
+
+// comment is one entry in the argument underneath a ticket.
+type comment struct {
+	ID      string          `json:"id"`
+	Author  *account        `json:"author"`
+	Body    json.RawMessage `json:"body"`
+	Created string          `json:"created"`
+	Updated string          `json:"updated"`
+
+	// Visibility is the restriction a single comment can carry, which limits it
+	// to one role or group inside a project everybody else can read.
+	Visibility *struct {
+		Type  string `json:"type"`
+		Value string `json:"value"`
+	} `json:"visibility"`
+}
+
+// comments is the paged listing of them, which arrives both inline on an issue
+// and on its own endpoint.
+type comments struct {
+	window
+	Comments []comment `json:"comments"`
+}
+
+// stamp turns a Jira timestamp into a time.
+//
+// Jira writes them as ISO 8601 with milliseconds and a numeric zone and no
+// colon in it, which is not RFC 3339 and will not parse as one. Both layouts
+// are tried, because a site behind a proxy that rewrites them, or a future
+// version that fixes it, should not be a crawl that thinks every issue changed
+// at the zero time.
+func stamp(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999-0700",
+		time.RFC3339Nano,
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// stampMillis renders a date node's timestamp, which arrives as milliseconds
+// since the epoch and is a date rather than an instant.
+func stampMillis(ms int64) string {
+	return time.UnixMilli(ms).UTC().Format("2006-01-02")
+}
+
+// jqlTime is the format JQL wants a time in.
+//
+// It has no seconds. JQL compares to the minute and rejects anything finer, so
+// the time is rounded down rather than truncated to the minute and rounded up,
+// because the direction that costs a re-read of a few issues is the one that
+// does not lose them.
+func jqlTime(t time.Time) string {
+	return t.UTC().Truncate(time.Minute).Format("2006-01-02 15:04")
+}

--- a/connector/jirasource/fake_test.go
+++ b/connector/jirasource/fake_test.go
@@ -1,0 +1,801 @@
+package jirasource_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A Jira site with the parts that matter and none of the parts that do not. It
+// has projects with permission schemes and roles, issues with descriptions and
+// comments, issue security levels, offset paging, enough JQL to answer the two
+// queries this adapter asks, a clock that only moves when something happens to
+// it, and the ability to be told to refuse.
+//
+// It exists so that these tests do not need a site, and it is also what the
+// committed recording under testdata was made from. Everything asserted against
+// the recording is asserted against this first, so the two cannot drift without
+// a test going red.
+
+// start is when everything in these tests happens.
+//
+// JQL compares times to the minute, so the clock moves a minute at a time. A
+// fake that ticked by a second would make every test agree with every query for
+// the wrong reason.
+var start = time.Date(2026, 3, 2, 9, 0, 0, 0, time.UTC)
+
+type site struct {
+	mu       sync.Mutex
+	clock    time.Time
+	projects []*proj
+	issues   []*tick
+	levels   map[string]*level
+	calls    map[string]int
+	fields   map[string]string
+
+	// named is what a test called a ticket, which is not what Jira calls it.
+	// The suite writes a document called a.md and the site answers with LINE-1.
+	named map[string]string
+
+	// fail makes one path refuse with a status, and hidden makes a project's
+	// permission scheme refuse the way it does for an account that is not an
+	// administrator.
+	fail   map[string]int
+	hidden map[string]bool
+
+	// throttle is how many more times the next request is answered with 429
+	// before it is answered properly.
+	throttle int
+
+	// page is how many items go in one page, which is small on purpose so that
+	// the paging is exercised by an ordinary sync rather than by one test.
+	page int
+}
+
+type proj struct {
+	id, key, name string
+	grants        []grant
+	roles         map[string]*role
+	counter       int
+}
+
+type grant struct {
+	kind, param string
+}
+
+type role struct {
+	users  []string
+	groups []string
+}
+
+type level struct {
+	id, name string
+	users    []string
+	groups   []string
+	roles    []int
+}
+
+type tick struct {
+	key, project string
+	summary      string
+	description  any
+	reporter     string
+	assignee     string
+	created      time.Time
+	updated      time.Time
+	status       string
+	kind         string
+	priority     string
+	labels       []string
+	security     string
+	comments     []*note
+}
+
+type note struct {
+	id      string
+	author  string
+	body    any
+	created time.Time
+	updated time.Time
+}
+
+func newSite() *site {
+	s := &site{
+		clock:  start,
+		levels: make(map[string]*level),
+		calls:  make(map[string]int),
+		fields: make(map[string]string),
+		named:  make(map[string]string),
+		fail:   make(map[string]int),
+		hidden: make(map[string]bool),
+		page:   2,
+	}
+	p := s.addProject("LINE", "Line two")
+	p.grants = []grant{{"projectRole", "10002"}}
+	p.roles["10002"] = &role{users: []string{"acc-mei"}, groups: []string{"engineering"}}
+	return s
+}
+
+// now is the site's clock, which is what the permission refresh schedule is
+// measured against.
+func (s *site) now() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.clock
+}
+
+// tick moves the clock on a minute and returns where it got to.
+//
+// A minute rather than a second, because JQL compares times to the minute. A
+// fake whose events all happened in the same minute would agree with every
+// query for the wrong reason.
+func (s *site) tick() time.Time {
+	s.clock = s.clock.Add(time.Minute)
+	return s.clock
+}
+
+// advance moves the clock without anything happening, which is how a test gets
+// to the far side of a permission refresh interval without waiting for it.
+func (s *site) advance(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clock = s.clock.Add(d)
+}
+
+func (s *site) addProject(key, name string) *proj {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := &proj{
+		id:    strconv.Itoa(10000 + len(s.projects)),
+		key:   key,
+		name:  name,
+		roles: make(map[string]*role),
+	}
+	s.projects = append(s.projects, p)
+	return p
+}
+
+func (s *site) project(key string) *proj {
+	for _, p := range s.projects {
+		if p.key == key {
+			return p
+		}
+	}
+	return nil
+}
+
+// addLevel makes an issue security level readable by some people.
+func (s *site) addLevel(id, name string, users ...string) *level {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	l := &level{id: id, name: name, users: users}
+	s.levels[id] = l
+	return l
+}
+
+// file raises a ticket and returns its key.
+func (s *site) file(project, summary, description string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.project(project)
+	p.counter++
+	at := s.tick()
+	t := &tick{
+		key:         fmt.Sprintf("%s-%d", project, p.counter),
+		project:     project,
+		summary:     summary,
+		description: adf(description),
+		reporter:    "acc-mei",
+		created:     at,
+		updated:     at,
+		status:      "To Do",
+		kind:        "Bug",
+		priority:    "Medium",
+	}
+	s.issues = append(s.issues, t)
+	s.named[summary] = t.key
+	return t.key
+}
+
+// home is the project the conformance suite works in.
+const home = "LINE"
+
+// write files a ticket under a name, or rewrites the one already filed under
+// it, which is what the conformance suite means by putting a document in a
+// source.
+func (s *site) write(name, body string) {
+	s.mu.Lock()
+	t := s.find(s.named[name])
+	if t != nil {
+		t.description = adf(body)
+		t.updated = s.tick()
+	}
+	s.mu.Unlock()
+
+	if t == nil {
+		s.file(home, name, body)
+	}
+}
+
+// keyOf is the Jira key of whatever a test filed under a name.
+//
+// A name nothing was ever filed under still gets a key, because the question
+// being asked of it is what this source would call that document and the answer
+// does not depend on whether the document is there. Jira numbers issues from
+// one, so nothing on the site is ever LINE-0.
+func (s *site) keyOf(name string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if key := s.named[name]; key != "" {
+		return key
+	}
+	return home + "-0"
+}
+
+// assign puts a ticket on somebody, which is a change with no words in it.
+func (s *site) assign(key, who string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t := s.find(key)
+	t.assignee = who
+	t.updated = s.tick()
+}
+
+// label tags a ticket.
+func (s *site) label(key string, labels ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t := s.find(key)
+	t.labels = labels
+	t.updated = s.tick()
+}
+
+// describe replaces a ticket's description with a document rather than with a
+// sentence, which is how the rendering is tested against the real shape.
+func (s *site) describe(key string, description any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t := s.find(key)
+	t.description = description
+	t.updated = s.tick()
+}
+
+// hide makes a project's permission scheme unreadable, which is what a site
+// does to an account that is a user rather than an administrator.
+func (s *site) hide(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hidden[key] = true
+}
+
+// refuse makes one path answer with a status until it is told otherwise.
+func (s *site) refuse(path string, status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.fail[path] = status
+}
+
+// slowDown makes the next n requests come back as 429, which is how Jira asks a
+// crawler to wait.
+func (s *site) slowDown(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.throttle = n
+}
+
+func (s *site) find(key string) *tick {
+	for _, t := range s.issues {
+		if t.key == key {
+			return t
+		}
+	}
+	return nil
+}
+
+// comment adds to the argument underneath a ticket, which moves the ticket.
+func (s *site) comment(key, author, body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t := s.find(key)
+	at := s.tick()
+	t.comments = append(t.comments, &note{
+		id:      strconv.Itoa(20000 + len(t.comments) + len(s.issues)*10),
+		author:  author,
+		body:    adf(body),
+		created: at,
+		updated: at,
+	})
+	t.updated = at
+}
+
+// transition moves a ticket's status, which is a change with nothing written in
+// it and is the case a source with no updated field could never report.
+func (s *site) transition(key, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t := s.find(key)
+	t.status = status
+	t.updated = s.tick()
+}
+
+// restrict puts a security level on a ticket.
+func (s *site) restrict(key, levelID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t := s.find(key)
+	t.security = levelID
+	t.updated = s.tick()
+}
+
+// remove deletes a ticket. Nothing in JQL reports that it was ever there, which
+// is why the sweep exists.
+func (s *site) remove(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// The name stays behind on purpose. A test that deletes a ticket goes on to
+	// ask what its id was, and a fake that forgot would answer a different
+	// question.
+	s.issues = slices.DeleteFunc(s.issues, func(t *tick) bool { return t.key == key })
+	s.tick()
+}
+
+func (s *site) counted(path string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls[path]
+}
+
+// lastFields is the fields parameter of the last request to a path, which is
+// how a test checks that a crawl asked for what it needed and not for a site's
+// three hundred custom fields.
+func (s *site) lastFields(path string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.fields[path]
+}
+
+func (s *site) resetCounts() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = make(map[string]int)
+}
+
+// server starts the site on a listener and returns its base URL.
+func (s *site) server(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(s.handle))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func (s *site) handle(rw http.ResponseWriter, req *http.Request) {
+	path := req.URL.Path
+	if err := req.ParseForm(); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	s.calls[path]++
+	s.fields[path] = req.Form.Get("fields")
+	if s.throttle > 0 {
+		s.throttle--
+		s.mu.Unlock()
+		rw.Header().Set("Retry-After", "0")
+		rw.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+	status, refusing := s.fail[path]
+	s.mu.Unlock()
+
+	if refusing {
+		s.deny(rw, status, "no")
+		return
+	}
+	// Basic authentication with an email and an API token, which is what a real
+	// site wants and what a request that forgot the header does not have.
+	if !strings.HasPrefix(req.Header.Get("Authorization"), "Basic ") {
+		s.deny(rw, http.StatusUnauthorized, "unauthorised")
+		return
+	}
+
+	switch {
+	case path == "/rest/api/3/project/search":
+		s.listProjects(rw, req)
+	case path == "/rest/api/3/search":
+		s.search(rw, req)
+	case path == "/rest/api/3/issuesecurityschemes/level/member":
+		s.levelMembers(rw, req)
+	case strings.HasSuffix(path, "/permissionscheme"):
+		s.scheme(rw, path)
+	case strings.Contains(path, "/role/"):
+		s.roleActors(rw, path)
+	case strings.HasSuffix(path, "/comment"):
+		s.listComments(rw, req, path)
+	case strings.HasPrefix(path, "/rest/api/3/issue/"):
+		s.readIssue(rw, path)
+	default:
+		s.deny(rw, http.StatusNotFound, "no such endpoint")
+	}
+}
+
+func (s *site) deny(rw http.ResponseWriter, status int, why string) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(status)
+	_, _ = rw.Write([]byte(`{"errorMessages":["` + why + `"],"errors":{}}`))
+}
+
+func (s *site) send(rw http.ResponseWriter, v any) {
+	rw.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(rw).Encode(v)
+}
+
+func (s *site) listProjects(rw http.ResponseWriter, req *http.Request) {
+	s.mu.Lock()
+	rows := make([]map[string]any, 0, len(s.projects))
+	for _, p := range s.projects {
+		rows = append(rows, map[string]any{"id": p.id, "key": p.key, "name": p.name})
+	}
+	s.mu.Unlock()
+
+	at, size := paging(req, s.page)
+	page, last := window(rows, at, size)
+	s.send(rw, map[string]any{
+		"startAt":    at,
+		"maxResults": size,
+		"total":      len(rows),
+		"isLast":     last,
+		"values":     page,
+	})
+}
+
+func (s *site) scheme(rw http.ResponseWriter, path string) {
+	key := segment(path, "/rest/api/3/project/", "/permissionscheme")
+	s.mu.Lock()
+	p, hidden := s.project(key), s.hidden[key]
+	var rows []map[string]any
+	if p != nil {
+		for _, g := range p.grants {
+			rows = append(rows, map[string]any{
+				"holder":     map[string]any{"type": g.kind, "parameter": g.param},
+				"permission": "BROWSE_PROJECTS",
+			})
+		}
+	}
+	s.mu.Unlock()
+
+	switch {
+	case p == nil:
+		s.deny(rw, http.StatusNotFound, "no such project")
+	case hidden:
+		s.deny(rw, http.StatusForbidden, "administrator only")
+	default:
+		s.send(rw, map[string]any{"id": 10100, "name": "scheme", "permissions": rows})
+	}
+}
+
+func (s *site) roleActors(rw http.ResponseWriter, path string) {
+	rest := strings.TrimPrefix(path, "/rest/api/3/project/")
+	key, id, _ := strings.Cut(rest, "/role/")
+
+	s.mu.Lock()
+	p := s.project(key)
+	var r *role
+	if p != nil {
+		r = p.roles[id]
+	}
+	var rows []map[string]any
+	if r != nil {
+		for _, u := range r.users {
+			rows = append(rows, map[string]any{
+				"type": "atlassian-user-role-actor", "displayName": u,
+				"actorUser": map[string]any{"accountId": u},
+			})
+		}
+		for _, g := range r.groups {
+			rows = append(rows, map[string]any{
+				"type": "atlassian-group-role-actor", "displayName": g,
+				"actorGroup": map[string]any{"name": g},
+			})
+		}
+	}
+	s.mu.Unlock()
+
+	if r == nil {
+		s.deny(rw, http.StatusNotFound, "no such role")
+		return
+	}
+	s.send(rw, map[string]any{"id": id, "name": "Role", "actors": rows})
+}
+
+func (s *site) levelMembers(rw http.ResponseWriter, req *http.Request) {
+	id := req.Form.Get("levelId")
+
+	s.mu.Lock()
+	l := s.levels[id]
+	var rows []map[string]any
+	if l != nil {
+		for _, u := range l.users {
+			rows = append(rows, map[string]any{
+				"id": "m" + u, "issueSecurityLevelId": id,
+				"holder": map[string]any{"type": "user", "user": map[string]any{"accountId": u}},
+			})
+		}
+		for _, g := range l.groups {
+			rows = append(rows, map[string]any{
+				"id": "m" + g, "issueSecurityLevelId": id,
+				"holder": map[string]any{"type": "group", "group": map[string]any{"name": g}},
+			})
+		}
+		for _, r := range l.roles {
+			rows = append(rows, map[string]any{
+				"id": "mr" + strconv.Itoa(r), "issueSecurityLevelId": id,
+				"holder": map[string]any{"type": "projectRole", "projectRole": map[string]any{"id": r}},
+			})
+		}
+	}
+	s.mu.Unlock()
+
+	if l == nil {
+		s.deny(rw, http.StatusForbidden, "administrator only")
+		return
+	}
+	at, size := paging(req, s.page)
+	page, last := window(rows, at, size)
+	s.send(rw, map[string]any{
+		"startAt": at, "maxResults": size, "total": len(rows), "isLast": last, "values": page,
+	})
+}
+
+func (s *site) readIssue(rw http.ResponseWriter, path string) {
+	key := strings.TrimPrefix(path, "/rest/api/3/issue/")
+	s.mu.Lock()
+	t := s.find(key)
+	var row map[string]any
+	if t != nil {
+		row = s.row(t, s.page)
+	}
+	s.mu.Unlock()
+
+	if t == nil {
+		s.deny(rw, http.StatusNotFound, "no such issue")
+		return
+	}
+	s.send(rw, row)
+}
+
+func (s *site) listComments(rw http.ResponseWriter, req *http.Request, path string) {
+	key := segment(path, "/rest/api/3/issue/", "/comment")
+	s.mu.Lock()
+	t := s.find(key)
+	var rows []map[string]any
+	if t != nil {
+		for _, c := range t.comments {
+			rows = append(rows, s.note(c))
+		}
+	}
+	s.mu.Unlock()
+
+	if t == nil {
+		s.deny(rw, http.StatusNotFound, "no such issue")
+		return
+	}
+	at, size := paging(req, s.page)
+	page, _ := window(rows, at, size)
+	s.send(rw, map[string]any{
+		"startAt": at, "maxResults": size, "total": len(rows), "comments": page,
+	})
+}
+
+// jqlProject and jqlUpdated are as much JQL as this fake understands, which is
+// exactly the two clauses the adapter writes. A fake that parsed the whole
+// language would be a second Jira with its own bugs in it.
+var (
+	jqlProject = regexp.MustCompile(`project\s*=\s*"([^"]+)"`)
+	jqlUpdated = regexp.MustCompile(`updated\s*>=\s*"([^"]+)"`)
+)
+
+func (s *site) search(rw http.ResponseWriter, req *http.Request) {
+	jql := req.Form.Get("jql")
+
+	m := jqlProject.FindStringSubmatch(jql)
+	if m == nil {
+		s.deny(rw, http.StatusBadRequest, "expected a project clause: "+jql)
+		return
+	}
+	key := m[1]
+
+	var since time.Time
+	if u := jqlUpdated.FindStringSubmatch(jql); u != nil {
+		got, err := time.Parse("2006-01-02 15:04", u[1])
+		if err != nil {
+			s.deny(rw, http.StatusBadRequest, "bad time in "+jql)
+			return
+		}
+		since = got.UTC()
+	}
+
+	s.mu.Lock()
+	p, hidden := s.project(key), s.hidden[key]
+	var found []*tick
+	for _, t := range s.issues {
+		if t.project == key && (since.IsZero() || !t.updated.Before(since)) {
+			found = append(found, t)
+		}
+	}
+	if strings.Contains(jql, "ORDER BY key") {
+		slices.SortFunc(found, func(a, b *tick) int { return strings.Compare(a.key, b.key) })
+	} else {
+		slices.SortFunc(found, func(a, b *tick) int {
+			if d := a.updated.Compare(b.updated); d != 0 {
+				return d
+			}
+			return strings.Compare(a.key, b.key)
+		})
+	}
+	// The fields a search asks for are honoured, because a crawl that asked for
+	// two fields and got thirty would never notice it was billing for thirty.
+	want := strings.Split(req.Form.Get("fields"), ",")
+	rows := make([]map[string]any, 0, len(found))
+	for _, t := range found {
+		rows = append(rows, only(s.row(t, s.page), want))
+	}
+	s.mu.Unlock()
+
+	switch {
+	case p == nil:
+		s.deny(rw, http.StatusBadRequest, "no such project: "+key)
+		return
+	case hidden && p.grants == nil:
+		s.deny(rw, http.StatusForbidden, "you may not browse "+key)
+		return
+	}
+
+	at, size := paging(req, s.page)
+	page, _ := window(rows, at, size)
+	s.send(rw, map[string]any{
+		"startAt": at, "maxResults": size, "total": len(rows), "issues": page,
+	})
+}
+
+// row is one issue the way the API reports it.
+func (s *site) row(t *tick, size int) map[string]any {
+	fields := map[string]any{
+		"summary":     t.summary,
+		"description": t.description,
+		"created":     jiraTime(t.created),
+		"updated":     jiraTime(t.updated),
+		"reporter":    who(t.reporter),
+		"creator":     who(t.reporter),
+		"status":      map[string]any{"name": t.status},
+		"issuetype":   map[string]any{"name": t.kind},
+	}
+	if len(t.labels) > 0 {
+		fields["labels"] = t.labels
+	}
+	if t.assignee != "" {
+		fields["assignee"] = who(t.assignee)
+	}
+	if t.priority != "" {
+		fields["priority"] = map[string]any{"name": t.priority}
+	}
+	if t.security != "" {
+		l := s.levels[t.security]
+		name := t.security
+		if l != nil {
+			name = l.name
+		}
+		fields["security"] = map[string]any{"id": t.security, "name": name}
+	}
+
+	// A search returns the first page of comments inline and says how many
+	// there are in total, which is what tells an adapter whether it has them
+	// all.
+	rows := make([]map[string]any, 0, len(t.comments))
+	for _, c := range t.comments {
+		rows = append(rows, s.note(c))
+	}
+	page, _ := window(rows, 0, size)
+	fields["comment"] = map[string]any{
+		"startAt": 0, "maxResults": size, "total": len(rows), "comments": page,
+	}
+
+	return map[string]any{"id": "i" + t.key, "key": t.key, "fields": fields}
+}
+
+func (s *site) note(c *note) map[string]any {
+	return map[string]any{
+		"id":      c.id,
+		"author":  who(c.author),
+		"body":    c.body,
+		"created": jiraTime(c.created),
+		"updated": jiraTime(c.updated),
+	}
+}
+
+// only keeps the fields a search asked for.
+func only(row map[string]any, want []string) map[string]any {
+	fields, _ := row["fields"].(map[string]any)
+	kept := make(map[string]any, len(want))
+	for _, name := range want {
+		name = strings.TrimSpace(name)
+		if v, ok := fields[name]; ok {
+			kept[name] = v
+		}
+	}
+	return map[string]any{"id": row["id"], "key": row["key"], "fields": kept}
+}
+
+func who(id string) map[string]any {
+	names := map[string]string{
+		"acc-mei": "Mei Tanaka",
+		"acc-sam": "Sam Okafor",
+		"acc-lee": "Lee Berger",
+	}
+	name := names[id]
+	if name == "" {
+		name = id
+	}
+	return map[string]any{
+		"accountId":    id,
+		"displayName":  name,
+		"emailAddress": strings.TrimPrefix(id, "acc-") + "@acme.com",
+		"active":       true,
+	}
+}
+
+// adf wraps a plain string in the smallest Atlassian document that holds it, so
+// that a test writing a sentence gets the shape the real API sends.
+func adf(text string) map[string]any {
+	if text == "" {
+		return nil
+	}
+	content := make([]any, 0, 1)
+	for _, para := range strings.Split(text, "\n\n") {
+		content = append(content, map[string]any{
+			"type":    "paragraph",
+			"content": []any{map[string]any{"type": "text", "text": para}},
+		})
+	}
+	return map[string]any{"type": "doc", "version": 1, "content": content}
+}
+
+// jiraTime is the format a Jira site writes a timestamp in, which is ISO 8601
+// with milliseconds and a numeric zone with no colon in it.
+func jiraTime(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05.000-0700")
+}
+
+// paging reads the offset and size off a request.
+func paging(req *http.Request, fallback int) (at, size int) {
+	at, _ = strconv.Atoi(req.Form.Get("startAt"))
+	size, _ = strconv.Atoi(req.Form.Get("maxResults"))
+	if size <= 0 {
+		size = fallback
+	}
+	// A real site caps what it will return whatever was asked for, which is the
+	// behaviour that catches an adapter trusting maxResults.
+	return at, min(size, fallback)
+}
+
+// window cuts a page out of a listing and says whether it is the last one.
+func window[T any](items []T, at, size int) (page []T, last bool) {
+	if at > len(items) {
+		at = len(items)
+	}
+	to := min(at+size, len(items))
+	return items[at:to], to >= len(items)
+}
+
+// segment pulls the middle out of a path.
+func segment(path, prefix, suffix string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+}

--- a/connector/jirasource/jirasource.go
+++ b/connector/jirasource/jirasource.go
@@ -1,0 +1,269 @@
+// Package jirasource indexes a Jira site.
+//
+// It is an adapter and nothing more. The crawl, the cursor, the resume, the
+// reconciliation sweep and the permission refresh are all in [threadsource],
+// and what is here is the four questions that package asks, answered against
+// the Jira Cloud REST API: list the projects and say who may read each one,
+// walk the issues in a project that changed since a time, list the issue keys a
+// project holds, and read one issue by its key.
+//
+// # An issue is the document
+//
+// A ticket is a summary, a description and the argument underneath it, and the
+// argument is where the answer usually is. A comment is not a document any more
+// than a reply is: it is a sentence in one. So an issue is fetched with its
+// comments, assembled by [thread.Conversation.Document] the same way a chat
+// thread is, and indexed as a single result that ranks as a whole.
+//
+// The difference from chat is who the document is by. A Slack thread is by the
+// person who started it. A ticket is by its reporter, who is very often not the
+// person who typed the description, and the assignee is a different person
+// again. The reporter is the author, and both of them are on the document as
+// properties, because "tickets Sam reported" and "tickets Sam is working on"
+// are different questions and an index that conflated them answers neither.
+//
+// # Permissions
+//
+// Jira decides who may read an issue in two places, and both of them are here.
+//
+// The project is the first. A project's browse permission is granted to roles,
+// to groups and to individual accounts through a permission scheme, and what
+// comes out of resolving it is a list of accounts and a list of groups, which is
+// an access control list. A project nobody can resolve a rule for is
+// quarantined rather than guessed at.
+//
+// The issue security level is the second, and it is the reason [threadsource]
+// lets a conversation override its container at all. An issue with a security
+// level on it is readable by that level's members and by nobody else, whatever
+// the project says, and a crawl that applied the project's rule to it would
+// publish exactly the tickets somebody went out of their way to restrict. Where
+// the level's members can be resolved they become the rule. Where they cannot,
+// because resolving them needs an administrator and this token is not one, the
+// issue is quarantined and reported. Quarantining a restricted ticket is the
+// only safe way to be wrong about it.
+//
+// # What incremental means here
+//
+// Unlike chat, Jira has a real change feed, and it is JQL. Every issue carries
+// an updated time, a comment moves it, an edit moves it, a transition moves it,
+// and JQL will both filter and order by it. So a sync asks for the issues in a
+// project updated at or after the cursor, in ascending order of update, and
+// that is the whole of it: no window, no guessing, and nothing found by the
+// sweep that the sync should have caught.
+//
+// What the sweep is still for is deletion. Nothing in JQL reports an issue that
+// was deleted or moved to another project, so the listing is what removes it,
+// and the version it reports is the issue's updated time.
+//
+// # Rate limits
+//
+// Jira Cloud does not publish a request rate. It bills by cost, the cost of a
+// request depends on what was asked for, and the way a client learns it has
+// spent too much is a 429 with a Retry-After header. So there is one bucket
+// rather than the per method tiers a source with published rates gets, it is
+// set to something a shared site will tolerate, and the header is what actually
+// governs. All of that is [limit] doing the work: the retries, the backoff, the
+// Retry-After header and the circuit breaker are the same ones every connector
+// in this repository uses.
+package jirasource
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/connector/limit"
+	"github.com/tamnd/genba/connector/threadsource"
+)
+
+// DefaultName is the source name a document's id is prefixed with when the
+// caller does not choose one.
+const DefaultName = "jira"
+
+// DefaultPageSize is how many items are asked for per page.
+//
+// Jira caps a search at a hundred and will silently return fewer, which is not
+// something to argue with: asking for more than the cap and getting less is how
+// a crawl convinces itself it has reached the end of a project.
+const DefaultPageSize = 100
+
+// DefaultRate is how many requests a second the adapter allows itself.
+//
+// There is no published number to match. Jira Cloud bills by cost and answers
+// with a Retry-After when the bill is too high, so this is a floor that keeps a
+// crawl from being the reason somebody else's integration starts seeing 429s,
+// and the header is what governs when it is not enough.
+const DefaultRate = 5
+
+// Service answers [threadsource.Service] against a Jira site.
+type Service struct {
+	http       *http.Client
+	base       string
+	email      string
+	token      string
+	name       string
+	page       int
+	aclRefresh time.Duration
+	now        func() time.Time
+	levels     *security
+	skipped    func(id string, reason error)
+}
+
+var _ threadsource.Service = (*Service)(nil)
+
+// Option configures a [Service].
+type Option func(*Service)
+
+// WithName sets the source name, which is what every document id from this site
+// is prefixed with. A deployment indexing two sites needs two names, because
+// the ids from them would otherwise collide.
+func WithName(name string) Option {
+	return func(s *Service) { s.name = name }
+}
+
+// WithHTTPClient replaces the client entirely, rate limiting included.
+//
+// A caller who passes one is taking on the limits themselves, which is right
+// for a test replaying a recording and wrong for anything talking to Jira.
+func WithHTTPClient(c *http.Client) Option {
+	return func(s *Service) { s.http = c }
+}
+
+// WithLimits changes what the site is allowed to cost. Zero rate selects
+// [DefaultRate].
+func WithLimits(l limit.Limits) Option {
+	return func(s *Service) {
+		if l.Rate <= 0 {
+			l.Rate = DefaultRate
+		}
+		s.http = limited(s.email, s.token, l)
+	}
+}
+
+// WithPageSize sets how many items are asked for per page. Zero selects
+// [DefaultPageSize].
+func WithPageSize(n int) Option {
+	return func(s *Service) { s.page = n }
+}
+
+// WithSkipped is told about a project or an issue that could not be indexed,
+// with the reason.
+//
+// The two worth having it for are a project whose permission scheme this token
+// may not read and an issue behind a security level whose members it may not
+// resolve. Both are quarantined, and an index quietly missing what nobody could
+// read looks exactly like an index that is complete.
+func WithSkipped(f func(id string, reason error)) Option {
+	return func(s *Service) { s.skipped = f }
+}
+
+// WithClock replaces the clock the permission refresh schedule is measured
+// against, which is what a test needs to make a day pass without waiting one.
+func WithClock(now func() time.Time) Option {
+	return func(s *Service) { s.now = now }
+}
+
+// NewService builds the adapter on its own, which is what a caller wanting to
+// wrap it or test it against a recording needs.
+//
+// The site is the base URL of a Jira Cloud instance, and the credentials are an
+// account's email address and an API token, which is what Jira's basic
+// authentication expects rather than a password.
+func NewService(site, email, token string, opts ...Option) (*Service, error) {
+	switch {
+	case site == "":
+		return nil, errors.New("jirasource: a site URL is required")
+	case email == "":
+		return nil, errors.New("jirasource: an account email is required")
+	case token == "":
+		return nil, errors.New("jirasource: an API token is required")
+	}
+
+	s := &Service{
+		base:  strings.TrimSuffix(site, "/"),
+		email: email,
+		token: token,
+		name:  DefaultName,
+		page:  DefaultPageSize,
+		now:   time.Now,
+	}
+	s.http = limited(email, token, limit.Limits{Rate: DefaultRate})
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.name == "" {
+		return nil, errors.New("jirasource: the source name cannot be empty")
+	}
+	if s.page < 1 {
+		s.page = DefaultPageSize
+	}
+	if s.now == nil {
+		s.now = time.Now
+	}
+	s.levels = newSecurity(s)
+	return s, nil
+}
+
+// New builds a connector over a Jira site, ready to be handed to the ingestion
+// pipeline.
+func New(site, email, token string, opts ...Option) (*threadsource.Source, error) {
+	svc, err := NewService(site, email, token, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var wrapped []threadsource.Option
+	if svc.skipped != nil {
+		wrapped = append(wrapped, threadsource.WithSkipped(svc.skipped))
+	}
+	return threadsource.New(svc, svc.name, wrapped...)
+}
+
+// Name is the source name documents from this site are filed under.
+func (s *Service) Name() string { return s.name }
+
+// skip reports something that could not be indexed, if anybody asked to hear
+// about it.
+func (s *Service) skip(id string, reason error) {
+	if s.skipped != nil {
+		s.skipped(id, reason)
+	}
+}
+
+// Error is what Jira says when it refuses.
+//
+// Unlike some APIs Jira does use status codes, so the status is what a caller
+// matches on. The messages are kept because a 400 from JQL is a syntax error
+// with the offending clause in it, and a crawl that threw that away would
+// report "bad request" for a thing the site was willing to explain.
+type Error struct {
+	Path     string
+	Status   int
+	Messages []string
+}
+
+func (e *Error) Error() string {
+	if len(e.Messages) == 0 {
+		return fmt.Sprintf("jira: %s: %d", e.Path, e.Status)
+	}
+	return fmt.Sprintf("jira: %s: %d: %s", e.Path, e.Status, strings.Join(e.Messages, "; "))
+}
+
+// refused reports whether an error is Jira saying no with this particular
+// status, which is how a caller tells "you may not read that project" from "the
+// network went away".
+func refused(err error, status int) bool {
+	var je *Error
+	return errors.As(err, &je) && je.Status == status
+}
+
+// missing reports whether an error is Jira saying the thing is not there.
+//
+// Both statuses mean it for our purposes. A 404 is an issue that was deleted,
+// and a 403 on a single issue read is an issue that was moved somewhere this
+// token cannot follow, which from the index's point of view is the same event:
+// it is not ours to hold any more.
+func missing(err error) bool {
+	return refused(err, http.StatusNotFound) || refused(err, http.StatusForbidden)
+}

--- a/connector/jirasource/jirasource_test.go
+++ b/connector/jirasource/jirasource_test.go
@@ -1,0 +1,842 @@
+package jirasource_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/connectortest"
+	"github.com/tamnd/genba/connector/jirasource"
+	"github.com/tamnd/genba/connector/limit"
+	"github.com/tamnd/genba/connector/threadsource"
+	"github.com/tamnd/genba/doc"
+)
+
+// The account the crawl runs as, which is a service account rather than a
+// person. It is deliberately not one of the accounts in the fake, because the
+// recording is checked for the crawling credential and a check that matched a
+// display email on a ticket would fail for the wrong reason.
+const (
+	email = "search-crawler@acme.com"
+	token = "a-real-looking-api-token"
+)
+
+// quick is a rate limit that does not slow a test down while still being the
+// real limiter, retries, backoff, circuit breaker and all.
+var quick = limit.Limits{Rate: 10000, Burst: 50, MinBackoff: time.Millisecond, MaxBackoff: 5 * time.Millisecond}
+
+func newSource(t *testing.T, s *site, opts ...jirasource.Option) *threadsource.Source {
+	t.Helper()
+	all := append([]jirasource.Option{
+		jirasource.WithLimits(quick),
+		jirasource.WithClock(s.now),
+		// An hour rather than a day, so that a test that wants to be on the far
+		// side of a refresh interval can move the clock rather than wait a day.
+		jirasource.WithACLRefresh(time.Hour),
+	}, opts...)
+	src, err := jirasource.New(s.server(t), email, token, all...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+	return src
+}
+
+func run(t *testing.T, src *threadsource.Source, from connector.Cursor) ([]connector.Change, connector.Cursor) {
+	t.Helper()
+	var got []connector.Change
+	next, err := src.Sync(t.Context(), from, func(_ context.Context, ch connector.Change) error {
+		got = append(got, ch)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	return got, next
+}
+
+func ids(changes []connector.Change) []string {
+	out := make([]string, 0, len(changes))
+	for _, ch := range changes {
+		out = append(out, ch.Document.ID)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func find(changes []connector.Change, id string) *connector.Change {
+	for i := range changes {
+		if changes[i].Document.ID == id {
+			return &changes[i]
+		}
+	}
+	return nil
+}
+
+// quarantined reports whether a document was indexed with nobody able to read
+// it, which is what a connector that could not work out an access control list
+// is required to produce rather than a guess.
+func quarantined(p acl.Permissions) bool { return p.Mode == acl.ModeUnknown }
+
+func enumerate(t *testing.T, src *threadsource.Source) []string {
+	t.Helper()
+	var out []string
+	if err := src.Enumerate(t.Context(), func(item connector.Item) bool {
+		out = append(out, item.ID)
+		return true
+	}); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// The conformance suite is what decides whether this is a connector, and
+// everything else in this file is about the parts that are specific to Jira.
+func TestConformance(t *testing.T) {
+	connectortest.Run(t, func(t *testing.T) connectortest.Fixture {
+		s := newSite()
+		src := newSource(t, s)
+		return connectortest.Fixture{
+			Connector: src,
+			ID:        func(name string) string { return "jira:" + s.keyOf(name) },
+			Write:     func(_ *testing.T, name, body string) { s.write(name, body) },
+			Remove:    func(_ *testing.T, name string) { s.remove(s.keyOf(name)) },
+			Share: func(_ *testing.T, _ string) {
+				// A project's rule changes and not one issue in it is touched,
+				// which is the case the schedule exists for. Nothing in Jira
+				// reports the edit, so the clock is what carries it.
+				p := s.project(home)
+				p.grants = []grant{{"group", "engineering"}}
+				s.advance(time.Hour)
+			},
+			// A security level nobody can resolve is the concrete case of an
+			// access control list beyond working out, and it is the reason this
+			// connector can override a container's rule at all.
+			Unresolvable: func(_ *testing.T, name string) { s.restrict(s.keyOf(name), "no-such-level") },
+		}
+	})
+}
+
+// An issue and the argument underneath it are one document. Somebody asking
+// what was decided about the gearbox wants the ticket, not the fourth comment
+// on it with no idea what it is replying to.
+func TestAnIssueAndItsCommentsAreOneDocument(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	s.comment(key, "acc-sam", "Bearing, I think.")
+	s.comment(key, "acc-lee", "Replacement ordered, arrives Thursday.")
+	s.file(home, "Coolant pump", "Coolant pump replaced.")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 2 {
+		t.Fatalf("a project with two issues and two comments produced %d documents: %v", len(changes), ids(changes))
+	}
+
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	for _, want := range []string{"making a noise", "Bearing, I think", "arrives Thursday"} {
+		if !strings.Contains(got.Document.Body, want) {
+			t.Errorf("the body does not hold %q:\n%s", want, got.Document.Body)
+		}
+	}
+	// Who said each thing goes in as well, which is the difference between
+	// searching for what Lee said about the gearbox and only being able to
+	// search for the gearbox.
+	for _, want := range []string{"Mei Tanaka", "Sam Okafor", "Lee Berger"} {
+		if !strings.Contains(got.Document.Body, want) {
+			t.Errorf("the body does not name %q:\n%s", want, got.Document.Body)
+		}
+	}
+	if got.Document.Kind != doc.KindTicket {
+		t.Errorf("the document is a %q, want a ticket", got.Document.Kind)
+	}
+	if !strings.HasPrefix(got.Document.Title, key+" ") {
+		t.Errorf("the title is %q, and a ticket without its key in the title is a ticket nobody can quote", got.Document.Title)
+	}
+}
+
+// The reporter is the author and the assignee is a property, because "tickets
+// Sam reported" and "tickets Sam is working on" are different questions.
+func TestTheReporterIsTheAuthorAndTheAssigneeIsAProperty(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	s.assign(key, "acc-sam")
+	s.label(key, "line-two", "mechanical")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if got.Document.Author.Name != "Mei Tanaka" {
+		t.Errorf("the author is %q, want the reporter", got.Document.Author.Name)
+	}
+	for name, want := range map[string]string{
+		"assignee": "Sam Okafor",
+		"status":   "To Do",
+		"type":     "Bug",
+		"priority": "Medium",
+		"labels":   "line-two, mechanical",
+	} {
+		if got := got.Document.Properties[name]; got != want {
+			t.Errorf("the %s property is %q, want %q", name, got, want)
+		}
+	}
+}
+
+// A description is a document tree rather than a sentence, and what is in it is
+// very often the answer: a stack trace, a snippet of configuration, a table of
+// what was tried. Flattening it answers the query and fails the person.
+func TestADescriptionKeepsItsStructure(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Gearbox noise", "placeholder")
+	s.describe(key, map[string]any{
+		"type":    "doc",
+		"version": 1,
+		"content": []any{
+			map[string]any{
+				"type":    "heading",
+				"attrs":   map[string]any{"level": 2},
+				"content": []any{map[string]any{"type": "text", "text": "What we tried"}},
+			},
+			map[string]any{
+				"type": "bulletList",
+				"content": []any{
+					map[string]any{"type": "listItem", "content": []any{
+						map[string]any{"type": "paragraph", "content": []any{
+							map[string]any{"type": "text", "text": "Replaced the bearing"},
+						}},
+					}},
+					map[string]any{"type": "listItem", "content": []any{
+						map[string]any{"type": "paragraph", "content": []any{
+							map[string]any{"type": "text", "text": "Checked the alignment"},
+						}},
+					}},
+				},
+			},
+			map[string]any{
+				"type":  "codeBlock",
+				"attrs": map[string]any{"language": "go"},
+				"content": []any{map[string]any{
+					"type": "text",
+					"text": "panic: runtime error: index out of range [3]",
+				}},
+			},
+			map[string]any{
+				"type": "paragraph",
+				"content": []any{
+					map[string]any{"type": "text", "text": "See "},
+					map[string]any{
+						"type":  "text",
+						"text":  "the runbook",
+						"marks": []any{map[string]any{"type": "link", "attrs": map[string]any{"href": "https://wiki.acme.com/runbook"}}},
+					},
+					map[string]any{"type": "text", "text": " and "},
+					map[string]any{
+						"type":  "text",
+						"text":  "restart --hard",
+						"marks": []any{map[string]any{"type": "code"}},
+					},
+				},
+			},
+		},
+	})
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	for _, want := range []string{
+		"## What we tried",
+		"- Replaced the bearing",
+		"- Checked the alignment",
+		"```go",
+		"panic: runtime error: index out of range [3]",
+		"[the runbook](https://wiki.acme.com/runbook)",
+		"`restart --hard`",
+	} {
+		if !strings.Contains(got.Document.Body, want) {
+			t.Errorf("the rendered description does not hold %q:\n%s", want, got.Document.Body)
+		}
+	}
+}
+
+// A table survives as a table, because a ticket whose description is a table of
+// readings is a ticket whose point is the table.
+func TestATableSurvivesAsATable(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Readings", "placeholder")
+	s.describe(key, map[string]any{
+		"type":    "doc",
+		"version": 1,
+		"content": []any{map[string]any{
+			"type": "table",
+			"content": []any{
+				row("Shift", "Temperature"),
+				row("Morning", "62"),
+				row("Night", "71"),
+			},
+		}},
+	})
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	for _, want := range []string{
+		"| Shift | Temperature |",
+		"| --- | --- |",
+		"| Night | 71 |",
+	} {
+		if !strings.Contains(got.Document.Body, want) {
+			t.Errorf("the rendered table does not hold %q:\n%s", want, got.Document.Body)
+		}
+	}
+}
+
+// row is one table row of plain text cells.
+func row(cells ...string) map[string]any {
+	out := make([]any, 0, len(cells))
+	for _, c := range cells {
+		out = append(out, map[string]any{
+			"type": "tableCell",
+			"content": []any{map[string]any{
+				"type":    "paragraph",
+				"content": []any{map[string]any{"type": "text", "text": c}},
+			}},
+		})
+	}
+	return map[string]any{"type": "tableRow", "content": out}
+}
+
+// This is the thing chat cannot do. A ticket moved from one column to another
+// changed, nobody wrote a word, and Jira says so, so the sync finds it without
+// a window to widen or a guess to make.
+func TestAStatusChangeWithNoCommentIsFoundBySync(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	src := newSource(t, s)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	if changes, _ := run(t, src, cursor); len(changes) != 0 {
+		t.Fatalf("a second sync of a project nothing happened in emitted %v", ids(changes))
+	}
+
+	s.transition(key, "In Progress")
+
+	changes, _ := run(t, src, cursor)
+	if len(changes) != 1 {
+		t.Fatalf("a status change emitted %d documents: %v", len(changes), ids(changes))
+	}
+	if got := changes[0].Document.Properties["status"]; got != "In Progress" {
+		t.Errorf("the status is %q, want the one it was moved to", got)
+	}
+}
+
+// A security level replaces the project's rule rather than adding to it. That
+// is what a security level is for, and it is the reason a conversation is
+// allowed to override the container it is in.
+func TestASecurityLevelReplacesTheProjectRule(t *testing.T) {
+	s := newSite()
+	s.addLevel("10500", "Legal only", "acc-lee")
+	open := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	shut := s.file(home, "Injury report", "Somebody was hurt on line two.")
+	s.restrict(shut, "10500")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+
+	ordinary := find(changes, "jira:"+open)
+	if ordinary == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if got := ordinary.Document.Permissions.AllowUsers; len(got) != 1 || got[0].Value != "acc-mei" {
+		t.Errorf("an ordinary issue allows %v, want the members of the project role", got)
+	}
+
+	restricted := find(changes, "jira:"+shut)
+	if restricted == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	perms := restricted.Document.Permissions
+	if perms.Mode != acl.ModeACL {
+		t.Fatalf("a restricted issue is %v, want an access control list", perms.Mode)
+	}
+	if got := perms.AllowUsers; len(got) != 1 || got[0].Value != "acc-lee" {
+		t.Errorf("a restricted issue allows %v, want only the security level", got)
+	}
+	if len(perms.AllowGroups) != 0 {
+		t.Errorf("a restricted issue still allows the groups the project allows: %v", perms.AllowGroups)
+	}
+
+	// Mei may read the project and is not in the level, which is the whole
+	// point of putting the level on.
+	mei := &acl.Principal{
+		Subject:    "acc-mei",
+		Identities: []acl.Identity{{Source: "jira", Value: "acc-mei"}},
+	}
+	if !ordinary.Document.Permissions.Allows(mei) {
+		t.Error("the reporter cannot read an ordinary issue in her own project")
+	}
+	if perms.Allows(mei) {
+		t.Error("a security level did not keep out somebody the project lets in")
+	}
+}
+
+// A level this token cannot resolve is quarantined rather than falling back to
+// the project, because the one thing a security level is is somebody deciding
+// on purpose to keep other people out.
+func TestAnUnresolvableSecurityLevelQuarantinesTheIssue(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Injury report", "Somebody was hurt on line two.")
+	s.restrict(key, "10500") // never registered, so the site refuses to resolve it
+
+	var skipped []string
+	src := newSource(t, s, jirasource.WithSkipped(func(id string, _ error) {
+		skipped = append(skipped, id)
+	}))
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if !quarantined(got.Document.Permissions) {
+		t.Errorf("an issue behind a level nobody could resolve is readable by %v", got.Document.Permissions)
+	}
+	if len(skipped) == 0 {
+		t.Error("the level could not be resolved and nothing said so, which is an index quietly missing what nobody can read")
+	}
+}
+
+// A level granted to a project role cannot be resolved without knowing which
+// project the issue is in, and this deliberately does not know. Guessing in
+// either direction is worse than saying so.
+func TestASecurityLevelGrantedToARoleIsQuarantined(t *testing.T) {
+	s := newSite()
+	l := s.addLevel("10600", "Managers")
+	l.roles = []int{10002}
+	key := s.file(home, "Pay review", "The pay review for line two.")
+	s.restrict(key, "10600")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if !quarantined(got.Document.Permissions) {
+		t.Errorf("a level granted to a role resolved to %v", got.Document.Permissions)
+	}
+}
+
+// The same level on a thousand issues is one request, not a thousand. A project
+// with a security scheme puts the same handful of levels on everything in it.
+func TestASecurityLevelIsResolvedOnce(t *testing.T) {
+	s := newSite()
+	s.addLevel("10500", "Legal only", "acc-lee")
+	for _, name := range []string{"one", "two", "three"} {
+		s.restrict(s.file(home, name, "Something happened."), "10500")
+	}
+	src := newSource(t, s)
+	s.resetCounts()
+
+	run(t, src, connector.Cursor{})
+	if got := s.counted("/rest/api/3/issuesecurityschemes/level/member"); got != 1 {
+		t.Errorf("three issues at one security level cost %d requests to resolve it", got)
+	}
+}
+
+// A project whose permission scheme this account may not read is quarantined
+// rather than indexed on a guess, and it says so.
+func TestAProjectWhosePermissionSchemeIsHiddenIsQuarantined(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	s.hide(home)
+
+	var skipped []string
+	src := newSource(t, s, jirasource.WithSkipped(func(id string, _ error) {
+		skipped = append(skipped, id)
+	}))
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if !quarantined(got.Document.Permissions) {
+		t.Errorf("a project nobody could work out the rule for is readable by %v", got.Document.Permissions)
+	}
+	if !slices.Contains(skipped, home) {
+		t.Errorf("the unreadable scheme was reported as %v, want the project", skipped)
+	}
+}
+
+// A permission scheme grants browse to a role and the project decides who is in
+// it. An adapter that stopped at the role name would produce an access control
+// list naming a thing rather than anybody.
+func TestAProjectRoleIsResolvedToItsMembers(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	perms := got.Document.Permissions
+	if len(perms.AllowUsers) != 1 || perms.AllowUsers[0].Value != "acc-mei" {
+		t.Errorf("the rule allows the accounts %v, want the one in the role", perms.AllowUsers)
+	}
+	if len(perms.AllowGroups) != 1 || perms.AllowGroups[0].Value != "engineering" {
+		t.Errorf("the rule allows the groups %v, want the one in the role", perms.AllowGroups)
+	}
+}
+
+// A project everybody with a licence can browse is a real configuration, and
+// describing it as an access control list of nobody would hide it instead.
+func TestAProjectOpenToTheTenantIsSaidToBeOpen(t *testing.T) {
+	s := newSite()
+	p := s.addProject("DOCS", "Documentation")
+	p.grants = []grant{{"applicationRole", "jira-software"}}
+	key := s.file("DOCS", "Style guide", "How we write things down.")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if got.Document.Permissions.Mode != acl.ModePublicToTenant {
+		t.Errorf("a project open to the tenant is %v", got.Document.Permissions.Mode)
+	}
+}
+
+// A scheme that grants browse to nobody is not a project everybody can read, it
+// is a project we failed to understand.
+func TestAProjectNobodyCanBrowseIsQuarantined(t *testing.T) {
+	s := newSite()
+	p := s.addProject("VOID", "Nobody home")
+	p.grants = nil
+	key := s.file("VOID", "Lost", "Nobody can see this.")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if !quarantined(got.Document.Permissions) {
+		t.Errorf("a project granting browse to nobody is readable by %v", got.Document.Permissions)
+	}
+}
+
+// Nothing in Jira reports that somebody was taken out of a project role. A
+// revocation that reaches the index when somebody next comments on a ticket is
+// not a revocation, so the rule is reapplied on a schedule.
+func TestARemovedRoleMemberIsAppliedOnTheSchedule(t *testing.T) {
+	s := newSite()
+	s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	src := newSource(t, s)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	if changes, _ := run(t, src, cursor); len(changes) != 0 {
+		t.Fatalf("a second sync in the same interval emitted %v", ids(changes))
+	}
+
+	s.project(home).roles["10002"] = &role{groups: []string{"engineering"}}
+	// Still inside the same interval, so the site has told us nothing and
+	// neither has the schedule.
+	if changes, _ := run(t, src, cursor); len(changes) != 0 {
+		t.Fatalf("the removal was applied before the schedule said to, which means every sync applies it: %v", ids(changes))
+	}
+
+	s.advance(time.Hour)
+	before := src.Counters()
+	changes, _ := run(t, src, cursor)
+	if len(changes) != 1 {
+		t.Fatalf("the interval passed and the sync emitted %v", ids(changes))
+	}
+	if !changes[0].PermissionsOnly {
+		t.Error("reapplying a rule read the issue again")
+	}
+	if spent := src.Counters().Since(before); spent.Fetches != 0 {
+		t.Errorf("a permission change read %d issues, and the point of it is that it reads none", spent.Fetches)
+	}
+	if got := changes[0].Document.Permissions.AllowUsers; len(got) != 0 {
+		t.Errorf("the rule still allows %v after the account was taken out of the role", got)
+	}
+}
+
+// Nothing in JQL reports an issue that was deleted, so the sweep is the only
+// thing that ever takes one out of the index.
+func TestADeletedIssueIsOnlyFoundByTheSweep(t *testing.T) {
+	s := newSite()
+	kept := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	gone := s.file(home, "Filed twice", "This one was raised by mistake.")
+	src := newSource(t, s)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	s.remove(gone)
+
+	if changes, _ := run(t, src, cursor); len(changes) != 0 {
+		t.Errorf("a deletion showed up in the change feed as %v, which Jira cannot do", ids(changes))
+	}
+	if got, want := enumerate(t, src), []string{"jira:" + kept}; !slices.Equal(got, want) {
+		t.Errorf("the enumeration lists %v, want %v", got, want)
+	}
+	if _, err := src.Fetch(t.Context(), "jira:"+gone); !errors.Is(err, connector.ErrGone) {
+		t.Errorf("fetching a deleted issue returned %v, want connector.ErrGone", err)
+	}
+}
+
+// The sweep compares versions, so the version a listing reports and the version
+// a read reports have to be the same string for an issue nothing happened to.
+// When they disagree the sweep refetches the whole project every time it runs.
+func TestTheListingAndTheReadAgreeOnTheVersion(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	s.comment(key, "acc-sam", "Bearing, I think.")
+	src := newSource(t, s)
+
+	var version string
+	if err := src.Enumerate(t.Context(), func(item connector.Item) bool {
+		if item.ID == "jira:"+key {
+			version = item.Version
+		}
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if version == "" {
+		t.Fatal("the enumeration reported no version, so the sweep has nothing to compare")
+	}
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if got.Document.SourceUpdate != version {
+		t.Errorf("the listing says the version is %q and the sync says %q, so every sweep refetches it", version, got.Document.SourceUpdate)
+	}
+}
+
+// JQL compares to the minute and the cursor does not, which is a boundary an
+// adapter has to get right in both directions: nothing lost, nothing indexed
+// twice.
+func TestAnIssueUpdatedInTheCursorsMinuteIsNeitherLostNorRepeated(t *testing.T) {
+	s := newSite()
+	first := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	src := newSource(t, s)
+
+	_, cursor := run(t, src, connector.Cursor{})
+
+	// Both of these land inside the minute the cursor stopped in, because the
+	// site's clock moves a minute per event and JQL rounds to the minute.
+	s.transition(first, "In Progress")
+	second := s.file(home, "Coolant pump", "Coolant pump replaced.")
+
+	changes, next := run(t, src, cursor)
+	if got, want := ids(changes), []string{"jira:" + first, "jira:" + second}; !slices.Equal(got, want) {
+		t.Fatalf("the sync emitted %v, want both changes in the cursor's minute: %v", got, want)
+	}
+	if again, _ := run(t, src, next); len(again) != 0 {
+		t.Errorf("the sync after that emitted %v again", ids(again))
+	}
+}
+
+// Decoding a page of JSON into the value the last page went in reuses the
+// elements and only overwrites the fields the new page mentions, so an issue
+// arriving with no assignee where one used to be inherits the previous
+// assignee. It is silent, it is wrong, and it is a permission field away from
+// being a leak.
+func TestAnIssueOnALaterPageInheritsNothingFromTheOneBefore(t *testing.T) {
+	s := newSite()
+	first := s.file(home, "One", "The first one.")
+	s.assign(first, "acc-sam")
+	s.label(first, "line-two")
+	s.file(home, "Two", "The second one.")
+	third := s.file(home, "Three", "The third one, on a later page.")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 3 {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	got := find(changes, "jira:"+third)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if who, ok := got.Document.Properties["assignee"]; ok {
+		t.Errorf("an issue with no assignee came back assigned to %q, which is the page before it showing through", who)
+	}
+	if labels, ok := got.Document.Properties["labels"]; ok {
+		t.Errorf("an issue with no labels came back labelled %q", labels)
+	}
+}
+
+// A site that caps the page size below what was asked for is the normal case,
+// and a crawl that read a short page as the end of the listing would index part
+// of a project and report success.
+func TestAProjectLargerThanAPageIsWalkedToTheEnd(t *testing.T) {
+	s := newSite()
+	want := make([]string, 0, 7)
+	for _, name := range []string{"one", "two", "three", "four", "five", "six", "seven"} {
+		want = append(want, "jira:"+s.file(home, name, "Something happened on line two."))
+	}
+	slices.Sort(want)
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if got := ids(changes); !slices.Equal(got, want) {
+		t.Errorf("the sync emitted %d of %d issues: %v", len(got), len(want), got)
+	}
+	if got := enumerate(t, src); !slices.Equal(got, want) {
+		t.Errorf("the enumeration listed %d of %d issues: %v", len(got), len(want), got)
+	}
+}
+
+// Comments page too, and a ticket with a long argument on it is the ticket
+// somebody is looking for.
+func TestAnIssueWithMoreCommentsThanAPageKeepsThemAll(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	for _, said := range []string{"Bearing, I think.", "Ordered a replacement.", "Arrives Thursday.", "Fitted, and it is quiet."} {
+		s.comment(key, "acc-sam", said)
+	}
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	got := find(changes, "jira:"+key)
+	if got == nil {
+		t.Fatalf("the sync emitted %v", ids(changes))
+	}
+	if !strings.Contains(got.Document.Body, "Fitted, and it is quiet.") {
+		t.Errorf("the last comment is not in the body, so the argument stops halfway:\n%s", got.Document.Body)
+	}
+}
+
+// A ticket with no comments on it costs no request for its comments. Asking
+// unconditionally would be a request per issue in the site to be told what we
+// were already holding.
+func TestAnIssueWithFewCommentsCostsNoExtraRequest(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	s.comment(key, "acc-sam", "Bearing, I think.")
+	src := newSource(t, s)
+	s.resetCounts()
+
+	run(t, src, connector.Cursor{})
+	if got := s.counted("/rest/api/3/issue/" + key + "/comment"); got != 0 {
+		t.Errorf("an issue whose comments arrived with it cost %d further requests for them", got)
+	}
+}
+
+// Jira asks a crawler to slow down with a 429 and a Retry-After, and a run that
+// gave up at the first one would be a run that never finished a large site.
+func TestAThrottledRequestIsRetriedRatherThanFailing(t *testing.T) {
+	s := newSite()
+	key := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	src := newSource(t, s)
+	s.slowDown(3)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if find(changes, "jira:"+key) == nil {
+		t.Fatalf("a run that was asked to slow down emitted %v", ids(changes))
+	}
+}
+
+// A site that has stopped answering is a failed sync rather than an empty one,
+// because an empty sync followed by a sweep is an emptied index.
+func TestASiteThatRefusesIsAFailedSyncRatherThanAnEmptyOne(t *testing.T) {
+	s := newSite()
+	s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	src := newSource(t, s)
+	s.refuse("/rest/api/3/search", http.StatusInternalServerError)
+
+	_, err := src.Sync(t.Context(), connector.Cursor{}, func(context.Context, connector.Change) error { return nil })
+	if err == nil {
+		t.Fatal("a site answering every search with an error produced a successful sync of nothing")
+	}
+}
+
+// An id this source could never have produced is refused rather than being put
+// into a URL path to find out what happens.
+func TestAnIdThatIsNotAnIssueKeyIsRefused(t *testing.T) {
+	s := newSite()
+	src := newSource(t, s)
+
+	for _, id := range []string{"jira:../../admin", "jira:not a key", "jira:LINE-", "jira:-1"} {
+		if _, err := src.Fetch(t.Context(), id); err == nil {
+			t.Errorf("fetching %q was allowed", id)
+		}
+	}
+}
+
+// The credentials go in a header. A token in a query string ends up in a server
+// log, in a recording and in a bug report.
+func TestTheTokenIsNeverInAURL(t *testing.T) {
+	s := newSite()
+	s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+
+	var seen []string
+	src := newSource(t, s, jirasource.WithHTTPClient(&http.Client{
+		Transport: watcher{seen: &seen},
+	}))
+
+	// The client above answers nothing, so the sync fails. What is being
+	// checked is what went out before it did.
+	_, _ = src.Sync(t.Context(), connector.Cursor{}, func(context.Context, connector.Change) error { return nil })
+	if len(seen) == 0 {
+		t.Fatal("nothing was requested")
+	}
+	for _, u := range seen {
+		if strings.Contains(u, token) || strings.Contains(u, email) {
+			t.Errorf("the credentials went out in %s", u)
+		}
+	}
+}
+
+// watcher records where requests went and refuses them.
+type watcher struct{ seen *[]string }
+
+func (w watcher) RoundTrip(req *http.Request) (*http.Response, error) {
+	*w.seen = append(*w.seen, req.URL.String())
+	return nil, errors.New("no")
+}
+
+// A site is not asked for three hundred custom fields when the document holds
+// twelve of them, because a page of everything is a request the site bills
+// accordingly.
+func TestOnlyTheFieldsThatEndUpInTheDocumentAreAskedFor(t *testing.T) {
+	s := newSite()
+	s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	src := newSource(t, s)
+
+	if err := src.Enumerate(t.Context(), func(connector.Item) bool { return true }); err != nil {
+		t.Fatal(err)
+	}
+	// The sweep needs one field, and asking for the description of every issue
+	// in a site to work out which of them changed would be the expensive way to
+	// learn nothing.
+	if got := s.lastFields("/rest/api/3/search"); got != "updated" {
+		t.Errorf("the listing asked for the fields %q, want only the one the sweep compares", got)
+	}
+}

--- a/connector/jirasource/permissions.go
+++ b/connector/jirasource/permissions.go
@@ -1,0 +1,365 @@
+package jirasource
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/threadsource"
+)
+
+// DefaultACLRefresh is how often a project's rule is reapplied to the issues in
+// it even though nothing said it had changed.
+//
+// Jira reports when an issue changed and reports nothing at all about when a
+// permission scheme changed. Somebody removed from a project role, a group
+// emptied out, a scheme swapped for a stricter one: none of those touch a single
+// issue, and all of them are revocations. A revocation that reaches the index
+// when somebody next comments on a ticket is not a revocation.
+//
+// So the rule is reapplied on a schedule as well. A day is the default: it
+// bounds how long somebody who lost access keeps seeing a project's tickets in
+// their results, and it costs one write per issue in the project once a day
+// rather than a read of any of them.
+const DefaultACLRefresh = 24 * time.Hour
+
+// WithACLRefresh sets how often a project's rule is reapplied. Zero selects
+// [DefaultACLRefresh].
+func WithACLRefresh(d time.Duration) Option {
+	return func(s *Service) { s.aclRefresh = d }
+}
+
+// browse is the Jira permission that decides whether somebody may see an issue
+// at all. Everything else a permission scheme grants is about changing things.
+const browse = "BROWSE_PROJECTS"
+
+// Containers lists the projects this account can see, with who may read each.
+func (s *Service) Containers(ctx context.Context) ([]threadsource.Container, error) {
+	type listing struct {
+		window
+		Values []project `json:"values"`
+	}
+
+	var found []project
+	err := pages(ctx, s, "/rest/api/3/project/search", url.Values{
+		"orderBy": {"key"},
+	}, func(page listing) (int, bool) {
+		found = append(found, page.Values...)
+		return len(page.Values), true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	containers := make([]threadsource.Container, 0, len(found))
+	for _, p := range found {
+		access, err := s.access(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		// The key is the id and the name is the label, because the key is what
+		// JQL calls the project and the name is what a person calls it.
+		containers = append(containers, threadsource.Container{
+			ID:       p.Key,
+			Name:     p.Name,
+			Access:   access,
+			AccessAt: s.tick(),
+		})
+	}
+	return containers, nil
+}
+
+// access works out who may browse a project.
+//
+// The answer comes from the permission scheme, which grants browse to some
+// mixture of roles, groups and named accounts, and Jira will resolve all of
+// that in one request if asked the right way. What comes back is what an access
+// control list is: a set of accounts and a set of groups.
+func (s *Service) access(ctx context.Context, p project) (acl.Permissions, error) {
+	type holder struct {
+		Type      string `json:"type"`
+		Parameter string `json:"parameter"`
+	}
+	type grant struct {
+		Holder holder `json:"holder"`
+		Permit string `json:"permission"`
+	}
+	type scheme struct {
+		Permissions []grant `json:"permissions"`
+	}
+
+	var out scheme
+	err := s.call(ctx, "/rest/api/3/project/"+url.PathEscape(p.Key)+"/permissionscheme", url.Values{
+		"expand": {"permissions"},
+	}, &out)
+	switch {
+	case err == nil:
+	case refused(err, http.StatusUnauthorized), refused(err, http.StatusForbidden), refused(err, http.StatusNotFound):
+		// Reading a permission scheme is an administrator's request on some
+		// sites, and this account may only be a user. Quarantining is the only
+		// safe answer and staying quiet about it is the only unsafe one.
+		s.skip(p.Key, fmt.Errorf("who may browse %s: %w", p.Key, err))
+		return connector.Unresolved(s.name), nil
+	default:
+		return acl.Permissions{}, err
+	}
+
+	var (
+		users  []acl.Ref
+		groups []acl.Ref
+		anyone bool
+	)
+	for _, g := range out.Permissions {
+		if g.Permit != browse {
+			continue
+		}
+		switch g.Holder.Type {
+		case "group", "groupCustomField":
+			if g.Holder.Parameter != "" {
+				groups = append(groups, acl.Ref{Source: s.name, Value: g.Holder.Parameter})
+			}
+		case "user", "userCustomField":
+			if g.Holder.Parameter != "" {
+				users = append(users, acl.Ref{Source: s.name, Value: g.Holder.Parameter})
+			}
+		case "projectRole":
+			members, err := s.role(ctx, p.Key, g.Holder.Parameter)
+			if err != nil {
+				return acl.Permissions{}, err
+			}
+			users = append(users, members.users...)
+			groups = append(groups, members.groups...)
+		case "applicationRole", "anyone", "sd.customer.portal.only":
+			// Granting browse to everybody with a licence, or to anonymous
+			// users, is a project that is open to the tenant. It is a real
+			// configuration and pretending it is an access control list of
+			// nobody would hide the project instead of describing it.
+			anyone = true
+		}
+	}
+
+	if anyone {
+		return acl.Permissions{Mode: acl.ModePublicToTenant, Source: s.name}, nil
+	}
+	if len(users) == 0 && len(groups) == 0 {
+		// A scheme that grants browse to nothing is not a project everybody can
+		// read, it is a project we failed to understand. Say so.
+		s.skip(p.Key, fmt.Errorf("the permission scheme for %s grants %s to nobody", p.Key, browse))
+		return connector.Unresolved(s.name), nil
+	}
+
+	return acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      s.name,
+		AllowUsers:  tidy(users),
+		AllowGroups: tidy(groups),
+	}, nil
+}
+
+// members is what a project role resolves to.
+type members struct {
+	users  []acl.Ref
+	groups []acl.Ref
+}
+
+// role resolves a project role to the accounts and groups in it.
+//
+// A role is Jira's indirection between a person and a permission, and it is the
+// one every real site uses: the scheme grants browse to Developers and the
+// project decides who they are. An adapter that stopped at the role name would
+// produce an access control list naming a thing rather than anybody.
+func (s *Service) role(ctx context.Context, key, id string) (members, error) {
+	if id == "" {
+		return members{}, nil
+	}
+
+	type actor struct {
+		Type      string `json:"type"`
+		Name      string `json:"displayName"`
+		ActorUser *struct {
+			AccountID string `json:"accountId"`
+		} `json:"actorUser"`
+		ActorGroup *struct {
+			Name string `json:"name"`
+		} `json:"actorGroup"`
+	}
+	var out struct {
+		Actors []actor `json:"actors"`
+	}
+
+	path := "/rest/api/3/project/" + url.PathEscape(key) + "/role/" + url.PathEscape(id)
+	if err := s.call(ctx, path, nil, &out); err != nil {
+		if refused(err, http.StatusUnauthorized) || missing(err) {
+			// The same story as the scheme itself. The caller turns an empty
+			// result plus nothing else into a quarantine rather than into a
+			// project readable by nobody.
+			s.skip(key, fmt.Errorf("who is in role %s of %s: %w", id, key, err))
+			return members{}, nil
+		}
+		return members{}, err
+	}
+
+	var got members
+	for _, a := range out.Actors {
+		switch {
+		case a.ActorUser != nil && a.ActorUser.AccountID != "":
+			got.users = append(got.users, acl.Ref{Source: s.name, Value: a.ActorUser.AccountID})
+		case a.ActorGroup != nil && a.ActorGroup.Name != "":
+			got.groups = append(got.groups, acl.Ref{Source: s.name, Value: a.ActorGroup.Name})
+		}
+	}
+	return got, nil
+}
+
+// tick is the time a project's rule is reported to have changed at.
+//
+// Jira reports nothing about that, so what is reported instead is the start of
+// the current refresh interval, which is what makes the schedule in
+// [DefaultACLRefresh] happen. It is quantised rather than measured from the
+// last sync so that the answer does not depend on when the syncs ran: two
+// servers reading the same site an hour apart agree about whether the rule has
+// moved, and a sync every five minutes still only reapplies it once.
+func (s *Service) tick() time.Time {
+	every := s.aclRefresh
+	if every <= 0 {
+		every = DefaultACLRefresh
+	}
+	return s.now().UTC().Truncate(every)
+}
+
+// security resolves issue security levels to the people who may read what is
+// behind them.
+//
+// It is a cache because a project with a security scheme puts the same handful
+// of levels on thousands of issues, and resolving one per issue would spend the
+// crawl on the same four answers. A failure is cached too, because a token that
+// may not resolve a level this minute may not resolve it next minute either,
+// and asking again per issue turns one refusal into a thousand.
+type security struct {
+	svc *Service
+
+	mu sync.Mutex
+	by map[string]acl.Permissions
+}
+
+func newSecurity(s *Service) *security {
+	return &security{svc: s, by: make(map[string]acl.Permissions)}
+}
+
+// level returns the rule for an issue security level.
+func (l *security) level(ctx context.Context, id, name string) acl.Permissions {
+	l.mu.Lock()
+	got, ok := l.by[id]
+	l.mu.Unlock()
+	if ok {
+		return got
+	}
+
+	found := l.resolve(ctx, id, name)
+
+	l.mu.Lock()
+	l.by[id] = found
+	l.mu.Unlock()
+	return found
+}
+
+// resolve asks the site who is in a security level.
+//
+// Everything about this is deliberately pessimistic. An issue security level is
+// the one thing in Jira somebody set on purpose to keep other people out, so a
+// level this token cannot resolve is a quarantine rather than a fall back to the
+// project's rule, and an empty level is a quarantine too rather than a level
+// that grants nothing and is therefore ignored.
+func (l *security) resolve(ctx context.Context, id, name string) acl.Permissions {
+	s := l.svc
+
+	type member struct {
+		Holder struct {
+			Type      string `json:"type"`
+			Parameter string `json:"parameter"`
+			User      *struct {
+				AccountID string `json:"accountId"`
+			} `json:"user"`
+			Group *struct {
+				Name string `json:"name"`
+			} `json:"group"`
+			ProjectRole *struct {
+				ID int `json:"id"`
+			} `json:"projectRole"`
+		} `json:"holder"`
+		IssueSecurityLevelID string `json:"issueSecurityLevelId"`
+	}
+	type listing struct {
+		window
+		Values []member `json:"values"`
+	}
+
+	var found []member
+	err := pages(ctx, s, "/rest/api/3/issuesecurityschemes/level/member", url.Values{
+		"levelId": {id},
+	}, func(page listing) (int, bool) {
+		found = append(found, page.Values...)
+		return len(page.Values), true
+	})
+	if err != nil {
+		s.skip("security level "+id, fmt.Errorf("who may read issues at security level %q: %w", name, err))
+		return connector.Unresolved(s.name)
+	}
+
+	var users, groups []acl.Ref
+	for _, m := range found {
+		switch {
+		case m.Holder.User != nil && m.Holder.User.AccountID != "":
+			users = append(users, acl.Ref{Source: s.name, Value: m.Holder.User.AccountID})
+		case m.Holder.Group != nil && m.Holder.Group.Name != "":
+			groups = append(groups, acl.Ref{Source: s.name, Value: m.Holder.Group.Name})
+		case m.Holder.ProjectRole != nil:
+			// A level granted to a role is granted to whoever is in that role
+			// in the issue's own project, and the project is not something this
+			// endpoint says. Resolving it correctly means knowing which issue is
+			// being asked about, which this cache deliberately does not, so it
+			// is a quarantine rather than a guess in either direction.
+			s.skip("security level "+id, fmt.Errorf(
+				"security level %q is granted to project role %d, which cannot be resolved without the project",
+				name, m.Holder.ProjectRole.ID))
+			return connector.Unresolved(s.name)
+		}
+	}
+
+	if len(users) == 0 && len(groups) == 0 {
+		s.skip("security level "+id, fmt.Errorf("security level %q resolves to nobody", name))
+		return connector.Unresolved(s.name)
+	}
+
+	return acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      s.name,
+		AllowUsers:  tidy(users),
+		AllowGroups: tidy(groups),
+	}
+}
+
+// tidy puts a set of references in order and drops the repeats.
+//
+// The order Jira lists anything in is not something anybody promised, and a
+// list that reorders itself between syncs is a permission change that never
+// happened, written to every document in the project.
+func tidy(refs []acl.Ref) []acl.Ref {
+	if len(refs) == 0 {
+		return nil
+	}
+	slices.SortFunc(refs, func(a, b acl.Ref) int {
+		if d := strings.Compare(a.Source, b.Source); d != 0 {
+			return d
+		}
+		return strings.Compare(a.Value, b.Value)
+	})
+	return slices.Compact(refs)
+}

--- a/connector/jirasource/recording_test.go
+++ b/connector/jirasource/recording_test.go
@@ -1,0 +1,348 @@
+package jirasource_test
+
+import (
+	"encoding/base64"
+	"flag"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/jirasource"
+	"github.com/tamnd/genba/connector/recorded"
+	"github.com/tamnd/genba/connector/threadsource"
+)
+
+// The fixture set is a crawl of a small site written down once and read back by
+// the tests below, so that the adapter is exercised against the bytes a Jira
+// site actually sends without anybody needing an account or a token to run the
+// tests.
+//
+// The fake next to this file is the other half of the story and neither
+// replaces the other. The fake is where behaviour is written: it can be made to
+// throttle, to hide a permission scheme, to lose an issue between two syncs. The
+// recording is where the wire format is pinned: it is the answer to "did we
+// change what we send" and it is the thing that would have to be refreshed if
+// Atlassian changed a field name.
+const fixtures = "testdata/site"
+
+// where the recording is replayed against. Nothing reaches it. It is the real
+// shape of a Jira Cloud address because a reader opening one of these files
+// should see the request that would have gone to a site.
+const siteURL = "https://acme.atlassian.net"
+
+// The ids the recorded site produces, written down rather than worked out. A
+// test that derived them from the fake would pass just as happily against a
+// recording of something else entirely.
+const (
+	gearboxID = "jira:LINE-1"
+	coolantID = "jira:LINE-2"
+	guardID   = "jira:SAFETY-1"
+)
+
+// pinned is what the clock says while the fixtures are being read back. A full
+// sync reads the whole site and asks for nothing that depends on the time, so
+// this only has to be steady rather than right.
+var pinned = func() time.Time { return start.Add(time.Hour) }
+
+var update = flag.Bool("update", false, "record the Jira fixtures in testdata again")
+
+// recordingSite is the site the fixtures are a crawl of.
+//
+// It is small on purpose and every part of it is there for a reason: two
+// projects so that the listing is more than one entry, a scheme granting browse
+// through a role and another granting it to a group so that both resolutions are
+// in the recording, a ticket with a structured description and an argument
+// underneath it from two different people, and an issue behind a security level
+// so that the override is in there too.
+func recordingSite() *site {
+	s := newSite()
+
+	gearbox := s.file(home, "Gearbox noise on line two", "placeholder")
+	s.describe(gearbox, map[string]any{
+		"type":    "doc",
+		"version": 1,
+		"content": []any{
+			map[string]any{"type": "paragraph", "content": []any{
+				map[string]any{"type": "text", "text": "The gearbox on line two is making a noise under load."},
+			}},
+			map[string]any{
+				"type":  "codeBlock",
+				"attrs": map[string]any{"language": "text"},
+				"content": []any{map[string]any{
+					"type": "text",
+					"text": "vibration 4.2 mm/s at 1450 rpm",
+				}},
+			},
+		},
+	})
+	s.assign(gearbox, "acc-sam")
+	s.label(gearbox, "line-two", "mechanical")
+	s.comment(gearbox, "acc-sam", "Sounds like the outboard bearing to me.")
+	s.comment(gearbox, "acc-lee", "I changed that one on Tuesday, so it should not be.")
+	s.transition(gearbox, "In Progress")
+
+	s.file(home, "Coolant pump replaced", "The coolant pump on line two was replaced this morning.")
+
+	safety := s.addProject("SAFETY", "Safety")
+	safety.grants = []grant{{"group", "safety-officers"}}
+	s.addLevel("10500", "Incident reports", "acc-lee")
+	s.restrict(s.file("SAFETY", "Guard on the press", "The guard on the press is being replaced on Friday morning."), "10500")
+
+	return s
+}
+
+// authed puts the credentials on the way the adapter does, so that what is
+// recorded is a real authenticated crawl rather than one made against a service
+// that was not asking.
+type authed struct{ base http.RoundTripper }
+
+func (a authed) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(email+":"+token)))
+	return a.base.RoundTrip(req)
+}
+
+// TestRecordTheFixtures writes the fixture set again. It is skipped unless the
+// flag is given, because a recording that refreshed itself on every run would
+// never fail: the thing it is there to catch is a change to what we send, and a
+// fixture regenerated alongside the change agrees with it by construction.
+func TestRecordTheFixtures(t *testing.T) {
+	if !*update {
+		t.Skip("run with -update to record the fixtures again")
+	}
+
+	s := recordingSite()
+	if got := "jira:" + s.keyOf("Gearbox noise on line two"); got != gearboxID {
+		t.Fatalf("the site filed the gearbox ticket under %s, and the tests below look for %s", got, gearboxID)
+	}
+
+	rec := recorded.Record(authed{http.DefaultTransport},
+		recorded.WithRedactedHeaders("Authorization"),
+	)
+	src, err := jirasource.New(s.server(t), email, token,
+		jirasource.WithHTTPClient(rec.Client()),
+		jirasource.WithClock(pinned),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = src.Close() }()
+
+	crawl(t, src)
+
+	// A crawl asks the same listing question more than once: the sync, the sweep
+	// and a fetch each need to know what the projects are and who may read each.
+	// Writing the answer down three times is three files to review and no more
+	// coverage, so the repeats are dropped and what is left is one file per
+	// distinct question.
+	var (
+		seen = map[string]bool{}
+		once []recorded.Exchange
+	)
+	for _, e := range rec.Exchanges() {
+		k := e.Request.Method + " " + e.Request.URL
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		once = append(once, settle(e))
+	}
+
+	if err := recorded.From(once).Save(fixtures); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %d of %d exchanges to %s", len(once), len(rec.Exchanges()), fixtures)
+}
+
+// settle takes the run out of a recorded exchange.
+//
+// Two things in one differ every time it is made: the address the test server
+// was given, and the date the answer came back on. Neither is matched against
+// and neither means anything, and leaving them in would make every refresh of
+// the fixtures a diff on every file with the real change somewhere in it.
+func settle(e recorded.Exchange) recorded.Exchange {
+	if u, err := url.Parse(e.Request.URL); err == nil {
+		site, err := url.Parse(siteURL)
+		if err != nil {
+			panic(err)
+		}
+		u.Scheme, u.Host = site.Scheme, site.Host
+		e.Request.URL = u.String()
+	}
+	delete(e.Response.Headers, "Date")
+	delete(e.Response.Headers, "Content-Length")
+	return e
+}
+
+// crawl is everything the fixture set has to answer, and it is shared so that
+// what is recorded and what is replayed cannot drift apart.
+func crawl(t *testing.T, src *threadsource.Source) []connector.Change {
+	t.Helper()
+
+	changes, _ := run(t, src, connector.Cursor{})
+
+	var listed []connector.Item
+	if err := src.Enumerate(t.Context(), func(item connector.Item) bool {
+		listed = append(listed, item)
+		return true
+	}); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(listed) == 0 {
+		t.Fatal("the listing found nothing")
+	}
+
+	if _, err := src.Fetch(t.Context(), gearboxID); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	return changes
+}
+
+// replaying is the adapter over the committed fixture set.
+func replaying(t *testing.T) *threadsource.Source {
+	t.Helper()
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := jirasource.New(siteURL, email, token,
+		jirasource.WithHTTPClient(rt.Client()),
+		jirasource.WithClock(pinned),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+	return src
+}
+
+// TestTheRecordedSiteCrawlsWithoutAnAccount is the point of the fixture set: the
+// whole adapter, the real paging and the real decoding, against bytes that came
+// off a site and are now a file.
+func TestTheRecordedSiteCrawlsWithoutAnAccount(t *testing.T) {
+	changes := crawl(t, replaying(t))
+
+	want := []string{gearboxID, coolantID, guardID}
+	slices.Sort(want)
+	if got := ids(changes); !slices.Equal(got, want) {
+		t.Fatalf("the recorded site crawled to %v, want %v", got, want)
+	}
+
+	gearbox := find(changes, gearboxID)
+	if gearbox == nil {
+		t.Fatal("the ticket with the argument on it is not in the crawl")
+	}
+	for _, phrase := range []string{
+		"making a noise under load",
+		"vibration 4.2 mm/s at 1450 rpm",
+		"outboard bearing",
+		"changed that one on Tuesday",
+	} {
+		if !strings.Contains(gearbox.Document.Body, phrase) {
+			t.Errorf("the ticket is missing %q:\n%s", phrase, gearbox.Document.Body)
+		}
+	}
+	if got := gearbox.Document.Properties["status"]; got != "In Progress" {
+		t.Errorf("the ticket is %q, want the status it was moved to", got)
+	}
+
+	// Names came out of the recording too, which is the part a crawl without an
+	// account usually cannot show.
+	if got := gearbox.Document.Author.Name; got != "Mei Tanaka" {
+		t.Errorf("the ticket is attributed to %q, want the name the recording holds", got)
+	}
+}
+
+// The permission work is in the recording as well, which is what makes it worth
+// committing. A role resolved to its members, a group named directly and a
+// security level overriding the project it is in are three different requests
+// and three different answers.
+func TestTheRecordedSiteResolvesItsPermissions(t *testing.T) {
+	changes := crawl(t, replaying(t))
+
+	gearbox := find(changes, gearboxID)
+	if gearbox == nil {
+		t.Fatalf("the crawl emitted %v", ids(changes))
+	}
+	if got := gearbox.Document.Permissions.AllowUsers; len(got) != 1 || got[0].Value != "acc-mei" {
+		t.Errorf("the project role resolved to the accounts %v", got)
+	}
+	if got := gearbox.Document.Permissions.AllowGroups; len(got) != 1 || got[0].Value != "engineering" {
+		t.Errorf("the project role resolved to the groups %v", got)
+	}
+
+	guard := find(changes, guardID)
+	if guard == nil {
+		t.Fatalf("the crawl emitted %v", ids(changes))
+	}
+	if got := guard.Document.Permissions.AllowUsers; len(got) != 1 || got[0].Value != "acc-lee" {
+		t.Errorf("an issue behind a security level allows %v, want only the level", got)
+	}
+	if got := guard.Document.Permissions.AllowGroups; len(got) != 0 {
+		t.Errorf("an issue behind a security level still allows the project's groups: %v", got)
+	}
+}
+
+// TestTheRecordingHoldsNothingItIsNotAskedFor keeps the fixture set from growing
+// a tail of responses nothing reads.
+//
+// A recording is a thing people add to and rarely take away from, and one that
+// has drifted is worse than none: a reviewer reading a file next to the test
+// reasonably assumes the test depends on it.
+func TestTheRecordingHoldsNothingItIsNotAskedFor(t *testing.T) {
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := jirasource.New(siteURL, email, token,
+		jirasource.WithHTTPClient(rt.Client()),
+		jirasource.WithClock(pinned),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = src.Close() }()
+
+	crawl(t, src)
+
+	if left := rt.Unused(); len(left) != 0 {
+		t.Errorf("the fixture set answers %d requests the crawl never makes:\n%s", len(left), strings.Join(left, "\n"))
+	}
+}
+
+// TestTheRecordingCarriesNoCredentials is the reason a fixture set is safe to
+// commit at all. It is a check on the recording rather than on the code, and it
+// is here because the file is here.
+func TestTheRecordingCarriesNoCredentials(t *testing.T) {
+	entries, err := os.ReadDir(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(fixtures, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		body := string(raw)
+		if strings.Contains(body, token) {
+			t.Errorf("%s holds the token it was recorded with", e.Name())
+		}
+		// The email address is half of a basic authentication credential on a
+		// Jira site, so it does not belong in a committed file either.
+		if strings.Contains(body, email) {
+			t.Errorf("%s holds the account the recording was made with", e.Name())
+		}
+		if strings.Contains(body, base64.StdEncoding.EncodeToString([]byte(email+":"+token))) {
+			t.Errorf("%s holds an encoded credential", e.Name())
+		}
+	}
+}

--- a/connector/jirasource/service.go
+++ b/connector/jirasource/service.go
@@ -1,0 +1,354 @@
+package jirasource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/thread"
+	"github.com/tamnd/genba/connector/threadsource"
+	"github.com/tamnd/genba/doc"
+)
+
+// fields is what a crawl asks for on every issue.
+//
+// It is written down rather than left as everything, because everything on a
+// site with three hundred custom fields is a page of search results the size of
+// a small database and a request the site bills accordingly. Every name here is
+// something that ends up in the document.
+var fields = strings.Join([]string{
+	"summary", "description", "created", "updated",
+	"reporter", "creator", "assignee",
+	"status", "issuetype", "priority", "labels",
+	"security", "comment",
+}, ",")
+
+// Threads walks the issues in a project that changed at or after since.
+//
+// This is the part chat cannot do. Jira's updated field moves when anything
+// about an issue moves, including a comment on it, and JQL will filter and
+// order by it, so what a sync needs is exactly one query and there is no window
+// to widen and nothing to guess at.
+func (s *Service) Threads(ctx context.Context, c threadsource.Container, since time.Time, fn func(context.Context, threadsource.Thread) error) error {
+	jql := "project = " + quote(c.ID)
+	if !since.IsZero() {
+		// At or after rather than after, because JQL compares to the minute and
+		// an issue updated in the same minute as the cursor is one an exclusive
+		// query loses for ever. The cursor's edge set is what stops the repeat
+		// from being emitted twice.
+		jql += ` AND updated >= "` + jqlTime(since) + `"`
+	}
+	jql += " ORDER BY updated ASC"
+
+	return s.search(ctx, c, jql, fields, func(ctx context.Context, is issue) error {
+		if !stamp(is.Fields.Updated).Before(since) {
+			th, err := s.build(ctx, is)
+			if err != nil {
+				return err
+			}
+			return fn(ctx, th)
+		}
+		// JQL rounds to the minute and this does not, so a query asked for the
+		// minute the cursor is in comes back with the issues from the first half
+		// of it as well. Dropping them here rather than widening the query is
+		// what keeps the request cheap and the answer exact.
+		return nil
+	})
+}
+
+// List reports every issue the project currently holds, with the version the
+// sweep compares.
+//
+// Nothing in JQL reports an issue that was deleted or moved to another project,
+// so this is the only thing that ever takes one out of the index.
+func (s *Service) List(ctx context.Context, c threadsource.Container, fn func(connector.Item) bool) error {
+	err := s.search(ctx, c, "project = "+quote(c.ID)+" ORDER BY key ASC", "updated", func(_ context.Context, is issue) error {
+		if !fn(connector.Item{ID: is.Key, Version: is.Fields.Updated}) {
+			return errStop
+		}
+		return nil
+	})
+	if errors.Is(err, errStop) {
+		// A listing the caller ended on purpose is not a failed listing, and
+		// reporting it as one is how a reconciliation sweep ends up emptying an
+		// index.
+		return nil
+	}
+	return err
+}
+
+// errStop is how a caller that has seen enough gets out of a walk, and it never
+// leaves this package.
+var errStop = errors.New("jirasource: enough")
+
+// search runs a JQL query and hands each issue to fn.
+//
+// The one thing worth knowing is what it does about a project this account
+// cannot browse: nothing, deliberately. Jira answers a query about a project
+// you may not see with an error rather than with no issues, and the caller of
+// this decides what that means, because it means different things to a sync and
+// to a sweep.
+func (s *Service) search(ctx context.Context, c threadsource.Container, jql, want string, fn func(context.Context, issue) error) error {
+	type results struct {
+		window
+		Issues []issue `json:"issues"`
+	}
+
+	var stopped error
+	err := pages(ctx, s, "/rest/api/3/search", url.Values{
+		"jql":    {jql},
+		"fields": {want},
+	}, func(page results) (int, bool) {
+		for _, is := range page.Issues {
+			if err := fn(ctx, is); err != nil {
+				stopped = err
+				return len(page.Issues), false
+			}
+		}
+		return len(page.Issues), true
+	})
+	if stopped != nil {
+		return stopped
+	}
+	return err
+}
+
+// Read fetches one issue by its key.
+func (s *Service) Read(ctx context.Context, id string) (threadsource.Thread, error) {
+	if !looksLikeKey(id) {
+		return threadsource.Thread{}, fmt.Errorf("%w: %q", errBadKey, id)
+	}
+
+	var is issue
+	err := s.call(ctx, "/rest/api/3/issue/"+url.PathEscape(id), url.Values{
+		"fields": {fields},
+	}, &is)
+	switch {
+	case err == nil:
+	case missing(err):
+		// Deleted, or moved somewhere this token cannot follow. From the
+		// index's point of view those are the same event.
+		return threadsource.Thread{}, connector.ErrGone
+	default:
+		return threadsource.Thread{}, err
+	}
+
+	return s.build(ctx, is)
+}
+
+// build turns an issue into the conversation the crawl above wants.
+func (s *Service) build(ctx context.Context, is issue) (threadsource.Thread, error) {
+	all, err := s.comments(ctx, is)
+	if err != nil {
+		return threadsource.Thread{}, err
+	}
+
+	replies := make([]thread.Message, 0, len(all))
+	for _, c := range all {
+		replies = append(replies, thread.Message{
+			ID:     c.ID,
+			Author: person(c.Author, s.name),
+			At:     stamp(c.Created),
+			Edited: edited(c),
+			Text:   text(c.Body),
+		})
+	}
+
+	conv := thread.Conversation{
+		ID:    is.Key,
+		Kind:  doc.KindTicket,
+		Title: is.Key + " " + strings.TrimSpace(is.Fields.Summary),
+		URL:   s.browseURL(is.Key),
+		Root: thread.Message{
+			ID: is.Key,
+			// The reporter rather than the creator. On a site with a service
+			// desk in front of it the creator is the automation that filed the
+			// ticket and the reporter is the person it is about, and the person
+			// is who a search for their tickets means.
+			Author: person(reporterOf(is), s.name),
+			At:     stamp(is.Fields.Created),
+			Text:   text(is.Fields.Description),
+		},
+		Replies:    replies,
+		Revision:   is.Fields.Updated,
+		Properties: properties(is),
+	}
+
+	th := threadsource.Thread{
+		Conversation: conv,
+		Container:    projectOf(is.Key),
+		Updated:      stamp(is.Fields.Updated),
+	}
+
+	// The security level, if there is one, replaces the project's rule rather
+	// than adding to it. That is the whole point of a security level, and it is
+	// the reason the crawl above lets a conversation override its container.
+	if sec := is.Fields.Security; sec != nil && sec.ID != "" {
+		th.Access = s.levels.level(ctx, sec.ID, sec.Name)
+	}
+
+	return th, nil
+}
+
+// comments reads the argument underneath a ticket.
+//
+// A search returns the first page of them inline, which is most issues in one
+// request rather than two, and the rest are paged for separately. Asking for
+// them unconditionally would be a request per issue in the site to be told what
+// we were already holding.
+func (s *Service) comments(ctx context.Context, is issue) ([]comment, error) {
+	inline := is.Fields.Comment
+	if inline == nil {
+		return nil, nil
+	}
+	got := inline.Comments
+	if inline.Total <= len(got) {
+		return got, nil
+	}
+
+	type listing struct {
+		window
+		Comments []comment `json:"comments"`
+	}
+	var all []comment
+	err := pages(ctx, s, "/rest/api/3/issue/"+url.PathEscape(is.Key)+"/comment", url.Values{
+		"orderBy": {"created"},
+	}, func(page listing) (int, bool) {
+		all = append(all, page.Comments...)
+		return len(page.Comments), true
+	})
+	switch {
+	case err == nil:
+		return all, nil
+	case missing(err):
+		// The issue went away between the search and this request, which is a
+		// race every crawl has. What is in hand is still a ticket worth
+		// indexing, and the sweep removes it if it really is gone.
+		return got, nil
+	default:
+		return nil, err
+	}
+}
+
+// properties are the fields a person filters on rather than reads.
+//
+// The assignee is here rather than being a second author because "tickets Sam
+// reported" and "tickets Sam is working on" are different questions, and an
+// index that conflated them would answer neither.
+func properties(is issue) map[string]string {
+	out := make(map[string]string, 6)
+	if f := is.Fields.Status; f != nil && f.Name != "" {
+		out["status"] = f.Name
+	}
+	if f := is.Fields.IssueType; f != nil && f.Name != "" {
+		out["type"] = f.Name
+	}
+	if f := is.Fields.Priority; f != nil && f.Name != "" {
+		out["priority"] = f.Name
+	}
+	if a := is.Fields.Assignee; a != nil && a.DisplayName != "" {
+		out["assignee"] = a.DisplayName
+	}
+	if len(is.Fields.Labels) > 0 {
+		out["labels"] = strings.Join(is.Fields.Labels, ", ")
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// person turns a Jira account into who a document says wrote something.
+//
+// The account id is the identity and the display name is a label, and they are
+// kept apart on purpose. A permission rule written against a display name is a
+// permission rule anybody can grant themselves by renaming.
+func person(a *account, source string) doc.Person {
+	if a == nil || a.AccountID == "" {
+		return doc.Person{}
+	}
+	name := a.DisplayName
+	if name == "" {
+		name = a.AccountID
+	}
+	return doc.Person{
+		Subject:  a.AccountID,
+		Identity: acl.Identity{Source: source, Value: a.AccountID},
+		Name:     name,
+		Email:    a.Email,
+	}
+}
+
+// reporterOf is who the ticket is by, falling back to who filed it.
+func reporterOf(is issue) *account {
+	if is.Fields.Reporter != nil {
+		return is.Fields.Reporter
+	}
+	return is.Fields.Creator
+}
+
+// edited is when a comment was last changed, and nothing when it never was.
+func edited(c comment) time.Time {
+	at, was := stamp(c.Updated), stamp(c.Created)
+	if at.After(was) {
+		return at
+	}
+	return time.Time{}
+}
+
+// browseURL is where a person goes to read the ticket at the source.
+func (s *Service) browseURL(key string) string {
+	return s.base + "/browse/" + url.PathEscape(key)
+}
+
+// projectOf is the project key an issue key belongs to, which is everything in
+// front of the dash.
+func projectOf(key string) string {
+	k, _, _ := strings.Cut(key, "-")
+	return k
+}
+
+// errBadKey is what an id that this source could never have produced comes back
+// as, which is different from an id it produced and no longer has.
+var errBadKey = errors.New("jirasource: not an issue key")
+
+// looksLikeKey reports whether an id is shaped like a Jira issue key, which is
+// a project key, a dash and a number.
+//
+// This is a check on our own ids rather than a validation of Jira's, and the
+// reason it is here is that the alternative is putting whatever the caller
+// passed into a URL path.
+func looksLikeKey(id string) bool {
+	project, number, ok := strings.Cut(id, "-")
+	if !ok || project == "" || number == "" {
+		return false
+	}
+	for _, r := range project {
+		upper := r >= 'A' && r <= 'Z'
+		digit := r >= '0' && r <= '9'
+		if !upper && !digit && r != '_' {
+			return false
+		}
+	}
+	for _, r := range number {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// quote puts a project key into a JQL query.
+//
+// Jira accepts a bare key and this quotes it anyway, because a key is
+// configurable, one of them will one day be a JQL keyword, and a query that
+// broke on the day somebody made a project called ORDER is not a thing to debug
+// twice.
+func quote(key string) string {
+	return `"` + strings.ReplaceAll(key, `"`, `\"`) + `"`
+}

--- a/connector/jirasource/testdata/site/0001-get-rest-api-3-project-search-maxresults-100-orderby-key-startat-0.json
+++ b/connector/jirasource/testdata/site/0001-get-rest-api-3-project-search-maxresults-100-orderby-key-startat-0.json
@@ -1,0 +1,39 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/rest/api/3/project/search?maxResults=100\u0026orderBy=key\u0026startAt=0",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "isLast": true,
+        "maxResults": 2,
+        "startAt": 0,
+        "total": 2,
+        "values": [
+          {
+            "id": "10000",
+            "key": "LINE",
+            "name": "Line two"
+          },
+          {
+            "id": "10001",
+            "key": "SAFETY",
+            "name": "Safety"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/connector/jirasource/testdata/site/0002-get-rest-api-3-project-line-permissionscheme-expand-permissions.json
+++ b/connector/jirasource/testdata/site/0002-get-rest-api-3-project-line-permissionscheme-expand-permissions.json
@@ -1,0 +1,34 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/rest/api/3/project/LINE/permissionscheme?expand=permissions",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "id": 10100,
+        "name": "scheme",
+        "permissions": [
+          {
+            "holder": {
+              "parameter": "10002",
+              "type": "projectRole"
+            },
+            "permission": "BROWSE_PROJECTS"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/connector/jirasource/testdata/site/0003-get-rest-api-3-project-line-role-10002.json
+++ b/connector/jirasource/testdata/site/0003-get-rest-api-3-project-line-role-10002.json
@@ -1,0 +1,41 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/rest/api/3/project/LINE/role/10002",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "actors": [
+          {
+            "actorUser": {
+              "accountId": "acc-mei"
+            },
+            "displayName": "acc-mei",
+            "type": "atlassian-user-role-actor"
+          },
+          {
+            "actorGroup": {
+              "name": "engineering"
+            },
+            "displayName": "engineering",
+            "type": "atlassian-group-role-actor"
+          }
+        ],
+        "id": "10002",
+        "name": "Role"
+      }
+    }
+  }
+}

--- a/connector/jirasource/testdata/site/0004-get-rest-api-3-project-safety-permissionscheme-expand-permissions.json
+++ b/connector/jirasource/testdata/site/0004-get-rest-api-3-project-safety-permissionscheme-expand-permissions.json
@@ -1,0 +1,34 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/rest/api/3/project/SAFETY/permissionscheme?expand=permissions",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "id": 10100,
+        "name": "scheme",
+        "permissions": [
+          {
+            "holder": {
+              "parameter": "safety-officers",
+              "type": "group"
+            },
+            "permission": "BROWSE_PROJECTS"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/connector/jirasource/testdata/site/0005-get-rest-api-3-search-fields-summary-description-created-updated-reporter.json
+++ b/connector/jirasource/testdata/site/0005-get-rest-api-3-search-fields-summary-description-created-updated-reporter.json
@@ -1,0 +1,205 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/rest/api/3/search?fields=summary%2Cdescription%2Ccreated%2Cupdated%2Creporter%2Ccreator%2Cassignee%2Cstatus%2Cissuetype%2Cpriority%2Clabels%2Csecurity%2Ccomment\u0026jql=project+%3D+%22LINE%22+ORDER+BY+updated+ASC\u0026maxResults=100\u0026startAt=0",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "issues": [
+          {
+            "fields": {
+              "assignee": {
+                "accountId": "acc-sam",
+                "active": true,
+                "displayName": "Sam Okafor",
+                "emailAddress": "sam@acme.com"
+              },
+              "comment": {
+                "comments": [
+                  {
+                    "author": {
+                      "accountId": "acc-sam",
+                      "active": true,
+                      "displayName": "Sam Okafor",
+                      "emailAddress": "sam@acme.com"
+                    },
+                    "body": {
+                      "content": [
+                        {
+                          "content": [
+                            {
+                              "text": "Sounds like the outboard bearing to me.",
+                              "type": "text"
+                            }
+                          ],
+                          "type": "paragraph"
+                        }
+                      ],
+                      "type": "doc",
+                      "version": 1
+                    },
+                    "created": "2026-03-02T09:05:00.000+0000",
+                    "id": "20010",
+                    "updated": "2026-03-02T09:05:00.000+0000"
+                  },
+                  {
+                    "author": {
+                      "accountId": "acc-lee",
+                      "active": true,
+                      "displayName": "Lee Berger",
+                      "emailAddress": "lee@acme.com"
+                    },
+                    "body": {
+                      "content": [
+                        {
+                          "content": [
+                            {
+                              "text": "I changed that one on Tuesday, so it should not be.",
+                              "type": "text"
+                            }
+                          ],
+                          "type": "paragraph"
+                        }
+                      ],
+                      "type": "doc",
+                      "version": 1
+                    },
+                    "created": "2026-03-02T09:06:00.000+0000",
+                    "id": "20011",
+                    "updated": "2026-03-02T09:06:00.000+0000"
+                  }
+                ],
+                "maxResults": 2,
+                "startAt": 0,
+                "total": 2
+              },
+              "created": "2026-03-02T09:01:00.000+0000",
+              "creator": {
+                "accountId": "acc-mei",
+                "active": true,
+                "displayName": "Mei Tanaka",
+                "emailAddress": "mei@acme.com"
+              },
+              "description": {
+                "content": [
+                  {
+                    "content": [
+                      {
+                        "text": "The gearbox on line two is making a noise under load.",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "paragraph"
+                  },
+                  {
+                    "attrs": {
+                      "language": "text"
+                    },
+                    "content": [
+                      {
+                        "text": "vibration 4.2 mm/s at 1450 rpm",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "codeBlock"
+                  }
+                ],
+                "type": "doc",
+                "version": 1
+              },
+              "issuetype": {
+                "name": "Bug"
+              },
+              "labels": [
+                "line-two",
+                "mechanical"
+              ],
+              "priority": {
+                "name": "Medium"
+              },
+              "reporter": {
+                "accountId": "acc-mei",
+                "active": true,
+                "displayName": "Mei Tanaka",
+                "emailAddress": "mei@acme.com"
+              },
+              "status": {
+                "name": "In Progress"
+              },
+              "summary": "Gearbox noise on line two",
+              "updated": "2026-03-02T09:07:00.000+0000"
+            },
+            "id": "iLINE-1",
+            "key": "LINE-1"
+          },
+          {
+            "fields": {
+              "comment": {
+                "comments": [],
+                "maxResults": 2,
+                "startAt": 0,
+                "total": 0
+              },
+              "created": "2026-03-02T09:08:00.000+0000",
+              "creator": {
+                "accountId": "acc-mei",
+                "active": true,
+                "displayName": "Mei Tanaka",
+                "emailAddress": "mei@acme.com"
+              },
+              "description": {
+                "content": [
+                  {
+                    "content": [
+                      {
+                        "text": "The coolant pump on line two was replaced this morning.",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "paragraph"
+                  }
+                ],
+                "type": "doc",
+                "version": 1
+              },
+              "issuetype": {
+                "name": "Bug"
+              },
+              "priority": {
+                "name": "Medium"
+              },
+              "reporter": {
+                "accountId": "acc-mei",
+                "active": true,
+                "displayName": "Mei Tanaka",
+                "emailAddress": "mei@acme.com"
+              },
+              "status": {
+                "name": "To Do"
+              },
+              "summary": "Coolant pump replaced",
+              "updated": "2026-03-02T09:08:00.000+0000"
+            },
+            "id": "iLINE-2",
+            "key": "LINE-2"
+          }
+        ],
+        "maxResults": 2,
+        "startAt": 0,
+        "total": 2
+      }
+    }
+  }
+}

--- a/connector/jirasource/testdata/site/0006-get-rest-api-3-search-fields-summary-description-created-updated-reporter.json
+++ b/connector/jirasource/testdata/site/0006-get-rest-api-3-search-fields-summary-description-created-updated-reporter.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/rest/api/3/search?fields=summary%2Cdescription%2Ccreated%2Cupdated%2Creporter%2Ccreator%2Cassignee%2Cstatus%2Cissuetype%2Cpriority%2Clabels%2Csecurity%2Ccomment\u0026jql=project+%3D+%22SAFETY%22+ORDER+BY+updated+ASC\u0026maxResults=100\u0026startAt=0",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "issues": [
+          {
+            "fields": {
+              "comment": {
+                "comments": [],
+                "maxResults": 2,
+                "startAt": 0,
+                "total": 0
+              },
+              "created": "2026-03-02T09:09:00.000+0000",
+              "creator": {
+                "accountId": "acc-mei",
+                "active": true,
+                "displayName": "Mei Tanaka",
+                "emailAddress": "mei@acme.com"
+              },
+              "description": {
+                "content": [
+                  {
+                    "content": [
+                      {
+                        "text": "The guard on the press is being replaced on Friday morning.",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "paragraph"
+                  }
+                ],
+                "type": "doc",
+                "version": 1
+              },
+              "issuetype": {
+                "name": "Bug"
+              },
+              "priority": {
+                "name": "Medium"
+              },
+              "reporter": {
+                "accountId": "acc-mei",
+                "active": true,
+                "displayName": "Mei Tanaka",
+                "emailAddress": "mei@acme.com"
+              },
+              "security": {
+                "id": "10500",
+                "name": "Incident reports"
+              },
+              "status": {
+                "name": "To Do"
+              },
+              "summary": "Guard on the press",
+              "updated": "2026-03-02T09:10:00.000+0000"
+            },
+            "id": "iSAFETY-1",
+            "key": "SAFETY-1"
+          }
+        ],
+        "maxResults": 2,
+        "startAt": 0,
+        "total": 1
+      }
+    }
+  }
+}

--- a/connector/jirasource/testdata/site/0007-get-rest-api-3-issuesecurityschemes-level-member-levelid-10500-maxresults-100.json
+++ b/connector/jirasource/testdata/site/0007-get-rest-api-3-issuesecurityschemes-level-member-levelid-10500-maxresults-100.json
@@ -1,0 +1,39 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/rest/api/3/issuesecurityschemes/level/member?levelId=10500\u0026maxResults=100\u0026startAt=0",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "isLast": true,
+        "maxResults": 2,
+        "startAt": 0,
+        "total": 1,
+        "values": [
+          {
+            "holder": {
+              "type": "user",
+              "user": {
+                "accountId": "acc-lee"
+              }
+            },
+            "id": "macc-lee",
+            "issueSecurityLevelId": "10500"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/connector/jirasource/testdata/site/0008-get-rest-api-3-search-fields-updated-jql-project-line-order-by-key-asc.json
+++ b/connector/jirasource/testdata/site/0008-get-rest-api-3-search-fields-updated-jql-project-line-order-by-key-asc.json
@@ -1,0 +1,42 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/rest/api/3/search?fields=updated\u0026jql=project+%3D+%22LINE%22+ORDER+BY+key+ASC\u0026maxResults=100\u0026startAt=0",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "issues": [
+          {
+            "fields": {
+              "updated": "2026-03-02T09:07:00.000+0000"
+            },
+            "id": "iLINE-1",
+            "key": "LINE-1"
+          },
+          {
+            "fields": {
+              "updated": "2026-03-02T09:08:00.000+0000"
+            },
+            "id": "iLINE-2",
+            "key": "LINE-2"
+          }
+        ],
+        "maxResults": 2,
+        "startAt": 0,
+        "total": 2
+      }
+    }
+  }
+}

--- a/connector/jirasource/testdata/site/0009-get-rest-api-3-search-fields-updated-jql-project-safety-order-by-key-asc.json
+++ b/connector/jirasource/testdata/site/0009-get-rest-api-3-search-fields-updated-jql-project-safety-order-by-key-asc.json
@@ -1,0 +1,35 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/rest/api/3/search?fields=updated\u0026jql=project+%3D+%22SAFETY%22+ORDER+BY+key+ASC\u0026maxResults=100\u0026startAt=0",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "issues": [
+          {
+            "fields": {
+              "updated": "2026-03-02T09:10:00.000+0000"
+            },
+            "id": "iSAFETY-1",
+            "key": "SAFETY-1"
+          }
+        ],
+        "maxResults": 2,
+        "startAt": 0,
+        "total": 1
+      }
+    }
+  }
+}

--- a/connector/jirasource/testdata/site/0010-get-rest-api-3-issue-line-1-fields-summary-description-created-updated-reporter.json
+++ b/connector/jirasource/testdata/site/0010-get-rest-api-3-issue-line-1-fields-summary-description-created-updated-reporter.json
@@ -1,0 +1,147 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/rest/api/3/issue/LINE-1?fields=summary%2Cdescription%2Ccreated%2Cupdated%2Creporter%2Ccreator%2Cassignee%2Cstatus%2Cissuetype%2Cpriority%2Clabels%2Csecurity%2Ccomment",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "fields": {
+          "assignee": {
+            "accountId": "acc-sam",
+            "active": true,
+            "displayName": "Sam Okafor",
+            "emailAddress": "sam@acme.com"
+          },
+          "comment": {
+            "comments": [
+              {
+                "author": {
+                  "accountId": "acc-sam",
+                  "active": true,
+                  "displayName": "Sam Okafor",
+                  "emailAddress": "sam@acme.com"
+                },
+                "body": {
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "Sounds like the outboard bearing to me.",
+                          "type": "text"
+                        }
+                      ],
+                      "type": "paragraph"
+                    }
+                  ],
+                  "type": "doc",
+                  "version": 1
+                },
+                "created": "2026-03-02T09:05:00.000+0000",
+                "id": "20010",
+                "updated": "2026-03-02T09:05:00.000+0000"
+              },
+              {
+                "author": {
+                  "accountId": "acc-lee",
+                  "active": true,
+                  "displayName": "Lee Berger",
+                  "emailAddress": "lee@acme.com"
+                },
+                "body": {
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "I changed that one on Tuesday, so it should not be.",
+                          "type": "text"
+                        }
+                      ],
+                      "type": "paragraph"
+                    }
+                  ],
+                  "type": "doc",
+                  "version": 1
+                },
+                "created": "2026-03-02T09:06:00.000+0000",
+                "id": "20011",
+                "updated": "2026-03-02T09:06:00.000+0000"
+              }
+            ],
+            "maxResults": 2,
+            "startAt": 0,
+            "total": 2
+          },
+          "created": "2026-03-02T09:01:00.000+0000",
+          "creator": {
+            "accountId": "acc-mei",
+            "active": true,
+            "displayName": "Mei Tanaka",
+            "emailAddress": "mei@acme.com"
+          },
+          "description": {
+            "content": [
+              {
+                "content": [
+                  {
+                    "text": "The gearbox on line two is making a noise under load.",
+                    "type": "text"
+                  }
+                ],
+                "type": "paragraph"
+              },
+              {
+                "attrs": {
+                  "language": "text"
+                },
+                "content": [
+                  {
+                    "text": "vibration 4.2 mm/s at 1450 rpm",
+                    "type": "text"
+                  }
+                ],
+                "type": "codeBlock"
+              }
+            ],
+            "type": "doc",
+            "version": 1
+          },
+          "issuetype": {
+            "name": "Bug"
+          },
+          "labels": [
+            "line-two",
+            "mechanical"
+          ],
+          "priority": {
+            "name": "Medium"
+          },
+          "reporter": {
+            "accountId": "acc-mei",
+            "active": true,
+            "displayName": "Mei Tanaka",
+            "emailAddress": "mei@acme.com"
+          },
+          "status": {
+            "name": "In Progress"
+          },
+          "summary": "Gearbox noise on line two",
+          "updated": "2026-03-02T09:07:00.000+0000"
+        },
+        "id": "iLINE-1",
+        "key": "LINE-1"
+      }
+    }
+  }
+}

--- a/connector/jirasource/testdata/site/README.md
+++ b/connector/jirasource/testdata/site/README.md
@@ -1,0 +1,47 @@
+# A recorded Jira site
+
+These files are one crawl of a small Jira site, written down so the tests next
+to them can exercise the whole adapter without an account, a token or a network.
+Each file is one request and the answer it got, numbered in the order the crawl
+made them.
+
+The site has two projects.
+`LINE` grants browse through a project role, and holds a ticket with a code
+block in its description, two comments from two different people, an assignee
+and a status that was moved, plus a second ticket with nothing special about it.
+`SAFETY` grants browse to a group, and its one ticket sits behind an issue
+security level so that a rule overriding the project it is in is in here too.
+Between them they cover the project listing, the permission scheme, the role
+resolution, the security level members, the JQL search, the offset paging, the
+comment assembly and a single issue read.
+
+## Refreshing them
+
+    go test ./connector/jirasource/ -run TestRecordTheFixtures -update
+
+That runs the crawl again against the fake site in `fake_test.go` and rewrites
+every numbered file here.
+It does not touch this README.
+
+Two things are taken out before the files are written: the address the fake was
+listening on, which is replaced with a Jira Cloud one, and the response headers
+that say how long the body was and what time it was.
+All of them change on every run and none of them is matched against, so leaving
+them in would turn every refresh into a diff on every file.
+
+The repeated requests are dropped as well.
+A crawl asks what the projects are three times, once for the sync, once for the
+sweep and once for a fetch, and three copies of the same answer is three files
+to review and no more coverage.
+
+## What is not in here
+
+No credentials.
+The API token is sent as basic authentication in a header and the header is
+redacted before anything is written, and there is a test that reads these files
+back and fails if the token, the crawling account or an encoded credential is in
+them.
+
+Nothing real either.
+The people, the projects and the tickets are made up, and the site they came
+from is the fake in `fake_test.go` rather than anybody's Jira.

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -491,6 +491,46 @@ Direct messages and group messages are not asked for rather than asked for and f
 Joins, leaves, topic changes and pinned messages are not documents either, since indexing "somebody has joined the channel" is how a search for a person's name returns four hundred results they never wrote.
 Display names are looked up once per person per crawl and cached, and a lookup that fails still produces an author with the identity filled in and the name missing, because failing a whole channel over a display name is the wrong trade.
 
+### Jira, and what a product does tell you
+
+`connector/jirasource` is the second adapter on that interface, and putting it next to the first one is the point.
+Slack is a product with no change feed and a simple permission model, and Jira is the other way round on both counts, so the same four methods end up carrying almost none of the same weight.
+
+Jira has a change feed and it is a good one.
+An issue's `updated` field moves when anything about it moves, including a comment on it, a status transition and a field somebody edited, and JQL will filter and order by it.
+So `Threads` is one query per project, `project = "KEY" AND updated >= "..." ORDER BY updated ASC`, and there is no reply window, no reading history back to a cursor and nothing to guess at.
+The one wrinkle is that JQL compares times to the minute and rejects anything finer, so the query asks for the minute the cursor is in and the issues from the first half of that minute are dropped after they arrive.
+Rounding the query down rather than up is deliberate: the direction that costs a re-read of a few issues is the one that does not lose them.
+
+The sweep is still there, and it is only for deletion.
+Nothing in JQL reports an issue that was deleted, or one that was moved to a project this token cannot see, and both of those leave the index holding a ticket that no longer exists.
+So `List` walks the project by key and reports the `updated` field as the version, which is the same string `Threads` puts in `Revision`, because a listing and a read that disagree on the version make every sweep refetch the whole project.
+
+Permissions are where the work is.
+Browse comes from the project's permission scheme, which grants it to some mixture of groups, named accounts, project roles and, on a site with a service desk, everybody with a licence.
+A project role is Jira's indirection between a person and a permission and it is the one every real site uses, so it is resolved to the accounts and groups in it rather than left as the name of a thing, which would be an access control list naming nobody.
+A scheme this token cannot read is an administrator's endpoint on many sites, and that is a quarantine and a `WithSkipped` report rather than a guess in either direction.
+A scheme that grants browse to nobody is a quarantine too, because that is not a project everybody can read, it is a project we failed to understand.
+
+An issue security level is the concrete case `Thread.Access` exists for.
+A ticket with one is readable by that level's members and by nobody else, whatever the project says, so it replaces the project's rule rather than adding to it.
+Everything about resolving one is deliberately pessimistic: a level this token cannot read is a quarantine, an empty level is a quarantine, and a level granted to a project role is a quarantine as well, because resolving that correctly means knowing which project the issue is in and the endpoint that lists a level's members does not say.
+The answers are cached per level, including the failures, because a project with a security scheme puts the same handful of levels on thousands of issues and asking per issue turns one refusal into a thousand.
+
+Jira reports nothing about when a permission scheme changed, which is the same gap Slack has and it is handled the same way.
+The rule is reapplied on a schedule, once a day by default, quantised to the interval rather than measured from the last sync so that two servers reading the same site an hour apart agree about whether it moved.
+
+The rate limit is one bucket rather than the per method tiers Slack needs, because Atlassian publishes no per method rates: a site bills by the cost of what was asked for and tells a client it has spent too much with a 429 and a `Retry-After`.
+Obeying that header is `connector/limit`'s job and it is the same code every other connector here uses.
+Every call is a GET for the same reason it is in the Slack adapter, that a request carrying a body is never retried, and the fields a search asks for are written down rather than left as everything, because everything on a site with three hundred custom fields is a page of results the size of a small database.
+
+The last part is the description, which is not text.
+It arrives as an Atlassian document tree, and there are two ways to get it wrong.
+Concatenating every text node produces a wall with the heading run into the paragraph, and an index built on that cannot tell a phrase somebody wrote from a phrase made by two unrelated lines meeting.
+Throwing the structure away is worse, because a ticket's description is very often a stack trace, a snippet of configuration or a table of what was tried, and a search result that shows the reader a flattened version of the thing they were looking for has answered the query and failed the person.
+So it renders Markdown: headings stay headings, code blocks keep their fences and their language, lists stay lists and tables stay tables.
+A description that will not parse comes back empty rather than as an error, because a ticket with a summary, a reporter, a status and a comment thread is still worth indexing.
+
 ### The conformance suite is the definition
 
 `connector/connectortest` is what a connector has to pass, and it rather than the interface is the definition of one.
@@ -580,3 +620,6 @@ The fake is where behaviour is written, because it can be told to throttle, to r
 The recording is where the wire format is pinned, and it is the test that would go red the day Slack renamed a field.
 Two of its rules are worth copying: the repeated requests are dropped, since a crawl asks what the channels are once for the sync, once for the sweep and once for a fetch and three copies of the same answer is three files to review and no more coverage, and everything that differs per run is taken out, which means the address the fake was listening on and the headers saying how long the body was and what time it is.
 Leaving those in makes every refresh a diff on every file with the real change somewhere inside it.
+
+`connector/jirasource/testdata/site` is the same thing for tickets, ten files refreshed the same way, and it is worth looking at as the second example because the shape held.
+The same fake, the same `-update` flag, the same dedupe, the same settling, and the same three tests over it: that the crawl works, that the recording answers nothing the crawl does not ask, and that no credential is in the files.


### PR DESCRIPTION
An issue and the comments underneath it are one document, on the same `threadsource` crawl the Slack adapter uses.

## Why this one is the opposite of the last one

Slack has no change feed and a simple permission model.
Jira is the other way round on both counts, so the same four methods carry almost none of the same weight and putting the two adapters next to each other is most of the value of having written the shared crawl.

Jira's `updated` field moves when anything about an issue moves, including a comment on it, a status transition and a field somebody edited, and JQL will filter and order by it.
So a sync is one query per project, `project = "KEY" AND updated >= "..." ORDER BY updated ASC`, with no reply window, no reading history back to a cursor and nothing to guess at.
A ticket moved from one column to another with nobody writing a word is found the same way a comment is, which is the case chat can never report.

The one wrinkle is that JQL compares times to the minute and rejects anything finer.
The query asks for the minute the cursor is in and the issues from the first half of that minute are dropped after they arrive, because rounding the query down costs a re-read of a few issues and rounding it up loses them.

The sweep is still there and it is only for deletion.
Nothing in JQL reports an issue that was deleted or moved to a project this token cannot see, and both leave the index holding a ticket that no longer exists.

## Permissions are where the work went

Browse comes from the project's permission scheme, which grants it to some mixture of groups, named accounts, project roles and, on a site with a service desk, everybody with a licence.
A project role is resolved to the accounts and groups in it rather than left as the name of a thing, because a role name is an access control list naming nobody.
A scheme this token cannot read is an administrator's endpoint on many sites, and that is a quarantine and a `WithSkipped` report rather than a guess in either direction.
A scheme granting browse to nobody is a quarantine too, since that is not a project everybody can read, it is a project we failed to understand.

An issue security level is the concrete case `threadsource.Thread.Access` exists for.
A ticket with one is readable by that level's members and by nobody else whatever the project says, so it replaces the project's rule rather than adding to it.
Resolving one is deliberately pessimistic: a level this token cannot read is a quarantine, an empty level is a quarantine, and a level granted to a project role is a quarantine as well, because resolving that correctly means knowing which project the issue is in and the endpoint that lists a level's members does not say.
The answers are cached per level, failures included, because a project with a security scheme puts the same handful of levels on thousands of issues.

Nothing in Jira reports that a permission scheme changed, which is the same gap Slack has and it is handled the same way.
The rule is reapplied on a schedule, quantised to the interval rather than measured from the last sync, so that two servers reading the same site an hour apart agree about whether it moved.

## Descriptions are documents, not text

An Atlassian description arrives as a tree, and there are two ways to get it wrong.
Concatenating every text node gives a wall with the heading run into the paragraph, and an index built on that cannot tell a phrase somebody wrote from a phrase made by two unrelated lines meeting.
Throwing the structure away is worse, because a ticket's description is very often a stack trace, a snippet of configuration or a table of what was tried, and a search result showing a flattened version of the thing somebody was looking for has answered the query and failed the person.

So it renders Markdown.
Headings stay headings, code blocks keep their fences and their language, lists stay lists and tables stay tables.
A description that will not parse comes back empty rather than as an error, because a ticket with a summary, a reporter, a status and a comment thread is still worth indexing.

## One thing worth writing down

The site caps the page size at whatever it is configured to allow and reports what it granted in `maxResults`, which is not what was asked for.
The first version of the paging compared the number of items on a page against the number requested to decide whether the listing had ended, so a request for a hundred answered with fifty read as the end of the project.
It now compares against the smaller of the two.
The test that catches it is an ordinary sync of a project with seven issues in it against a fake that caps every page at two.

## Testing

The same two halves as the Slack adapter, because neither replaces the other.

A fake Jira site in `fake_test.go` is where behaviour is written: it has permission schemes, roles, security levels, offset paging, enough JQL to answer the two queries the adapter asks, a clock that only moves when something happens, and the ability to be told to throttle or to refuse.
A committed recording under `connector/jirasource/testdata/site` is where the wire format is pinned, and it is what would go red the day a field is renamed.
Ten files, refreshed with `go test ./connector/jirasource/ -run TestRecordTheFixtures -update`, no credentials in them and a test that reads them back to check.

The conformance suite runs, including the permission change case and the unresolvable case, which for this source is a security level nobody can resolve.

Part of #15.
