### PR TITLE
Make the navigation what the corpus holds

### DIFF
--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -137,6 +137,41 @@ async function walk() {
     })()`,
   );
 
+  // The corpus here is this repository, which holds code, pages and files and
+  // no messages, tickets or people. Those three tabs used to be on screen
+  // anyway, and every one of them was a click that led to an empty page.
+  await check(
+    session,
+    "the tab strip is what the corpus holds and nothing else",
+    `(() => {
+      const on = [...document.querySelectorAll('.tab')].map((t) => t.textContent);
+      const named = (name) => on.some((t) => t.startsWith(name));
+      return named('All') && named('Documents') && named('Code') &&
+        !named('Messages') && !named('Tickets') && !named('People');
+    })()`,
+  );
+
+  await check(
+    session,
+    "one source is not a filter, so the rail does not offer it",
+    "document.querySelector('#rail-sources').children.length === 0",
+  );
+
+  // The two boundaries the corpus above cannot show, asked of the function
+  // directly. It is a module in the page, so the browser is the test runner and
+  // there is nothing to install.
+  await check(
+    session,
+    "images are a vertical, and an empty index has none at all",
+    `import('/assets/results.js').then(({ verticalsFor }) => {
+      const withImages = verticalsFor([
+        { value: 'page', count: 4 },
+        { value: 'image', count: 912 },
+      ]);
+      return withImages.some((v) => v.id === 'images') && verticalsFor([]).length === 0;
+    })`,
+  );
+
   await press(session, "j", "KeyJ", 74);
   await check(
     session,
@@ -199,6 +234,24 @@ async function walk() {
       const u = new URL(a.href, location.href);
       return !(u.pathname.startsWith('/d/') && u.search);
     })`,
+  );
+
+  // Last, because it changes the viewport for everything after it. 390 is the
+  // narrowest phone worth drawing for, and it is the width at which the strip
+  // used to shrink its tabs to fit instead of scrolling, so the last one read
+  // "Tick".
+  await narrow(session, 390, 780);
+  await visit(session, `${BASE}/?q=cache`, "document.querySelectorAll('.tab').length > 0");
+  await check(
+    session,
+    "at 390 pixels the tab strip scrolls rather than cutting a label in half",
+    `(() => {
+      const tabs = document.querySelector('.tabs');
+      const whole = [...document.querySelectorAll('.tab')].every(
+        (t) => t.scrollWidth <= t.clientWidth + 1,
+      );
+      return whole && tabs.scrollWidth > tabs.clientWidth && tabs.dataset.scroll === 'end';
+    })()`,
   );
 }
 
