### PR TITLE
Make the keyboard the whole interface

### DIFF
--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -236,6 +236,131 @@ async function walk() {
     })`,
   );
 
+  // The keyboard on its own. Everything above uses it in passing; this is the
+  // part an audit finds and the part somebody using it all day notices.
+  await visit(session, `${BASE}/?q=cache`, "document.querySelectorAll('.result').length > 0");
+
+  await check(
+    session,
+    "the result list is one tab stop rather than twenty",
+    `(() => {
+      const rows = [...document.querySelectorAll('.results__list [data-index]')];
+      const stops = rows.filter((r) => r.tabIndex === 0);
+      const inside = [...document.querySelectorAll('.results__list a[href], .results__list button')];
+      return rows.length > 1 && stops.length === 1 && stops[0] === rows[0] &&
+        inside.length > 0 && inside.every((el) => el.tabIndex === -1);
+    })()`,
+  );
+
+  await press(session, "j", "KeyJ", 74);
+  await check(
+    session,
+    "the cursor takes focus with it and writes itself into the URL",
+    `document.activeElement.dataset.index === '0' &&
+      document.activeElement.dataset.active === 'true' &&
+      new URLSearchParams(location.search).get('cursor') === '0'`,
+  );
+
+  await press(session, "End", "End", 35);
+  await check(
+    session,
+    "End moves the cursor to the last result on the page",
+    `(() => {
+      const rows = [...document.querySelectorAll('.results__list [data-index]')];
+      const last = String(rows.length - 1);
+      return document.activeElement.dataset.index === last &&
+        new URLSearchParams(location.search).get('cursor') === last;
+    })()`,
+  );
+
+  await press(session, "Home", "Home", 36);
+  await check(session, "Home moves it back to the first", "document.activeElement.dataset.index === '0'");
+
+  await press(session, "Tab", "Tab", 9);
+  await check(
+    session,
+    "Tab leaves the list in one press",
+    "!document.querySelector('.results__list').contains(document.activeElement)",
+  );
+
+  // A row named in the URL is the row the page opens on, which is what makes
+  // the cursor survive a repaint and a link to a particular result work.
+  await visit(session, `${BASE}/?q=cache&cursor=2`, "document.querySelectorAll('.result').length > 2");
+  await check(
+    session,
+    "a cursor in the URL is where the page opens",
+    "document.querySelector('.result[data-active=\"true\"]').dataset.index === '2'",
+  );
+
+  const opened = await evaluate(session, "document.querySelector('.result__title').getAttribute('href')");
+  await visit(session, BASE + opened, "document.querySelector('.page__title').textContent.trim().length > 0");
+  await evaluate(session, "history.back()");
+  await settle(session, "document.querySelectorAll('.result').length > 2");
+  await check(
+    session,
+    "back from a document returns to the row the eye was on",
+    "document.querySelector('.result[data-active=\"true\"]').dataset.index === '2'",
+  );
+
+  // The omnibox as a screen reader meets it. axe cannot type, so the list is
+  // opened here and the relationships it would check are asserted directly.
+  await press(session, "/", "Slash", 191);
+  await type(session, "cache");
+  await settle(session, "document.querySelectorAll('.suggestion').length > 0");
+  await check(
+    session,
+    "an open suggestion list is a combobox that describes itself",
+    `(() => {
+      const input = document.querySelector('.omnibox__input');
+      const list = document.getElementById(input.getAttribute('aria-controls'));
+      const options = [...list.querySelectorAll('[role="option"]')];
+      return input.getAttribute('role') === 'combobox' &&
+        input.getAttribute('aria-expanded') === 'true' &&
+        list.getAttribute('role') === 'listbox' &&
+        Boolean(list.getAttribute('aria-label')) &&
+        options.length > 0 && options.every((o) => o.id);
+    })()`,
+  );
+  await check(
+    session,
+    "the suggestion count is announced politely",
+    `(() => {
+      const region = document.querySelector('.omnibox [role="status"]');
+      const options = document.querySelectorAll('.omnibox [role="option"]').length;
+      return region.getAttribute('aria-live') === 'polite' &&
+        region.textContent.trim() === options + (options === 1 ? ' suggestion' : ' suggestions');
+    })()`,
+  );
+
+  await press(session, "ArrowDown", "ArrowDown", 40);
+  await check(
+    session,
+    "the arrow keys move a highlight the input points at",
+    `(() => {
+      const input = document.querySelector('.omnibox__input');
+      const id = input.getAttribute('aria-activedescendant');
+      const option = id && document.getElementById(id);
+      return Boolean(option) && option.getAttribute('aria-selected') === 'true' &&
+        document.activeElement === input;
+    })()`,
+  );
+
+  await press(session, "Escape", "Escape", 27);
+  await check(
+    session,
+    "Escape closes the list and keeps what was typed",
+    `document.querySelector('.suggestions').hidden &&
+      document.querySelector('.omnibox__input').value === 'cache' &&
+      document.querySelector('.omnibox__input').getAttribute('aria-expanded') === 'false'`,
+  );
+
+  await press(session, "Escape", "Escape", 27);
+  await check(
+    session,
+    "a second Escape clears the field",
+    "document.querySelector('.omnibox__input').value === ''",
+  );
+
   // The grid. The pictures behind this query are written into the corpus by the
   // gate before the server starts, because the repository itself holds none.
   await visit(session, `${BASE}/?q=gatepix`, "document.querySelectorAll('.cell').length > 0");
@@ -456,6 +581,14 @@ async function press(session, key, code, keyCode) {
   }
   // One frame for the handler to run and the paint to land.
   await sleep(150);
+}
+
+/** type presses one key per character, which is how text reaches an input. */
+async function type(session, text) {
+  for (const ch of text) {
+    const upper = ch.toUpperCase();
+    await press(session, ch, `Key${upper}`, upper.charCodeAt(0));
+  }
 }
 
 /**

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -724,6 +724,16 @@ time {
   border-left-color: var(--focus-ring);
 }
 
+/* A row is a focus target, because the list is one tab stop and the cursor
+   carries focus with it. The ring is drawn inside the row rather than around
+   it: a full width outline offset outwards is clipped on both sides by the
+   scroller, which reads as a broken line rather than as a focus ring. */
+.result:focus-visible,
+.cell:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
 /*
  * The tile is the only part of a row that is not words.
  *

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -9,6 +9,7 @@ import { h, replace, svg } from "./dom.js";
 import { api, identity, setIdentity, ApiError } from "./api.js";
 import { cache } from "./cache.js";
 import { Live } from "./live.js";
+import { copies, copy } from "./clipboard.js";
 import * as urlState from "./state.js";
 import { followable, icon, initials, label, number, sourceColor, when } from "./format.js";
 import { Omnibox, modifierLabel, shortcutLabel } from "./omnibox.js";
@@ -73,13 +74,19 @@ class App {
       onOpen: (id) => this.open(id),
       onHover: (id) => this.guessDocument(id),
       onSay: (text) => this.say(text),
+      onCursor: (i) => this.rememberCursor(i),
     });
     this.home = new Home({
       onQuery: (q) => this.go({ ...urlState.read(""), ...q }),
       onOpen: (id) => this.open(id),
     });
     this.drawer = new Drawer({
-      onClose: () => this.go({ ...this.query, open: "" }, { replace: true }),
+      onClose: () => {
+        this.go({ ...this.query, open: "" }, { replace: true });
+        // Back to the row it was opened from rather than to the top of the
+        // page, which is the whole reason the cursor is in the URL.
+        this.results.focusCursor();
+      },
       onSay: (text) => this.say(text),
     });
     this.page = new Page({
@@ -356,11 +363,33 @@ class App {
 
   /** go pushes a new query into the URL and renders it. */
   go(query, opts = {}) {
-    const url = urlState.write(query);
+    const next = { ...query };
+    // A different question gets a fresh cursor, and the same question keeps
+    // the one it had. Opening a preview is the second case, which is what
+    // makes the way back from a preview land on the row it opened from.
+    if (!urlState.same(urlState.params(next, VERTICALS), urlState.params(this.query, VERTICALS))) {
+      next.cursor = -1;
+    }
+    const url = urlState.write(next);
     if (opts.replace) history.replaceState(null, "", url);
     else history.pushState(null, "", url);
     this.query = urlState.read();
     this.sync();
+  }
+
+  /**
+   * rememberCursor writes the row somebody is on into the address bar.
+   *
+   * Replace rather than push, because twenty presses of j are one journey and
+   * not twenty, and back from a result should leave the results rather than
+   * walk up the page a row at a time. Nothing is fetched and nothing is
+   * rendered: the cursor is not part of the request, so the answer on screen is
+   * already the answer to this URL.
+   */
+  rememberCursor(i) {
+    if (this.query.cursor === i) return;
+    this.query = { ...this.query, cursor: i };
+    history.replaceState(null, "", urlState.write(this.query));
   }
 
   /** sync renders whatever the URL currently says. */
@@ -689,10 +718,17 @@ class App {
       ["Focus search", [shortcutLabel()]],
       ["Next result", ["j"]],
       ["Previous result", ["k"]],
+      ["First result", ["Home"]],
+      ["Last result", ["End"]],
       ["Open preview", ["Enter"]],
       ["Open as a page, in a new tab", [modifierLabel(), "Enter"]],
       ["Open in source", ["o"]],
+      ["Copy a link to this result", ["y"]],
+      ["Previous page", ["["]],
+      ["Next page", ["]"]],
+      ["Filters", ["f"]],
       ["Go home", ["g", "h"]],
+      ["Recent", ["g", "s"]],
       ["Close", ["Esc"]],
       ["This list", ["?"]],
     ];
@@ -735,6 +771,46 @@ class App {
     );
     document.body.appendChild(dialog);
     dialog.querySelector(".dialog__panel").focus();
+  }
+
+  /**
+   * page is the bracket keys: the page before this one and the page after.
+   *
+   * It reports whether it did anything, so that a bracket typed on the last
+   * page is a bracket rather than a key that was quietly swallowed.
+   */
+  page(delta) {
+    const limit = this.query.limit || 20;
+    const offset = (this.query.offset || 0) + delta * limit;
+    if (offset < 0 || offset >= this.results.total) return false;
+    this.go({ ...this.query, offset, open: "" });
+    return true;
+  }
+
+  /**
+   * copyLink is the y key: a link to the result under the cursor.
+   *
+   * The link is this product's address for the document rather than the
+   * source's, which is the same choice the title makes and for the same reason:
+   * a connector's URL is whatever it found, and for a file that is a file://
+   * URL that nobody can follow from a message.
+   */
+  copyLink() {
+    const hit = this.results.current();
+    if (!hit) return false;
+    const link = new URL(urlState.documentPath(hit.id), location.origin).href;
+    const row = this.results.list.querySelector(`[data-index="${this.results.selected}"]`);
+    const button = row && row.querySelector(".icon-button--copy");
+    // The tick where there is a control to draw it on, so the keyboard and the
+    // pointer produce the same answer, and the spoken sentence either way.
+    if (button) copies(button, link, (text) => this.say(text));
+    else copy(link, (text) => this.say(text));
+    return true;
+  }
+
+  /** inList reports whether focus is on a row of the result list. */
+  inList() {
+    return this.results.list.contains(document.activeElement);
   }
 
   bindKeys() {
@@ -792,6 +868,26 @@ class App {
           e.preventDefault();
           this.results.move(-1);
           break;
+        // The arrow keys move inside the list and only inside it. A page has
+        // one scrollbar and somebody reading a preview with the arrow keys is
+        // scrolling it, so these are answered where the pattern says they are:
+        // when focus is in the widget they belong to.
+        case "ArrowDown":
+          if (!this.inList()) return;
+          e.preventDefault();
+          this.results.move(1);
+          break;
+        case "ArrowUp":
+          if (!this.inList()) return;
+          e.preventDefault();
+          this.results.move(-1);
+          break;
+        case "Home":
+        case "End":
+          if (this.drawer.open || !this.results.hits.length) return;
+          e.preventDefault();
+          this.results.edge(e.key === "Home" ? "first" : "last");
+          break;
         case "Enter":
         case "p": {
           const hit = this.results.current();
@@ -810,6 +906,20 @@ class App {
           window.open(hit.url, "_blank", "noreferrer");
           break;
         }
+        case "[":
+        case "]":
+          if (this.page(e.key === "]" ? 1 : -1)) e.preventDefault();
+          break;
+        case "f":
+          // Not from inside the preview, which is modal. Moving focus behind a
+          // modal is the one way out of a focus trap that nobody asked for.
+          if (this.drawer.open) return;
+          e.preventDefault();
+          this.results.focusFilters();
+          break;
+        case "y":
+          if (this.copyLink()) e.preventDefault();
+          break;
         case "?":
           e.preventDefault();
           this.shortcuts();

--- a/web/dist/assets/clipboard.js
+++ b/web/dist/assets/clipboard.js
@@ -26,13 +26,7 @@ const CONFIRM = 1600;
  * the person can select it themselves.
  */
 export async function copies(button, text, say = () => {}) {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch {
-    say(`Could not copy ${text}`);
-    return;
-  }
-  say(`Copied ${text}`);
+  if (!(await copy(text, say))) return;
 
   const held = Array.from(button.childNodes);
   const labelled = button.hasAttribute("aria-label");
@@ -46,4 +40,22 @@ export async function copies(button, text, say = () => {}) {
     replace(button, held);
     if (labelled) button.setAttribute("aria-label", label);
   }, CONFIRM);
+}
+
+/**
+ * copy is the same write without a control to change.
+ *
+ * The keyboard shortcut for copying a link has no button under it, so the
+ * sentence in the live region is the whole of the feedback. It reports whether
+ * it worked so that a caller with a control can decide what to draw.
+ */
+export async function copy(text, say = () => {}) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    say(`Could not copy ${text}`);
+    return false;
+  }
+  say(`Copied ${text}`);
+  return true;
 }

--- a/web/dist/assets/live.js
+++ b/web/dist/assets/live.js
@@ -46,6 +46,22 @@ export class Live {
     document.addEventListener("visibilitychange", () => this.visibility());
     window.addEventListener("online", () => this.connection(true));
     window.addEventListener("offline", () => this.connection(false));
+    // A page the browser puts in its back forward cache is frozen with its
+    // connections still open, and a browser allows six of them to one origin.
+    // Six pages back through the history, each holding a stream, is a live page
+    // that cannot fetch anything at all: the request queues behind connections
+    // belonging to documents nobody is looking at. That is how a grid of
+    // thumbnails came to wait forty seconds for an endpoint answering in two
+    // milliseconds. So the stream is dropped on the way out and opened again if
+    // this page is the one that comes back.
+    window.addEventListener("pagehide", () => this.stop());
+    window.addEventListener("pageshow", (e) => {
+      if (!e.persisted) return;
+      this.retry = RETRY;
+      this.listen();
+      // However long this page spent frozen, it heard nothing during it.
+      this.onRefresh("visible");
+    });
     this.tick();
     this.listen();
   }
@@ -81,6 +97,19 @@ export class Live {
     this.retry = RETRY;
     this.onRefresh("online");
     this.listen();
+  }
+
+  /**
+   * stop drops the stream without arranging for another one.
+   *
+   * The stream is cleared before the abort so that the handler below sees a
+   * page that no longer wants one, rather than a drop worth reconnecting from.
+   */
+  stop() {
+    const controller = this.stream;
+    if (!controller) return;
+    this.stream = null;
+    controller.abort();
   }
 
   /**

--- a/web/dist/assets/omnibox.js
+++ b/web/dist/assets/omnibox.js
@@ -27,6 +27,10 @@ export class Omnibox {
     this.active = -1;
     this.timer = null;
     this.latest = "";
+    // What the live region last said, so that eight suggestions followed by
+    // eight more suggestions is announced once. A region that repeats itself on
+    // every keystroke is a region people turn off.
+    this.said = "";
 
     this.input = h("input", {
       class: "omnibox__input",
@@ -54,6 +58,17 @@ export class Omnibox {
       hidden: true,
     });
 
+    // A list that appears under a text field is invisible to a screen reader
+    // unless something says so. The combobox attributes describe the highlight
+    // once somebody arrows onto it, and this is the sentence that tells them
+    // there is anything to arrow onto in the first place.
+    this.status = h("div", {
+      class: "visually-hidden",
+      role: "status",
+      "aria-live": "polite",
+      "aria-atomic": "true",
+    });
+
     this.el = h(
       "div",
       { class: "omnibox", role: "search" },
@@ -65,6 +80,7 @@ export class Omnibox {
         h("kbd", { class: "kbd" }, shortcutLabel()),
       ),
       this.list,
+      this.status,
     );
   }
 
@@ -147,6 +163,14 @@ export class Omnibox {
     );
     this.list.hidden = false;
     this.input.setAttribute("aria-expanded", "true");
+    this.announce(`${items.length} ${items.length === 1 ? "suggestion" : "suggestions"}`);
+  }
+
+  /** announce says one thing in the polite region, and never says it twice. */
+  announce(text) {
+    if (this.said === text) return;
+    this.said = text;
+    replace(this.status, text);
   }
 
   close() {
@@ -154,6 +178,10 @@ export class Omnibox {
     this.input.setAttribute("aria-expanded", "false");
     this.input.removeAttribute("aria-activedescendant");
     this.active = -1;
+    // Emptied rather than left saying eight suggestions after the list has
+    // gone, and reset so that the same count is announced again next time.
+    this.said = "";
+    replace(this.status);
   }
 
   highlight(i) {
@@ -210,12 +238,26 @@ export class Omnibox {
         this.close();
         this.onSearch(this.input.value);
         break;
+      // Escape in three steps, which is the order every address bar uses. The
+      // reference implementations of this pattern clear the text on the first
+      // press, and losing what somebody typed because they dismissed a dropdown
+      // is how people learn not to use the keyboard here.
       case "Escape":
         if (open) {
           e.preventDefault();
           e.stopPropagation();
           this.close();
+          return;
         }
+        if (this.input.value) {
+          e.preventDefault();
+          e.stopPropagation();
+          this.input.value = "";
+          this.announce("Search cleared");
+          return;
+        }
+        // Empty and closed, so this one belongs to the shell, which blurs the
+        // field and closes whatever else is open.
         break;
       default:
         break;

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -75,14 +75,16 @@ const FACETS = [
 const FACET_VISIBLE = 8;
 
 export class Results {
-  constructor({ onQuery, onOpen, onHover, onSay }) {
+  constructor({ onQuery, onOpen, onHover, onSay, onCursor }) {
     this.onQuery = onQuery;
     this.onOpen = onOpen;
     this.onHover = onHover || (() => {});
     this.onSay = onSay || (() => {});
+    this.onCursor = onCursor || (() => {});
     this.expanded = new Set();
     this.selected = -1;
     this.hits = [];
+    this.total = 0;
     // Empty until the session says what the corpus holds, so the strip is never
     // painted with tabs that are about to be taken away.
     this.verticals = [];
@@ -187,9 +189,19 @@ export class Results {
     this.list.setAttribute("aria-busy", String(Boolean(on)));
   }
 
+  /**
+   * render draws one answer, cursor and all.
+   *
+   * The cursor is restored from the query rather than reset, because this
+   * function runs again on every repaint and on the way back from a preview,
+   * and a cursor that only lived in this object would be lost both times.
+   */
   render(query, res) {
     this.hits = res.hits || [];
-    this.selected = -1;
+    // Kept because the paging keys have to know where the last page ends, and
+    // the pager itself is rebuilt from the response every time.
+    this.total = res.total || 0;
+    this.selected = query.cursor >= 0 && query.cursor < this.hits.length ? query.cursor : -1;
     this.renderTabs(query, res);
     this.renderChips(query);
     this.renderHead(query, res);
@@ -366,11 +378,48 @@ export class Results {
 
     const view = this.viewFor(query);
     this.list.dataset.view = view;
+    // Every row on screen is about to be replaced, and one of them may be the
+    // element focus is on. Losing focus to the body in the middle of a
+    // background revalidation is how a keyboard interface quietly stops.
+    const held = this.list.contains(document.activeElement);
     replace(
       this.list,
       this.hits.map((hit, i) => (view === "grid" ? this.cell(hit, i) : this.row(hit, i))),
     );
+    // The row is the tab stop, so nothing inside a row is one. A list of twenty
+    // rows with a title and three buttons each is eighty tab stops between the
+    // search box and the pager, which is the thing the roving tabindex exists
+    // to prevent. Everything in here has a key of its own instead: Enter
+    // previews, o opens at the source and y copies the link.
+    for (const control of this.list.querySelectorAll("a[href], button")) control.tabIndex = -1;
+    this.mark();
+    // Focus is only ever put back, never taken. A repaint while somebody is
+    // typing in the search box must not pull the caret out of it.
+    if (held) this.focusCursor({ scroll: false });
     replace(this.aside, pager(query, res, this.onQuery));
+  }
+
+  /**
+   * seat is what every row and every cell carries so the list is one tab stop.
+   *
+   * A list where each of twenty rows is a tab stop takes forty presses to get
+   * past, which is the case the roving tabindex pattern exists for. Exactly one
+   * of them is reachable with Tab and the arrow keys move which one that is.
+   *
+   * Roving tabindex here rather than aria-activedescendant, which is what the
+   * omnibox uses, because a row is genuinely focusable and a browser scrolls a
+   * focused element into view on its own.
+   */
+  seat(i) {
+    return {
+      role: "listitem",
+      tabindex: "-1",
+      dataset: { index: String(i) },
+      // Tabbing in lands on whichever row holds the zero, and clicking a row
+      // focuses it. Either way the cursor is now there, so j and k carry on
+      // from what somebody is looking at rather than from where they left off.
+      onFocus: () => this.at(i),
+    };
   }
 
   /**
@@ -387,8 +436,7 @@ export class Results {
       "article",
       {
         class: "cell",
-        role: "listitem",
-        dataset: { index: String(i) },
+        ...this.seat(i),
         onMouseenter: () => this.onHover(hit.id),
         onMouseleave: () => this.onHover(null),
         onClick: (e) => {
@@ -437,8 +485,7 @@ export class Results {
       "article",
       {
         class: "result",
-        role: "listitem",
-        dataset: { index: String(i) },
+        ...this.seat(i),
         // A pointer resting on a row is a good guess at the next preview, and
         // the shell is what decides how long resting means and how many of
         // those guesses may be in the air at once.
@@ -529,7 +576,10 @@ export class Results {
             h(
               "button",
               {
-                class: "icon-button",
+                // The class is how the y key finds this button, so that a
+                // copy from the keyboard draws the same tick as a copy from
+                // the pointer rather than happening invisibly.
+                class: "icon-button icon-button--copy",
                 type: "button",
                 title: "Copy path",
                 "aria-label": "Copy path",
@@ -598,24 +648,86 @@ export class Results {
     );
   }
 
-  /** move walks the selection with j and k, and scrolls it into view. */
+  /** move walks the cursor with j and k, or with the arrow keys. */
   move(delta) {
     if (!this.hits.length) return;
     const next = Math.min(Math.max(this.selected + delta, 0), this.hits.length - 1);
     this.select(next);
   }
 
+  /** edge is Home and End: the first row and the last row on this page. */
+  edge(which) {
+    if (!this.hits.length) return;
+    this.select(which === "first" ? 0 : this.hits.length - 1);
+  }
+
+  /** select moves the cursor to a row and puts focus on it. */
   select(i) {
-    // Both layouts, by the attribute they share rather than by class, so j and
-    // k walk a grid exactly as they walk a list.
-    const rows = this.list.querySelectorAll("[data-index]");
-    rows.forEach((row, n) => row.setAttribute("data-active", String(n === i)));
+    this.at(i);
+    // Focus rather than scrollIntoView: the browser brings a focused element
+    // into view on its own, and a row that is highlighted but not focused is a
+    // row a screen reader is not reading.
+    this.focusCursor();
+  }
+
+  /**
+   * focusCursor puts focus on the row the cursor is on, if there is one.
+   *
+   * It is also the way back from the preview. The drawer keeps a reference to
+   * whatever had focus when it opened, and by the time it closes that row has
+   * been rebuilt by a repaint, so the element it remembers is not in the
+   * document any more. The cursor is, and it names the same row.
+   */
+  focusCursor(opts = {}) {
+    if (this.selected < 0) return;
+    const row = this.list.querySelector(`[data-index="${this.selected}"]`);
+    if (row) row.focus({ preventScroll: opts.scroll === false });
+  }
+
+  /** at records where the cursor is without touching focus. */
+  at(i) {
+    if (this.selected === i) return;
     this.selected = i;
-    if (rows[i]) rows[i].scrollIntoView({ block: "nearest" });
+    this.mark();
+    this.onCursor(i);
+  }
+
+  /**
+   * mark writes the cursor into the list.
+   *
+   * Both layouts, by the attribute they share rather than by class, so j and k
+   * walk a grid exactly as they walk a list. Exactly one row holds the zero,
+   * and where there is no cursor yet that is the first row, so the first Tab
+   * into the list arrives at the top of it rather than nowhere.
+   */
+  mark() {
+    const rows = this.list.querySelectorAll("[data-index]");
+    const roving = this.selected < 0 ? 0 : this.selected;
+    rows.forEach((row, n) => {
+      row.setAttribute("data-active", String(n === this.selected));
+      row.tabIndex = n === roving ? 0 : -1;
+    });
   }
 
   current() {
     return this.hits[this.selected];
+  }
+
+  /**
+   * focusFilters is the f key.
+   *
+   * The first filter where the panel is on screen, and the disclosure that
+   * opens the panel where it is not, because below the medium breakpoint the
+   * facets are behind a button and focusing something inside a collapsed panel
+   * is focusing nothing.
+   */
+  focusFilters() {
+    const first = this.facets.querySelector("button");
+    if (first && first.offsetParent !== null) {
+      first.focus();
+      return;
+    }
+    if (this.toggle.offsetParent !== null) this.toggle.focus();
   }
 }
 

--- a/web/dist/assets/state.js
+++ b/web/dist/assets/state.js
@@ -57,9 +57,25 @@ export function read(search = location.search) {
     // has to stop happening the moment somebody says they want the list, so the
     // absence of an answer and the answer list cannot be the same value.
     view: params.get("view") === "grid" || params.get("view") === "list" ? params.get("view") : "",
+    // Which row the eye is on. Minus one is no row, which is what a search
+    // starts as and what anything typed into the box goes back to.
+    cursor: cursorOf(params.get("cursor")),
   };
   for (const key of LIST_KEYS) query[key] = params.getAll(key).filter(Boolean);
   return query;
+}
+
+/**
+ * cursorOf reads the row index out of the address bar.
+ *
+ * Anything that is not a whole number at or above zero is no cursor at all,
+ * because this parameter is as editable as the rest of the URL and a cursor of
+ * "four" or of minus six would otherwise reach the roving tabindex.
+ */
+function cursorOf(value) {
+  if (value === null) return -1;
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 0 ? n : -1;
 }
 
 /** write turns a query back into a query string, leaving out the defaults. */
@@ -73,6 +89,7 @@ export function write(query) {
   if (query.offset) params.set("offset", String(query.offset));
   if (query.tab && query.tab !== "all") params.set("tab", query.tab);
   if (query.view) params.set("view", query.view);
+  if (query.cursor >= 0) params.set("cursor", String(query.cursor));
   if (query.open) params.set("open", query.open);
   // Rooted rather than relative, because a search reached from a document page
   // is a search and not a document with a query string stuck on the end of it.


### PR DESCRIPTION
Closes #105.

## The list is one tab stop

The row at the cursor carries `tabindex="0"` and every other row carries `tabindex="-1"`, so Tab enters the list once and Tab again leaves it.
Rows hold a title link and a copy button, and those are taken out of the tab order too, otherwise a roving tabindex on the row is not one stop but three.
Everything that became unreachable that way got a key instead: Enter previews, `o` opens at the source, `y` copies a link to the result at the cursor.
`[` and `]` page, `f` moves to the filters, `Home` and `End` move the cursor to the first and last result on the page.

## The omnibox is a combobox

The ARIA 1.2 pattern with the role on the input rather than on a wrapper, so focus never leaves the field.
`aria-expanded` says whether the list is open, `aria-controls` points at a named listbox, every option has an id, and `aria-activedescendant` follows the highlight.
A polite live region announces the count when the list changes, and repeats nothing, so arrowing through five suggestions is one announcement rather than five.

Escape is three stages now.
An open list closes and the text stays.
A closed list with text in the field clears the field and says so.
An empty field lets the shell take the key, which is what blurs the box.

## The cursor survives

The cursor is a URL parameter.
It is written with `replaceState`, so twenty presses of `j` are one history entry rather than twenty.
It is left out of the request parameters, so moving it never refetches and never changes a cache key.
It is read back on render, so a repaint keeps it and back from a document page returns to the row the eye was on.
The drawer hands focus back to that row when it closes, because the element it remembered has been rebuilt by then.

## An event stream that lets go

Not in the issue, but the work found it.
A page the browser freezes into the back forward cache keeps its connections open, and a browser allows six of them to one origin.
Six pages back through the history, each holding an event stream, is a live page that cannot fetch anything at all.
The grid of thumbnails is where that showed up: a request to an endpoint answering in two milliseconds sat in a queue for forty seconds, and eight parallel requests from the shell against the same endpoint all came back inside a third of a second, which is what ruled out the server.
So the stream is dropped on `pagehide` and opened again on a persisted `pageshow`, along with a refresh, because a page hears nothing while it is frozen.

## Testing

`make ui-gate` passes: the keyboard walk, axe on five screens with zero violations, Lighthouse at 93 performance and 100 accessibility.
Eleven assertions are new in the walk, covering one tab stop, the cursor writing itself into the URL, `Home` and `End`, Tab leaving the list in one press, a cursor in the URL being where the page opens, back from a document landing on the right row, and the combobox graph with the list open.

The last of those is how the sixth box on the issue is met.
axe cannot type, so it cannot open the suggestion list itself.
The walk opens the list and asserts the whole ARIA graph directly instead: the role, `aria-expanded`, `aria-controls` resolving to a listbox with an accessible name, every option carrying an id, `aria-activedescendant` resolving to an option marked selected, and focus still in the input.
axe then runs over the same screen for everything that does not need the list open.

`make fmt vet lint race` and `go test ./...` pass.
