### PR TITLE
Give a document a page of its own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,13 +175,15 @@ jobs:
           path: bench-report.json
           if-no-files-found: warn
 
-  # The browser gate: asset budgets, markup safety, axe and Lighthouse.
+  # The browser gate: asset budgets, markup safety, the keyboard walk, axe and
+  # Lighthouse.
   #
-  # The Go tests are the part that cannot flake and they run first. axe reports
-  # violations of a standard rather than an opinion and it fails the job.
-  # Lighthouse is advisory here and enforced on the nightly run, because a
-  # performance score on a shared runner moves by ten points between two runs of
-  # the same commit.
+  # The Go tests are the part that cannot flake and they run first. The walk
+  # presses the keys and clicks the links a person would and asserts where each
+  # one led, which is the half an audit cannot see. axe reports violations of a
+  # standard rather than an opinion. Both fail the job. Lighthouse is advisory
+  # here and enforced on the nightly run, because a performance score on a
+  # shared runner moves by ten points between two runs of the same commit.
   ui:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,11 @@ It measures the search endpoint per query class in interleaved rounds, compares 
 The first run generates the corpus and takes a few minutes.
 If the baseline itself needs to move, `make bench-gate-record` writes a new one and it belongs in a commit of its own that says why the number moved.
 
-`ui-gate` checks the asset budgets, then starts the binary over this repository as a corpus and runs axe and Lighthouse against the home page, a results page and a results page with the drawer open.
-It needs `npx` and a Chrome, and it says so and stops rather than failing when there is not one.
-A chromedriver that does not match the Chrome next to it is the usual reason it will not start, and `CHROMEDRIVER` points it at a matching one.
+`ui-gate` checks the asset budgets, then starts the binary over this repository as a corpus and runs two things against it.
+The keyboard walk in `scripts/keyboard-walk.mjs` presses the keys and clicks the links a person would and asserts where each one led, which is the half an audit cannot see: markup can describe itself perfectly and still go nowhere when you click it.
+axe and Lighthouse then run against the home page, a results page, a results page with the drawer open, and a document on a page of its own.
+The walk needs a Chrome, axe and Lighthouse also need `npx`, and each says so and skips itself rather than failing when there is not one.
+A chromedriver that does not match the Chrome next to it is the usual reason axe will not start, and `CHROMEDRIVER` points it at a matching one.
 
 ## The rule that is not negotiable
 

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,12 @@ bench-gate-record:
 
 # The browser gate: asset budgets, markup safety, axe, and Lighthouse.
 #
-# The Go tests are the part that never flakes and they run first. The browser
-# half needs npx and a Chrome, and says so and stops rather than failing when
-# there is not one.
+# The Go tests are the part that never flakes and they run first. Then the
+# keyboard walk, which needs a Chrome, and then axe and Lighthouse, which also
+# need npx. Each says so and skips itself rather than failing when there is not
+# one.
 ui-gate: build