@@ -283,6 +336,16 @@ async function attach(url) {
   const { sessionId } = await send("Target.attachToTarget", { targetId, flatten: true });
   await send("Page.bringToFront", {}, sessionId);
   return (method, params) => send(method, params, sessionId);
+}
+
+/** narrow tells the page it is on a small screen, media queries and all. */
+async function narrow(session, width, height) {
+  await session("Emulation.setDeviceMetricsOverride", {
+    width,
+    height,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
 }
 
 /** visit navigates and waits for the interface to have painted the answer. */

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -501,8 +501,18 @@ time {
   gap: var(--space-1);
 }
 
+/* Absent, rather than an empty strip holding a border and a row of height, on a
+   corpus with nothing to divide into verticals. */
+.tabs[hidden] {
+  display: none;
+}
+
 .tab {
   position: relative;
+  /* Never narrower than its own label. Without this the strip below the
+     breakpoint shrinks its tabs to fit instead of scrolling, and at 390 pixels
+     the last one read "Tick". */
+  flex: none;
   display: flex;
   align-items: center;
   gap: var(--space-2);
@@ -2034,10 +2044,47 @@ h6.prose__h {
     min-width: 0;
     overflow-x: auto;
     scrollbar-width: none;
+    scroll-snap-type: x proximity;
   }
 
   .tabs::-webkit-scrollbar {
     display: none;
+  }
+
+  /* Proximity rather than mandatory, because mandatory takes a flick that was
+     meant to reveal the end of the strip and puts it back where it started. */
+  .tab {
+    scroll-snap-align: start;
+  }
+
+  /* The fade means there is more that way, so it is only drawn on a side where
+     there is. results.js sets the attribute from the scroll position, and a
+     strip that fits gets no fade at all. */
+  .tabs[data-scroll="end"] {
+    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 32px), transparent);
+    mask-image: linear-gradient(to right, #000 calc(100% - 32px), transparent);
+  }
+
+  .tabs[data-scroll="start"] {
+    -webkit-mask-image: linear-gradient(to right, transparent, #000 32px);
+    mask-image: linear-gradient(to right, transparent, #000 32px);
+  }
+
+  .tabs[data-scroll="both"] {
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent,
+      #000 32px,
+      #000 calc(100% - 32px),
+      transparent
+    );
+    mask-image: linear-gradient(
+      to right,
+      transparent,
+      #000 32px,
+      #000 calc(100% - 32px),
+      transparent
+    );
   }
 
   .filterbar__toggle {

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -10,9 +10,9 @@ import { api, identity, setIdentity, ApiError } from "./api.js";
 import { cache } from "./cache.js";
 import { Live } from "./live.js";
 import * as urlState from "./state.js";
-import { followable, icon, initials, label, sourceColor, when } from "./format.js";
+import { followable, icon, initials, label, number, sourceColor, when } from "./format.js";
 import { Omnibox, modifierLabel, shortcutLabel } from "./omnibox.js";
-import { Results, VERTICALS } from "./results.js";
+import { Results, VERTICALS, verticalsFor } from "./results.js";
 import { Drawer } from "./drawer.js";
 import { Page } from "./page.js";
 import { Home } from "./home.js";
@@ -246,24 +246,11 @@ class App {
           h("span", { class: "rail__label" }, "Recent"),
         ),
       ),
-      h(
-        "div",
-        { class: "rail__section" },
-        h("h2", { class: "rail__title" }, "Verticals"),
-        VERTICALS.filter((v) => v.id !== "all").map((v) =>
-          h(
-            "a",
-            {
-              class: "rail__link",
-              href: `/?tab=${v.id}`,
-              title: v.title,
-              onClick: (e) => this.link(e, { ...this.query, tab: v.id, kind: [], offset: 0 }),
-            },
-            svg(icon(v.id === "people" ? "people" : v.id === "code" ? "code" : v.id === "messages" ? "chat" : v.id === "tickets" ? "ticket" : "doc"), 20),
-            h("span", { class: "rail__label" }, v.title),
-          ),
-        ),
-      ),
+      // Both of these are filled once the session says what the corpus holds.
+      // They are empty until then rather than full of guesses, because a rail
+      // that shortens a moment after it paints is worse than one that arrives a
+      // moment late.
+      h("div", { class: "rail__section", id: "rail-verticals" }),
       h("div", { class: "rail__section", id: "rail-sources" }),
       h(
         "button",
@@ -293,6 +280,8 @@ class App {
       // anything is read and the switcher below empties the cache by changing
       // it. Nothing cached under one identity is reachable from another.
       cache.as(this.session.view || "");
+      this.results.verticals = verticalsFor(this.session.kinds);
+      this.renderVerticals();
       this.renderSources();
     } catch (err) {
       this.fail(err);
@@ -302,10 +291,46 @@ class App {
     this.refresher.start();
   }
 
+  /** renderVerticals fills the rail with the verticals the corpus has. */
+  renderVerticals() {
+    const holder = this.rail.querySelector("#rail-verticals");
+    // All is the tab strip's way of saying no filter, and on the rail it is the
+    // brand and the Home link, so it does not get a row of its own.
+    const verticals = this.results.verticals.filter((v) => v.id !== "all");
+    if (!verticals.length) {
+      replace(holder);
+      return;
+    }
+    replace(
+      holder,
+      h("h2", { class: "rail__title" }, "Verticals"),
+      verticals.map((v) =>
+        h(
+          "a",
+          {
+            class: "rail__link",
+            href: `/?tab=${v.id}`,
+            title: v.title,
+            onClick: (e) => this.link(e, { ...this.query, tab: v.id, kind: [], offset: 0 }),
+          },
+          svg(icon(v.icon), 20),
+          h("span", { class: "rail__label" }, v.title),
+          h("span", { class: "rail__count" }, number(countIn(this.session.kinds, v))),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * renderSources fills the rail with where the documents came from.
+   *
+   * One source is not a filter. It always selects everything, and it sits above
+   * a facet panel saying the same word again.
+   */
   renderSources() {
     const holder = this.rail.querySelector("#rail-sources");
     const sources = (this.session && this.session.sources) || [];
-    if (!sources.length) {
+    if (sources.length < 2) {
       replace(holder);
       return;
     }
@@ -323,7 +348,7 @@ class App {
           },
           h("span", { class: "source__dot", style: { background: sourceColor(s.value) } }),
           h("span", { class: "rail__label" }, label(s.value)),
-          h("span", { class: "rail__count" }, s.count),
+          h("span", { class: "rail__count" }, number(s.count)),
         ),
       ),
     );
@@ -794,6 +819,19 @@ class App {
       }
     });
   }
+}
+
+/**
+ * countIn adds up the corpus wide counts of the kinds a vertical covers.
+ *
+ * This is the rail's number and it is deliberately not the tab strip's. The rail
+ * says how much of this there is, which does not change while somebody types.
+ * The tab says how much of this the current query matched.
+ */
+function countIn(kinds, vertical) {
+  return (kinds || [])
+    .filter((k) => vertical.kinds.includes(k.value))
+    .reduce((n, k) => n + k.count, 0);
 }
 
 // Theme before first paint, so a dark theme does not arrive as a white flash.

--- a/web/dist/assets/format.js
+++ b/web/dist/assets/format.js
@@ -21,6 +21,7 @@ const ICONS = {
   rows: "M4 6h16M4 10h16M4 14h16M4 18h16",
   preview: "M4 6h16v12H4zM4 10h16",
   copy: "M9 9h10v11H9zM5 15V4h10",
+  image: "M4 5h16v14H4V5ZM4 16l4.5-4.5 3 3 3.5-3.5L20 16M9.5 9.5h.01",
   "arrow-left": "M19 12H5M11 6l-6 6 6 6",
   link: "M10.5 13.5a4 4 0 0 0 5.7 0l2.3-2.3a4 4 0 0 0-5.7-5.7l-1.1 1.1M13.5 10.5a4 4 0 0 0-5.7 0l-2.3 2.3a4 4 0 0 0 5.7 5.7l1.1-1.1",
 };
@@ -38,6 +39,8 @@ const KIND_ICONS = {
   code: "code",
   person: "people",
   calendar: "clock",
+  image: "image",
+  video: "image",
 };
 
 export function kindIcon(kind) {

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -23,15 +23,44 @@ import * as urlState from "./state.js";
  * They are presets over document kinds rather than separate indexes, so the
  * counts across them add up and moving between them does not run a different
  * query with different ranking. A tab with no kinds is everything.
+ *
+ * The table is the editorial part and it stays a constant, because which kinds
+ * belong together is a judgement a count cannot make. Which of them a person is
+ * shown is decided by verticalsFor below.
  */
 export const VERTICALS = [
-  { id: "all", title: "All", kinds: [] },
-  { id: "documents", title: "Documents", kinds: ["page", "file"] },
-  { id: "messages", title: "Messages", kinds: ["message", "email"] },
-  { id: "tickets", title: "Tickets", kinds: ["ticket"] },
-  { id: "code", title: "Code", kinds: ["code"] },
-  { id: "people", title: "People", kinds: ["person"] },
+  { id: "all", title: "All", icon: "rows", kinds: [] },
+  { id: "documents", title: "Documents", icon: "doc", kinds: ["page", "file"] },
+  { id: "messages", title: "Messages", icon: "chat", kinds: ["message", "email"] },
+  { id: "tickets", title: "Tickets", icon: "ticket", kinds: ["ticket"] },
+  { id: "code", title: "Code", icon: "code", kinds: ["code"] },
+  { id: "images", title: "Images", icon: "image", kinds: ["image", "video"] },
+  { id: "people", title: "People", icon: "people", kinds: ["person"] },
 ];
+
+/**
+ * verticalsFor is the navigation this viewer should actually be offered.
+ *
+ * It takes the per kind counts from /api/v1/me, which are corpus wide and for
+ * this principal, and keeps a vertical when at least one of its kinds has a
+ * document in it. Counts for the current query are a different number and they
+ * belong on the tab; a tab that vanished when a search narrowed would be a tab
+ * nobody could use to widen one again.
+ *
+ * Being per viewer rather than per deployment is the same argument the source
+ * list already makes. Telling somebody a vertical exists that they have nothing
+ * in says a little about what other people can see.
+ *
+ * Two boundary cases both come out as nothing at all. An empty index reads as a
+ * system with nothing in it rather than as one with five broken tabs. A corpus
+ * that lands in exactly one vertical makes that vertical and All the same set of
+ * documents, and a choice between two identical answers is not a choice.
+ */
+export function verticalsFor(kinds) {
+  const counts = new Map((kinds || []).map((k) => [k.value, k.count]));
+  const held = VERTICALS.filter((v) => v.kinds.some((k) => (counts.get(k) || 0) > 0));
+  return held.length > 1 ? [VERTICALS[0], ...held] : [];
+}
 
 // A source and a kind are ours and read better capitalised. A container and a
 // person are somebody else's string, and a folder called store/sqlitestore is
@@ -54,8 +83,23 @@ export class Results {
     this.expanded = new Set();
     this.selected = -1;
     this.hits = [];
+    // Empty until the session says what the corpus holds, so the strip is never
+    // painted with tabs that are about to be taken away.
+    this.verticals = [];
 
-    this.tabs = h("div", { class: "tabs", role: "tablist", "aria-label": "Result types" });
+    this.tabs = h("div", {
+      class: "tabs",
+      role: "tablist",
+      "aria-label": "Result types",
+      hidden: true,
+      onScroll: () => this.edges(),
+    });
+    // The strip only scrolls on a narrow viewport, and whether it can is a
+    // question about its own width rather than about the window's, since the
+    // facet column comes and goes beside it.
+    if (typeof ResizeObserver === "function") {
+      new ResizeObserver(() => this.edges()).observe(this.tabs);
+    }
     this.facets = h("aside", { class: "facets", "aria-label": "Filters" });
 
     // The facet column becomes a disclosure below the medium breakpoint, where
@@ -154,9 +198,10 @@ export class Results {
   }
 
   renderTabs(query, res) {
+    this.tabs.hidden = this.verticals.length === 0;
     replace(
       this.tabs,
-      VERTICALS.map((v) => {
+      this.verticals.map((v) => {
         const active = (query.tab || "all") === v.id;
         const count = res ? countFor(res, v) : null;
         return h(
@@ -173,6 +218,25 @@ export class Results {
         );
       }),
     );
+    this.edges();
+  }
+
+  /**
+   * edges records which way the tab strip can still be scrolled.
+   *
+   * The fade at the edge of a narrow strip means there is more over there, so it
+   * has to know whether there is. A mask that is always on fades the last tab of
+   * a strip that fits, which reads as a rendering fault rather than as an
+   * invitation to scroll.
+   */
+  edges() {
+    const room = this.tabs.scrollWidth - this.tabs.clientWidth;
+    // A scroll position on a display whose pixel ratio is not one lands on a
+    // fraction and never reaches the far end exactly, so each end gets a pixel.
+    const before = this.tabs.scrollLeft > 1;
+    const after = room > 1 && this.tabs.scrollLeft < room - 1;
+    const state = before && after ? "both" : before ? "start" : after ? "end" : "none";
+    if (this.tabs.dataset.scroll !== state) this.tabs.dataset.scroll = state;
   }
 
   renderChips(query) {


### PR DESCRIPTION
Closes #103.

The tab strip and the rail were a fixed list of seven verticals.
A deployment holding code and pages showed Messages, Tickets and People anyway, and each one was a click that led to an empty page.
The count beside the tab was the only way to learn that, and only after the click.

Both are now derived from the per kind counts in `/api/v1/me`, which the interface already asks for once at startup.
A vertical is offered when the viewer can see at least one document of one of its kinds.
That is per viewer rather than per deployment, for the same reason the source list already is: telling somebody that a vertical exists which they have nothing in says something about what other people can see.

The counts differ by where they appear, on purpose.
The rail says how much of this there is, which does not change while somebody types.
The tab says how much of this the current query matched.
A tab that vanished when a search narrowed would be a tab nobody could use to widen one again, so the strip itself is decided by the corpus rather than by the query.

## Two boundaries

An empty index gets no strip, so it reads as a system with nothing in it rather than one with five broken tabs.
A corpus that lands in exactly one vertical also gets no strip, because All and that vertical are then the same set of documents.

## Also here

The rail loses its sources section when there is exactly one source.
A filter that always selects everything is not a filter, and it sat directly above a facet panel repeating the same word.

Images and video are a vertical now, and they get an icon of their own instead of the page icon they were borrowing.

Below 960 pixels the strip scrolls.
It used to shrink its tabs to fit, which at 390 pixels left the last one reading "Tick".
Tabs no longer shrink, and the strip fades whichever edge it can still be scrolled towards, so the fade means there is more that way rather than being permanent decoration.

## Testing

Four new assertions in the keyboard walk, thirteen in total, all passing.

Two of them read the live page against this repository's corpus, which holds one source and the kinds `code`, `page` and `file`.
The strip there reads All, Documents, Code, and the sources rail is absent.

The other two call `verticalsFor` directly through a dynamic import of `/assets/results.js` inside the page under test.
That is how the boundary cases this corpus cannot show, a corpus with images and an empty index, get tested with no bundler and no test runner, which is the direction #111 sets.

`make ui-gate` is green on the walk and on Lighthouse, 94 performance, 100 accessibility, 100 best practices.
axe does not run on my machine right now because the local ChromeDriver is 152 and the local Chrome is 151; CI installs a matched pair, so it runs there.