### PR TITLE
Show what this person opened and what changed

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -158,6 +158,8 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("GET /api/v1/documents/{id}", s.authenticated(s.handleDocument))
 	mux.Handle("GET /api/v1/documents/{id}/content", s.authenticated(s.handleContent))
 	mux.Handle("GET /api/v1/documents/{id}/thumbnail", s.authenticated(s.handleThumbnail))
+	mux.Handle("GET /api/v1/recent", s.authenticated(s.handleRecent))
+	mux.Handle("POST /api/v1/recent", s.authenticated(s.handleRecordOpen))
 	mux.Handle("GET /api/v1/stats", s.authenticated(s.handleStats))
 	mux.Handle("GET /api/v1/events", s.authenticated(s.handleEvents))
 	if s.assets != nil {
@@ -308,20 +310,9 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 		Hits:    []searchHit{},
 	}
 	for _, h := range res.Hits {
-		out.Hits = append(out.Hits, searchHit{
-			ID:         h.Document.ID,
-			Title:      h.Document.Title,
-			URL:        h.Document.URL,
-			Source:     h.Document.Source,
-			Kind:       string(h.Document.Kind),
-			Container:  h.Document.Container,
-			Author:     personName(h.Document.Author),
-			MediaType:  h.Document.Properties[doc.MediaType],
-			ModifiedAt: h.Document.ModifiedAt,
-			Snippet:    h.Snippet,
-			Passages:   passages(h.Passages),
-			Score:      h.Score,
-		})
+		hit := hitOf(h.Document)
+		hit.Snippet, hit.Passages, hit.Score = h.Snippet, passages(h.Passages), h.Score
+		out.Hits = append(out.Hits, hit)
 	}
 	writeConditional(w, r, http.StatusOK, out, out.identity())
 }

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -138,6 +138,43 @@ func BenchmarkAPIMe(b *testing.B) {
 	}
 }
 