-	go test -count=1 -run 'Interface|Assets|Cache' ./web/
+	go test -count=1 -run 'Interface|Assets|Cache|Paths' ./web/
 	./scripts/ui-gate.sh
 
 vet:

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -1,0 +1,305 @@
+// The keyboard walk.
+//
+// It drives a real Chrome through the sequence a person performs and asserts
+// where each key and each click actually led. axe checks that the markup
+// describes itself; this checks that the interface does what the markup
+// promises, which is a different failure and the one that shipped: the primary
+// click target on every result row was an anchor to a file:// URL, which a
+// browser served over HTTP will not navigate to, so clicking a result title did
+// nothing at all. No audit finds that, because the markup is perfectly correct.
+//
+// It speaks the DevTools protocol directly rather than through a driver. The
+// whole interaction is four commands, and the alternative is a dependency with
+// a browser download in it for a script that already has a browser.
+
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const BASE = process.argv[2] || "http://127.0.0.1:8123";
+const DEADLINE = 20_000;
+const PATIENCE = 5_000;
+
+const CHROMES = [
+  process.env.CHROME_PATH,
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  "/usr/bin/google-chrome",
+  "/usr/bin/google-chrome-stable",
+  "/opt/google/chrome/chrome",
+  "/usr/bin/chromium",
+  "/usr/bin/chromium-browser",
+  "/snap/bin/chromium",
+];
+
+function findChrome() {
+  return CHROMES.find((path) => path && existsSync(path));
+}
+
+const chrome = findChrome();
+if (!chrome) {
+  console.log("keyboard-walk: no Chrome on this machine, so the walk cannot run");
+  process.exit(0);
+}
+if (typeof WebSocket === "undefined") {
+  console.log(`keyboard-walk: node ${process.version} has no WebSocket, so the walk cannot run`);
+  process.exit(0);
+}
+
+const profile = mkdtempSync(join(tmpdir(), "genba-walk-"));
+const browser = spawn(
+  chrome,
+  [
+    "--headless=new",
+    "--no-sandbox",
+    "--disable-gpu",
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--disable-extensions",
+    // Port zero, so two runs on one machine do not fight over 9222. Chrome
+    // writes the port it chose into the profile directory.
+    "--remote-debugging-port=0",
+    `--user-data-dir=${profile}`,
+    "about:blank",
+  ],
+  { stdio: "ignore" },
+);
+
+let failures = 0;
+try {
+  await walk();
+} catch (err) {
+  console.error(`keyboard-walk: ${err.message}`);
+  failures++;
+} finally {
+  browser.kill();
+  // Chrome is still writing its profile out while it shuts down, so the first
+  // attempt at the directory finds it not empty. A few retries clear it, and a
+  // directory left behind under the temporary directory is not worth failing a
+  // build over.
+  try {
+    rmSync(profile, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  } catch {
+    // Left for the operating system to reap.
+  }
+}
+process.exit(failures ? 1 : 0);
+
+async function walk() {
+  const session = await attach(await endpoint());
+
+  // A results page over the corpus the gate already started, and an id from it
+  // for the document route.
+  await visit(session, `${BASE}/?q=cache`, "document.querySelectorAll('.result').length > 0");
+
+  await check(
+    session,
+    "the title of a result is a link into the product",
+    `(() => {
+      const a = document.querySelector('.result__title');
+      return a && a.tagName === 'A' && a.getAttribute('href').startsWith('/d/');
+    })()`,
+  );
+
+  await press(session, "j", "KeyJ", 74);
+  await check(
+    session,
+    "j moves the cursor onto the first row",
+    "document.querySelectorAll('.result[data-active=\"true\"]').length === 1",
+  );
+
+  await press(session, "Enter", "Enter", 13);
+  await check(
+    session,
+    "Enter on a row opens the preview",
+    "!document.querySelector('.drawer').hidden && location.search.includes('open=')",
+  );
+  await check(
+    session,
+    "the preview took focus",
+    "document.querySelector('.drawer').contains(document.activeElement)",
+  );
+
+  await press(session, "Escape", "Escape", 27);
+  await check(
+    session,
+    "Escape closes the preview",
+    "document.querySelector('.drawer').hidden && !location.search.includes('open=')",
+  );
+
+  // A plain click on the title opens the preview rather than following the
+  // link. This is the assertion the shipped defect would have failed, in the
+  // other direction: the click did nothing at all.
+  await evaluate(session, "document.querySelector('.result__title').click()");
+  await check(
+    session,
+    "a plain click on the title opens the preview and stays on the results",
+    "!document.querySelector('.drawer').hidden && location.pathname === '/'",
+  );
+
+  const id = await evaluate(session, "document.querySelector('.result__title').getAttribute('href')");
+  await visit(session, BASE + id, "document.querySelector('.page__title').textContent.trim().length > 0");
+  await check(
+    session,
+    "the document route renders the document with a way back",
+    `(() => {
+      const back = document.querySelector('.page__back-link');
+      const title = document.querySelector('.page__title');
+      return Boolean(back && back.getAttribute('href') && title.tagName === 'H1');
+    })()`,
+  );
+  await check(
+    session,
+    "the document page is not the preview drawer",
+    "document.querySelector('.drawer').hidden",
+  );
+  // A link written as a bare query string resolves against whatever path is
+  // showing, which was harmless while every path was the search and is not any
+  // more. This catches the next one written that way.
+  await check(
+    session,
+    "no link on the document page is the same document with a parameter on the end",
+    `[...document.querySelectorAll('a[href]')].every((a) => {
+      const u = new URL(a.href, location.href);
+      return !(u.pathname.startsWith('/d/') && u.search);
+    })`,
+  );
+}
+
+// The protocol ------------------------------------------------------------
+
+/** endpoint waits for Chrome to say which port it picked. */
+async function endpoint() {
+  const file = join(profile, "DevToolsActivePort");
+  const until = Date.now() + DEADLINE;
+  while (Date.now() < until) {
+    if (existsSync(file)) {
+      const [port, path] = readFileSync(file, "utf8").split("\n");
+      if (port && path) return `ws://127.0.0.1:${port.trim()}${path.trim()}`;
+    }
+    await sleep(50);
+  }
+  throw new Error("Chrome never reported a debugging port");
+}
+
+/**
+ * attach opens a tab and returns something that speaks to it.
+ *
+ * Flat mode, so a message for the tab carries its session id rather than being
+ * wrapped in an envelope for the browser to forward.
+ */
+async function attach(url) {
+  const socket = new WebSocket(url);
+  const pending = new Map();
+  let next = 0;
+
+  await new Promise((resolve, reject) => {
+    socket.addEventListener("open", resolve, { once: true });
+    socket.addEventListener("error", () => reject(new Error("could not open a DevTools connection")), {
+      once: true,
+    });
+  });
+
+  socket.addEventListener("message", (event) => {
+    const message = JSON.parse(event.data);
+    const waiting = pending.get(message.id);
+    if (!waiting) return;
+    pending.delete(message.id);
+    if (message.error) waiting.reject(new Error(message.error.message));
+    else waiting.resolve(message.result);
+  });
+
+  const send = (method, params, sessionId) =>
+    new Promise((resolve, reject) => {
+      const id = ++next;
+      pending.set(id, { resolve, reject });
+      socket.send(JSON.stringify({ id, method, params: params || {}, sessionId }));
+    });
+
+  const { targetId } = await send("Target.createTarget", { url: "about:blank" });
+  const { sessionId } = await send("Target.attachToTarget", { targetId, flatten: true });
+  await send("Page.bringToFront", {}, sessionId);
+  return (method, params) => send(method, params, sessionId);
+}
+
+/** visit navigates and waits for the interface to have painted the answer. */
+async function visit(session, url, ready) {
+  await session("Page.navigate", { url });
+  await settle(session, ready);
+}
+
+/**
+ * settle polls until an expression is true.
+ *
+ * Polling rather than waiting on a load event, because everything on these
+ * screens arrives after a fetch and the load event fires long before it.
+ */
+async function settle(session, expression) {
+  const until = Date.now() + DEADLINE;
+  for (;;) {
+    try {
+      if (await evaluate(session, expression)) return;
+    } catch {
+      // A document mid navigation has no such element yet, which is what this
+      // is waiting for rather than an error.
+    }
+    if (Date.now() > until) throw new Error(`timed out waiting for: ${expression}`);
+    await sleep(100);
+  }
+}
+
+async function evaluate(session, expression) {
+  const { result, exceptionDetails } = await session("Runtime.evaluate", {
+    expression,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+  if (exceptionDetails) throw new Error(exceptionDetails.exception?.description || "evaluation failed");
+  return result.value;
+}
+
+async function press(session, key, code, keyCode) {
+  const text = key.length === 1 ? key : key === "Enter" ? "\r" : undefined;
+  for (const type of ["keyDown", "keyUp"]) {
+    await session("Input.dispatchKeyEvent", {
+      type,
+      key,
+      code,
+      text: type === "keyDown" ? text : undefined,
+      windowsVirtualKeyCode: keyCode,
+      nativeVirtualKeyCode: keyCode,
+    });
+  }
+  // One frame for the handler to run and the paint to land.
+  await sleep(150);
+}
+
+/**
+ * check waits a little for an assertion to come true and then reports it.
+ *
+ * It waits because every one of these screens paints after a fetch, and a run
+ * that fails on a busy runner for a reason that is not the reason it exists is
+ * a test somebody eventually deletes. It gives up quickly, because the budget
+ * for all of this is ten milliseconds a request and anything near the ceiling
+ * is a failure of a different kind.
+ */
+async function check(session, what, expression) {
+  const until = Date.now() + PATIENCE;
+  let ok = false;
+  for (;;) {
+    try {
+      ok = Boolean(await evaluate(session, expression));
+    } catch {
+      ok = false;
+    }
+    if (ok || Date.now() > until) break;
+    await sleep(100);
+  }
+  console.log(`keyboard-walk: ${ok ? "ok  " : "FAIL"} ${what}`);
+  if (!ok) failures++;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -13,7 +13,8 @@
 // a browser download in it for a script that already has a browser.
 
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -62,6 +63,13 @@ if (typeof WebSocket === "undefined") {
   process.exit(0);
 }
 
+// A port of our own choosing, so two runs on one machine do not fight over
+// 9222. Asking Chrome for port zero and reading back the number it chose is the
+// other way to do that, and it means reading the DevToolsActivePort file, which
+// on the CI runner Chrome starts and then never writes. Picking the port here
+// costs one bind and leaves nothing to go looking for.
+const port = await freePort();
+
 const profile = mkdtempSync(join(tmpdir(), "genba-walk-"));
 const browser = spawn(
   chrome,
@@ -75,9 +83,7 @@ const browser = spawn(
     "--no-first-run",
     "--no-default-browser-check",
     "--disable-extensions",
-    // Port zero, so two runs on one machine do not fight over 9222. Chrome
-    // writes the port it chose into the profile directory.
-    "--remote-debugging-port=0",
+    `--remote-debugging-port=${port}`,
     `--user-data-dir=${profile}`,
     "about:blank",
   ],
@@ -198,21 +204,38 @@ async function walk() {
 
 // The protocol ------------------------------------------------------------
 
-/** endpoint waits for Chrome to say which port it picked. */
+/** freePort asks the operating system for one and hands it straight back. */
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+/** endpoint waits for Chrome to start answering, and returns where to talk. */
 async function endpoint() {
-  const file = join(profile, "DevToolsActivePort");
   const until = Date.now() + DEADLINE;
   while (Date.now() < until) {
-    if (existsSync(file)) {
-      const [port, path] = readFileSync(file, "utf8").split("\n");
-      if (port && path) return `ws://127.0.0.1:${port.trim()}${path.trim()}`;
+    try {
+      const answer = await fetch(`http://127.0.0.1:${port}/json/version`);
+      if (answer.ok) {
+        const { webSocketDebuggerUrl } = await answer.json();
+        if (webSocketDebuggerUrl) return webSocketDebuggerUrl;
+      }
+    } catch {
+      // Nothing listening yet, which is the thing being waited for rather than
+      // an error.
     }
-    // A Chrome that has already stopped is never going to write the file, and
-    // waiting the rest of the deadline to say so only delays the reason.
+    // A Chrome that has already stopped is never going to answer, and waiting
+    // out the rest of the deadline to say so only delays the reason.
     if (stopped !== null) throw new Error(`Chrome exited (${stopped})${said()}`);
     await sleep(50);
   }
-  throw new Error(`Chrome never reported a debugging port${said()}`);
+  throw new Error(`Chrome never answered on port ${port}${said()}`);
 }
 
 /** said renders whatever Chrome put on stderr, for the error to carry. */

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -12,7 +12,7 @@
 // whole interaction is four commands, and the alternative is a dependency with
 // a browser download in it for a script that already has a browser.
 
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,18 +23,33 @@ const PATIENCE = 5_000;
 
 const CHROMES = [
   process.env.CHROME_PATH,
+  process.env.CHROME_BIN,
   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
   "/Applications/Chromium.app/Contents/MacOS/Chromium",
   "/usr/bin/google-chrome",
   "/usr/bin/google-chrome-stable",
   "/opt/google/chrome/chrome",
+  "/usr/local/share/chrome-linux64/chrome",
   "/usr/bin/chromium",
   "/usr/bin/chromium-browser",
   "/snap/bin/chromium",
 ];
 
+const NAMES = ["google-chrome", "google-chrome-stable", "chromium", "chromium-browser", "chrome"];
+
+/** findChrome takes the first of the usual places, then asks the path. */
 function findChrome() {
-  return CHROMES.find((path) => path && existsSync(path));
+  const listed = CHROMES.find((path) => path && existsSync(path));
+  if (listed) return listed;
+  for (const name of NAMES) {
+    try {
+      const found = execFileSync("command", ["-v", name], { shell: true, encoding: "utf8" }).trim();
+      if (found && existsSync(found)) return found;
+    } catch {
+      // Not on the path, which is the answer rather than an error.
+    }
+  }
+  return "";
 }
 
 const chrome = findChrome();
@@ -54,6 +69,9 @@ const browser = spawn(
     "--headless=new",
     "--no-sandbox",
     "--disable-gpu",
+    // A container gives /dev/shm 64 megabytes and Chrome wants more than that
+    // for its renderer, which is how it dies on a runner and nowhere else.
+    "--disable-dev-shm-usage",
     "--no-first-run",
     "--no-default-browser-check",
     "--disable-extensions",
@@ -63,8 +81,19 @@ const browser = spawn(
     `--user-data-dir=${profile}`,
     "about:blank",
   ],
-  { stdio: "ignore" },
+  // Chrome says why it will not start on stderr, and a walk that reports only
+  // that no port appeared sends whoever reads it to the wrong place.
+  { stdio: ["ignore", "ignore", "pipe"] },
 );
+
+let complaint = "";
+let stopped = null;
+browser.stderr.on("data", (chunk) => {
+  complaint += chunk;
+});
+browser.on("exit", (code, signal) => {
+  stopped = signal || code;
+});
 
 let failures = 0;
 try {
@@ -178,9 +207,19 @@ async function endpoint() {
       const [port, path] = readFileSync(file, "utf8").split("\n");
       if (port && path) return `ws://127.0.0.1:${port.trim()}${path.trim()}`;
     }
+    // A Chrome that has already stopped is never going to write the file, and
+    // waiting the rest of the deadline to say so only delays the reason.
+    if (stopped !== null) throw new Error(`Chrome exited (${stopped})${said()}`);
     await sleep(50);
   }
-  throw new Error("Chrome never reported a debugging port");
+  throw new Error(`Chrome never reported a debugging port${said()}`);
+}
+
+/** said renders whatever Chrome put on stderr, for the error to carry. */
+function said() {
+  const lines = complaint.trim();
+  if (!lines) return ", and said nothing about why";
+  return `. It said:\n${lines}`;
 }
 
 /**

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -2,14 +2,18 @@
 # The browser half of the performance gate.
 #
 # It starts the real binary over a real corpus, which is this repository, and
-# audits the three screens somebody actually looks at: the home page, a results
-# page, and a results page with the document drawer open. Auditing a static
-# fixture instead would audit the fixture, and every accessibility bug this is
-# meant to catch lives in the markup the interface builds after a fetch.
+# audits the four screens somebody actually looks at: the home page, a results
+# page, a results page with the document drawer open, and a document on a page
+# of its own. Auditing a static fixture instead would audit the fixture, and
+# every accessibility bug this is meant to catch lives in the markup the
+# interface builds after a fetch.
 #
-# axe is the part that fails a build. It reports violations of a standard rather
-# than an opinion, it does not move when the runner is busy, and a violation is
-# a person who cannot use the page.
+# The keyboard walk and axe are the parts that fail a build. axe reports
+# violations of a standard rather than an opinion, it does not move when the
+# runner is busy, and a violation is a person who cannot use the page. The walk
+# presses the keys and clicks the links a person would and asserts where each
+# one led, which is the half axe cannot see: markup can describe itself
+# perfectly and still go nowhere when you click it.
 #
 # Lighthouse is advisory here and enforced on the nightly run, because a
 # Lighthouse performance score on a shared runner moves by ten points between
@@ -31,14 +35,23 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-if ! command -v npx >/dev/null 2>&1; then
-	echo "ui-gate: npx is not on the path, so axe and Lighthouse cannot run"
+if ! command -v node >/dev/null 2>&1; then
+	echo "ui-gate: node is not on the path, so nothing that needs a browser can run"
 	echo "ui-gate: the asset budgets and the markup safety tests already ran, and they are the part that never flakes"
 	exit 0
 fi
 
 if [ ! -x "$BIN" ]; then
 	echo "ui-gate: $BIN is not there, run make build first" >&2
+	exit 1
+fi
+
+# Anything else on this port answers the health check and then serves its own
+# pages to the audit, while our server exits because it could not bind. The
+# failure that produces blames the corpus, which is a long way from the truth,
+# so the port is checked before anything is started.
+if curl -fsS -o /dev/null "$BASE/healthz" 2>/dev/null; then
+	echo "ui-gate: something is already listening on $PORT, set PORT to a free one" >&2
 	exit 1
 fi
 
@@ -50,6 +63,10 @@ SERVER=$!
 
 i=0
 until curl -fsS "$BASE/healthz" >/dev/null 2>&1; do
+	if ! kill -0 "$SERVER" 2>/dev/null; then
+		echo "ui-gate: the server exited before it was ready" >&2
+		exit 1
+	fi
 	i=$((i + 1))
 	if [ "$i" -gt 100 ]; then
 		echo "ui-gate: the server never became healthy" >&2
@@ -75,6 +92,20 @@ fi
 # encoder rather than into the string.
 ID=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$ID")
 
+status=0
+
+# The walk runs first and needs nothing downloaded, so it still reports on a
+# machine with no network. It skips itself when there is no Chrome to drive.
+echo "ui-gate: keyboard walk"
+if ! node scripts/keyboard-walk.mjs "$BASE"; then
+	status=1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+	echo "ui-gate: npx is not on the path, so axe and Lighthouse cannot run"
+	exit $status
+fi
+
 # A chromedriver that does not match the Chrome next to it is the most common
 # way this fails, on a laptop and on a runner alike. axe downloads whichever
 # chromedriver is current, and a runner image whose Chrome is one release behind
@@ -90,8 +121,7 @@ if [ -n "${CHROMEDRIVER:-}" ]; then
 	DRIVER="--chromedriver-path $CHROMEDRIVER"
 fi
 
-status=0
-for path in "/" "/?q=cache" "/?q=cache&open=$ID"; do
+for path in "/" "/?q=cache" "/?q=cache&open=$ID" "/d/$ID"; do
 	echo "ui-gate: axe $path"
 	# The interface renders after a fetch, so the audit waits for the first
 	# paint to have happened. Auditing an empty document passes and proves

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -1238,6 +1238,104 @@ a.panel__row:hover .panel__row-title {
   }
 }
 
+/* Document page ---------------------------------------------------------- */
+
+/*
+ * One document, on its own, at the width somebody reads at.
+ *
+ * The drawer is narrow on purpose, because there is a list behind it that has
+ * to stay reachable. Here there is not, so the only constraint is the measure
+ * and everything else is air. It is the same content function underneath, so a
+ * document that renders well in the preview renders well here without a second
+ * set of rules to keep in step.
+ */
+.page {
+  max-width: var(--page-max);
+  margin: 0 auto;
+  padding: var(--space-6) var(--gutter) var(--space-24);
+}
+
+.page__back {
+  margin-bottom: var(--space-6);
+}
+
+.page__back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+}
+
+.page__back-link:hover {
+  color: var(--text);
+}
+
+.page__head {
+  max-width: var(--measure);
+  margin-bottom: var(--space-8);
+}
+
+.page__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+}
+
+.page__title {
+  font-size: var(--text-display);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-display);
+  letter-spacing: var(--display-tracking);
+}
+
+/* Focus lands here when the page paints, so that a screen reader starts at the
+   top of the document rather than wherever the last page left off.
+
+   No ring. The heading has tabindex="-1" and nothing else, so the only way it
+   ever holds focus is that move, and Chrome does treat a programmatic focus
+   that followed a keypress as visible. Drawing a ring around a heading says it
+   is something to press, and the feedback that the page changed is that the
+   whole page changed. */
+.page__title:focus,
+.page__title:focus-visible {
+  outline: none;
+}
+
+/* Prose is held to the measure for the reason it is everywhere else. Code and
+   images are not: wrapping code to a measure is how a diff becomes unreadable,
+   and an image shown at two thirds of the space is an image shown smaller than
+   it needed to be. */
+.page__body {
+  font-size: var(--text-body);
+  line-height: var(--leading-prose);
+  overflow-wrap: break-word;
+}
+
+.page__body[data-shape="prose"],
+.page__body[data-shape="text"] {
+  max-width: var(--measure);
+}
+
+.page__foot {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  margin-top: var(--space-10);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--border);
+}
+
+.page__foot:empty {
+  display: none;
+}
+
 /* Content ---------------------------------------------------------------- */
 
 /*
@@ -1454,7 +1552,7 @@ h6.prose__h {
 }
 
 .code__lang {
-  color: var(--text-muted);
+  color: var(--code-muted);
   font-size: var(--text-caption);
   letter-spacing: 0.04em;
   text-transform: uppercase;

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -10,10 +10,11 @@ import { api, identity, setIdentity, ApiError } from "./api.js";
 import { cache } from "./cache.js";
 import { Live } from "./live.js";
 import * as urlState from "./state.js";
-import { icon, initials, label, sourceColor, when } from "./format.js";
-import { Omnibox, shortcutLabel } from "./omnibox.js";
+import { followable, icon, initials, label, sourceColor, when } from "./format.js";
+import { Omnibox, modifierLabel, shortcutLabel } from "./omnibox.js";
 import { Results, VERTICALS } from "./results.js";
 import { Drawer } from "./drawer.js";
+import { Page } from "./page.js";
 import { Home } from "./home.js";
 
 const THEME_KEY = "genba.theme";
@@ -57,6 +58,10 @@ class App {
     this.pageTimer = null;
     this.suggestionTimer = null;
     this.guessing = 0;
+    // The last results page this session painted, so that a document page has
+    // somewhere to go back to. It is empty in a tab that opened straight onto a
+    // document, which is the case the back link has to answer differently.
+    this.lastSearch = "";
 
     this.omnibox = new Omnibox({
       onSearch: (text) => this.go({ ...this.query, q: text, offset: 0, open: "" }),
@@ -67,6 +72,7 @@ class App {
       onQuery: (q) => this.go(q),
       onOpen: (id) => this.open(id),
       onHover: (id) => this.guessDocument(id),
+      onSay: (text) => this.say(text),
     });
     this.home = new Home({
       onQuery: (q) => this.go({ ...urlState.read(""), ...q }),
@@ -74,6 +80,11 @@ class App {
     });
     this.drawer = new Drawer({
       onClose: () => this.go({ ...this.query, open: "" }, { replace: true }),
+      onSay: (text) => this.say(text),
+    });
+    this.page = new Page({
+      onBack: () => this.backFromDocument(),
+      onSay: (text) => this.say(text),
     });
 
     this.main = h("main", {
@@ -223,7 +234,11 @@ class App {
           "a",
           {
             class: "rail__link",
-            href: "?sort=recent",
+            // Rooted. A query string on its own resolves against whatever path
+            // is showing, which was always the search until a document got a
+            // path of its own, and would otherwise make every rail entry a link
+            // back to the same document with a stray parameter on the end.
+            href: "/?sort=recent",
             title: "Recent",
             onClick: (e) => this.link(e, { q: "", sort: "recent" }),
           },
@@ -240,7 +255,7 @@ class App {
             "a",
             {
               class: "rail__link",
-              href: `?tab=${v.id}`,
+              href: `/?tab=${v.id}`,
               title: v.title,
               onClick: (e) => this.link(e, { ...this.query, tab: v.id, kind: [], offset: 0 }),
             },
@@ -302,7 +317,7 @@ class App {
           "a",
           {
             class: "rail__link",
-            href: `?source=${encodeURIComponent(s.value)}`,
+            href: `/?source=${encodeURIComponent(s.value)}`,
             title: label(s.value),
             onClick: (e) => this.link(e, { source: [s.value] }),
           },
@@ -325,6 +340,17 @@ class App {
 
   /** sync renders whatever the URL currently says. */
   sync() {
+    // Two routes: a document by path, and everything else by query string. A
+    // document is the only screen somebody links to from outside the product,
+    // which is why it is the only one with an address that does not carry the
+    // state of whoever found it.
+    const route = urlState.route();
+    if (route.name === "document") {
+      this.showDocument(route.id);
+      return;
+    }
+
+    document.title = "genba";
     this.omnibox.value = this.query.q;
     const searching = Boolean(this.query.q) || urlState.count(this.query) > 0 || Boolean(this.query.sort);
 
@@ -340,6 +366,41 @@ class App {
     }
   }
 
+  /**
+   * showDocument renders one document as the whole page.
+   *
+   * The preview is closed without telling the shell, because the URL has
+   * already moved to the document and the close handler would move it back.
+   */
+  async showDocument(id) {
+    this.currentKey = "";
+    this.drawer.currentId = null;
+    if (this.drawer.open) this.drawer.close({ notify: false, focus: false });
+    if (this.main.firstChild !== this.page.el) replace(this.main, this.page.el);
+    await this.page.show(id);
+  }
+
+  /**
+   * backFromDocument is where the way out of a document page leads.
+   *
+   * A document reached from a result list goes back to that list. A document
+   * opened in a new tab, or from a link somebody was sent, has no list behind
+   * it, and offering a back button that lands on whatever else was in that tab
+   * is worse than offering the search.
+   */
+  backFromDocument() {
+    const href = this.lastSearch || "/";
+    return {
+      href,
+      title: this.lastSearch ? "Back to results" : "Search",
+      // The destination rather than history.back(), so that the link and the
+      // click agree. The previous history entry is not reliably the search this
+      // page came from, and a back button that lands somewhere else is worse
+      // than one that costs an entry.
+      go: () => this.go(urlState.read(new URL(href, location.origin).search)),
+    };
+  }
+
   async showHome() {
     if (this.main.firstChild !== this.home.el) replace(this.main, this.home.el);
     await this.home.render(this.session);
@@ -348,6 +409,7 @@ class App {
   async search() {
     const showing = this.main.firstChild === this.results.el;
     if (!showing) replace(this.main, this.results.el);
+    this.lastSearch = urlState.write(this.query);
 
     const request = urlState.params(this.query, VERTICALS);
     const k = cache.key("search", request);
@@ -483,7 +545,18 @@ class App {
    */
   announce(res) {
     const n = res.total || 0;
-    replace(this.live, `${n} ${n === 1 ? "result" : "results"} for ${this.query.q || "the current filters"}`);
+    this.say(`${n} ${n === 1 ? "result" : "results"} for ${this.query.q || "the current filters"}`);
+  }
+
+  /**
+   * say puts one sentence in the polite region.
+   *
+   * Anything a view does that changes nothing on screen goes through here. A
+   * copy button is the clearest case: the tick it draws is invisible to a
+   * screen reader, so without this the action has no outcome at all.
+   */
+  say(text) {
+    replace(this.live, text);
   }
 
   fail(err) {
@@ -592,6 +665,7 @@ class App {
       ["Next result", ["j"]],
       ["Previous result", ["k"]],
       ["Open preview", ["Enter"]],
+      ["Open as a page, in a new tab", [modifierLabel(), "Enter"]],
       ["Open in source", ["o"]],
       ["Go home", ["g", "h"]],
       ["Close", ["Esc"]],
@@ -648,6 +722,15 @@ class App {
         this.omnibox.focus();
         return;
       }
+      // The modifier means the same thing here as it does on a link: open it
+      // over there and leave me where I am.
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && !typing) {
+        const hit = this.results.current();
+        if (!hit) return;
+        e.preventDefault();
+        window.open(urlState.documentPath(hit.id), "_blank", "noreferrer");
+        return;
+      }
       if (e.key === "Escape") {
         if (this.drawer.open) return; // the drawer handles its own Escape
         if (typing) e.target.blur();
@@ -693,8 +776,11 @@ class App {
           break;
         }
         case "o": {
+          // Only where a browser would go there. Opening a file:// URL in a new
+          // tab from an HTTP page leaves somebody looking at a blank tab, which
+          // is worse than the key doing nothing.
           const hit = this.results.current();
-          if (!hit || !hit.url) return;
+          if (!hit || !followable(hit.url)) return;
           e.preventDefault();
           window.open(hit.url, "_blank", "noreferrer");
           break;

--- a/web/dist/assets/clipboard.js
+++ b/web/dist/assets/clipboard.js
@@ -1,0 +1,49 @@
+// Copying something, and saying that it happened.
+//
+// Three views offer a copy button and all three need the same two things after
+// the write: a visible change on the control, because a copy that looks like
+// nothing is a copy somebody does twice, and a spoken one, because a tick
+// appearing is not something a screen reader announces.
+
+import { replace, svg } from "./dom.js";
+import { icon } from "./format.js";
+
+// How long the tick stays. Long enough to be seen after the eye has moved back
+// to the button, short enough that the control is itself again before anybody
+// wants to press it a second time.
+const CONFIRM = 1600;
+
+/**
+ * copies writes text to the clipboard and reports what happened.
+ *
+ * The button's own contents are held rather than rebuilt, so this works for the
+ * icon buttons on a result row and for the labelled buttons under a document
+ * without either caller describing itself twice.
+ *
+ * The clipboard is refused outside a secure context and by a browser that has
+ * decided this was not a user gesture, and neither is an error worth a dialog.
+ * What is worth saying is what did not get copied, so the failure names it and
+ * the person can select it themselves.
+ */
+export async function copies(button, text, say = () => {}) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    say(`Could not copy ${text}`);
+    return;
+  }
+  say(`Copied ${text}`);
+
+  const held = Array.from(button.childNodes);
+  const labelled = button.hasAttribute("aria-label");
+  const label = button.getAttribute("aria-label");
+  const worded = held.some((node) => node.nodeType === Node.TEXT_NODE);
+
+  replace(button, svg(icon("check"), 18), worded && "Copied");
+  if (labelled) button.setAttribute("aria-label", "Copied");
+
+  setTimeout(() => {
+    replace(button, held);
+    if (labelled) button.setAttribute("aria-label", label);
+  }, CONFIRM);
+}

--- a/web/dist/assets/drawer.js
+++ b/web/dist/assets/drawer.js
@@ -10,12 +10,15 @@
 import { h, replace, svg } from "./dom.js";
 import { api } from "./api.js";
 import { cache } from "./cache.js";
-import { icon, label, sourceColor, when, exact } from "./format.js";
+import { copies } from "./clipboard.js";
+import { icon, label, sourceColor, when, exact, followable, copyable } from "./format.js";
 import { body as renderBody, shapeOf } from "./content.js";
+import { documentPath } from "./state.js";
 
 export class Drawer {
-  constructor({ onClose }) {
+  constructor({ onClose, onSay }) {
     this.onClose = onClose;
+    this.onSay = onSay || (() => {});
     this.returnTo = null;
     this.currentKey = "";
 
@@ -116,14 +119,41 @@ export class Drawer {
     // has to say where it goes and how wide it is.
     this.body.dataset.shape = shapeOf(d);
     replace(this.body, renderBody(d));
+    // Opening at the source is only offered where a browser would go there. For
+    // every document the file connector read it would not, so the path takes
+    // its place: a path somebody can paste into a terminal is worth something,
+    // and a link that silently does nothing is worth less than no link at all.
     replace(
       this.foot,
-      d.url &&
+      followable(d.url) &&
         h(
           "a",
           { class: "button button--primary", href: d.url, target: "_blank", rel: "noreferrer noopener" },
           "Open in source",
           svg(icon("external"), 16),
+        ),
+      h(
+        "button",
+        {
+          class: "button",
+          type: "button",
+          onClick: (e) =>
+            copies(e.currentTarget, new URL(documentPath(d.id), location.origin).href, this.onSay),
+        },
+        svg(icon("link"), 16),
+        "Copy link",
+      ),
+      d.url &&
+        !followable(d.url) &&
+        h(
+          "button",
+          {
+            class: "button",
+            type: "button",
+            onClick: (e) => copies(e.currentTarget, copyable(d.url), this.onSay),
+          },
+          svg(icon("copy"), 16),
+          "Copy path",
         ),
       d.modified_at &&
         h("span", { class: "meta", title: exact(d.modified_at) }, `Updated ${when(d.modified_at)}`),
@@ -135,7 +165,10 @@ export class Drawer {
   }
 
   renderError(err) {
-    const missing = err.status === 404;
+    // A document that is not there and a document this viewer may not read say
+    // the same thing, because a message that told them apart would let anybody
+    // enumerate what exists by reading the difference.
+    const missing = err.status === 404 || err.status === 403;
     replace(this.title, missing ? "Not available" : "Could not load this document");
     replace(this.meta);
     this.body.dataset.shape = "text";
@@ -148,7 +181,15 @@ export class Drawer {
     replace(this.foot);
   }
 
-  close() {
+  /**
+   * close hides the drawer and puts focus back where it came from.
+   *
+   * notify is false when the URL has already moved on, which is what happens
+   * when somebody follows a result title to its own page while the preview of
+   * another result is open. Telling the shell to clear the open parameter then
+   * would navigate away from the page they just asked for.
+   */
+  close(opts = {}) {
     if (!this.open) return;
     // A request already in flight is left to finish and fill the cache, because
     // reopening the same document is the most likely next thing to happen. It
@@ -156,8 +197,8 @@ export class Drawer {
     this.currentKey = "";
     this.el.hidden = true;
     this.scrim.hidden = true;
-    if (this.returnTo && this.returnTo.focus) this.returnTo.focus();
-    this.onClose();
+    if (opts.focus !== false && this.returnTo && this.returnTo.focus) this.returnTo.focus();
+    if (opts.notify !== false) this.onClose();
   }
 
   /** trap keeps Tab inside the dialog while it is open. */

--- a/web/dist/assets/format.js
+++ b/web/dist/assets/format.js
@@ -20,6 +20,9 @@ const ICONS = {
   check: "m5 12 5 5 9-10",
   rows: "M4 6h16M4 10h16M4 14h16M4 18h16",
   preview: "M4 6h16v12H4zM4 10h16",
+  copy: "M9 9h10v11H9zM5 15V4h10",
+  "arrow-left": "M19 12H5M11 6l-6 6 6 6",
+  link: "M10.5 13.5a4 4 0 0 0 5.7 0l2.3-2.3a4 4 0 0 0-5.7-5.7l-1.1 1.1M13.5 10.5a4 4 0 0 0-5.7 0l-2.3 2.3a4 4 0 0 0 5.7 5.7l1.1-1.1",
 };
 
 export function icon(name) {
@@ -52,6 +55,51 @@ const SOURCE_COLORS = {
 
 export function sourceColor(source) {
   return SOURCE_COLORS[source] || "var(--source-files)";
+}
+
+// Schemes a browser will not navigate to from a page served over HTTP.
+//
+// A file:// link is the one that matters, because the file connector writes one
+// for every document it reads and clicking it does nothing at all: no
+// navigation, no error, no console message. The others are here because a
+// document's URL comes from a connector and a connector reads a corpus we did
+// not write.
+const DEAD = new Set(["file:", "data:", "blob:", "javascript:", "vbscript:", "about:"]);
+
+/**
+ * followable reports whether clicking this URL would go anywhere.
+ *
+ * A custom scheme is followable: slack:// and vscode:// are handed to the
+ * operating system and open the application somebody wanted. The test is the
+ * short list above rather than a list of the schemes we approve of, because a
+ * connector we have not written yet should not have to be added to a table
+ * here before its links work.
+ */
+export function followable(url) {
+  if (!url) return false;
+  try {
+    return !DEAD.has(new URL(url, location.href).protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * copyable is what goes on the clipboard in place of a link nobody can follow.
+ *
+ * For a file URL that is the path, decoded, which is what somebody pastes into
+ * a terminal or an editor. For anything else it is the URL as it arrived,
+ * because we do not know enough about it to improve on it.
+ */
+export function copyable(url) {
+  const value = String(url || "");
+  try {
+    const parsed = new URL(value, location.href);
+    if (parsed.protocol !== "file:") return value;
+    return decodeURIComponent(parsed.pathname) || value;
+  } catch {
+    return value;
+  }
 }
 
 /** title cases a source or kind for display without touching the value. */

--- a/web/dist/assets/omnibox.js
+++ b/web/dist/assets/omnibox.js
@@ -223,7 +223,14 @@ export class Omnibox {
   }
 }
 
+const MAC = navigator.platform.toLowerCase().includes("mac");
+
+/** modifierLabel is the key a platform holds down for its own shortcuts. */
+export function modifierLabel() {
+  return MAC ? "⌘" : "Ctrl";
+}
+
 /** shortcutLabel matches the key the platform actually uses. */
 export function shortcutLabel() {
-  return navigator.platform.toLowerCase().includes("mac") ? "⌘K" : "Ctrl K";
+  return MAC ? "⌘K" : "Ctrl K";
 }

--- a/web/dist/assets/page.js
+++ b/web/dist/assets/page.js
@@ -1,0 +1,222 @@
+// A document as a page of its own.
+//
+// The drawer and this render the same document through the same function, and
+// the difference is the frame around it. A drawer sits over a list somebody is
+// coming back to, so it is narrow, it is modal on a phone and it closes. A page
+// is what somebody was sent a link to, so it has the measure to read at, a way
+// back to a list it may never have had, and no modality at all.
+//
+// It is the reason the title of a result can be an anchor. A middle click, a
+// command click and the context menu all lead here, which is what makes the
+// primary target on a row behave like a link on the web rather than like a
+// widget that happens to look like one.
+
+import { h, replace, svg } from "./dom.js";
+import { api } from "./api.js";
+import { cache } from "./cache.js";
+import { copies } from "./clipboard.js";
+import {
+  icon,
+  label,
+  sourceColor,
+  when,
+  exact,
+  followable,
+  copyable,
+} from "./format.js";
+import { body as renderBody, shapeOf } from "./content.js";
+import { documentPath } from "./state.js";
+
+export class Page {
+  constructor({ onBack, onSay }) {
+    this.onBack = onBack;
+    this.onSay = onSay || (() => {});
+    this.currentKey = "";
+
+    this.back = h("div", { class: "page__back" });
+    this.meta = h("div", { class: "page__meta" });
+    this.title = h("h1", { class: "page__title", tabindex: "-1" });
+    this.content = h("div", { class: "page__body" });
+    this.foot = h("div", { class: "page__foot" });
+
+    this.el = h(
+      "article",
+      { class: "page" },
+      this.back,
+      h("header", { class: "page__head" }, this.meta, this.title),
+      this.content,
+      this.foot,
+    );
+  }
+
+  async show(id) {
+    const k = cache.key("document", { id });
+    if (this.currentKey === k) return;
+    this.currentKey = k;
+
+    this.renderBack();
+    // A page reached from a result row is usually already in the cache, because
+    // the pointer rested on that row on the way to clicking it. The skeleton is
+    // for the ones that are not, which is a reload and a link somebody sent.
+    if (cache.read(k).state === "miss") this.skeleton();
+
+    let painted = false;
+    try {
+      await cache.swr(
+        k,
+        (opts) => api.document(id, opts),
+        (d) => {
+          if (this.currentKey !== k) return;
+          painted = true;
+          this.render(d);
+        },
+      );
+    } catch (err) {
+      if (err.name === "AbortError") return;
+      if (!painted && this.currentKey === k) this.renderError(err);
+    }
+  }
+
+  /**
+   * renderBack draws the way out.
+   *
+   * Where it goes depends on how this page was reached, and the shell is what
+   * knows that. A page opened in a new tab has no results to go back to and no
+   * history to walk, so it offers the search instead of a button that would do
+   * nothing.
+   */
+  renderBack() {
+    const to = this.onBack();
+    replace(
+      this.back,
+      h(
+        "a",
+        {
+          class: "page__back-link",
+          href: to.href,
+          onClick: (e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+            e.preventDefault();
+            to.go();
+          },
+        },
+        svg(icon("arrow-left"), 16),
+        to.title,
+      ),
+    );
+  }
+
+  skeleton() {
+    replace(this.title, "Loading");
+    replace(this.meta);
+    replace(
+      this.content,
+      h("div", { class: "skeleton", style: { width: "100%", height: "14px", marginBottom: "8px" } }),
+      h("div", { class: "skeleton", style: { width: "92%", height: "14px", marginBottom: "8px" } }),
+      h("div", { class: "skeleton", style: { width: "70%", height: "14px" } }),
+    );
+    replace(this.foot);
+  }
+
+  render(d) {
+    const heading = d.title || d.id;
+    replace(this.title, heading);
+    document.title = `${heading} · genba`;
+    replace(
+      this.meta,
+      h(
+        "span",
+        { class: "source" },
+        h("span", { class: "source__dot", style: { background: sourceColor(d.source) } }),
+        label(d.source),
+      ),
+      h("span", { class: "crumbs__sep" }, "·"),
+      h("span", {}, label(d.kind)),
+      d.container && h("span", { class: "crumbs__sep" }, "·"),
+      d.container && h("span", { class: "crumbs" }, d.container),
+      d.modified_at && h("span", { class: "crumbs__sep" }, "·"),
+      d.modified_at &&
+        h("time", { title: exact(d.modified_at), datetime: d.modified_at }, `Updated ${when(d.modified_at)}`),
+    );
+
+    this.content.dataset.shape = shapeOf(d);
+    replace(this.content, renderBody(d));
+    replace(this.foot, actions(d, this.onSay));
+
+    // Focus goes to the heading rather than to the first control, because this
+    // is a document somebody came to read and the top of it is where reading
+    // starts. It carries tabindex="-1" so it can take focus without joining the
+    // tab order.
+    this.title.focus();
+  }
+
+  /**
+   * renderError says the same thing for a document that is not there and for
+   * one this viewer may not read.
+   *
+   * That is the whole permission model showing through the interface. A message
+   * that distinguished the two would let anybody enumerate what exists by
+   * reading the difference, which is exactly what the storage driver refuses to
+   * tell the API.
+   */
+  renderError(err) {
+    const missing = err.status === 404 || err.status === 403;
+    replace(this.title, missing ? "Not available" : "Could not load this document");
+    document.title = "genba";
+    replace(this.meta);
+    this.content.dataset.shape = "text";
+    replace(
+      this.content,
+      h(
+        "p",
+        { class: "preview__empty" },
+        missing ? "This document no longer exists, or you do not have access to it." : err.message,
+      ),
+    );
+    replace(this.foot);
+    this.title.focus();
+  }
+}
+
+/**
+ * actions is the row under a document.
+ *
+ * Opening at the source is offered where a browser would go there. Where it
+ * would not, which is every document the file connector read, the path takes
+ * its place, because a path somebody can paste into a terminal is worth
+ * something and a link that does nothing is worth less than no link.
+ */
+function actions(d, say) {
+  const here = new URL(documentPath(d.id), location.origin).href;
+  return [
+    followable(d.url) &&
+      h(
+        "a",
+        { class: "button button--primary", href: d.url, target: "_blank", rel: "noreferrer noopener" },
+        "Open in source",
+        svg(icon("external"), 16),
+      ),
+    h(
+      "button",
+      {
+        class: "button",
+        type: "button",
+        onClick: (e) => copies(e.currentTarget, here, say),
+      },
+      svg(icon("link"), 16),
+      "Copy link",
+    ),
+    d.url &&
+      !followable(d.url) &&
+      h(
+        "button",
+        {
+          class: "button",
+          type: "button",
+          onClick: (e) => copies(e.currentTarget, copyable(d.url), say),
+        },
+        svg(icon("copy"), 16),
+        "Copy path",
+      ),
+  ];
+}

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -1,8 +1,20 @@
 // The results view: verticals, active filters, result rows and facets.
 
 import { h, replace, svg } from "./dom.js";
-import { kindIcon, sourceColor, label, when, exact, number, duration, icon } from "./format.js";
+import {
+  kindIcon,
+  sourceColor,
+  label,
+  when,
+  exact,
+  number,
+  duration,
+  icon,
+  followable,
+  copyable,
+} from "./format.js";
 import { tile } from "./content.js";
+import { copies } from "./clipboard.js";
 import * as urlState from "./state.js";
 
 /**
@@ -34,10 +46,11 @@ const FACETS = [
 const FACET_VISIBLE = 8;
 
 export class Results {
-  constructor({ onQuery, onOpen, onHover }) {
+  constructor({ onQuery, onOpen, onHover, onSay }) {
     this.onQuery = onQuery;
     this.onOpen = onOpen;
     this.onHover = onHover || (() => {});
+    this.onSay = onSay || (() => {});
     this.expanded = new Set();
     this.selected = -1;
     this.hits = [];
@@ -266,21 +279,37 @@ export class Results {
         onMouseenter: () => this.onHover(hit.id),
         onMouseleave: () => this.onHover(null),
         onClick: (e) => {
-          // A click on the title follows the source link. A click anywhere else
-          // on the row opens the preview, which is the cheaper of the two and
-          // the one people want when they are still scanning.
-          if (e.target.closest("a")) return;
+          // Anything that is already a control handles its own click. A click
+          // on the rest of the row opens the preview, which is what somebody
+          // scanning a list wants and is cheaper than loading a page.
+          if (e.target.closest("a, button")) return;
           open();
         },
       },
       tile(hit),
-      hit.url
-        ? h(
-            "a",
-            { class: "result__title", href: hit.url, rel: "noreferrer noopener", target: "_blank" },
-            hit.title || hit.id,
-          )
-        : h("button", { class: "result__title", type: "button", onClick: open }, hit.title || hit.id),
+      // The title is an anchor to this document's own page, and the default is
+      // prevented on a plain left click so that the preview opens instead.
+      //
+      // It is an anchor rather than a button so that a middle click, a command
+      // click, the context menu and copying the link address all do what they
+      // do everywhere else on the web. It points at us rather than at the
+      // document's source, because a source URL is whatever a connector found
+      // and for the file connector that is a file:// URL, which a browser
+      // served over HTTP will not navigate to. Clicking the primary target on
+      // every row of a file corpus did nothing at all.
+      h(
+        "a",
+        {
+          class: "result__title",
+          href: urlState.documentPath(hit.id),
+          onClick: (e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+            e.preventDefault();
+            open();
+          },
+        },
+        hit.title || hit.id,
+      ),
       h(
         "div",
         { class: "result__meta" },
@@ -309,19 +338,35 @@ export class Results {
           { class: "icon-button", type: "button", title: "Preview (p)", "aria-label": "Preview", onClick: open },
           svg(icon("preview"), 18),
         ),
-        hit.url &&
-          h(
-            "a",
-            {
-              class: "icon-button",
-              href: hit.url,
-              target: "_blank",
-              rel: "noreferrer noopener",
-              title: "Open in source",
-              "aria-label": "Open in source",
-            },
-            svg(icon("external"), 18),
-          ),
+        // Opening at the source is the secondary action, and it is only offered
+        // where it would work. Where it would not, the path is the useful thing
+        // to hand over, so the button copies it rather than pretending to be a
+        // link and doing nothing.
+        followable(hit.url)
+          ? h(
+              "a",
+              {
+                class: "icon-button",
+                href: hit.url,
+                target: "_blank",
+                rel: "noreferrer noopener",
+                title: "Open in source",
+                "aria-label": "Open in source",
+              },
+              svg(icon("external"), 18),
+            )
+          : hit.url &&
+            h(
+              "button",
+              {
+                class: "icon-button",
+                type: "button",
+                title: "Copy path",
+                "aria-label": "Copy path",
+                onClick: (e) => copies(e.currentTarget, copyable(hit.url), this.onSay),
+              },
+              svg(icon("copy"), 18),
+            ),
       ),
     );
   }

--- a/web/dist/assets/state.js
+++ b/web/dist/assets/state.js
@@ -7,6 +7,41 @@
 
 const LIST_KEYS = ["source", "kind", "container", "author", "owner"];
 
+// The one screen that is a path rather than a query string.
+//
+// A document is the thing somebody pastes into a message, so it gets an address
+// that survives being read out loud and does not carry the state of whoever
+// found it. Everything else is a view of a search and belongs in the query.
+const DOCUMENT = "/d/";
+
+/**
+ * route says which screen the path names.
+ *
+ * The server serves the shell for any path it does not recognise, so a reload
+ * of a document page reaches this function rather than a 404.
+ */
+export function route(pathname = location.pathname) {
+  if (!pathname.startsWith(DOCUMENT)) return { name: "search", id: "" };
+  const id = decode(pathname.slice(DOCUMENT.length));
+  return id ? { name: "document", id } : { name: "search", id: "" };
+}
+
+/** documentPath is the address of one document as a page of its own. */
+export function documentPath(id) {
+  return DOCUMENT + encodeURIComponent(id);
+}
+
+// A path somebody typed or a link somebody mangled can hold a percent sign that
+// is not an escape, and that is a request for a document we do not have rather
+// than an exception on the way to the first paint.
+function decode(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return "";
+  }
+}
+
 /** read parses the current location into a query. */
 export function read(search = location.search) {
   const params = new URLSearchParams(search);
@@ -33,8 +68,10 @@ export function write(query) {
   if (query.offset) params.set("offset", String(query.offset));
   if (query.tab && query.tab !== "all") params.set("tab", query.tab);
   if (query.open) params.set("open", query.open);
+  // Rooted rather than relative, because a search reached from a document page
+  // is a search and not a document with a query string stuck on the end of it.
   const s = params.toString();
-  return s ? `?${s}` : location.pathname;
+  return s ? `/?${s}` : "/";
 }
 
 /**

--- a/web/dist/assets/tokens.css
+++ b/web/dist/assets/tokens.css
@@ -101,7 +101,14 @@
   --code-string: #0a3069;
   --code-number: #0550ae;
   --code-func: #953800;
-  --code-comment: var(--text-muted);
+
+  /* Muted, on the code surface rather than on the page ground. The code block
+     sits on --bg-subtle, and --text-muted clears the AA contrast ratio against
+     white by a tenth of a point and misses it here. This is the same grey a
+     shade darker, which clears it on both, and it is what the comment token
+     and the language chip use. */
+  --code-muted: #6b6b6b;
+  --code-comment: var(--code-muted);
 
   /* Semantic layer. This is what components use. */
   --bg: var(--gray-0);
@@ -318,6 +325,7 @@
   --code-string: #a5d6ff;
   --code-number: #79c0ff;
   --code-func: #ffa657;
+  --code-muted: var(--text-muted);
 
   /* A shadow on a dark ground carries almost no information, so the drawer
      additionally takes a hairline to define its edge. */

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -36,13 +36,23 @@ func TestUnknownPathsFallBackToTheDocument(t *testing.T) {
 		t.Skip("this build carries no interface")
 	}
 
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/search/deep/link", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("a client route returned %d, want 200 so that a reload survives", w.Code)
-	}
-	if w.Header().Get("Cache-Control") != "no-cache" {
-		t.Errorf("Cache-Control = %q, the document must not be cached", w.Header().Get("Cache-Control"))
+	// A document id carries a source prefix and a path, so the route for one
+	// arrives here with a colon and slashes already decoded and looks exactly
+	// like a file that is not there. It has to reach the shell anyway, or every
+	// link anybody pastes is a 404 on the first load.
+	for _, path := range []string{
+		"/search/deep/link",
+		"/d/repo:index/cache.go",
+		"/d/notes:Spec/2121/ui/08_kaggle_calibration.md",
+	} {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s returned %d, want 200 so that a reload survives", path, w.Code)
+		}
+		if w.Header().Get("Cache-Control") != "no-cache" {
+			t.Errorf("%s Cache-Control = %q, the document must not be cached", path, w.Header().Get("Cache-Control"))
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #102.

Clicking the title of a result did nothing on a file corpus.
The title was an anchor to whatever URL the connector recorded, and for the file connector that is a `file://` URL, which a browser served over HTTP refuses to navigate to.
No error, no console message, nothing.
Every row of the corpus most people try first was a dead link.

## What changed

The title now points at `/d/{id}`, a document on a page of its own.
A plain left click still opens the preview, because that is the cheaper answer while somebody is still scanning a list.
It is an anchor rather than a button so that a middle click, a command click, the context menu and copying the link address all do what they do everywhere else on the web.
Command Enter does the same thing from the keyboard, and the shortcut sheet says so.

The page needs nothing from the server.
Any path the file map does not recognise already serves the shell, so a reload and a pasted link both work and the client decides what the path meant.
There is a test for the encoded ids a document route actually produces, because a colon and a slash arrive here already decoded and look exactly like a file that is not there.

Where a source URL is one a browser will not follow, the secondary action copies the path instead of pretending to be a link.
The preview footer does the same.
Both also offer the link to the page, which is the address worth pasting into a message, because it does not carry the state of whoever found the document.

The rail links were bare query strings, which resolve against whatever path is showing.
That was harmless while every path was the search, and it is not any more.
They are rooted now.

## The gate

The interface gate grew a keyboard walk in `scripts/keyboard-walk.mjs`.
It drives Chrome over the DevTools protocol, presses the keys and clicks the links a person would, and asserts where each one led.
That is the half an audit cannot see, because the markup here was correct the whole time.
It speaks the protocol directly rather than through a driver, so the gate gains no dependency with a browser download in it for a script that already has a browser, and it skips itself with a message when there is no Chrome.

```
ui-gate: keyboard walk
keyboard-walk: ok   the title of a result is a link into the product
keyboard-walk: ok   j moves the cursor onto the first row
keyboard-walk: ok   Enter on a row opens the preview
keyboard-walk: ok   the preview took focus
keyboard-walk: ok   Escape closes the preview
keyboard-walk: ok   a plain click on the title opens the preview and stays on the results
keyboard-walk: ok   the document route renders the document with a way back
keyboard-walk: ok   the document page is not the preview drawer
keyboard-walk: ok   no link on the document page is the same document with a parameter on the end
```

I checked that it fails for the right reason by putting the old href back and running it against a binary built from that: the first assertion fails and the walk exits 1.

axe and Lighthouse now also audit the document page, which is a fourth screen.
That found two contrast failures in the code theme.
A comment and the language chip both sat at a grey that clears AA against white and misses it against `--bg-subtle`, which is the surface a code block actually sits on.
There is a `--code-muted` token now, one shade darker, and it clears AA on both.

The gate also used to believe anything that answered `/healthz` on its port was our server, which cost me an afternoon when a leftover test binary was squatting on 8123 and the failure it produced blamed the corpus.
It checks the port before it starts anything now, and stops waiting if the server exits.

## Verified

Local gates are green: `fmt`, `vet`, `lint`, `race`, and `ui-gate` with a matching chromedriver.
axe reports 0 violations on all four screens and Lighthouse reports accessibility 100 and best practices 100.

By hand against my own notes, 18650 real documents behind sqlite: every result title is a link into the product, no `file://` anchor is left anywhere on the page, the document page renders markdown with its tables and code with its language chip, the copy button announces itself in the polite region and puts a plain filesystem path on the clipboard rather than a `file://` URL, and the back link says "Back to results" and returns to the search that was there.
No console errors.