+// BenchmarkAPIRecent is the home screen: what this person opened and what has
+// changed in the corpus they can see. The history is filled first, because an
+// empty one is a read of nothing and the number that matters is the one with a
+// screen of rows in it.
+func BenchmarkAPIRecent(b *testing.B) {
+	h, hdr := handler(b)
+
+	w := get(b, h, "/api/v1/search?q="+urlQuery(benchcorpus.ByClass(benchcorpus.Queries())[benchcorpus.ClassCommon][0].Text), hdr)
+	var page struct {
+		Hits []struct {
+			ID string `json:"id"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil {
+		b.Fatalf("decoding the search page: %v", err)
+	}
+	for _, hit := range page.Hits {
+		r := httptest.NewRequestWithContext(b.Context(), http.MethodPost, "/api/v1/recent",
+			strings.NewReader(`{"id":"`+hit.ID+`"}`))
+		for k, v := range hdr {
+			r.Header.Set(k, v)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, r)
+		if rec.Code != http.StatusNoContent {
+			b.Fatalf("POST /api/v1/recent = %d, %s", rec.Code, rec.Body)
+		}
+	}
+
+	get(b, h, "/api/v1/recent", hdr)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		get(b, h, "/api/v1/recent", hdr)
+	}
+}
+
 func BenchmarkAPIStats(b *testing.B) {
 	h, hdr := handler(b)
 	get(b, h, "/api/v1/stats", hdr)

--- a/api/recent.go
+++ b/api/recent.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// Recent answers two questions with one request, because the home screen asks
+// both of them at once and a screen that paints in two stages paints twice.
+//
+// What somebody opened is theirs and comes from the server, so it follows them
+// from the laptop to the desk machine, which is the whole value of the list.
+// What changed is the corpus, sorted by recency, and it is the same query the
+// browse screen runs. Neither half is a search, and both are permission
+// filtered inside the storage driver like everything else.
+const (
+	// RecentLimit is how many rows each half carries when the caller does not
+	// say. Twenty is a screen of them.
+	RecentLimit = 20
+
+	// RecentMax is the most a caller can ask for. The list is read at a glance
+	// and nobody scrolls two hundred rows of it, so the ceiling is here to keep
+	// a URL from turning a four millisecond endpoint into a slow one.
+	RecentMax = 50
+
+	// recentBodyLimit is how many bytes a record of an open may be. The body is
+	// one document id.
+	recentBodyLimit = 4 << 10
+)
+
+type recentResponse struct {
+	Opened  []openedHit `json:"opened"`
+	Changed []searchHit `json:"changed"`
+
+	// At is when the server answered, which is what the interface shows next to
+	// a list it is holding from a minute ago.
+	At time.Time `json:"at"`
+}
+
+// openedHit is a hit with the time this person opened it. The document fields
+// are embedded rather than nested, so one row of the opened list and one row of
+// a result list are the same shape to a client and can be drawn by the same
+// code.
+type openedHit struct {
+	searchHit
+	At time.Time `json:"at"`
+}
+
+// identity is the response without the fields that move on their own, for the
+// same reason as [searchResponse.identity]. When the server answered is one of
+// them: it is a different number on every request and hashing it would make a
+// tag that can never match. The time an entry was opened is not, because that
+// is a fact about the past.
+func (r recentResponse) identity() any {
+	r.At = time.Time{}
+	opened := make([]openedHit, len(r.Opened))
+	copy(opened, r.Opened)
+	for i := range opened {
+		opened[i].Score = 0
+	}
+	changed := make([]searchHit, len(r.Changed))
+	copy(changed, r.Changed)
+	for i := range changed {
+		changed[i].Score = 0
+	}
+	r.Opened, r.Changed = opened, changed
+	return r
+}
+
+func (s *Server) handleRecent(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	limit, err := intParam(r.URL.Query().Get("limit"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "limit must be a number")
+		return
+	}
+	if limit <= 0 {
+		limit = RecentLimit
+	}
+	limit = min(limit, RecentMax)
+
+	out := recentResponse{
+		Opened:  []openedHit{},
+		Changed: []searchHit{},
+		At:      s.now().UTC(),
+	}
+
+	// A driver that cannot remember an open serves the other half rather than an
+	// error. The interface is built for that: a deployment on a store with no
+	// history still has a home screen, it just has one list on it.
+	if log, ok := s.store.(store.OpenLog); ok {
+		opens, err := log.Opens(r.Context(), p, limit)
+		if err != nil {
+			// The same reasoning one level up. A history that could not be read is
+			// a degraded home screen, and failing the whole request over it would
+			// take the corpus half down with it.
+			s.log.Warn("reading the open history failed", "error", err, "tenant", p.Tenant)
+		}
+		for _, o := range opens {
+			out.Opened = append(out.Opened, openedHit{searchHit: hitOf(o.Document), At: o.At.UTC()})
+		}
+	}
+
+	changed, err := s.searcher.Recent(r.Context(), p, limit)
+	if err != nil {
+		s.log.Error("recent failed", "error", err, "tenant", p.Tenant)
+		writeError(w, http.StatusInternalServerError, "internal", "the recent list could not be read")
+		return
+	}
+	for _, d := range changed {
+		out.Changed = append(out.Changed, hitOf(d))
+	}
+	writeConditional(w, r, http.StatusOK, out, out.identity())
+}
+
+// handleRecordOpen notes that the caller opened a document.
+//
+// It answers 204 for anything it understood, including an id nobody may read
+// and a store that keeps no history. The client sends this with keepalive on
+// the way to another screen and never looks at the answer, so the only reason
+// to say anything else is a body this endpoint cannot parse, which is a bug in
+// the caller rather than a fact about the corpus.
+func (s *Server) handleRecordOpen(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	var body struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, recentBodyLimit)).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "the body must be a JSON object with an id")
+		return
+	}
+	if body.ID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "id is required")
+		return
+	}
+
+	if log, ok := s.store.(store.OpenLog); ok {
+		if err := log.RecordOpen(r.Context(), p, body.ID, s.now()); err != nil {
+			s.log.Warn("recording an open failed", "error", err, "tenant", p.Tenant)
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// hitOf is the wire shape of a document on its own, with no search behind it.
+//
+// A result carries a snippet, a set of matched passages and a score, and none
+// of those exist for a document that arrived by being recently opened or
+// recently changed. Everything else about the row is the same, and it is the
+// same function so that a field added to a result cannot go missing from the
+// home screen.
+func hitOf(d doc.Document) searchHit {
+	return searchHit{
+		ID:         d.ID,
+		Title:      d.Title,
+		URL:        d.URL,
+		Source:     d.Source,
+		Kind:       string(d.Kind),
+		Container:  d.Container,
+		Author:     personName(d.Author),
+		MediaType:  d.Properties[doc.MediaType],
+		ModifiedAt: d.ModifiedAt,
+	}
+}

--- a/api/recent_test.go
+++ b/api/recent_test.go
@@ -1,0 +1,259 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// The recent screen is the one place where the server keeps something about a
+// person rather than about the corpus, so most of what is worth testing here is
+// that it keeps it for exactly one person and stops keeping it the moment they
+// lose access to what it names.
+
+type recentBody struct {
+	Opened []struct {
+		ID    string    `json:"id"`
+		Title string    `json:"title"`
+		At    time.Time `json:"at"`
+	} `json:"opened"`
+	Changed []struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	} `json:"changed"`
+	At time.Time `json:"at"`
+}
+
+func recentServer(t *testing.T) (http.Handler, *memstore.Store) {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	perm := func(group string) acl.Permissions {
+		return acl.Permissions{
+			Mode:        acl.ModeACL,
+			Source:      "gdrive",
+			AllowGroups: []acl.Ref{{Source: "gdrive", Value: group}},
+			Version:     1,
+		}
+	}
+	day := func(n int) time.Time { return time.Date(2026, 8, n, 9, 0, 0, 0, time.UTC) }
+	docs := []doc.Document{
+		{
+			ID: "d1", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Payments failover runbook", Body: "Fail the payments queue over to the replica.",
+			ModifiedAt: day(1), Permissions: perm("eng@acme.com"),
+		},
+		{
+			ID: "d2", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "On call handover", Body: "Who is holding the pager this week.",
+			ModifiedAt: day(2), Permissions: perm("eng@acme.com"),
+		},
+		{
+			ID: "d3", Tenant: "acme", Source: "salesforce", Kind: doc.KindTicket,
+			Title: "Renewal for Globex", Body: "The discount expires in March.",
+			ModifiedAt: day(3), Permissions: perm("sales@acme.com"),
+		},
+	}
+	if err := st.Put(t.Context(), docs...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	return api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}).Handler(), st
+}
+
+// open posts a record of an open the way the interface does, and reports the
+// status so a test can say what the endpoint answered.
+func open(t *testing.T, h http.Handler, id string, headers map[string]string) int {
+	t.Helper()
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/recent",
+		strings.NewReader(`{"id":`+quote(id)+`}`))
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w.Code
+}
+
+func quote(s string) string { return `"` + s + `"` }
+
+func salesperson() map[string]string {
+	return map[string]string{
+		api.HeaderSubject: "u_sam",
+		api.HeaderGroups:  "gdrive:sales@acme.com",
+	}
+}
+
+func TestRecentAnswersBothHalves(t *testing.T) {
+	h, _ := recentServer(t)
+
+	if code := open(t, h, "d1", engineer()); code != http.StatusNoContent {
+		t.Fatalf("POST /api/v1/recent = %d, want 204", code)
+	}
+	if code := open(t, h, "d2", engineer()); code != http.StatusNoContent {
+		t.Fatalf("POST /api/v1/recent = %d, want 204", code)
+	}
+
+	w := request(t, h, http.MethodGet, "/api/v1/recent", engineer())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body)
+	}
+	body := decode[recentBody](t, w)
+
+	if len(body.Opened) != 2 || body.Opened[0].ID != "d2" || body.Opened[1].ID != "d1" {
+		t.Fatalf("opened = %+v, want d2 then d1", body.Opened)
+	}
+	if body.Opened[0].Title != "On call handover" {
+		t.Fatalf("opened carries %q, want the title", body.Opened[0].Title)
+	}
+	if body.Opened[0].At.IsZero() {
+		t.Fatal("an opened entry carries no time, so the interface has nothing to show next to it")
+	}
+
+	// Changed is the corpus this person can see, newest first, and d3 belongs to
+	// somebody else.
+	if len(body.Changed) != 2 || body.Changed[0].ID != "d2" || body.Changed[1].ID != "d1" {
+		t.Fatalf("changed = %+v, want d2 then d1", body.Changed)
+	}
+	if strings.Contains(w.Body.String(), "Globex") {
+		t.Fatal("the response leaked a document the caller may not read")
+	}
+	if body.At.IsZero() {
+		t.Fatal("the response does not say when it was answered")
+	}
+}
+
+func TestRecentIsOnePersonsHistory(t *testing.T) {
+	h, _ := recentServer(t)
+	if code := open(t, h, "d1", engineer()); code != http.StatusNoContent {
+		t.Fatalf("POST /api/v1/recent = %d, want 204", code)
+	}
+
+	body := decode[recentBody](t, request(t, h, http.MethodGet, "/api/v1/recent", salesperson()))
+	if len(body.Opened) != 0 {
+		t.Fatalf("opened = %+v for somebody who has opened nothing", body.Opened)
+	}
+	if len(body.Changed) != 1 || body.Changed[0].ID != "d3" {
+		t.Fatalf("changed = %+v, want only the document this reader may see", body.Changed)
+	}
+}
+
+// Recording an open of something the caller may not read is a 204 and records
+// nothing. Anything else would answer which ids exist.
+func TestRecordOpenSaysNothingAboutWhatExists(t *testing.T) {
+	h, _ := recentServer(t)
+	for _, id := range []string{"d3", "no-such-document"} {
+		if code := open(t, h, id, engineer()); code != http.StatusNoContent {
+			t.Errorf("POST /api/v1/recent with %q = %d, want 204", id, code)
+		}
+	}
+	if body := decode[recentBody](t, request(t, h, http.MethodGet, "/api/v1/recent", engineer())); len(body.Opened) != 0 {
+		t.Fatalf("opened = %+v, want nothing: neither id was readable", body.Opened)
+	}
+}
+
+func TestRecordOpenRejectsABodyItCannotRead(t *testing.T) {
+	h, _ := recentServer(t)
+	for _, body := range []string{"", "{}", "not json"} {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/recent", strings.NewReader(body))
+		for k, v := range engineer() {
+			r.Header.Set(k, v)
+		}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("POST /api/v1/recent with %q = %d, want 400", body, w.Code)
+		}
+	}
+}
+
+// An open is not a licence to keep reading. Access revoked after the fact takes
+// the entry out of the list, and it does so without the handler filtering
+// anything.
+func TestRecentDropsWhatTheReaderLost(t *testing.T) {
+	h, st := recentServer(t)
+	if code := open(t, h, "d1", engineer()); code != http.StatusNoContent {
+		t.Fatalf("POST /api/v1/recent = %d, want 204", code)
+	}
+
+	moved := doc.Document{
+		ID: "d1", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+		Title: "Payments failover runbook", ModifiedAt: time.Date(2026, 8, 4, 9, 0, 0, 0, time.UTC),
+		Permissions: acl.Permissions{
+			Mode:        acl.ModeACL,
+			Source:      "gdrive",
+			AllowGroups: []acl.Ref{{Source: "gdrive", Value: "sales@acme.com"}},
+			Version:     1,
+		},
+	}
+	if err := st.Put(t.Context(), moved); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	body := decode[recentBody](t, request(t, h, http.MethodGet, "/api/v1/recent", engineer()))
+	if len(body.Opened) != 0 {
+		t.Fatalf("opened = %+v after the reader lost access to it", body.Opened)
+	}
+	if strings.Contains(body.Changed[0].ID, "d1") {
+		t.Fatal("the changed list still carries a document this reader may not read")
+	}
+}
+
+func TestRecentHonoursTheLimit(t *testing.T) {
+	h, _ := recentServer(t)
+	body := decode[recentBody](t, request(t, h, http.MethodGet, "/api/v1/recent?limit=1", engineer()))
+	if len(body.Changed) != 1 {
+		t.Fatalf("changed = %+v with a limit of one", body.Changed)
+	}
+	if w := request(t, h, http.MethodGet, "/api/v1/recent?limit=lots", engineer()); w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d for a limit that is not a number, want 400", w.Code)
+	}
+}
+
+// The endpoint is revalidated rather than reused, like every other read, and
+// the tag has to survive the response saying when it was answered.
+func TestRecentRevalidates(t *testing.T) {
+	h, _ := recentServer(t)
+	w := request(t, h, http.MethodGet, "/api/v1/recent", engineer())
+	tag := w.Header().Get("ETag")
+	if tag == "" {
+		t.Fatal("no ETag, so the interface has to download the list every time")
+	}
+	if got := w.Header().Get("Cache-Control"); !strings.Contains(got, "private") {
+		t.Fatalf("Cache-Control = %q, want a private response", got)
+	}
+
+	headers := engineer()
+	headers["If-None-Match"] = tag
+	again := request(t, h, http.MethodGet, "/api/v1/recent", headers)
+	if again.Code != http.StatusNotModified {
+		t.Fatalf("status = %d for a request carrying the tag it was given, want 304", again.Code)
+	}
+
+	// And it stops matching when the list changes.
+	if code := open(t, h, "d1", engineer()); code != http.StatusNoContent {
+		t.Fatalf("POST /api/v1/recent = %d, want 204", code)
+	}
+	changed := request(t, h, http.MethodGet, "/api/v1/recent", headers)
+	if changed.Code != http.StatusOK {
+		t.Fatalf("status = %d after the history changed, want 200", changed.Code)
+	}
+}
+
+func TestRecentNeedsACredential(t *testing.T) {
+	h, _ := recentServer(t)
+	if w := request(t, h, http.MethodGet, "/api/v1/recent", nil); w.Code != http.StatusUnauthorized {
+		t.Fatalf("GET /api/v1/recent = %d, want 401", w.Code)
+	}
+	if code := open(t, h, "d1", nil); code != http.StatusUnauthorized {
+		t.Fatalf("POST /api/v1/recent = %d, want 401", code)
+	}
+}

--- a/index/index.go
+++ b/index/index.go
@@ -283,7 +283,9 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 	limit = min(limit, MaxLimit)
 
 	req := q.Request()
-	sel := store.Selection{Limit: CandidatePool(q.Offset, limit), Recent: q.Sort == ByRecent}
+	// A search shows a total and a facet sidebar, so it asks for the counts. See
+	// [Searcher.Recent] for the read that does not.
+	sel := store.Selection{Limit: CandidatePool(q.Offset, limit), Recent: q.Sort == ByRecent, Counts: true}
 
 	// Phase one. Which documents are worth ranking, how many matched, and what
 	// the facet counts are, all under the permission rule and none of it
@@ -321,12 +323,7 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 	// paging stays stable.
 	switch q.Sort {
 	case ByRecent:
-		sort.SliceStable(scored, func(i, j int) bool {
-			if !scored[i].cand.ModifiedAt.Equal(scored[j].cand.ModifiedAt) {
-				return scored[i].cand.ModifiedAt.After(scored[j].cand.ModifiedAt)
-			}
-			return scored[i].cand.ID < scored[j].cand.ID
-		})
+		byRecent(scored)
 	default:
 		sort.SliceStable(scored, func(i, j int) bool {
 			if scored[i].score != scored[j].score {
@@ -369,6 +366,75 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 type ranked struct {
 	cand  store.Candidate
 	score float64
+}
+
+// byRecent orders newest first, breaking ties on the id so that two runs of the
+// same query return the same page.
+//
+// A driver that made the cut for itself has already done this, and doing it
+// again over a page of twenty costs nothing. A driver that has not is the whole
+// reason it is here.
+func byRecent(scored []ranked) {
+	sort.SliceStable(scored, func(i, j int) bool {
+		if !scored[i].cand.ModifiedAt.Equal(scored[j].cand.ModifiedAt) {
+			return scored[i].cand.ModifiedAt.After(scored[j].cand.ModifiedAt)
+		}
+		return scored[i].cand.ID < scored[j].cand.ID
+	})
+}
+
+// Recent is what changed in the corpus this principal can see, newest first.
+//
+// It is a browse with no query, and it is a separate method rather than a
+// [Query] because of what it leaves out. There is no relevance to compute with
+// no terms to compute it from, no total to show and no facet sidebar next to it,
+// and those counts are the one part of a retrieval whose cost follows the match
+// set rather than the page. A browse through Search on twenty thousand
+// documents spends most of its time counting a match set nobody asked about the
+// size of.
+//
+// The permission rule is where it always is, inside the driver, so a document
+// that stopped being readable is absent from this list rather than filtered out
+// of it here.
+func (s *Searcher) Recent(ctx context.Context, p *acl.Principal, limit int) ([]doc.Document, error) {
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+	limit = min(limit, MaxLimit)
+
+	found, err := s.collect(ctx, p, store.Request{}, store.Selection{Limit: limit, Recent: true})
+	if err != nil {
+		return nil, err
+	}
+	if len(found.cands) == 0 {
+		return nil, nil
+	}
+
+	// The candidates carry no score and none is computed. Recency is the whole
+	// order, and a scored one would be a different list with a more expensive
+	// way of arriving at it.
+	scored := make([]ranked, 0, len(found.cands))
+	for _, c := range found.cands {
+		scored = append(scored, ranked{cand: c})
+	}
+	byRecent(scored)
+
+	window := page(scored, 0, limit)
+	bodies, err := s.fetch(ctx, p, window)
+	if err != nil {
+		return nil, err
+	}
+	// An id that has stopped being readable between the cut and the fetch is
+	// missing from what came back, and is dropped here for the same reason a
+	// search drops it: showing the title of a document somebody just lost access
+	// to is a leak, and losing a row is the cheaper mistake.
+	out := make([]doc.Document, 0, len(window))
+	for _, r := range window {
+		if d, ok := bodies[r.cand.ID]; ok {
+			out = append(out, d)
+		}
+	}
+	return out, nil
 }
 
 // fetch reads the documents behind one page.

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -157,6 +157,16 @@ async function walk() {
     "document.querySelector('#rail-sources').children.length === 0",
   );
 
+  // The part of the page that scrolls is a tab stop of its own, so a screen
+  // whose rows have not arrived yet can still be scrolled and read. Everything
+  // else on this walk is content, and content is exactly what is missing in the
+  // moment this covers.
+  await check(
+    session,
+    "the region that scrolls can be reached from the keyboard",
+    "document.querySelector('#main').tabIndex === 0",
+  );
+
   // The two boundaries the corpus above cannot show, asked of the function
   // directly. It is a module in the page, so the browser is the test runner and
   // there is nothing to install.
@@ -359,6 +369,96 @@ async function walk() {
     session,
     "a second Escape clears the field",
     "document.querySelector('.omnibox__input').value === ''",
+  );
+
+  // The recent screen. It is the one screen made of somebody's own history
+  // rather than of the corpus, so the walk has to make some history first and
+  // then go and look for it.
+  await visit(session, `${BASE}/?q=cache`, "document.querySelectorAll('.result').length > 0");
+  const read = await evaluate(session, "document.querySelector('.result__title').textContent.trim()");
+  await evaluate(session, "document.querySelector('.result__title').click()");
+  await settle(session, "!document.querySelector('.drawer').hidden");
+  await press(session, "Escape", "Escape", 27);
+
+  // Through the rail rather than by typing the address, because being one click
+  // away from every other screen is the reason it is on the rail at all.
+  await evaluate(session, "document.querySelector('.rail__link[data-route=\"recent\"]').click()");
+  await settle(session, "location.pathname === '/recent'");
+  await check(
+    session,
+    "the rail leads to the recent screen and says which entry you are on",
+    `document.querySelector('.rail__link[data-route="recent"]').getAttribute('aria-current') === 'page' &&
+      !document.querySelector('.rail__link[data-route="home"]').hasAttribute('aria-current')`,
+  );
+
+  await check(
+    session,
+    "the two halves are two lists with names of their own",
+    `(() => {
+      const lists = [...document.querySelectorAll('.recent [role="list"]')];
+      const names = lists.map((l) => l.getAttribute('aria-label'));
+      return lists.length === 2 && names.every(Boolean) && names[0] !== names[1];
+    })()`,
+  );
+
+  // The assertion the whole endpoint exists for. Opening a document from a
+  // search is recorded on the server, so it is there on the next screen and
+  // would be there on another machine.
+  await settle(session, "document.querySelectorAll('.recent .result').length > 0");
+  await check(
+    session,
+    "a document opened from a search is at the top of your own history",
+    `(() => {
+      const first = document.querySelector('.recent [aria-label="Documents you opened"] .result');
+      return Boolean(first) && first.querySelector('.result__title').textContent.trim() === ${JSON.stringify(read)};
+    })()`,
+  );
+
+  await check(
+    session,
+    "a row of history is the same row as a result, with the time it was read on it",
+    `(() => {
+      const first = document.querySelector('.recent [aria-label="Documents you opened"] .result');
+      const at = first && first.querySelector('.result__meta time[datetime]:last-of-type');
+      return Boolean(at) && at.textContent.includes('you opened this');
+    })()`,
+  );
+
+  await press(session, "j", "KeyJ", 74);
+  await check(
+    session,
+    "j walks the list of what you read rather than the one under it",
+    `document.querySelector('.recent [aria-label="Documents you opened"]').contains(document.activeElement) &&
+      document.activeElement.dataset.index === '0'`,
+  );
+
+  await press(session, "Enter", "Enter", 13);
+  await check(
+    session,
+    "Enter opens the preview without leaving the recent screen",
+    `!document.querySelector('.drawer').hidden && location.pathname === '/recent' &&
+      location.search.includes('open=')`,
+  );
+
+  await press(session, "Escape", "Escape", 27);
+  await check(
+    session,
+    "Escape closes it and leaves the cursor on the row it opened from",
+    `document.querySelector('.drawer').hidden && !location.search.includes('open=') &&
+      document.querySelector('.recent [aria-label="Documents you opened"]').contains(document.activeElement)`,
+  );
+
+  // Home asks the same question of the same endpoint and shows the top of the
+  // answer, with the way to the whole of it beside the heading.
+  await visit(session, `${BASE}/`, "document.querySelectorAll('.home .panel').length > 0");
+  await check(
+    session,
+    "home shows what was opened and what changed, with a real link to the rest",
+    `(() => {
+      const links = [...document.querySelectorAll('.home .panel__link')];
+      const rows = document.querySelectorAll('.home .panel__row-title').length;
+      return links.length >= 2 && links.every((a) => a.getAttribute('href') === '/recent') && rows > 0;
+    })()`,
   );
 
   // The grid. The pictures behind this query are written into the corpus by the

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -2,9 +2,10 @@
 # The browser half of the performance gate.
 #
 # It starts the real binary over a real corpus, which is this repository, and
-# audits the four screens somebody actually looks at: the home page, a results
-# page, a results page with the document drawer open, and a document on a page
-# of its own. Auditing a static fixture instead would audit the fixture, and
+# audits the screens somebody actually looks at: the home page, a results page,
+# a results page with the document drawer open, a document on a page of its own,
+# a grid of pictures, and the recent screen. Auditing a static fixture would
+# audit the fixture, and
 # every accessibility bug this is meant to catch lives in the markup the
 # interface builds after a fetch.
 #
@@ -131,7 +132,7 @@ if [ -n "${CHROMEDRIVER:-}" ]; then
 	DRIVER="--chromedriver-path $CHROMEDRIVER"
 fi
 
-for path in "/" "/?q=cache" "/?q=cache&open=$ID" "/d/$ID" "/?q=gatepix"; do
+for path in "/" "/?q=cache" "/?q=cache&open=$ID" "/d/$ID" "/?q=gatepix" "/recent"; do
 	echo "ui-gate: axe $path"
 	# The interface renders after a fetch, so the audit waits for the first
 	# paint to have happened. Auditing an empty document passes and proves

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -36,7 +36,11 @@ type Store struct {
 	// keeps it in its own table: a scan that carried image bytes would make
 	// every query pay for them.
 	content map[string]doc.Content
-	closed  bool
+
+	// opens is what each person has been reading, keyed by tenant and subject.
+	opens map[[2]string]*opened
+
+	closed bool
 }
 
 // New returns an empty store.
@@ -44,6 +48,7 @@ func New() *Store {
 	return &Store{
 		docs:    make(map[string]doc.Document),
 		content: make(map[string]doc.Content),
+		opens:   make(map[[2]string]*opened),
 	}
 }
 

--- a/store/memstore/open.go
+++ b/store/memstore/open.go
@@ -75,6 +75,13 @@ func (s *Store) Opens(ctx context.Context, p *acl.Principal, limit int) ([]store
 	if limit <= 0 {
 		return nil, nil
 	}
+	// Nobody can be given more history than a driver keeps, so a caller asking
+	// for a thousand is asking for all of it. Clamping here rather than trusting
+	// the number makes the allocation below a fact about this driver instead of
+	// a fact about whatever arrived in a query string.
+	if limit > store.OpenHistory {
+		limit = store.OpenHistory
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.closed {

--- a/store/memstore/open.go
+++ b/store/memstore/open.go
@@ -1,0 +1,108 @@
+package memstore
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.OpenLog = (*Store)(nil)
+
+// opened is one person's reading history, newest last.
+//
+// A slice rather than a map because it is short, bounded by store.OpenHistory,
+// and every read of it is in order. Moving an entry to the end is a linear
+// search over at most two hundred strings, which is faster than the map plus
+// sort that would replace it.
+type opened struct {
+	ids []string
+	at  map[string]time.Time
+}
+
+// RecordOpen notes that the principal opened a document.
+func (s *Store) RecordOpen(ctx context.Context, p *acl.Principal, id string, at time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return genba.ErrClosed
+	}
+	// The visibility check is here rather than in the caller so that this driver
+	// obeys the same rule as the rest of the interface: the principal is applied
+	// while the driver walks its own data.
+	d, ok := s.docs[id]
+	if !ok || !visible(p, d) {
+		return nil
+	}
+
+	key := reader(p)
+	log, ok := s.opens[key]
+	if !ok {
+		log = &opened{at: make(map[string]time.Time)}
+		s.opens[key] = log
+	}
+	if i := slices.Index(log.ids, id); i >= 0 {
+		log.ids = slices.Delete(log.ids, i, i+1)
+	}
+	log.ids = append(log.ids, id)
+	log.at[id] = at
+	if over := len(log.ids) - store.OpenHistory; over > 0 {
+		for _, dropped := range log.ids[:over] {
+			delete(log.at, dropped)
+		}
+		log.ids = slices.Delete(log.ids, 0, over)
+	}
+	return nil
+}
+
+// Opens returns what the principal opened, most recent first.
+func (s *Store) Opens(ctx context.Context, p *acl.Principal, limit int) ([]store.Open, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, genba.ErrClosed
+	}
+
+	log, ok := s.opens[reader(p)]
+	if !ok {
+		return nil, nil
+	}
+	out := make([]store.Open, 0, min(limit, len(log.ids)))
+	for i := len(log.ids) - 1; i >= 0 && len(out) < limit; i-- {
+		id := log.ids[i]
+		d, ok := s.docs[id]
+		// A document that was deleted, or that this person may no longer read,
+		// is not in the list. The entry is left where it is rather than removed,
+		// because a read is not the place to write and because a permission that
+		// comes back should bring the document back with it.
+		if !ok || !visible(p, d) {
+			continue
+		}
+		out = append(out, store.Open{Document: d, At: log.at[id]})
+	}
+	return out, nil
+}
+
+// reader is the key a reading history is kept under.
+//
+// The tenant is in it because two tenants can use the same subject string, and
+// the whole point of the tenant field is that they do not see each other.
+func reader(p *acl.Principal) [2]string { return [2]string{p.Tenant, p.Subject} }

--- a/store/open.go
+++ b/store/open.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+)
+
+// OpenLog is the optional capability of a driver that can remember which
+// documents a person opened.
+//
+// It is on the server rather than in the browser because the value of the
+// feature is that it follows somebody from their laptop to their desktop, and a
+// list kept in local storage does not. It is optional for the same reason
+// [ContentStore] is: a driver over a search service somebody else runs may have
+// nowhere to put a write of its own, and refusing to implement this is a better
+// answer than implementing it somewhere the next process cannot find it.
+//
+// The permission rule does not move. What somebody opened is not a licence to
+// keep reading it, so the read applies the principal inside the driver exactly
+// as a search does, and a document that stopped being visible stops being in the
+// list. A record of an open is not evidence that a document exists either: a
+// driver records an open only for a document the principal can see at the time,
+// so writing an id nobody may read is a write that does not happen rather than
+// an error that says the id was wrong.
+type OpenLog interface {
+	// RecordOpen notes that the principal opened a document, at the time given.
+	//
+	// It is idempotent per document: opening the same thing twice moves the
+	// entry rather than adding a second one, because a list of the last twenty
+	// things somebody looked at is not useful when nineteen of them are the same
+	// document. Opening a document the principal may not read, or one that is
+	// not there, records nothing and is not an error.
+	RecordOpen(ctx context.Context, p *acl.Principal, id string, at time.Time) error
+
+	// Opens returns what the principal opened, most recent first, at most limit
+	// entries. A limit of zero or less returns nothing.
+	Opens(ctx context.Context, p *acl.Principal, limit int) ([]Open, error)
+}
+
+// Open is one entry in an [OpenLog].
+//
+// It carries the document rather than its id, because every caller wants a
+// title and a source to put on a row, and a list of ids that the caller then
+// resolves one at a time is twenty round trips where the driver could do one.
+type Open struct {
+	Document doc.Document
+
+	// At is when it was last opened.
+	At time.Time
+}
+
+// OpenHistory is how many opens a driver keeps per person.
+//
+// It is a constant rather than an option because it is not a tuning knob: the
+// list is read twenty at a time, nobody scrolls a history of their own reading
+// into the hundreds, and the number exists to stop a table growing forever in a
+// deployment nobody prunes. A driver drops the oldest entry past this.
+const OpenHistory = 200

--- a/store/pgstore/migrations/0003_document_open.down.sql
+++ b/store/pgstore/migrations/0003_document_open.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE document_open;

--- a/store/pgstore/migrations/0003_document_open.up.sql
+++ b/store/pgstore/migrations/0003_document_open.up.sql
@@ -1,0 +1,27 @@
+-- document_open is what each person opened, which is the half of the recent
+-- screen that no amount of searching can reconstruct.
+--
+-- One row per person per document rather than one per open, because the list
+-- answers what somebody was reading, and a person who opened the same runbook
+-- nine times this morning wants the other nineteen entries rather than nine
+-- copies of that one.
+--
+-- The cascade is what keeps it honest. A document that leaves the corpus leaves
+-- everybody's history with it, so this table cannot hold an id that nothing
+-- else in the database knows about, and nobody has to write a sweep for it.
+CREATE TABLE document_open (
+    tenant    text   NOT NULL,
+    subject   text   NOT NULL,
+    doc_id    text   NOT NULL REFERENCES document(id) ON DELETE CASCADE,
+
+    -- Unix nanoseconds, for the same reason document.modified_at is: a
+    -- timestamptz keeps microseconds, and a time read back out of one does not
+    -- compare equal to the time that went in.
+    opened_at bigint NOT NULL,
+
+    PRIMARY KEY (tenant, subject, doc_id)
+);
+
+-- The read is one person's history, newest first, and this is the whole of it:
+-- an index only scan of at most twenty rows, with no sort.
+CREATE INDEX document_open_recent ON document_open (tenant, subject, opened_at DESC);

--- a/store/pgstore/migrations/0004_document_recent.down.sql
+++ b/store/pgstore/migrations/0004_document_recent.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX document_recent;

--- a/store/pgstore/migrations/0004_document_recent.up.sql
+++ b/store/pgstore/migrations/0004_document_recent.up.sql
@@ -4,11 +4,19 @@
 -- document_modified is on the column alone and is no use to it, because the
 -- predicate fixes the tenant and the ordering follows, so the planner sorts
 -- every visible document to answer a request for twenty rows. With the tenant
--- and the queryable flag in front of the date the same request is a walk down
--- the index that stops when the page is full.
+-- in front of the date the same request is a walk down the index that stops
+-- when the page is full, and the id is in it so the tie break does not put the
+-- sort back.
 --
 -- The nulls ordering is part of the index rather than left to the default,
 -- because the query says DESC NULLS LAST and an index built the other way is an
--- index the planner will not use for it. The id is in it so the tie break does
--- not put the sort back.
-CREATE INDEX document_recent ON document (tenant, queryable, modified_at DESC NULLS LAST, id);
+-- index the planner will not use for it.
+--
+-- Partial, on the flag rather than with the flag in the key. Written as
+-- (tenant, queryable, ...) it is two equality columns for the predicate every
+-- query in the product starts with, which is an invitation to use it for
+-- filtered searches that have nothing to do with recency, and it is a wider
+-- index than the ones they use today. SQLite took that invitation and filtered
+-- searches got half again slower.
+CREATE INDEX document_recent ON document (tenant, modified_at DESC NULLS LAST, id)
+	WHERE queryable;

--- a/store/pgstore/migrations/0004_document_recent.up.sql
+++ b/store/pgstore/migrations/0004_document_recent.up.sql
@@ -1,0 +1,14 @@
+-- document_recent answers what changed in the corpus, which is a query with no
+-- terms to cut the match set with.
+--
+-- document_modified is on the column alone and is no use to it, because the
+-- predicate fixes the tenant and the ordering follows, so the planner sorts
+-- every visible document to answer a request for twenty rows. With the tenant
+-- and the queryable flag in front of the date the same request is a walk down
+-- the index that stops when the page is full.
+--
+-- The nulls ordering is part of the index rather than left to the default,
+-- because the query says DESC NULLS LAST and an index built the other way is an
+-- index the planner will not use for it. The id is in it so the tie break does
+-- not put the sort back.
+CREATE INDEX document_recent ON document (tenant, queryable, modified_at DESC NULLS LAST, id);

--- a/store/pgstore/open.go
+++ b/store/pgstore/open.go
@@ -1,0 +1,121 @@
+package pgstore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.OpenLog = (*Store)(nil)
+
+// RecordOpen notes that the principal opened a document.
+//
+// The insert selects from document rather than binding the id directly, and the
+// select carries the visibility predicate, so a write for something this person
+// may not read inserts no rows. That is also the only form of this that cannot
+// race: nothing can change between the check and the write when they are the
+// same statement.
+//
+// It deliberately does not take the write lock the ingestion path holds. This
+// table is not part of the corpus bookkeeping, and a person opening a document
+// while a crawl is running should not be waiting for the crawl.
+func (s *Store) RecordOpen(ctx context.Context, p *acl.Principal, id string, at time.Time) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+
+	c := visible(p)
+	insert := append([]any{p.Tenant, p.Subject, at.UnixNano(), id}, c.args...)
+	err := s.retry(ctx, func(ctx context.Context) error {
+		s.counters.statements.Add(1)
+		if _, err := s.pool.Exec(ctx, rebind(`
+			INSERT INTO document_open (tenant, subject, doc_id, opened_at)
+			SELECT ?, ?, d.id, ? FROM document d WHERE d.id = ? AND `+c.where()+`
+			ON CONFLICT (tenant, subject, doc_id) DO UPDATE SET opened_at = excluded.opened_at`),
+			insert...); err != nil {
+			return err
+		}
+		// The history is trimmed here rather than by a job, because the only
+		// moment it can grow is this one and a deployment nobody prunes is the
+		// normal case.
+		s.counters.statements.Add(1)
+		_, err := s.pool.Exec(ctx, rebind(`
+			DELETE FROM document_open o
+			WHERE o.tenant = ? AND o.subject = ? AND o.doc_id NOT IN (
+				SELECT doc_id FROM document_open
+				WHERE tenant = ? AND subject = ?
+				ORDER BY opened_at DESC LIMIT ?
+			)`), p.Tenant, p.Subject, p.Tenant, p.Subject, store.OpenHistory)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("pgstore: record open: %w", err)
+	}
+	return nil
+}
+
+// Opens returns what the principal opened, most recent first.
+//
+// The visibility predicate is in the same statement as the history, so a
+// document that stopped being readable is gone from the list without a second
+// query and without a chance to forget the rule.
+func (s *Store) Opens(ctx context.Context, p *acl.Principal, limit int) ([]store.Open, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	c := visible(p)
+	args := append([]any{p.Tenant, p.Subject}, c.args...)
+	args = append(args, limit)
+
+	var out []store.Open
+	err := s.retry(ctx, func(ctx context.Context) error {
+		out = out[:0]
+		rows, err := s.query(ctx, `
+			SELECT o.opened_at, x.data
+			FROM document_open o
+			JOIN document d ON d.id = o.doc_id
+			JOIN document_data x ON x.doc_id = d.id
+			WHERE o.tenant = ? AND o.subject = ? AND `+c.where()+`
+			ORDER BY o.opened_at DESC
+			LIMIT ?`, args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var (
+				at   int64
+				data string
+			)
+			if err := rows.Scan(&at, &data); err != nil {
+				return err
+			}
+			s.counters.rows.Add(1)
+			d, err := s.decoded(data)
+			if err != nil {
+				return err
+			}
+			out = append(out, store.Open{Document: d, At: unixNano(at)})
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: opens: %w", err)
+	}
+	return out, nil
+}

--- a/store/pgstore/rank.go
+++ b/store/pgstore/rank.go
@@ -25,7 +25,9 @@ import (
 // proportional to the corpus outside the index walk Postgres does for itself.
 //
 // Three statements: the candidates, their term frequencies, and one that
-// carries the total and every facet count over the same predicate.
+// carries the total and every facet count over the same predicate. The third
+// runs only for a caller that asked for the counts, because it is the only one
+// of the three whose cost follows the match set rather than the page.
 func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel store.Selection) (store.Ranked, error) {
 	if err := s.ready(ctx); err != nil {
 		return store.Ranked{}, err
@@ -74,6 +76,13 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 			if err := s.frequencies(ctx, cands, r.Terms); err != nil {
 				return err
 			}
+		}
+		if !sel.Counts {
+			// The counts are the one statement here whose cost follows the match
+			// set, so a caller that shows neither a total nor a sidebar does not
+			// run it.
+			out = store.Ranked{Candidates: cands}
+			return nil
 		}
 		total, facets, err := s.counts(ctx, c)
 		if err != nil {

--- a/store/rank.go
+++ b/store/rank.go
@@ -27,7 +27,8 @@ type Ranker interface {
 // Selection is how many candidates to cut to, and in what order.
 type Selection struct {
 	// Limit is the size of the candidate pool. A driver returns at most this
-	// many candidates and still counts the whole match set.
+	// many candidates, and when it is also asked for the counts it counts the
+	// whole match set.
 	Limit int
 
 	// Recent asks for the most recently modified rather than the best matching.
@@ -37,6 +38,20 @@ type Selection struct {
 	// most recent of the most relevant, which is neither of the two things
 	// anybody asked for.
 	Recent bool
+
+	// Counts asks for [Ranked.Total] and [Ranked.Facets].
+	//
+	// They are the one part of a retrieval whose cost follows the match set
+	// rather than the page: a facet count has to count something, and on a query
+	// with no terms that something is every document the asker may read. A
+	// screen that shows neither a result count nor a sidebar should not pay for
+	// them, so it says so, and a driver that is not asked leaves both empty.
+	//
+	// It is opt in rather than opt out because leaving it out is the cheap
+	// answer and a caller that forgets to ask gets a screen with no facets on
+	// it, which is visible. Defaulting the other way would mean a caller who
+	// forgets gets the slow query, which is not.
+	Counts bool
 }
 
 // Ranked is one query's retrieval: the candidates worth scoring and the counts
@@ -44,16 +59,19 @@ type Selection struct {
 type Ranked struct {
 	Candidates []Candidate
 
-	// Total is the size of the match set, not of the candidate pool.
+	// Total is the size of the match set, not of the candidate pool. It is zero
+	// when the selection did not ask for the counts.
 	Total int
 
 	// Truncated reports that the match set was larger than the pool, so the
 	// ranking is over candidates rather than over everything. A caller is
-	// entitled to know which of the two it got.
+	// entitled to know which of the two it got. Without the counts there is
+	// nothing to compare the pool against, so it is false.
 	Truncated bool
 
 	// Facets are counted over the whole match set, which is what makes them
-	// usable as filters rather than as a description of the current page.
+	// usable as filters rather than as a description of the current page. They
+	// are empty when the selection did not ask for the counts.
 	Facets map[string][]Facet
 }
 

--- a/store/sqlitestore/open.go
+++ b/store/sqlitestore/open.go
@@ -1,0 +1,108 @@
+package sqlitestore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.OpenLog = (*Store)(nil)
+
+// RecordOpen notes that the principal opened a document.
+//
+// The insert selects from document rather than binding the id directly, and the
+// select carries the visibility predicate, so a write for something this person
+// may not read inserts no rows. That is one statement rather than a read, a
+// decision in Go and a write, and it is also the only form of this that cannot
+// race: nothing can change between the check and the write when they are the
+// same statement.
+func (s *Store) RecordOpen(ctx context.Context, p *acl.Principal, id string, at time.Time) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+
+	c := visible(p)
+	args := append([]any{p.Tenant, p.Subject, at.UnixNano(), id}, c.args...)
+	s.counters.statements.Add(1)
+	if _, err := s.db.ExecContext(ctx, `
+		INSERT INTO document_open (tenant, subject, doc_id, opened_at)
+		SELECT ?, ?, d.id, ? FROM document d WHERE d.id = ? AND `+c.where()+`
+		ON CONFLICT (tenant, subject, doc_id) DO UPDATE SET opened_at = excluded.opened_at`,
+		args...); err != nil {
+		return fmt.Errorf("sqlitestore: record open: %w", err)
+	}
+
+	// The history is trimmed here rather than by a job, because the only moment
+	// it can grow is this one and a deployment nobody prunes is the normal case.
+	s.counters.statements.Add(1)
+	if _, err := s.db.ExecContext(ctx, `
+		DELETE FROM document_open
+		WHERE tenant = ? AND subject = ? AND opened_at < (
+			SELECT min(opened_at) FROM (
+				SELECT opened_at FROM document_open
+				WHERE tenant = ? AND subject = ?
+				ORDER BY opened_at DESC LIMIT ?
+			)
+		)`, p.Tenant, p.Subject, p.Tenant, p.Subject, store.OpenHistory); err != nil {
+		return fmt.Errorf("sqlitestore: trim opens: %w", err)
+	}
+	return nil
+}
+
+// Opens returns what the principal opened, most recent first.
+//
+// The visibility predicate is in the same statement as the history, so a
+// document that stopped being readable is gone from the list without a second
+// query and without a chance to forget the rule.
+func (s *Store) Opens(ctx context.Context, p *acl.Principal, limit int) ([]store.Open, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	c := visible(p)
+	args := append([]any{p.Tenant, p.Subject}, c.args...)
+	args = append(args, limit)
+	rows, err := s.query(ctx, `
+		SELECT o.opened_at, x.data
+		FROM document_open o
+		JOIN document d ON d.id = o.doc_id
+		JOIN document_data x ON x.doc_id = d.id
+		WHERE o.tenant = ? AND o.subject = ? AND `+c.where()+`
+		ORDER BY o.opened_at DESC
+		LIMIT ?`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlitestore: opens: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []store.Open
+	for rows.Next() {
+		var (
+			at   int64
+			data string
+		)
+		if err := rows.Scan(&at, &data); err != nil {
+			return nil, fmt.Errorf("sqlitestore: opens: %w", err)
+		}
+		s.counters.rows.Add(1)
+		d, err := s.decoded(data)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, store.Open{Document: d, At: unixNano(at)})
+	}
+	return out, rows.Err()
+}

--- a/store/sqlitestore/rank.go
+++ b/store/sqlitestore/rank.go
@@ -24,7 +24,9 @@ import (
 // proportional to the corpus outside the index walk SQLite does for itself.
 //
 // Three statements: the candidates, their term frequencies, and one that
-// carries the total and every facet count over the same predicate.
+// carries the total and every facet count over the same predicate. The third
+// runs only for a caller that asked for the counts, because it is the only one
+// of the three whose cost follows the match set rather than the page.
 func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel store.Selection) (store.Ranked, error) {
 	if err := s.ready(ctx); err != nil {
 		return store.Ranked{}, err
@@ -55,9 +57,16 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 	from := `document d`
 	order := `d.id`
 	if sel.Recent {
-		// NULLs last, because a document whose date the source never gave us is
-		// not the most recent thing in the corpus.
-		order = `d.modified_at IS NULL, d.modified_at DESC, d.id`
+		// A document whose date the source never gave us is not the most recent
+		// thing in the corpus, and it does not have to be said: SQLite orders
+		// NULL below every value, so a descending scan puts them last for
+		// itself. Saying it anyway, as an ORDER BY d.modified_at IS NULL term in
+		// front of this one, cost a full sort of the match set. No index can
+		// satisfy an ordering that leads with an expression, so the planner
+		// walked every visible document into a temporary b-tree to answer a
+		// query for twenty rows, which is the whole of why an empty browse was
+		// slow. See document_recent in schema.go for the index this walks.
+		order = `d.modified_at DESC, d.id`
 	}
 	if q, ok := match(r.Terms); ok {
 		from = `document_fts CROSS JOIN document d ON d.rowid = document_fts.rowid`
@@ -82,6 +91,11 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 		if err := s.frequencies(ctx, cands, rowids, r.Terms); err != nil {
 			return store.Ranked{}, err
 		}
+	}
+	if !sel.Counts {
+		// The counts are the one statement here whose cost follows the match set,
+		// so a caller that shows neither a total nor a sidebar does not run it.
+		return out, nil
 	}
 	if out.Total, out.Facets, err = s.counts(ctx, from, c); err != nil {
 		return store.Ranked{}, err

--- a/store/sqlitestore/schema.go
+++ b/store/sqlitestore/schema.go
@@ -194,6 +194,35 @@ var migrations = []step{
 	ddl(`UPDATE document SET source_update = COALESCE(
 		(SELECT json_extract(dd.data, '$.SourceUpdate') FROM document_data dd WHERE dd.doc_id = document.id), '')`),
 	ddl(`CREATE INDEX document_tenant_source ON document (tenant, source)`),
+
+	// document_open is what each person opened, which is the half of the recent
+	// screen that no amount of searching can reconstruct.
+	//
+	// One row per person per document rather than one per open, because the list
+	// answers what somebody was reading and a person who opened the same runbook
+	// nine times this morning wants the other nineteen entries, not nine copies
+	// of that one. The cascade is what keeps it honest: a document that leaves
+	// the corpus leaves everybody's history with it, so the table cannot hold an
+	// id nothing else in the database knows about.
+	ddl(`CREATE TABLE document_open (
+		tenant    TEXT    NOT NULL,
+		subject   TEXT    NOT NULL,
+		doc_id    TEXT    NOT NULL REFERENCES document(id) ON DELETE CASCADE,
+		opened_at INTEGER NOT NULL,
+		PRIMARY KEY (tenant, subject, doc_id)
+	) WITHOUT ROWID`),
+	ddl(`CREATE INDEX document_open_recent ON document_open (tenant, subject, opened_at DESC)`),
+
+	// document_recent is the other half of that screen: what changed in the
+	// corpus, which is a query with no terms to cut the match set with.
+	//
+	// document_modified is on the column alone and is no use to it, because the
+	// predicate fixes the tenant and the ordering follows, so the planner sorted
+	// every visible document into a temporary b-tree to answer a request for
+	// twenty rows. With the tenant and the queryable flag in front of the date
+	// the same request is a walk down the index that stops when the page is
+	// full. The id is in it so the tie break does not put the sort back.
+	ddl(`CREATE INDEX document_recent ON document (tenant, queryable, modified_at DESC, id)`),
 }
 
 // backfill recomputes the ranking statistics for every document already stored.

--- a/store/sqlitestore/schema.go
+++ b/store/sqlitestore/schema.go
@@ -219,10 +219,19 @@ var migrations = []step{
 	// document_modified is on the column alone and is no use to it, because the
 	// predicate fixes the tenant and the ordering follows, so the planner sorted
 	// every visible document into a temporary b-tree to answer a request for
-	// twenty rows. With the tenant and the queryable flag in front of the date
-	// the same request is a walk down the index that stops when the page is
-	// full. The id is in it so the tie break does not put the sort back.
-	ddl(`CREATE INDEX document_recent ON document (tenant, queryable, modified_at DESC, id)`),
+	// twenty rows. With the tenant in front of the date the same request is a
+	// walk down the index that stops when the page is full, and the id is in it
+	// so the tie break does not put the sort back.
+	//
+	// Partial, on the flag rather than with the flag in the key, and that is the
+	// whole difference between this index and one that made every filtered
+	// search slower. Written as (tenant, queryable, ...) it is two equality
+	// columns for the predicate every query in the product starts with, so the
+	// planner picked this index for filtered searches that have nothing to do
+	// with recency and walked a wider b-tree than the one it used to walk. As a
+	// partial index it offers one equality column, a source filter beats it on
+	// its own index, and the browse query still gets its ordering for free.
+	ddl(`CREATE INDEX document_recent ON document (tenant, modified_at DESC, id) WHERE queryable = 1`),
 }
 
 // backfill recomputes the ranking statistics for every document already stored.

--- a/store/storetest/open.go
+++ b/store/storetest/open.go
@@ -1,0 +1,180 @@
+package storetest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+// Remembering what somebody opened is the one write in this interface that a
+// person makes about themselves rather than about the corpus, and it is the one
+// place where a driver could reasonably decide the permission rule does not
+// apply, on the grounds that this person had the document in front of them a
+// moment ago. It does apply. Access is revoked between the open and the read
+// often enough that it is the case worth writing down, and a list that keeps
+// showing the title of a document somebody has been cut out of is a leak with a
+// friendly name on it.
+
+// openLog skips a case for a driver that cannot remember an open.
+func openLog(t *testing.T, s store.Store) store.OpenLog {
+	t.Helper()
+	l, ok := s.(store.OpenLog)
+	if !ok {
+		t.Skip("driver does not implement store.OpenLog")
+	}
+	return l
+}
+
+// at is a fixed clock, so that the order of a history is the order the test
+// asked for rather than whatever the machine managed between two calls.
+func at(minute int) time.Time {
+	return time.Date(2026, 8, 21, 9, minute, 0, 0, time.UTC)
+}
+
+func opened(t *testing.T, l store.OpenLog, p *acl.Principal, limit int) []string {
+	t.Helper()
+	opens, err := l.Opens(t.Context(), p, limit)
+	if err != nil {
+		t.Fatalf("Opens: %v", err)
+	}
+	ids := make([]string, 0, len(opens))
+	for _, o := range opens {
+		ids = append(ids, o.Document.ID)
+	}
+	return ids
+}
+
+func testOpenLogOrder(t *testing.T, s store.Store) {
+	l := openLog(t, s)
+	mustPut(t, s, document("d1", readable()), document("d2", readable()), document("d3", readable()))
+
+	for i, id := range []string{"d1", "d2", "d3"} {
+		if err := l.RecordOpen(t.Context(), reader(), id, at(i)); err != nil {
+			t.Fatalf("RecordOpen %s: %v", id, err)
+		}
+	}
+
+	got := opened(t, l, reader(), 10)
+	want := []string{"d3", "d2", "d1"}
+	if len(got) != len(want) {
+		t.Fatalf("Opens returned %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Opens returned %v, want most recent first: %v", got, want)
+		}
+	}
+
+	// The same document again moves rather than repeats, and the entry carries
+	// the later time.
+	if err := l.RecordOpen(t.Context(), reader(), "d1", at(9)); err != nil {
+		t.Fatalf("RecordOpen: %v", err)
+	}
+	opens, err := l.Opens(t.Context(), reader(), 10)
+	if err != nil {
+		t.Fatalf("Opens: %v", err)
+	}
+	if len(opens) != 3 {
+		t.Fatalf("Opens returned %d entries after opening a document twice, want 3", len(opens))
+	}
+	if opens[0].Document.ID != "d1" {
+		t.Fatalf("Opens returned %s first, want the document that was just opened again", opens[0].Document.ID)
+	}
+	if !opens[0].At.Equal(at(9)) {
+		t.Fatalf("the entry says it was opened at %v, want %v", opens[0].At, at(9))
+	}
+
+	// The document itself is in the entry, because every caller wants a title.
+	if opens[0].Document.Title != "runbook d1" {
+		t.Fatalf("the entry carries %+v, want the document", opens[0].Document)
+	}
+}
+
+func testOpenLogLimit(t *testing.T, s store.Store) {
+	l := openLog(t, s)
+	mustPut(t, s, document("d1", readable()), document("d2", readable()))
+	for i, id := range []string{"d1", "d2"} {
+		if err := l.RecordOpen(t.Context(), reader(), id, at(i)); err != nil {
+			t.Fatalf("RecordOpen: %v", err)
+		}
+	}
+	if got := opened(t, l, reader(), 1); len(got) != 1 || got[0] != "d2" {
+		t.Fatalf("Opens with a limit of one returned %v, want the most recent entry", got)
+	}
+	if got := opened(t, l, reader(), 0); len(got) != 0 {
+		t.Fatalf("Opens with a limit of zero returned %v, want nothing", got)
+	}
+}
+
+func testOpenLogPermissions(t *testing.T, s store.Store) {
+	l := openLog(t, s)
+	mustPut(t, s, document("d1", readable()))
+
+	// Recording an open of something this person cannot read is not an error and
+	// does not record anything. It cannot be an error: the answer would tell a
+	// caller which ids exist.
+	if err := l.RecordOpen(t.Context(), stranger(), "d1", at(0)); err != nil {
+		t.Fatalf("RecordOpen for a document the caller may not read: %v", err)
+	}
+	if err := l.RecordOpen(t.Context(), stranger(), "does-not-exist", at(0)); err != nil {
+		t.Fatalf("RecordOpen for a document that is not there: %v", err)
+	}
+	if got := opened(t, l, stranger(), 10); len(got) != 0 {
+		t.Fatalf("Opens returned %v for a reader who opened nothing they may read", got)
+	}
+
+	// A history is one person's. Nobody else's open appears in it.
+	if err := l.RecordOpen(t.Context(), reader(), "d1", at(0)); err != nil {
+		t.Fatalf("RecordOpen: %v", err)
+	}
+	if got := opened(t, l, stranger(), 10); len(got) != 0 {
+		t.Fatalf("Opens returned %v, want nothing: that was somebody else's open", got)
+	}
+
+	// Access revoked after the open. The entry stops being served, and it stops
+	// being served without the caller filtering anything.
+	mustPut(t, s, document("d1", acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "gdrive",
+		AllowGroups: []acl.Ref{{Source: "gdrive", Value: "sales@acme.com"}},
+		Version:     1,
+	}))
+	if got := opened(t, l, reader(), 10); len(got) != 0 {
+		t.Fatalf("Opens returned %v after the reader lost access to it", got)
+	}
+}
+
+func testOpenLogDelete(t *testing.T, s store.Store) {
+	l := openLog(t, s)
+	mustPut(t, s, document("d1", readable()), document("d2", readable()))
+	for i, id := range []string{"d1", "d2"} {
+		if err := l.RecordOpen(t.Context(), reader(), id, at(i)); err != nil {
+			t.Fatalf("RecordOpen: %v", err)
+		}
+	}
+	if err := s.Delete(t.Context(), "d2"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got := opened(t, l, reader(), 10)
+	if len(got) != 1 || got[0] != "d1" {
+		t.Fatalf("Opens returned %v after the document was deleted, want only d1", got)
+	}
+}
+
+func testOpenLogTenants(t *testing.T, s store.Store) {
+	l := openLog(t, s)
+	mustPut(t, s, document("d1", readable()))
+
+	// The same subject string in another tenant is another person. A history
+	// keyed by the subject alone would hand one of them the other's reading.
+	other := reader()
+	other.Tenant = "other"
+	if err := l.RecordOpen(t.Context(), reader(), "d1", at(0)); err != nil {
+		t.Fatalf("RecordOpen: %v", err)
+	}
+	if got := opened(t, l, other, 10); len(got) != 0 {
+		t.Fatalf("Opens returned %v for the same subject in another tenant", got)
+	}
+}

--- a/store/storetest/rank.go
+++ b/store/storetest/rank.go
@@ -44,6 +44,7 @@ var rankCases = []rankCase{
 	{"the total counts the match set and not the pool", testRankTotal},
 	{"truncated says whether the ranking saw everything", testRankTruncated},
 	{"facets are counted over the match set and not over the pool", testRankFacets},
+	{"a selection with no counts ranks the same documents", testRankWithoutCounts},
 	{"the principal is applied inside rank", testRankPermission},
 	{"a nil principal ranks nothing", testRankNilPrincipal},
 	{"a candidate carries the token counts the analyzer produces", testRankTokens},
@@ -109,8 +110,9 @@ func candidateIDs(ranked store.Ranked) []string {
 	return ids
 }
 
-// pool is a selection large enough that nothing in the fixture is cut.
-func pool() store.Selection { return store.Selection{Limit: 100} }
+// pool is a selection large enough that nothing in the fixture is cut, with the
+// counts asked for, which is what a search does.
+func pool() store.Selection { return store.Selection{Limit: 100, Counts: true} }
 
 // wantFacets counts the facets the slow way, from the documents the principal
 // can actually read.
@@ -188,7 +190,7 @@ func testRankTotal(t *testing.T, s store.Store) {
 	// matched. A total that reports the pool would tell the interface there is
 	// one result when there are four, which is the number a person reads before
 	// deciding the search is broken.
-	got := mustRank(t, rk, reader(), store.Request{}, store.Selection{Limit: 1})
+	got := mustRank(t, rk, reader(), store.Request{}, store.Selection{Limit: 1, Counts: true})
 	if len(got.Candidates) != 1 {
 		t.Fatalf("asked for one candidate and got %d", len(got.Candidates))
 	}
@@ -204,7 +206,7 @@ func testRankTruncated(t *testing.T, s store.Store) {
 	if got := mustRank(t, rk, reader(), store.Request{}, pool()); got.Truncated {
 		t.Fatal("Truncated is set for a pool that held the whole match set")
 	}
-	if got := mustRank(t, rk, reader(), store.Request{}, store.Selection{Limit: 2}); !got.Truncated {
+	if got := mustRank(t, rk, reader(), store.Request{}, store.Selection{Limit: 2, Counts: true}); !got.Truncated {
 		t.Fatal("Truncated is not set for a pool that cut the match set in half")
 	}
 }
@@ -218,10 +220,38 @@ func testRankFacets(t *testing.T, s store.Store) {
 	// over the pool would make the sidebar change as somebody pages, and the
 	// counts it shows would be a description of the current page rather than of
 	// what ticking the filter is about to do.
-	for _, sel := range []store.Selection{pool(), {Limit: 1}} {
+	for _, sel := range []store.Selection{pool(), {Limit: 1, Counts: true}} {
 		got := gotFacets(t, mustRank(t, rk, reader(), store.Request{}, sel))
 		if !maps.EqualFunc(got, want, maps.Equal) {
 			t.Fatalf("facets for a pool of %d are %v, expected %v", sel.Limit, got, want)
+		}
+	}
+}
+
+// A selection that asks for no counts gets the same candidates and none of the
+// counting. It is what the home screen runs, and the point of it is the work
+// that does not happen, so what is asserted here is that skipping the counting
+// did not quietly change which documents came back.
+func testRankWithoutCounts(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	for _, r := range []store.Request{{}, {Terms: []string{"payments"}}, {Sources: []string{"gdrive"}}} {
+		counted := mustRank(t, rk, reader(), r, pool())
+		plain := mustRank(t, rk, reader(), r, store.Selection{Limit: 100})
+		if got, want := candidateIDs(plain), candidateIDs(counted); !slices.Equal(got, want) {
+			t.Fatalf("a selection with no counts ranked %v for %+v, and one with them ranked %v", got, r, want)
+		}
+		if plain.Total != 0 {
+			t.Fatalf("Total = %d for a selection that asked for no counts", plain.Total)
+		}
+		if plain.Truncated {
+			t.Fatal("Truncated is set for a selection with no total to compare the pool against")
+		}
+		for field, values := range plain.Facets {
+			if len(values) != 0 {
+				t.Fatalf("the %s facet was counted for a selection that asked for no counts: %v", field, values)
+			}
 		}
 	}
 }

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -60,6 +60,11 @@ var cases = []testCase{
 	{"content never rides along on a query path", testContentIsNotInTheDocument},
 	{"deleting a document deletes its content", testContentDelete},
 	{"writes are reported after they are visible", testNotifyWrites},
+	{"opens come back most recent first", testOpenLogOrder},
+	{"opens honour the limit", testOpenLogLimit},
+	{"an open is not a licence to keep reading", testOpenLogPermissions},
+	{"a deleted document leaves the history", testOpenLogDelete},
+	{"a history belongs to one tenant", testOpenLogTenants},
 }
 
 // contentStore skips a case for a driver that does not hold bytes.

--- a/web/dist/assets/api.js
+++ b/web/dist/assets/api.js
@@ -97,6 +97,25 @@ async function get(path, params, opts = {}) {
 }
 
 /**
+ * recordOpen tells the server that this document was read.
+ *
+ * keepalive, because this fires on the way to somewhere else and a plain fetch
+ * is cancelled when the page that started it goes away, which is exactly the
+ * navigation being recorded. Nothing waits for the answer and nothing reports a
+ * failure: a lost entry in a recency list is not worth interrupting a read for,
+ * and the read itself has already happened by the time this is called.
+ */
+function recordOpen(id) {
+  if (!id) return;
+  fetch(BASE + "/recent", {
+    method: "POST",
+    headers: { ...headers(), "Content-Type": "application/json" },
+    body: JSON.stringify({ id }),
+    keepalive: true,
+  }).catch(() => {});
+}
+
+/**
  * events reads the index change stream.
  *
  * EventSource would be the obvious way to do this and cannot be used, because
@@ -166,6 +185,10 @@ export const api = {
   me: (opts) => get("/me", {}, opts),
   stats: (opts) => get("/stats", {}, opts),
   search: (query, opts) => get("/search", query, opts),
+  // One request for both halves of the recent screen, because the screen asks
+  // both questions at once and a screen that paints in two stages paints twice.
+  recent: (limit, opts) => get("/recent", { limit }, opts),
+  recordOpen,
   suggest: (q, opts) => get("/suggest", { q }, opts),
   document: (id, opts) => get(`/documents/${encodeURIComponent(id)}`, {}, opts),
   content: (id, opts) => bytes(`/documents/${encodeURIComponent(id)}/content`, opts),

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -167,6 +167,13 @@ time {
   overflow-y: auto;
 }
 
+/* The scrolling region takes focus, so the ring is drawn inside it. The default
+   offset would put it outside the viewport on three sides, which is a ring
+   nobody can see on the one element that fills the screen. */
+.main:focus-visible {
+  outline-offset: -2px;
+}
+
 /* Rail ------------------------------------------------------------------- */
 
 .brand {
@@ -1156,10 +1163,18 @@ mark::after {
 
 /* Home ------------------------------------------------------------------- */
 
-.home {
+.home,
+.recent {
   max-width: var(--page-max);
   margin: 0 auto;
   padding: var(--space-16) var(--gutter) var(--space-24);
+}
+
+/* The two halves of the recent screen are two answers, and the space between
+   them is what says so. There is no rule and no card: the heading and the gap
+   do the separating, which is the same argument the panels make. */
+.recent__section + .recent__section {
+  margin-top: var(--space-16);
 }
 
 .home__greeting {

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -17,6 +17,8 @@ import { Results, VERTICALS, verticalsFor } from "./results.js";
 import { Drawer } from "./drawer.js";
 import { Page } from "./page.js";
 import { Home } from "./home.js";
+import { Recent } from "./recent.js";
+import { forget, remember } from "./queries.js";
 
 const THEME_KEY = "genba.theme";
 const DENSITY_KEY = "genba.density";
@@ -59,13 +61,19 @@ class App {
     this.pageTimer = null;
     this.suggestionTimer = null;
     this.guessing = 0;
+    // The last document this session told the server about, so a page that
+    // renders itself again does not say it twice.
+    this.recorded = "";
     // The last results page this session painted, so that a document page has
     // somewhere to go back to. It is empty in a tab that opened straight onto a
     // document, which is the case the back link has to answer differently.
     this.lastSearch = "";
 
     this.omnibox = new Omnibox({
-      onSearch: (text) => this.go({ ...this.query, q: text, offset: 0, open: "" }),
+      // Explicitly the search, because the box is on every screen and a search
+      // run from the recent screen is a search rather than a recent screen with
+      // a query string on it.
+      onSearch: (text) => this.go({ ...this.query, q: text, offset: 0, open: "" }, { path: "/" }),
       onOpen: (id) => this.open(id),
       onHighlight: (item) => this.guessSuggestion(item),
     });
@@ -77,15 +85,22 @@ class App {
       onCursor: (i) => this.rememberCursor(i),
     });
     this.home = new Home({
-      onQuery: (q) => this.go({ ...urlState.read(""), ...q }),
+      onQuery: (q) => this.go({ ...urlState.read(""), ...q }, { path: "/" }),
       onOpen: (id) => this.open(id),
+      onVisit: (path) => this.visit(path),
+    });
+    this.recent = new Recent({
+      onOpen: (id) => this.open(id),
+      onHover: (id) => this.guessDocument(id),
+      onSay: (text) => this.say(text),
     });
     this.drawer = new Drawer({
       onClose: () => {
         this.go({ ...this.query, open: "" }, { replace: true });
         // Back to the row it was opened from rather than to the top of the
         // page, which is the whole reason the cursor is in the URL.
-        this.results.focusCursor();
+        const rows = this.rows();
+        if (rows) rows.focusCursor();
       },
       onSay: (text) => this.say(text),
     });
@@ -97,6 +112,14 @@ class App {
     this.main = h("main", {
       class: "main",
       id: "main",
+      // This element is what scrolls, and a region that scrolls has to be
+      // reachable from the keyboard, because Safari will not scroll one that
+      // focus cannot enter. Until now it passed for the wrong reason: every
+      // screen happened to have something focusable on it, which stops being
+      // true for the moment a screen is loading and its rows are placeholders.
+      // It is also where the skip link points, and a target with no tabindex is
+      // a skip link that scrolls without moving focus.
+      tabindex: "0",
       // The header carries a hairline only once there is something scrolled
       // under it, so a page at rest has one less line on it.
       onScroll: () => {
@@ -231,7 +254,10 @@ class App {
             class: "rail__link",
             href: "/",
             title: "Home",
-            "aria-current": this.query.q || urlState.count(this.query) ? null : "page",
+            // Which entry is current is decided on every render rather than
+            // once here, because the rail is built when the shell is and
+            // outlives every screen it points at.
+            dataset: { route: "home" },
             onClick: (e) => this.link(e, {}),
           },
           svg(icon("home"), 20),
@@ -241,13 +267,14 @@ class App {
           "a",
           {
             class: "rail__link",
-            // Rooted. A query string on its own resolves against whatever path
-            // is showing, which was always the search until a document got a
-            // path of its own, and would otherwise make every rail entry a link
-            // back to the same document with a stray parameter on the end.
-            href: "/?sort=recent",
+            // A screen of its own rather than a recency sorted search. The two
+            // look alike and answer different questions: a search cannot say
+            // what this person read, and that is the half everybody comes here
+            // for.
+            href: urlState.RECENT,
             title: "Recent",
-            onClick: (e) => this.link(e, { q: "", sort: "recent" }),
+            dataset: { route: "recent" },
+            onClick: (e) => this.follow(e, urlState.RECENT),
           },
           svg(icon("clock"), 20),
           h("span", { class: "rail__label" }, "Recent"),
@@ -277,7 +304,31 @@ class App {
   link(e, query) {
     if (e.metaKey || e.ctrlKey || e.shiftKey) return;
     e.preventDefault();
-    this.go({ ...urlState.read(""), ...query });
+    // Rooted at the search. A query string on its own resolves against whatever
+    // path is showing, which was harmless while every path was the search and
+    // would now make every rail entry a link back to the document or the recent
+    // screen with a stray parameter on the end.
+    this.go({ ...urlState.read(""), ...query }, { path: "/" });
+  }
+
+  /** follow is the same thing for a rail entry that is a path rather than a query. */
+  follow(e, path) {
+    if (e.metaKey || e.ctrlKey || e.shiftKey) return;
+    e.preventDefault();
+    this.visit(path);
+  }
+
+  /**
+   * visit moves to a screen that has an address rather than a query.
+   *
+   * The query is emptied rather than carried, because a filter belongs to the
+   * search it was set on and a sort belongs to a result list. Nothing on the
+   * recent screen is a view of either.
+   */
+  visit(path) {
+    if (location.pathname !== path || location.search) history.pushState(null, "", path);
+    this.query = urlState.read("");
+    this.sync();
   }
 
   async start() {
@@ -370,7 +421,7 @@ class App {
     if (!urlState.same(urlState.params(next, VERTICALS), urlState.params(this.query, VERTICALS))) {
       next.cursor = -1;
     }
-    const url = urlState.write(next);
+    const url = urlState.write(next, opts.path === undefined ? this.here() : opts.path);
     if (opts.replace) history.replaceState(null, "", url);
     else history.pushState(null, "", url);
     this.query = urlState.read();
@@ -389,16 +440,28 @@ class App {
   rememberCursor(i) {
     if (this.query.cursor === i) return;
     this.query = { ...this.query, cursor: i };
-    history.replaceState(null, "", urlState.write(this.query));
+    history.replaceState(null, "", urlState.write(this.query, this.here()));
+  }
+
+  /**
+   * here is the path the query state currently belongs to.
+   *
+   * Two screens carry it: the search and the recent list. A document page never
+   * does, so a go from one of those is a go back to the search, which is the
+   * only place its query came from.
+   */
+  here() {
+    return urlState.route().name === "recent" ? urlState.RECENT : "/";
   }
 
   /** sync renders whatever the URL currently says. */
   sync() {
-    // Two routes: a document by path, and everything else by query string. A
-    // document is the only screen somebody links to from outside the product,
-    // which is why it is the only one with an address that does not carry the
-    // state of whoever found it.
+    // Three routes: a document and the recent list by path, and everything else
+    // by query string. A document is the only screen somebody links to from
+    // outside the product, which is why it is the only one with an address that
+    // does not carry the state of whoever found it.
     const route = urlState.route();
+    this.markRail();
     if (route.name === "document") {
       this.showDocument(route.id);
       return;
@@ -408,7 +471,8 @@ class App {
     this.omnibox.value = this.query.q;
     const searching = Boolean(this.query.q) || urlState.count(this.query) > 0 || Boolean(this.query.sort);
 
-    if (searching) this.search();
+    if (route.name === "recent") this.showRecent();
+    else if (searching) this.search();
     else this.showHome();
 
     if (this.query.open && this.drawer.currentId !== this.query.open) {
@@ -428,6 +492,10 @@ class App {
    */
   async showDocument(id) {
     this.currentKey = "";
+    // Both ways in count. A document reached by its own address, from a link
+    // somebody was sent or from a new tab, was read exactly as much as one
+    // opened in the preview beside a list.
+    this.record(id);
     this.drawer.currentId = null;
     if (this.drawer.open) this.drawer.close({ notify: false, focus: false });
     if (this.main.firstChild !== this.page.el) replace(this.main, this.page.el);
@@ -460,10 +528,45 @@ class App {
     await this.home.render(this.session);
   }
 
+  /**
+   * showRecent renders what this person opened and what changed.
+   *
+   * A failure only reaches the error screen when there is nothing to show. A
+   * check that failed behind a list already on screen keeps the list, for the
+   * same reason a search does: what is there was correct when it was painted,
+   * and the banner already says the connection is gone.
+   */
+  async showRecent() {
+    this.currentKey = this.recent.key();
+    if (this.main.firstChild !== this.recent.el) replace(this.main, this.recent.el);
+    try {
+      await this.recent.render();
+    } catch (err) {
+      if (err.name === "AbortError") return;
+      if (!this.recent.painted) this.fail(err);
+    }
+  }
+
+  /** markRail says which rail entry is the screen somebody is on. */
+  markRail() {
+    const searching = Boolean(this.query.q) || urlState.count(this.query) > 0 || Boolean(this.query.sort);
+    const route = urlState.route();
+    const here = route.name === "recent" ? "recent" : route.name === "search" && !searching ? "home" : "";
+    for (const link of this.rail.querySelectorAll("[data-route]")) {
+      if (link.dataset.route === here) link.setAttribute("aria-current", "page");
+      else link.removeAttribute("aria-current");
+    }
+  }
+
   async search() {
     const showing = this.main.firstChild === this.results.el;
     if (!showing) replace(this.main, this.results.el);
     this.lastSearch = urlState.write(this.query);
+    // Their own words, on their own machine. It happens here rather than in the
+    // omnibox so that a search reached from a link or from the back button is
+    // remembered too, which is what makes the list a history rather than a log
+    // of what was typed.
+    remember(this.query.q);
 
     const request = urlState.params(this.query, VERTICALS);
     const k = cache.key("search", request);
@@ -652,7 +755,26 @@ class App {
   }
 
   open(id) {
+    this.record(id);
     this.go({ ...this.query, open: id }, { replace: true });
+  }
+
+  /**
+   * record tells the server this document was read, and forgets what it knew.
+   *
+   * Nothing waits for either half. The write is fire and forget by design, and
+   * the cache entry is marked stale rather than dropped, so the recent screen
+   * still paints instantly from what it holds and finds the new row on the
+   * revalidation behind that paint.
+   */
+  record(id) {
+    // The same document twice running is one read. A document page is rendered
+    // again on every background refresh, and without this the recency list
+    // would be a record of how long a tab was left open.
+    if (!id || this.recorded === id) return;
+    this.recorded = id;
+    api.recordOpen(id);
+    cache.invalidate(cache.key("recent", {}));
   }
 
   theme() {
@@ -704,6 +826,10 @@ class App {
     );
     if (identities === null) return;
 
+    // The searches go with the results. They are this person's own input, and
+    // the next person at this machine is not entitled to know what the last one
+    // was looking for.
+    forget();
     setIdentity({
       subject: subject.trim() || "dev",
       tenant: tenant.trim(),
@@ -788,6 +914,21 @@ class App {
   }
 
   /**
+   * rows is the list the keyboard is walking, or nothing.
+   *
+   * Two screens are made of rows now and the keys mean the same thing on both,
+   * so the shell asks which one is on screen rather than holding a reference to
+   * the results and hoping. Home and the document page have no list at all,
+   * which is why this returns nothing rather than an empty one: j on the home
+   * screen should be a j, not a silent no-op somewhere else.
+   */
+  rows() {
+    if (this.main.firstChild === this.results.el) return this.results.rows;
+    if (this.main.firstChild === this.recent.el) return this.recent.active();
+    return null;
+  }
+
+  /**
    * copyLink is the y key: a link to the result under the cursor.
    *
    * The link is this product's address for the document rather than the
@@ -796,11 +937,11 @@ class App {
    * URL that nobody can follow from a message.
    */
   copyLink() {
-    const hit = this.results.current();
+    const rows = this.rows();
+    const hit = rows && rows.current();
     if (!hit) return false;
     const link = new URL(urlState.documentPath(hit.id), location.origin).href;
-    const row = this.results.list.querySelector(`[data-index="${this.results.selected}"]`);
-    const button = row && row.querySelector(".icon-button--copy");
+    const button = rows.copyTarget();
     // The tick where there is a control to draw it on, so the keyboard and the
     // pointer produce the same answer, and the spoken sentence either way.
     if (button) copies(button, link, (text) => this.say(text));
@@ -808,9 +949,10 @@ class App {
     return true;
   }
 
-  /** inList reports whether focus is on a row of the result list. */
+  /** inList reports whether focus is on a row of a document list. */
   inList() {
-    return this.results.list.contains(document.activeElement);
+    const rows = this.rows();
+    return Boolean(rows && rows.holds());
   }
 
   bindKeys() {
@@ -826,7 +968,8 @@ class App {
       // The modifier means the same thing here as it does on a link: open it
       // over there and leave me where I am.
       if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && !typing) {
-        const hit = this.results.current();
+        const rows = this.rows();
+        const hit = rows && rows.current();
         if (!hit) return;
         e.preventDefault();
         window.open(urlState.documentPath(hit.id), "_blank", "noreferrer");
@@ -843,10 +986,17 @@ class App {
       // disarms itself, so a stray g does nothing rather than waiting forever.
       if (chord === "g") {
         chord = null;
-        const destinations = { h: {}, s: { q: "", sort: "recent" }, a: { tab: "all" } };
+        // s is the recent screen, which is a path rather than a query, so it
+        // is the one destination in here that is not a search.
+        if (e.key === "s") {
+          e.preventDefault();
+          this.visit(urlState.RECENT);
+          return;
+        }
+        const destinations = { h: {}, a: { tab: "all" } };
         if (destinations[e.key]) {
           e.preventDefault();
-          this.go({ ...urlState.read(""), ...destinations[e.key] });
+          this.go({ ...urlState.read(""), ...destinations[e.key] }, { path: "/" });
         }
         return;
       }
@@ -861,36 +1011,38 @@ class App {
           setTimeout(() => (chord = null), 1200);
           break;
         case "j":
+        case "k": {
+          const rows = this.rows();
+          if (!rows) return;
           e.preventDefault();
-          this.results.move(1);
+          rows.move(e.key === "j" ? 1 : -1);
           break;
-        case "k":
-          e.preventDefault();
-          this.results.move(-1);
-          break;
+        }
         // The arrow keys move inside the list and only inside it. A page has
         // one scrollbar and somebody reading a preview with the arrow keys is
         // scrolling it, so these are answered where the pattern says they are:
         // when focus is in the widget they belong to.
         case "ArrowDown":
+        case "ArrowUp": {
           if (!this.inList()) return;
+          const rows = this.rows();
+          if (!rows) return;
           e.preventDefault();
-          this.results.move(1);
+          rows.move(e.key === "ArrowDown" ? 1 : -1);
           break;
-        case "ArrowUp":
-          if (!this.inList()) return;
-          e.preventDefault();
-          this.results.move(-1);
-          break;
+        }
         case "Home":
-        case "End":
-          if (this.drawer.open || !this.results.hits.length) return;
+        case "End": {
+          const rows = this.rows();
+          if (this.drawer.open || !rows || !rows.hits.length) return;
           e.preventDefault();
-          this.results.edge(e.key === "Home" ? "first" : "last");
+          rows.edge(e.key === "Home" ? "first" : "last");
           break;
+        }
         case "Enter":
         case "p": {
-          const hit = this.results.current();
+          const rows = this.rows();
+          const hit = rows && rows.current();
           if (!hit) return;
           e.preventDefault();
           this.open(hit.id);
@@ -900,7 +1052,8 @@ class App {
           // Only where a browser would go there. Opening a file:// URL in a new
           // tab from an HTTP page leaves somebody looking at a blank tab, which
           // is worse than the key doing nothing.
-          const hit = this.results.current();
+          const rows = this.rows();
+          const hit = rows && rows.current();
           if (!hit || !followable(hit.url)) return;
           e.preventDefault();
           window.open(hit.url, "_blank", "noreferrer");
@@ -912,8 +1065,9 @@ class App {
           break;
         case "f":
           // Not from inside the preview, which is modal. Moving focus behind a
-          // modal is the one way out of a focus trap that nobody asked for.
-          if (this.drawer.open) return;
+          // modal is the one way out of a focus trap that nobody asked for, and
+          // not from a screen with no filters on it either.
+          if (this.drawer.open || this.main.firstChild !== this.results.el) return;
           e.preventDefault();
           this.results.focusFilters();
           break;

--- a/web/dist/assets/home.js
+++ b/web/dist/assets/home.js
@@ -1,24 +1,29 @@
 // The home screen.
 //
-// It answers "what is in here and what changed" without anybody having to
-// think of a query first. Everything on it is a real query against the same
-// API the search page uses, so nothing here can show a document the person
-// could not have found by searching for it.
+// It answers three questions and nothing else. What is in here, from the session
+// and the index statistics. What was I doing, from the recent endpoint and from
+// the searches this browser remembers. What is going on, which is what changed
+// in the corpus. Everything on it is a real read against the same API the search
+// page uses, so nothing here can show a document the person could not have found
+// by searching for it.
 
 import { h, replace } from "./dom.js";
 import { api } from "./api.js";
 import { cache } from "./cache.js";
+import { queries } from "./queries.js";
+import { LIMIT as RECENT_LIMIT } from "./recent.js";
 import { label, sourceColor, when, number, initials } from "./format.js";
 
-// RECENT is the query behind the what changed panel. It is a constant because
-// it is also a cache key, and a request built twice must be built the same way
-// twice or the second build is a miss.
-const RECENT = { sort: "recent", limit: 6 };
+// How many rows a panel on this screen carries. Home is a summary and the whole
+// answer is one click away, so six is a panel somebody reads rather than one
+// they scroll.
+const PANEL_ROWS = 6;
 
 export class Home {
-  constructor({ onQuery, onOpen }) {
+  constructor({ onQuery, onOpen, onVisit }) {
     this.onQuery = onQuery;
     this.onOpen = onOpen;
+    this.onVisit = onVisit;
     this.el = h("div", { class: "home" });
   }
 
@@ -26,12 +31,12 @@ export class Home {
    * render paints the home screen, from cache if there is one.
    *
    * Home is the destination of the back button and of the brand in the rail, so
-   * it is loaded far more often than it is loaded for the first time. Both
-   * panels are painted from whatever is held, and repainted only if the check
-   * behind them comes back with something different.
+   * it is loaded far more often than it is loaded for the first time. Both reads
+   * are painted from whatever is held, and repainted only if the check behind
+   * them comes back with something different.
    */
   async render(session) {
-    const recentKey = cache.key("search", RECENT);
+    const recentKey = cache.key("recent", { limit: RECENT_LIMIT });
     const statsKey = cache.key("stats", {});
     let recent = cache.read(recentKey).data || null;
     let stats = cache.read(statsKey).data || null;
@@ -42,7 +47,7 @@ export class Home {
     // not a change, and again only if the server disagreed with it.
     await Promise.all([
       cache
-        .swr(recentKey, (opts) => api.search(RECENT, opts), (d) => {
+        .swr(recentKey, (opts) => api.recent(RECENT_LIMIT, opts), (d) => {
           if (d === recent) return;
           recent = d;
           changed = true;
@@ -73,8 +78,10 @@ export class Home {
         ? h(
             "div",
             { class: "home__grid" },
-            this.recentPanel(recent),
-            this.sourcesPanel(session, recent),
+            this.openedPanel(recent),
+            this.changedPanel(recent),
+            this.searchesPanel(),
+            this.sourcesPanel(session),
             this.statsPanel(stats, session),
             this.tipsPanel(),
           )
@@ -95,36 +102,97 @@ export class Home {
     );
   }
 
-  recentPanel(res) {
-    const hits = (res && res.hits) || [];
+  /**
+   * openedPanel is what this person was reading.
+   *
+   * It comes from the server rather than from this browser, because the whole
+   * value of the list is that it follows somebody from the laptop to the desk
+   * machine. It is also the panel that is empty on a first visit, and an empty
+   * panel that says why is better than one that is missing.
+   */
+  openedPanel(recent) {
+    const opened = (recent && recent.opened) || [];
     return h(
       "section",
       { class: "panel" },
-      h(
-        "div",
-        { class: "panel__head" },
-        h("h2", { class: "panel__title" }, "Recently updated"),
-        h(
-          "button",
-          { class: "panel__link", type: "button", onClick: () => this.onQuery({ q: "", sort: "recent" }) },
-          "See all",
-        ),
-      ),
-      hits.length
-        ? hits.map((hit) =>
-            h(
-              "button",
-              { class: "panel__row", type: "button", onClick: () => this.onOpen(hit.id) },
-              h("span", { class: "source__dot", style: { background: sourceColor(hit.source) } }),
-              h("span", { class: "panel__row-title" }, hit.title || hit.id),
-              h("span", { class: "panel__row-meta" }, when(hit.modified_at)),
-            ),
-          )
+      this.head("Recently opened"),
+      opened.length
+        ? opened.slice(0, PANEL_ROWS).map((hit) => this.documentRow(hit, hit.at))
+        : h("p", { class: "meta" }, "Nothing yet. Whatever you open shows up here, on any machine you sign in from."),
+    );
+  }
+
+  /** changedPanel is what moved in the corpus, which is nobody's history. */
+  changedPanel(recent) {
+    const changed = (recent && recent.changed) || [];
+    return h(
+      "section",
+      { class: "panel" },
+      this.head("Recently updated"),
+      changed.length
+        ? changed.slice(0, PANEL_ROWS).map((hit) => this.documentRow(hit, hit.modified_at))
         : h("p", { class: "meta" }, "Nothing has been indexed yet."),
     );
   }
 
-  sourcesPanel(session, res) {
+  /** head is a panel title with the way to the whole list beside it. */
+  head(title) {
+    return h(
+      "div",
+      { class: "panel__head" },
+      h("h2", { class: "panel__title" }, title),
+      h(
+        "a",
+        {
+          class: "panel__link",
+          href: "/recent",
+          onClick: (e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+            e.preventDefault();
+            this.onVisit("/recent");
+          },
+        },
+        "See all",
+      ),
+    );
+  }
+
+  documentRow(hit, at) {
+    return h(
+      "button",
+      { class: "panel__row", type: "button", onClick: () => this.onOpen(hit.id) },
+      h("span", { class: "source__dot", style: { background: sourceColor(hit.source) } }),
+      h("span", { class: "panel__row-title" }, hit.title || hit.id),
+      h("span", { class: "panel__row-meta" }, when(at)),
+    );
+  }
+
+  /**
+   * searchesPanel is what this person searched for, from this browser.
+   *
+   * The one panel on the screen that is not a read. A query is somebody's own
+   * input rather than corpus content, so it stays on their machine, which is
+   * written down in the client cache specification and is why this list is empty
+   * in a fresh browser even when the opened list is not.
+   */
+  searchesPanel() {
+    const held = queries();
+    if (!held.length) return null;
+    return h(
+      "section",
+      { class: "panel" },
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Your searches")),
+      held.slice(0, PANEL_ROWS).map((q) =>
+        h(
+          "button",
+          { class: "panel__row", type: "button", onClick: () => this.onQuery({ q }) },
+          h("span", { class: "panel__row-title" }, q),
+        ),
+      ),
+    );
+  }
+
+  sourcesPanel(session) {
     const sources = (session && session.sources) || [];
     return h(
       "section",

--- a/web/dist/assets/queries.js
+++ b/web/dist/assets/queries.js
@@ -1,0 +1,67 @@
+// The searches this person has run, kept on their own machine.
+//
+// This is the one half of the recent screen that does not come from the server,
+// and the split is deliberate. What somebody opened is a document, and the title
+// that makes a list of documents useful is corpus content, so it is read back
+// from the server under the same permission rule as everything else and it
+// follows them from the laptop to the desk machine. A query is their own input.
+// It is not corpus content, nobody else needs it, and it is the thing that makes
+// an empty search box useful, so it stays here.
+//
+// localStorage is allowed to hold this for the same reason it is allowed to hold
+// the theme and nothing else: there are no titles and no excerpts in it. It is
+// emptied by the identity switcher along with the result cache, because the next
+// person at this machine is not entitled to know what the last one was looking
+// for.
+
+const KEY = "genba.recent";
+
+// Twenty, which is what the client cache specification says. It is a list
+// somebody glances at rather than searches, and the entries below the twentieth
+// are ones they would type again faster than they would find.
+const LIMIT = 20;
+
+/** queries is what was searched for, most recent first. */
+export function queries() {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const held = JSON.parse(raw);
+    // Anything that is not a list of strings is something else's key or a half
+    // written value, and an empty history is a better answer than a broken
+    // screen.
+    if (!Array.isArray(held)) return [];
+    return held.filter((q) => typeof q === "string" && q.trim()).slice(0, LIMIT);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * remember records one search.
+ *
+ * Repeating a search moves it to the top rather than adding a second copy of it,
+ * because a list of the last twenty searches that is nine copies of the one
+ * somebody is iterating on is a list with eleven entries.
+ */
+export function remember(q) {
+  const text = (q || "").trim();
+  if (!text) return;
+  const next = [text, ...queries().filter((held) => held !== text)].slice(0, LIMIT);
+  try {
+    localStorage.setItem(KEY, JSON.stringify(next));
+  } catch {
+    // A full or disabled store means no history, which costs a convenience and
+    // nothing else. It is not worth an error on a screen.
+  }
+}
+
+/** forget empties the history, which is what switching identity does. */
+export function forget() {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    // Same reasoning as above, one step further: a store that will not delete
+    // is a store that was never written to.
+  }
+}

--- a/web/dist/assets/recent.js
+++ b/web/dist/assets/recent.js
@@ -1,0 +1,149 @@
+// The recent screen.
+//
+// It answers a different question from search: not what matches, but what has
+// been going on. Until now it was a rail entry that ran a recency sorted search,
+// which answers half of that and cannot answer the other half at all, because no
+// amount of searching reconstructs what one person happened to read.
+//
+// Two sections, one request. The server sends both halves together because a
+// screen that fetches twice paints twice, and both are permission filtered
+// inside the storage driver like everything else, so a document somebody lost
+// access to leaves this screen silently.
+
+import { h, replace, svg } from "./dom.js";
+import { api } from "./api.js";
+import { cache } from "./cache.js";
+import { icon } from "./format.js";
+import { RowList } from "./rows.js";
+
+// LIMIT is how many rows each half carries, and it is the server's own default.
+// Twenty is a screen of them, and this list is read at a glance rather than
+// scrolled, so there is no pager under it.
+//
+// Home shows the top few of the same answer rather than asking for a shorter
+// one, so the two screens share a cache entry and moving between them costs a
+// revalidation at most.
+export const LIMIT = 20;
+
+export class Recent {
+  constructor({ onOpen, onHover, onSay }) {
+    // Two lists rather than one, because they are two answers and a reader
+    // needs to be told which is which. Each carries its own name, since a
+    // screen with two lists on it is a screen where "list, 20 items" twice
+    // says nothing.
+    this.opened = new RowList({ onOpen, onHover, onSay, label: "Documents you opened" });
+    this.changed = new RowList({ onOpen, onHover, onSay, label: "Documents that changed" });
+    this.openedNote = h("div", {});
+    this.changedNote = h("div", {});
+    this.painted = false;
+
+    this.el = h(
+      "div",
+      { class: "recent" },
+      h(
+        "header",
+        { class: "home__greeting" },
+        h("h1", { class: "home__title" }, "Recent"),
+        h("p", { class: "home__subtitle" }, "What you opened, and what has changed since."),
+      ),
+      section("You opened", this.opened.el, this.openedNote),
+      section("Changed in the corpus", this.changed.el, this.changedNote),
+    );
+  }
+
+  /** key is the entry this screen paints from, which the offline banner names. */
+  key() {
+    return cache.key("recent", { limit: LIMIT });
+  }
+
+  /**
+   * render paints the screen, from cache if there is one.
+   *
+   * This is a screen people come back to rather than one they load once, so what
+   * is held is painted first and the check runs behind it. The entity tag means
+   * the usual answer to that check is a few hundred bytes and no repaint at all,
+   * which is what keeps the cursor and the scroll position where they were.
+   */
+  async render() {
+    const k = this.key();
+    let held = cache.read(k).data || null;
+    if (held) this.paint(held);
+    else this.loading();
+
+    await cache.swr(k, (opts) => api.recent(LIMIT, opts), (data) => {
+      if (data === held) return;
+      held = data;
+      this.paint(data);
+    });
+  }
+
+  /** loading is the shape of the answer, for a first visit with nothing held. */
+  loading() {
+    this.opened.skeleton(3);
+    this.changed.skeleton(3);
+    replace(this.openedNote);
+    replace(this.changedNote);
+  }
+
+  paint(data) {
+    this.painted = true;
+    const opened = (data && data.opened) || [];
+    const changed = (data && data.changed) || [];
+    // The cursor each list already had, rather than none, because this runs
+    // again on a revalidation and losing the row somebody was on to a
+    // background request is the thing the tag exists to avoid.
+    this.opened.render(opened, { cursor: this.opened.selected });
+    this.changed.render(changed, { cursor: this.changed.selected });
+
+    replace(
+      this.openedNote,
+      opened.length
+        ? null
+        : note(
+            "search",
+            "Nothing opened yet",
+            "Open a document from a search and it appears here, on whichever machine you sign in from.",
+          ),
+    );
+    replace(
+      this.changedNote,
+      changed.length
+        ? null
+        : note("clock", "Nothing has changed", "Nothing you can read has been indexed or updated yet."),
+    );
+  }
+
+  /**
+   * active is the list the keyboard is walking.
+   *
+   * Two lists on one screen means j and k have to mean one of them. Whichever
+   * holds focus wins, and before anything has focus it is the first list with
+   * rows in it, so the first press of j lands somewhere useful rather than on a
+   * heading with nothing under it.
+   */
+  active() {
+    if (this.opened.holds()) return this.opened;
+    if (this.changed.holds()) return this.changed;
+    return this.opened.hits.length ? this.opened : this.changed;
+  }
+}
+
+function section(title, list, note) {
+  return h(
+    "section",
+    { class: "recent__section" },
+    h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, title)),
+    list,
+    note,
+  );
+}
+
+function note(name, title, body) {
+  return h(
+    "div",
+    { class: "state" },
+    h("span", { class: "state__icon" }, svg(icon(name), 40)),
+    h("p", { class: "state__title" }, title),
+    h("p", { class: "state__body" }, body),
+  );
+}

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -1,20 +1,9 @@
 // The results view: verticals, active filters, result rows and facets.
 
 import { h, replace, svg } from "./dom.js";
-import {
-  kindIcon,
-  sourceColor,
-  label,
-  when,
-  exact,
-  number,
-  duration,
-  icon,
-  followable,
-  copyable,
-} from "./format.js";
-import { tile, cover, shapeOf } from "./content.js";
-import { copies } from "./clipboard.js";
+import { label, number, duration, icon } from "./format.js";
+import { shapeOf } from "./content.js";
+import { RowList } from "./rows.js";
 import * as urlState from "./state.js";
 
 /**
@@ -77,14 +66,14 @@ const FACET_VISIBLE = 8;
 export class Results {
   constructor({ onQuery, onOpen, onHover, onSay, onCursor }) {
     this.onQuery = onQuery;
-    this.onOpen = onOpen;
-    this.onHover = onHover || (() => {});
-    this.onSay = onSay || (() => {});
-    this.onCursor = onCursor || (() => {});
     this.expanded = new Set();
-    this.selected = -1;
     this.hits = [];
     this.total = 0;
+    // The rows and the keyboard that walks them are shared with the recent
+    // screen. What is left in here is everything a result list has that a list
+    // of documents does not: the verticals, the filters, the count and the
+    // pager.
+    this.rows = new RowList({ onOpen, onHover, onSay, onCursor });
     // Empty until the session says what the corpus holds, so the strip is never
     // painted with tabs that are about to be taken away.
     this.verticals = [];
@@ -127,7 +116,7 @@ export class Results {
     this.progress = h("div", { class: "progress", hidden: true });
     this.chips = h("div", { class: "chips" });
     this.head = h("div", { class: "results__head" });
-    this.list = h("div", { class: "results__list", role: "list" });
+    this.list = this.rows.el;
     this.aside = h("div", { class: "results__aside" });
 
     this.el = h(
@@ -154,25 +143,12 @@ export class Results {
    */
   loading(query) {
     this.renderTabs(query, null);
+    // The list is emptied through the row list rather than around it, so that
+    // the cursor and the hits it walks go with the rows on screen.
+    this.hits = [];
+    this.rows.skeleton();
     replace(this.chips);
     replace(this.head, h("div", { class: "skeleton", style: { width: "180px", height: "16px" } }));
-    replace(
-      this.list,
-      Array.from({ length: 6 }, () =>
-        h(
-          "div",
-          // The skeleton rows sit inside the list, so they carry the role its
-          // children are supposed to carry. A placeholder that is not an item
-          // makes the list itself invalid while it is loading.
-          { class: "skeleton-result", role: "listitem" },
-          h("div", { class: "skeleton skeleton-result__tile" }),
-          h("div", { class: "skeleton", style: { width: "60%", height: "20px" } }),
-          h("div", { class: "skeleton", style: { width: "40%", height: "14px" } }),
-          h("div", { class: "skeleton", style: { width: "100%", height: "14px" } }),
-          h("div", { class: "skeleton", style: { width: "82%", height: "14px" } }),
-        ),
-      ),
-    );
     replace(this.aside);
     replace(this.facets);
   }
@@ -186,22 +162,15 @@ export class Results {
    */
   revalidating(on) {
     this.progress.hidden = !on;
-    this.list.setAttribute("aria-busy", String(Boolean(on)));
+    this.rows.busy(on);
   }
 
-  /**
-   * render draws one answer, cursor and all.
-   *
-   * The cursor is restored from the query rather than reset, because this
-   * function runs again on every repaint and on the way back from a preview,
-   * and a cursor that only lived in this object would be lost both times.
-   */
+  /** render draws one answer, cursor and all. */
   render(query, res) {
     this.hits = res.hits || [];
     // Kept because the paging keys have to know where the last page ends, and
     // the pager itself is rebuilt from the response every time.
     this.total = res.total || 0;
-    this.selected = query.cursor >= 0 && query.cursor < this.hits.length ? query.cursor : -1;
     this.renderTabs(query, res);
     this.renderChips(query);
     this.renderHead(query, res);
@@ -369,226 +338,8 @@ export class Results {
   // item, so a reader on a screen reader is told there are twenty one results
   // and the last one is a pair of buttons.
   renderList(query, res) {
-    if (!this.hits.length) {
-      this.list.dataset.view = "list";
-      replace(this.list);
-      replace(this.aside, emptyState(query, res, this.onQuery));
-      return;
-    }
-
-    const view = this.viewFor(query);
-    this.list.dataset.view = view;
-    // Every row on screen is about to be replaced, and one of them may be the
-    // element focus is on. Losing focus to the body in the middle of a
-    // background revalidation is how a keyboard interface quietly stops.
-    const held = this.list.contains(document.activeElement);
-    replace(
-      this.list,
-      this.hits.map((hit, i) => (view === "grid" ? this.cell(hit, i) : this.row(hit, i))),
-    );
-    // The row is the tab stop, so nothing inside a row is one. A list of twenty
-    // rows with a title and three buttons each is eighty tab stops between the
-    // search box and the pager, which is the thing the roving tabindex exists
-    // to prevent. Everything in here has a key of its own instead: Enter
-    // previews, o opens at the source and y copies the link.
-    for (const control of this.list.querySelectorAll("a[href], button")) control.tabIndex = -1;
-    this.mark();
-    // Focus is only ever put back, never taken. A repaint while somebody is
-    // typing in the search box must not pull the caret out of it.
-    if (held) this.focusCursor({ scroll: false });
-    replace(this.aside, pager(query, res, this.onQuery));
-  }
-
-  /**
-   * seat is what every row and every cell carries so the list is one tab stop.
-   *
-   * A list where each of twenty rows is a tab stop takes forty presses to get
-   * past, which is the case the roving tabindex pattern exists for. Exactly one
-   * of them is reachable with Tab and the arrow keys move which one that is.
-   *
-   * Roving tabindex here rather than aria-activedescendant, which is what the
-   * omnibox uses, because a row is genuinely focusable and a browser scrolls a
-   * focused element into view on its own.
-   */
-  seat(i) {
-    return {
-      role: "listitem",
-      tabindex: "-1",
-      dataset: { index: String(i) },
-      // Tabbing in lands on whichever row holds the zero, and clicking a row
-      // focuses it. Either way the cursor is now there, so j and k carry on
-      // from what somebody is looking at rather than from where they left off.
-      onFocus: () => this.at(i),
-    };
-  }
-
-  /**
-   * cell is one result in the grid.
-   *
-   * The picture is the result and everything else is a label under it, so the
-   * cell carries the title and one line of provenance and nothing more. A
-   * snippet is left out rather than truncated: an image has no text to snip, and
-   * the ones that do are the reason the list view still exists.
-   */
-  cell(hit, i) {
-    const open = () => this.onOpen(hit.id);
-    return h(
-      "article",
-      {
-        class: "cell",
-        ...this.seat(i),
-        onMouseenter: () => this.onHover(hit.id),
-        onMouseleave: () => this.onHover(null),
-        onClick: (e) => {
-          if (e.target.closest("a, button")) return;
-          open();
-        },
-      },
-      cover(hit),
-      h(
-        "a",
-        {
-          class: "cell__title",
-          href: urlState.documentPath(hit.id),
-          title: hit.title || hit.id,
-          onClick: (e) => {
-            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
-            e.preventDefault();
-            open();
-          },
-        },
-        hit.title || hit.id,
-      ),
-      // Where it is, rather than what it is. A grid of pictures from one source
-      // is twenty four copies of the same word, and the folder a picture is in
-      // is the thing that tells two similar screenshots apart.
-      h(
-        "div",
-        { class: "cell__meta" },
-        h("span", { class: "source__dot", style: { background: sourceColor(hit.source) } }),
-        h("span", { class: "cell__where", title: hit.container || label(hit.source) }, hit.container || label(hit.source)),
-      ),
-    );
-  }
-
-  /**
-   * row is one result.
-   *
-   * A tile, then the title, then the line of provenance, then the snippet. The
-   * old order put provenance above the title, which meant the first thing on
-   * every row was the least distinguishing thing about it. The tile is the only
-   * part of a row that is not words, and for an image it is the whole answer.
-   */
-  row(hit, i) {
-    const open = () => this.onOpen(hit.id);
-    return h(
-      "article",
-      {
-        class: "result",
-        ...this.seat(i),
-        // A pointer resting on a row is a good guess at the next preview, and
-        // the shell is what decides how long resting means and how many of
-        // those guesses may be in the air at once.
-        onMouseenter: () => this.onHover(hit.id),
-        onMouseleave: () => this.onHover(null),
-        onClick: (e) => {
-          // Anything that is already a control handles its own click. A click
-          // on the rest of the row opens the preview, which is what somebody
-          // scanning a list wants and is cheaper than loading a page.
-          if (e.target.closest("a, button")) return;
-          open();
-        },
-      },
-      tile(hit),
-      // The title is an anchor to this document's own page, and the default is
-      // prevented on a plain left click so that the preview opens instead.
-      //
-      // It is an anchor rather than a button so that a middle click, a command
-      // click, the context menu and copying the link address all do what they
-      // do everywhere else on the web. It points at us rather than at the
-      // document's source, because a source URL is whatever a connector found
-      // and for the file connector that is a file:// URL, which a browser
-      // served over HTTP will not navigate to. Clicking the primary target on
-      // every row of a file corpus did nothing at all.
-      h(
-        "a",
-        {
-          class: "result__title",
-          href: urlState.documentPath(hit.id),
-          onClick: (e) => {
-            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
-            e.preventDefault();
-            open();
-          },
-        },
-        hit.title || hit.id,
-      ),
-      h(
-        "div",
-        { class: "result__meta" },
-        h(
-          "span",
-          { class: "source" },
-          h("span", { class: "source__dot", style: { background: sourceColor(hit.source) } }),
-          label(hit.source),
-        ),
-        h("span", { class: "crumbs__sep" }, "·"),
-        h("span", { class: "crumbs" }, svg(kindIcon(hit.kind), 14), label(hit.kind)),
-        hit.container && h("span", { class: "crumbs__sep" }, "·"),
-        hit.container && h("span", { class: "crumbs" }, hit.container),
-        hit.author && h("span", { class: "crumbs__sep" }, "·"),
-        hit.author && h("span", { class: "crumbs" }, hit.author),
-        hit.modified_at && h("span", { class: "crumbs__sep" }, "·"),
-        hit.modified_at &&
-          h("time", { title: exact(hit.modified_at), datetime: hit.modified_at }, when(hit.modified_at)),
-      ),
-      // A row with nothing to quote does not reserve the space for a quote. An
-      // image has no text in it, so every image row used to end in two empty
-      // lines, which is what made a list of screenshots look like a list of
-      // documents that had failed to load.
-      hasText(hit) && h("p", { class: "result__snippet" }, passages(hit)),
-      h(
-        "div",
-        { class: "result__actions" },
-        h(
-          "button",
-          { class: "icon-button", type: "button", title: "Preview (p)", "aria-label": "Preview", onClick: open },
-          svg(icon("preview"), 18),
-        ),
-        // Opening at the source is the secondary action, and it is only offered
-        // where it would work. Where it would not, the path is the useful thing
-        // to hand over, so the button copies it rather than pretending to be a
-        // link and doing nothing.
-        followable(hit.url)
-          ? h(
-              "a",
-              {
-                class: "icon-button",
-                href: hit.url,
-                target: "_blank",
-                rel: "noreferrer noopener",
-                title: "Open in source",
-                "aria-label": "Open in source",
-              },
-              svg(icon("external"), 18),
-            )
-          : hit.url &&
-            h(
-              "button",
-              {
-                // The class is how the y key finds this button, so that a
-                // copy from the keyboard draws the same tick as a copy from
-                // the pointer rather than happening invisibly.
-                class: "icon-button icon-button--copy",
-                type: "button",
-                title: "Copy path",
-                "aria-label": "Copy path",
-                onClick: (e) => copies(e.currentTarget, copyable(hit.url), this.onSay),
-              },
-              svg(icon("copy"), 18),
-            ),
-      ),
-    );
+    this.rows.render(this.hits, { view: this.viewFor(query), cursor: query.cursor });
+    replace(this.aside, this.hits.length ? pager(query, res, this.onQuery) : emptyState(query, res, this.onQuery));
   }
 
   renderFacets(query, res) {
@@ -648,71 +399,6 @@ export class Results {
     );
   }
 
-  /** move walks the cursor with j and k, or with the arrow keys. */
-  move(delta) {
-    if (!this.hits.length) return;
-    const next = Math.min(Math.max(this.selected + delta, 0), this.hits.length - 1);
-    this.select(next);
-  }
-
-  /** edge is Home and End: the first row and the last row on this page. */
-  edge(which) {
-    if (!this.hits.length) return;
-    this.select(which === "first" ? 0 : this.hits.length - 1);
-  }
-
-  /** select moves the cursor to a row and puts focus on it. */
-  select(i) {
-    this.at(i);
-    // Focus rather than scrollIntoView: the browser brings a focused element
-    // into view on its own, and a row that is highlighted but not focused is a
-    // row a screen reader is not reading.
-    this.focusCursor();
-  }
-
-  /**
-   * focusCursor puts focus on the row the cursor is on, if there is one.
-   *
-   * It is also the way back from the preview. The drawer keeps a reference to
-   * whatever had focus when it opened, and by the time it closes that row has
-   * been rebuilt by a repaint, so the element it remembers is not in the
-   * document any more. The cursor is, and it names the same row.
-   */
-  focusCursor(opts = {}) {
-    if (this.selected < 0) return;
-    const row = this.list.querySelector(`[data-index="${this.selected}"]`);
-    if (row) row.focus({ preventScroll: opts.scroll === false });
-  }
-
-  /** at records where the cursor is without touching focus. */
-  at(i) {
-    if (this.selected === i) return;
-    this.selected = i;
-    this.mark();
-    this.onCursor(i);
-  }
-
-  /**
-   * mark writes the cursor into the list.
-   *
-   * Both layouts, by the attribute they share rather than by class, so j and k
-   * walk a grid exactly as they walk a list. Exactly one row holds the zero,
-   * and where there is no cursor yet that is the first row, so the first Tab
-   * into the list arrives at the top of it rather than nowhere.
-   */
-  mark() {
-    const rows = this.list.querySelectorAll("[data-index]");
-    const roving = this.selected < 0 ? 0 : this.selected;
-    rows.forEach((row, n) => {
-      row.setAttribute("data-active", String(n === this.selected));
-      row.tabIndex = n === roving ? 0 : -1;
-    });
-  }
-
-  current() {
-    return this.hits[this.selected];
-  }
-
   /**
    * focusFilters is the f key.
    *
@@ -744,24 +430,6 @@ function countFor(res, vertical) {
 
 function labelFor(field) {
   return { source: "Source", kind: "Type", container: "In", author: "Person" }[field] || field;
-}
-
-/**
- * passages renders the snippet with the matched words marked.
- *
- * The server decided which runs matched, using the analyzer that produced the
- * index. Marking them here with a substring search instead would highlight
- * things the index never matched, which teaches people the wrong thing about
- * why a result came back.
- */
-/** hasText reports whether the server found anything in this hit worth quoting. */
-function hasText(hit) {
-  return Boolean((hit.passages && hit.passages.length) || hit.snippet);
-}
-
-function passages(hit) {
-  if (!hit.passages || !hit.passages.length) return hit.snippet || "";
-  return hit.passages.map((p) => (p.match ? h("mark", {}, p.text) : document.createTextNode(p.text)));
 }
 
 function pager(query, res, onQuery) {

--- a/web/dist/assets/rows.js
+++ b/web/dist/assets/rows.js
@@ -1,0 +1,403 @@
+// A list of documents, and the keyboard that walks it.
+//
+// It is one module rather than part of the results view because there is more
+// than one screen made of these rows now. The recent screen shows what somebody
+// opened and what changed, and those have to be the same row as a search result:
+// the same tile, the same line of provenance, the same click that opens a
+// preview, the same j and k. A second implementation of a row would be a second
+// place every one of those decisions lives, and the two would drift within a
+// month.
+//
+// What it does not know about is where the documents came from. There is no
+// query in here, no paging, no facets and no empty state, because those are
+// different questions on every screen that uses this one.
+
+import { h, replace, svg } from "./dom.js";
+import { kindIcon, sourceColor, label, when, exact, icon, followable, copyable } from "./format.js";
+import { tile, cover } from "./content.js";
+import { copies } from "./clipboard.js";
+import * as urlState from "./state.js";
+
+export class RowList {
+  constructor({ onOpen, onHover, onSay, onCursor, label: name } = {}) {
+    this.onOpen = onOpen || (() => {});
+    this.onHover = onHover || (() => {});
+    this.onSay = onSay || (() => {});
+    this.onCursor = onCursor || (() => {});
+    this.hits = [];
+    this.selected = -1;
+
+    this.el = h("div", { class: "results__list", role: "list" });
+    // A screen with two of these on it has two lists, and a reader moving
+    // between them is told which is which. The results page has one and its
+    // heading is the count above it, so it passes no name.
+    if (name) this.el.setAttribute("aria-label", name);
+  }
+
+  /**
+   * render draws one page of documents.
+   *
+   * The cursor is a parameter rather than state, because this runs again on
+   * every repaint and on the way back from a preview, and a cursor that only
+   * lived in this object would be lost both times.
+   */
+  render(hits, opts = {}) {
+    this.hits = hits || [];
+    const cursor = opts.cursor === undefined ? -1 : opts.cursor;
+    this.selected = cursor >= 0 && cursor < this.hits.length ? cursor : -1;
+
+    const view = opts.view === "grid" ? "grid" : "list";
+    this.el.dataset.view = view;
+    if (!this.hits.length) {
+      replace(this.el);
+      return;
+    }
+
+    // Every row on screen is about to be replaced, and one of them may be the
+    // element focus is on. Losing focus to the body in the middle of a
+    // background revalidation is how a keyboard interface quietly stops.
+    const held = this.el.contains(document.activeElement);
+    replace(
+      this.el,
+      this.hits.map((hit, i) => (view === "grid" ? this.cell(hit, i) : this.row(hit, i))),
+    );
+    // The row is the tab stop, so nothing inside a row is one. A list of twenty
+    // rows with a title and three buttons each is eighty tab stops between the
+    // search box and the pager, which is the thing the roving tabindex exists
+    // to prevent. Everything in here has a key of its own instead: Enter
+    // previews, o opens at the source and y copies the link.
+    for (const control of this.el.querySelectorAll("a[href], button")) control.tabIndex = -1;
+    this.mark();
+    // Focus is only ever put back, never taken. A repaint while somebody is
+    // typing in the search box must not pull the caret out of it.
+    if (held) this.focusCursor({ scroll: false });
+  }
+
+  /** busy says a cached answer is being checked, without dimming it. */
+  busy(on) {
+    this.el.setAttribute("aria-busy", String(Boolean(on)));
+  }
+
+  /**
+   * skeleton paints the shape of an answer before the answer arrives.
+   *
+   * The placeholders go inside the list and carry the role its children are
+   * supposed to carry, because a placeholder that is not an item makes the list
+   * itself invalid for as long as it is loading.
+   */
+  skeleton(n = 6) {
+    this.render([]);
+    replace(
+      this.el,
+      Array.from({ length: n }, () =>
+        h(
+          "div",
+          { class: "skeleton-result", role: "listitem" },
+          h("div", { class: "skeleton skeleton-result__tile" }),
+          h("div", { class: "skeleton", style: { width: "60%", height: "20px" } }),
+          h("div", { class: "skeleton", style: { width: "40%", height: "14px" } }),
+          h("div", { class: "skeleton", style: { width: "100%", height: "14px" } }),
+          h("div", { class: "skeleton", style: { width: "82%", height: "14px" } }),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * seat is what every row and every cell carries so the list is one tab stop.
+   *
+   * A list where each of twenty rows is a tab stop takes forty presses to get
+   * past, which is the case the roving tabindex pattern exists for. Exactly one
+   * of them is reachable with Tab and the arrow keys move which one that is.
+   *
+   * Roving tabindex here rather than aria-activedescendant, which is what the
+   * omnibox uses, because a row is genuinely focusable and a browser scrolls a
+   * focused element into view on its own.
+   */
+  seat(i) {
+    return {
+      role: "listitem",
+      tabindex: "-1",
+      dataset: { index: String(i) },
+      // Tabbing in lands on whichever row holds the zero, and clicking a row
+      // focuses it. Either way the cursor is now there, so j and k carry on
+      // from what somebody is looking at rather than from where they left off.
+      onFocus: () => this.at(i),
+    };
+  }
+
+  /**
+   * cell is one result in the grid.
+   *
+   * The picture is the result and everything else is a label under it, so the
+   * cell carries the title and one line of provenance and nothing more. A
+   * snippet is left out rather than truncated: an image has no text to snip, and
+   * the ones that do are the reason the list view still exists.
+   */
+  cell(hit, i) {
+    const open = () => this.onOpen(hit.id);
+    return h(
+      "article",
+      {
+        class: "cell",
+        ...this.seat(i),
+        onMouseenter: () => this.onHover(hit.id),
+        onMouseleave: () => this.onHover(null),
+        onClick: (e) => {
+          if (e.target.closest("a, button")) return;
+          open();
+        },
+      },
+      cover(hit),
+      h(
+        "a",
+        {
+          class: "cell__title",
+          href: urlState.documentPath(hit.id),
+          title: hit.title || hit.id,
+          onClick: (e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+            e.preventDefault();
+            open();
+          },
+        },
+        hit.title || hit.id,
+      ),
+      // Where it is, rather than what it is. A grid of pictures from one source
+      // is twenty four copies of the same word, and the folder a picture is in
+      // is the thing that tells two similar screenshots apart.
+      h(
+        "div",
+        { class: "cell__meta" },
+        h("span", { class: "source__dot", style: { background: sourceColor(hit.source) } }),
+        h("span", { class: "cell__where", title: hit.container || label(hit.source) }, hit.container || label(hit.source)),
+      ),
+    );
+  }
+
+  /**
+   * row is one result.
+   *
+   * A tile, then the title, then the line of provenance, then the snippet. The
+   * old order put provenance above the title, which meant the first thing on
+   * every row was the least distinguishing thing about it. The tile is the only
+   * part of a row that is not words, and for an image it is the whole answer.
+   */
+  row(hit, i) {
+    const open = () => this.onOpen(hit.id);
+    return h(
+      "article",
+      {
+        class: "result",
+        ...this.seat(i),
+        // A pointer resting on a row is a good guess at the next preview, and
+        // the shell is what decides how long resting means and how many of
+        // those guesses may be in the air at once.
+        onMouseenter: () => this.onHover(hit.id),
+        onMouseleave: () => this.onHover(null),
+        onClick: (e) => {
+          // Anything that is already a control handles its own click. A click
+          // on the rest of the row opens the preview, which is what somebody
+          // scanning a list wants and is cheaper than loading a page.
+          if (e.target.closest("a, button")) return;
+          open();
+        },
+      },
+      tile(hit),
+      // The title is an anchor to this document's own page, and the default is
+      // prevented on a plain left click so that the preview opens instead.
+      //
+      // It is an anchor rather than a button so that a middle click, a command
+      // click, the context menu and copying the link address all do what they
+      // do everywhere else on the web. It points at us rather than at the
+      // document's source, because a source URL is whatever a connector found
+      // and for the file connector that is a file:// URL, which a browser
+      // served over HTTP will not navigate to. Clicking the primary target on
+      // every row of a file corpus did nothing at all.
+      h(
+        "a",
+        {
+          class: "result__title",
+          href: urlState.documentPath(hit.id),
+          onClick: (e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+            e.preventDefault();
+            open();
+          },
+        },
+        hit.title || hit.id,
+      ),
+      h(
+        "div",
+        { class: "result__meta" },
+        h(
+          "span",
+          { class: "source" },
+          h("span", { class: "source__dot", style: { background: sourceColor(hit.source) } }),
+          label(hit.source),
+        ),
+        h("span", { class: "crumbs__sep" }, "·"),
+        h("span", { class: "crumbs" }, svg(kindIcon(hit.kind), 14), label(hit.kind)),
+        hit.container && h("span", { class: "crumbs__sep" }, "·"),
+        hit.container && h("span", { class: "crumbs" }, hit.container),
+        hit.author && h("span", { class: "crumbs__sep" }, "·"),
+        hit.author && h("span", { class: "crumbs" }, hit.author),
+        hit.modified_at && h("span", { class: "crumbs__sep" }, "·"),
+        hit.modified_at &&
+          h("time", { title: exact(hit.modified_at), datetime: hit.modified_at }, when(hit.modified_at)),
+        // Only the recent endpoint sends this, and only on the half of it that
+        // is somebody's own history. It is on the provenance line rather than
+        // in a column of its own so that a row is the same row everywhere, with
+        // one more fact on it where there is one more fact to say.
+        hit.at && h("span", { class: "crumbs__sep" }, "·"),
+        hit.at &&
+          h(
+            "time",
+            { class: "crumbs", title: exact(hit.at), datetime: hit.at },
+            `you opened this ${when(hit.at)}`,
+          ),
+      ),
+      // A row with nothing to quote does not reserve the space for a quote. An
+      // image has no text in it, so every image row used to end in two empty
+      // lines, which is what made a list of screenshots look like a list of
+      // documents that had failed to load.
+      hasText(hit) && h("p", { class: "result__snippet" }, passages(hit)),
+      h(
+        "div",
+        { class: "result__actions" },
+        h(
+          "button",
+          { class: "icon-button", type: "button", title: "Preview (p)", "aria-label": "Preview", onClick: open },
+          svg(icon("preview"), 18),
+        ),
+        // Opening at the source is the secondary action, and it is only offered
+        // where it would work. Where it would not, the path is the useful thing
+        // to hand over, so the button copies it rather than pretending to be a
+        // link and doing nothing.
+        followable(hit.url)
+          ? h(
+              "a",
+              {
+                class: "icon-button",
+                href: hit.url,
+                target: "_blank",
+                rel: "noreferrer noopener",
+                title: "Open in source",
+                "aria-label": "Open in source",
+              },
+              svg(icon("external"), 18),
+            )
+          : hit.url &&
+            h(
+              "button",
+              {
+                // The class is how the y key finds this button, so that a
+                // copy from the keyboard draws the same tick as a copy from
+                // the pointer rather than happening invisibly.
+                class: "icon-button icon-button--copy",
+                type: "button",
+                title: "Copy path",
+                "aria-label": "Copy path",
+                onClick: (e) => copies(e.currentTarget, copyable(hit.url), this.onSay),
+              },
+              svg(icon("copy"), 18),
+            ),
+      ),
+    );
+  }
+
+  /** move walks the cursor with j and k, or with the arrow keys. */
+  move(delta) {
+    if (!this.hits.length) return;
+    const next = Math.min(Math.max(this.selected + delta, 0), this.hits.length - 1);
+    this.select(next);
+  }
+
+  /** edge is Home and End: the first row and the last row on this page. */
+  edge(which) {
+    if (!this.hits.length) return;
+    this.select(which === "first" ? 0 : this.hits.length - 1);
+  }
+
+  /** select moves the cursor to a row and puts focus on it. */
+  select(i) {
+    this.at(i);
+    // Focus rather than scrollIntoView: the browser brings a focused element
+    // into view on its own, and a row that is highlighted but not focused is a
+    // row a screen reader is not reading.
+    this.focusCursor();
+  }
+
+  /**
+   * focusCursor puts focus on the row the cursor is on, if there is one.
+   *
+   * It is also the way back from the preview. The drawer keeps a reference to
+   * whatever had focus when it opened, and by the time it closes that row has
+   * been rebuilt by a repaint, so the element it remembers is not in the
+   * document any more. The cursor is, and it names the same row.
+   */
+  focusCursor(opts = {}) {
+    if (this.selected < 0) return;
+    const row = this.el.querySelector(`[data-index="${this.selected}"]`);
+    if (row) row.focus({ preventScroll: opts.scroll === false });
+  }
+
+  /** at records where the cursor is without touching focus. */
+  at(i) {
+    if (this.selected === i) return;
+    this.selected = i;
+    this.mark();
+    this.onCursor(i);
+  }
+
+  /**
+   * mark writes the cursor into the list.
+   *
+   * Both layouts, by the attribute they share rather than by class, so j and k
+   * walk a grid exactly as they walk a list. Exactly one row holds the zero,
+   * and where there is no cursor yet that is the first row, so the first Tab
+   * into the list arrives at the top of it rather than nowhere.
+   */
+  mark() {
+    const rows = this.el.querySelectorAll("[data-index]");
+    const roving = this.selected < 0 ? 0 : this.selected;
+    rows.forEach((row, n) => {
+      row.setAttribute("data-active", String(n === this.selected));
+      row.tabIndex = n === roving ? 0 : -1;
+    });
+  }
+
+  /** current is the document under the cursor, if the cursor is on one. */
+  current() {
+    return this.hits[this.selected];
+  }
+
+  /** holds reports whether focus is inside this list. */
+  holds() {
+    return this.el.contains(document.activeElement);
+  }
+
+  /** copyTarget is the copy button on the row under the cursor, if it has one. */
+  copyTarget() {
+    const row = this.el.querySelector(`[data-index="${this.selected}"]`);
+    return row && row.querySelector(".icon-button--copy");
+  }
+}
+
+/** hasText reports whether the server found anything in this hit worth quoting. */
+export function hasText(hit) {
+  return Boolean((hit.passages && hit.passages.length) || hit.snippet);
+}
+
+/**
+ * passages renders the snippet with the matched words marked.
+ *
+ * The server decided which runs matched, using the analyzer that produced the
+ * index. Marking them here with a substring search instead would highlight
+ * things the index never matched, which teaches people the wrong thing about
+ * why a result came back.
+ */
+export function passages(hit) {
+  if (!hit.passages || !hit.passages.length) return hit.snippet || "";
+  return hit.passages.map((p) => (p.match ? h("mark", {}, p.text) : document.createTextNode(p.text)));
+}

--- a/web/dist/assets/state.js
+++ b/web/dist/assets/state.js
@@ -7,12 +7,15 @@
 
 const LIST_KEYS = ["source", "kind", "container", "author", "owner"];
 
-// The one screen that is a path rather than a query string.
+// The two screens that are a path rather than a query string.
 //
 // A document is the thing somebody pastes into a message, so it gets an address
 // that survives being read out loud and does not carry the state of whoever
-// found it. Everything else is a view of a search and belongs in the query.
+// found it. Recent is a path because it is not a view of a search: it answers
+// what has been going on rather than what matches, and a rail entry that ran a
+// recency sorted search was answering the wrong question with the right rows.
 const DOCUMENT = "/d/";
+export const RECENT = "/recent";
 
 /**
  * route says which screen the path names.
@@ -21,6 +24,7 @@ const DOCUMENT = "/d/";
  * of a document page reaches this function rather than a 404.
  */
 export function route(pathname = location.pathname) {
+  if (pathname === RECENT) return { name: "recent", id: "" };
   if (!pathname.startsWith(DOCUMENT)) return { name: "search", id: "" };
   const id = decode(pathname.slice(DOCUMENT.length));
   return id ? { name: "document", id } : { name: "search", id: "" };
@@ -78,8 +82,15 @@ function cursorOf(value) {
   return Number.isInteger(n) && n >= 0 ? n : -1;
 }
 
-/** write turns a query back into a query string, leaving out the defaults. */
-export function write(query) {
+/**
+ * write turns a query back into an address, leaving out the defaults.
+ *
+ * The path is a parameter because two screens carry this state now. Opening a
+ * preview from the recent screen has to stay on the recent screen, and a
+ * function that always wrote a slash would have quietly moved somebody to the
+ * search every time they pressed Enter on a row.
+ */
+export function write(query, path = "/") {
   const params = new URLSearchParams();
   if (query.q) params.set("q", query.q);
   for (const key of LIST_KEYS) {
@@ -94,7 +105,7 @@ export function write(query) {
   // Rooted rather than relative, because a search reached from a document page
   // is a search and not a document with a query string stuck on the end of it.
   const s = params.toString();
-  return s ? `/?${s}` : "/";
+  return s ? `${path}?${s}` : path;
 }
 
 /**

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -140,9 +140,11 @@ func TestTheInterfaceFitsItsTransferBudget(t *testing.T) {
 // a convention because the tempting change is one line long and would look like
 // an improvement.
 func TestTheCacheKeepsNothingOnDisk(t *testing.T) {
-	// The theme, the density and the development identity are the whole of what
-	// may persist, and none of them is anything the corpus said.
-	persist := map[string]bool{"api.js": true, "app.js": true}
+	// The theme, the density, the development identity and the queries somebody
+	// typed are the whole of what may persist, and none of them is anything the
+	// corpus said. A query is the asker's own words, which is why it stays on
+	// their machine rather than being kept for them on the server.
+	persist := map[string]bool{"api.js": true, "app.js": true, "queries.js": true}
 
 	err := fs.WalkDir(os.DirFS("dist"), ".", func(name string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || path.Ext(name) != ".js" {
@@ -161,7 +163,7 @@ func TestTheCacheKeepsNothingOnDisk(t *testing.T) {
 			}
 		}
 		if strings.Contains(string(body), "localStorage.") && !persist[path.Base(name)] {
-			t.Errorf("%s writes to localStorage, which is only for the theme, the density and the identity", name)
+			t.Errorf("%s writes to localStorage, which is only for the theme, the density, the identity and the queries somebody typed", name)
 		}
 		return nil
 	})


### PR DESCRIPTION
Home answered one of the three questions it is supposed to answer.
It said what is in the index and it said nothing about what anybody was reading, which is what most people come back for.

## One endpoint, two questions

`GET /api/v1/recent` returns what the caller opened, most recent first, and what changed in what they may read.
It is one request because the screen asks both questions at the same moment, and a screen that fetches twice paints twice.
Both halves are filtered inside the storage driver by the same predicate search uses, so a document somebody loses access to leaves the list on its own.
The response carries an entity tag and the same private cache headers as everything else, so coming back to the screen usually costs a few hundred bytes and no repaint.

`POST /api/v1/recent` records an open.
The client sends it with keepalive, because it fires on the way to another screen and a plain fetch is cancelled by the navigation being recorded.
Nothing waits for the answer and nothing reports a failure.
A lost row in a recency list is not worth interrupting a read for, and by the time the request is made the read has already happened.

## Where the history lives

What somebody opened is kept on the server, so it follows them from the laptop to the desk machine, which is the whole value of the list.
The queries they typed stay in `localStorage`, because a query is their own words rather than corpus content, and `perf/04_client_cache.md` already reserves `genba.recent` for exactly that.
The identity switcher forgets them along with everything else.

Every driver can remember an open: memory, SQLite and Postgres.
It is an optional capability rather than part of the store interface, so a deployment on a driver without one still has a home screen, with one list on it instead of two.

## The screen

`/recent` has an address of its own rather than being a recency sorted search.
The two look alike and answer different questions, and no amount of searching reconstructs what one person happened to read.
That made the URL writer take a path, because opening a preview from the recent screen has to stay on the recent screen.

The rows are the same rows.
A list of documents and the keyboard that walks it moved out of the results view into a module of its own, so the recent screen gets the same tile, the same line of provenance, the same click that opens a preview and the same `j`, `k`, `Enter`, `o` and `y` without a second implementation of any of it.
The shell asks which list is on screen rather than holding a reference to the results, and which rail entry is current is decided on every render rather than once when the rail is built.

## One accessibility fix that is not about this screen

The part of the page that scrolls is now a tab stop.
It passed the audit until now for the wrong reason, which is that every screen happened to have something focusable on it, and that stops being true for the moment a screen is loading and its rows are placeholders.
Safari will not scroll a region focus cannot enter, and `#main` is also where the skip link points.

## Measurement

`GET /api/v1/recent` runs in 2.6ms on the reference corpus, against a budget of four.

```
BenchmarkAPIRecent-10   200   2662755 ns/op   1021780 B/op   2165 allocs/op
BenchmarkAPIRecent-10   200   2588727 ns/op   1020466 B/op   2163 allocs/op
BenchmarkAPIRecent-10   200   3290477 ns/op   1020062 B/op   2163 allocs/op
```

## Testing

- `make fmt vet race lint` clean
- `make ui-gate` clean, with `/recent` added to the axe screen list and eight new assertions in the keyboard walk
- Seven tests for the endpoint, four for the open log across all three drivers

Closes #107
