### PR TITLE
Open a file at the line somebody was sent to

### DIFF
--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -154,12 +154,18 @@ async function walk(session) {
   // A link written as a bare query string resolves against whatever path is
   // showing, which was harmless while every path was the search and is not any
   // more. This catches the next one written that way.
+  //
+  // A link to a line is a fragment, so it keeps the address it is written on and
+  // the words on the end of it with it, which is the whole point of it. What
+  // this rules out is a link that puts anything else on a document address.
   await check(
     session,
-    "no link on the document page is the same document with a parameter on the end",
+    "no link on the document page hangs the state of a search off the document",
     `[...document.querySelectorAll('a[href]')].every((a) => {
+      if (a.getAttribute('href').startsWith('#')) return true;
       const u = new URL(a.href, location.href);
-      return !(u.pathname.startsWith('/d/') && u.search);
+      if (!u.pathname.startsWith('/d/')) return true;
+      return [...new URLSearchParams(u.search).keys()].every((k) => k === 'q');
     })`,
   );
 

--- a/scripts/render-check.mjs
+++ b/scripts/render-check.mjs
@@ -253,6 +253,110 @@ async function run(session) {
 
   await check(
     session,
+    "a file shows a number on every line and each one is a link to that line",
+    expr(`
+      const { body } = await import('/assets/content.js');
+      const out = body({ id: 'repo:main.go', media_type: 'text/x-go', body: 'package main\\n\\nfunc main() {}\\n' });
+      const numbers = [...out.querySelectorAll('.line__no')];
+      return numbers.length === 4 &&
+        numbers.map((a) => a.textContent).join(',') === '1,2,3,4' &&
+        numbers[3].getAttribute('href') === '#L4' &&
+        numbers[0].getAttribute('aria-label') === 'Line 1';
+    `),
+  );
+
+  // The reason the whole file goes through the lexer in one pass. Highlighting
+  // a file a line at a time is faster to write and gets this wrong from the
+  // second line of the comment onwards, along with every raw string and every
+  // docstring.
+  await check(
+    session,
+    "a comment that runs over several lines is one comment on all of them",
+    expr(`
+      const { rows } = await import('/assets/highlight.js');
+      const lines = rows('/*\\n one\\n two\\n*/\\nfunc main() {}', 'go');
+      return lines.length === 5 &&
+        lines.slice(0, 4).every((line) => line.querySelector('.tok--comment')) &&
+        lines[4].querySelector('.tok--keyword').textContent === 'func';
+    `),
+  );
+
+  await check(
+    session,
+    "an address that names a line opens the file at it and marks which one",
+    expr(`
+      const { body } = await import('/assets/content.js');
+      const { reveal } = await import('/assets/marks.js');
+      const source = Array.from({ length: 60 }, (_, i) => 'line ' + i).join('\\n');
+      const out = body({ id: 'repo:main.go', media_type: 'text/x-go', body: source });
+      const at = reveal(out, '#L42');
+      return Boolean(at) && at.dataset.line === '42' &&
+        at.classList.contains('line--current') &&
+        out.querySelectorAll('.line--current').length === 1;
+    `),
+  );
+
+  // Following a link to a line in the file already on screen changes nothing but
+  // the address, so the move to that line is the only thing that can answer it.
+  await check(
+    session,
+    "a line address that arrives on an open file moves to that line and no further",
+    expr(`
+      const { body } = await import('/assets/content.js');
+      const { reveal, toLine } = await import('/assets/marks.js');
+      const source = Array.from({ length: 60 }, (_, i) => 'line ' + i).join('\\n');
+      const out = body({ id: 'repo:main.go', media_type: 'text/x-go', body: source });
+      reveal(out, '#L42');
+      const moved = toLine(out, '#L7');
+      const stayed = toLine(out, '#main');
+      return moved.dataset.line === '7' && stayed === null &&
+        out.querySelectorAll('.line--current').length === 1 &&
+        out.querySelector('.line--current').dataset.line === '7';
+    `),
+  );
+
+  await check(
+    session,
+    "a document opened from a search opens at the first of the words somebody typed",
+    expr(`
+      const { body } = await import('/assets/content.js');
+      const { reveal, terms } = await import('/assets/marks.js');
+      const out = body(
+        {
+          id: 'repo:notes.md',
+          media_type: 'text/markdown',
+          body: '# Notes\\n\\nThe first paragraph.\\n\\nThe cache is warmed at start up.\\n',
+        },
+        { query: 'source:repo cache -cold' },
+      );
+      const marks = [...out.querySelectorAll('mark.hit')];
+      return terms('source:repo cache -cold').join() === 'cache' &&
+        marks.length === 1 && marks[0].textContent === 'cache' &&
+        reveal(out, '') === marks[0];
+    `),
+  );
+
+  // A line number is a coordinate rather than a word in the file, so a query
+  // that happens to be a number must not paint the gutter with itself.
+  await check(
+    session,
+    "a search for a number marks the code and not the line numbers",
+    expr(`
+      const { body } = await import('/assets/content.js');
+      const lines = Array.from({ length: 60 }, () => 'const x = 1');
+      lines[2] = 'const limit = 42';
+      const out = body(
+        { id: 'repo:main.go', media_type: 'text/x-go', body: lines.join('\\n') },
+        { query: '42' },
+      );
+      const marks = [...out.querySelectorAll('mark.hit')];
+      return out.querySelectorAll('.line').length === 60 &&
+        marks.length === 1 && marks[0].closest('.line').dataset.line === '3';
+    `),
+  );
+
+  await check(
+    session,
     "a body the extractor could not read to the end says which half is missing",
     expr(`
       const { body } = await import('/assets/content.js');

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -1881,6 +1881,51 @@ h6.prose__h {
   tab-size: 4;
 }
 
+/* A whole file, one line at a time, with its number beside it.
+ *
+ * The gutter stays put while a long line scrolls past it, which is the only
+ * reason to number lines at all: a number that scrolls off the left edge is
+ * gone exactly when somebody is reading the line it belongs to. It sits on the
+ * block's own background so the code passes underneath rather than through it.
+ */
+.code--file .code__pre {
+  padding-left: 0;
+}
+
+.line {
+  display: block;
+}
+
+.line__no {
+  position: sticky;
+  left: 0;
+  display: inline-block;
+  width: 6ch;
+  padding-right: var(--space-3);
+  border-right: 1px solid var(--border);
+  margin-right: var(--space-4);
+  background: var(--bg-subtle);
+  color: var(--code-muted);
+  text-align: right;
+  text-decoration: none;
+  /* A line number is a coordinate rather than part of the file, so selecting
+     the code and copying it does not take the numbers along with it. */
+  user-select: none;
+}
+
+.line__no:hover {
+  color: var(--text);
+}
+
+.line--current {
+  background: var(--bg-active);
+}
+
+.line--current .line__no {
+  background: var(--bg-active);
+  color: var(--text);
+}
+
 .tok--keyword {
   color: var(--code-keyword);
 }

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -156,6 +156,14 @@ class App {
       this.query = urlState.read();
       this.sync();
     });
+
+    // A line address is the one link that lands on the screen it was sent from.
+    // Nothing above reacts to it: the path is the same, so sync would repaint
+    // the document it is already showing, and the document itself only looks at
+    // the address when it paints. This asks it to look again.
+    window.addEventListener("hashchange", () => {
+      if (urlState.route().name === "document") this.page.toLine();
+    });
   }
 
   build() {
@@ -477,7 +485,7 @@ class App {
 
     if (this.query.open && this.drawer.currentId !== this.query.open) {
       this.drawer.currentId = this.query.open;
-      this.drawer.show(this.query.open);
+      this.drawer.show(this.query.open, this.query.q);
     } else if (!this.query.open) {
       this.drawer.currentId = null;
       if (this.drawer.open) this.drawer.close();
@@ -499,7 +507,9 @@ class App {
     this.drawer.currentId = null;
     if (this.drawer.open) this.drawer.close({ notify: false, focus: false });
     if (this.main.firstChild !== this.page.el) replace(this.main, this.page.el);
-    await this.page.show(id);
+    // A document page carries the words that found it, so it opens where they
+    // are. A link somebody was sent carries none and opens at the top.
+    await this.page.show(id, this.query.q);
   }
 
   /**
@@ -972,7 +982,7 @@ class App {
         const hit = rows && rows.current();
         if (!hit) return;
         e.preventDefault();
-        window.open(urlState.documentPath(hit.id), "_blank", "noreferrer");
+        window.open(urlState.documentPath(hit.id, this.query.q), "_blank", "noreferrer");
         return;
       }
       if (e.key === "Escape") {

--- a/web/dist/assets/content.js
+++ b/web/dist/assets/content.js
@@ -12,6 +12,7 @@ import { render as markdown, codeBlock } from "./markdown.js";
 import { render as htmlDocument } from "./html.js";
 import { parse as parseNotebook, render as notebookCells } from "./notebook.js";
 import { player } from "./media.js";
+import { terms, mark } from "./marks.js";
 import { kindIcon, sourceColor, bytes as formatBytes } from "./format.js";
 
 // Media types the interface knows how to draw as code, and the language each
@@ -132,8 +133,20 @@ export function languageOf(d) {
  * Every branch produces the same reading experience at a different density:
  * one measure, one type scale, and no case where the reader has to work out
  * what they are looking at.
+ *
+ * options.query is what somebody typed to get here. Those words are marked
+ * wherever they appear in the text, whatever shape the document turned out to
+ * be, which is why it happens once out here rather than six times in there. The
+ * caller reveals the first of them once the nodes are on the page, because
+ * scrolling to something that is not in a document yet scrolls to nothing.
  */
-export function body(d) {
+export function body(d, options = {}) {
+  const node = draw(d);
+  mark(node, terms(options.query));
+  return node;
+}
+
+function draw(d) {
   const shape = shapeOf(d);
 
   if (shape === "image") {
@@ -168,10 +181,10 @@ export function body(d) {
     }
   }
   if (shape === "prose") {
-    const options = { imageNode: (src, alt) => inlineImage(d, src, alt) };
+    const imaging = { imageNode: (src, alt) => inlineImage(d, src, alt) };
     const media = (d.media_type || "").toLowerCase();
     const nodes =
-      PROSE[media] === "html" ? htmlDocument(d.body, options) : markdown(d.body, options);
+      PROSE[media] === "html" ? htmlDocument(d.body, imaging) : markdown(d.body, imaging);
     // A document whose first line is its own title would otherwise show that
     // title twice, once in the head of the drawer and once at the top of the
     // body, which reads as a rendering bug rather than as a document.
@@ -180,7 +193,14 @@ export function body(d) {
     return h("div", { class: "prose" }, truncated(d), nodes);
   }
   if (shape === "code") {
-    return h("div", { class: "preview preview--code" }, codeBlock(d.body, languageOf(d)));
+    // Numbers here and nowhere else. This is the whole file, so its first line
+    // is line one and every line below it has an address somebody can send.
+    return h(
+      "div",
+      { class: "preview preview--code" },
+      truncated(d),
+      codeBlock(d.body, languageOf(d), { numbers: true }),
+    );
   }
   // Reachable by keyboard for the same reason a code block is: the preview
   // scrolls, and a scrolling region a keyboard cannot reach is a document a

--- a/web/dist/assets/drawer.js
+++ b/web/dist/assets/drawer.js
@@ -13,6 +13,7 @@ import { cache } from "./cache.js";
 import { copies } from "./clipboard.js";
 import { icon, label, sourceColor, when, exact, followable, copyable } from "./format.js";
 import { body as renderBody, shapeOf, detailOf } from "./content.js";
+import { reveal } from "./marks.js";
 import { documentPath } from "./state.js";
 
 export class Drawer {
@@ -21,6 +22,7 @@ export class Drawer {
     this.onSay = onSay || (() => {});
     this.returnTo = null;
     this.currentKey = "";
+    this.query = "";
 
     this.title = h("h2", { class: "drawer__title", id: "drawer-title" });
     this.meta = h("div", { class: "drawer__meta" });
@@ -57,7 +59,8 @@ export class Drawer {
     return !this.el.hidden;
   }
 
-  async show(id) {
+  async show(id, query = "") {
+    this.query = query;
     this.returnTo = document.activeElement;
     this.el.hidden = false;
     this.scrim.hidden = false;
@@ -121,7 +124,10 @@ export class Drawer {
     // The body decides its own shape from the media type, so the drawer only
     // has to say where it goes and how wide it is.
     this.body.dataset.shape = shapeOf(d);
-    replace(this.body, renderBody(d));
+    replace(this.body, renderBody(d, { query: this.query }));
+    // Once the body is on the page and not before, because scrolling to a match
+    // that is still in a fragment scrolls to nothing.
+    reveal(this.body);
     // Opening at the source is only offered where a browser would go there. For
     // every document the file connector read it would not, so the path takes
     // its place: a path somebody can paste into a terminal is worth something,

--- a/web/dist/assets/highlight.js
+++ b/web/dist/assets/highlight.js
@@ -37,8 +37,54 @@ export function highlight(source, lang) {
   }
 
   root.textContent = source;
+  // Whatever is in here now is thrown away when the highlighter reaches it, so
+  // nothing else may write into it in the meantime. marks.js is the one that
+  // would, and this is how it knows to leave this block alone.
+  root.dataset.lazy = "1";
   watch(root, () => fill(root, source, spec));
   return root;
+}
+
+/**
+ * rows returns one element per line of the source, highlighted.
+ *
+ * A whole file is read by line number, so it has to be built line by line, and
+ * the tempting way to do that is to highlight each line on its own. That gets a
+ * block comment wrong from its second line onwards, and a raw string, and a
+ * triple quoted docstring, which between them are most of what colour is for.
+ * So the scan is over the whole source, exactly as it is for a block, and the
+ * tokens it returns are cut at the newlines afterwards.
+ *
+ * This is eager where the block renderer is lazy. A file is one block and it is
+ * the thing somebody opened the page to read, so there is nothing to defer it
+ * behind, and the numbers in the gutter have to be there before anything can
+ * scroll to line four hundred.
+ */
+export function rows(source, lang) {
+  const spec = LANGS[alias(lang)];
+  const lines = source.split("\n").map((text) => h("span", { class: "line__text" }, text));
+  if (spec) split(lines, scan(source, spec));
+  return lines;
+}
+
+/** split lays a scan of the whole source back out over its lines. */
+function split(lines, tokens) {
+  const built = lines.map(() => document.createDocumentFragment());
+  let at = 0;
+  for (const token of tokens) {
+    const parts = token.text.split("\n");
+    for (let i = 0; i < parts.length; i++) {
+      if (i) at++;
+      if (at >= built.length || !parts[i]) continue;
+      built[at].appendChild(
+        token.cls ? h("span", { class: `tok tok--${token.cls}` }, parts[i]) : document.createTextNode(parts[i]),
+      );
+    }
+  }
+  lines.forEach((line, i) => {
+    line.textContent = "";
+    line.appendChild(built[i]);
+  });
 }
 
 /** languages returns the names highlighting is available for. */
@@ -53,6 +99,7 @@ function fill(root, source, spec) {
   }
   root.textContent = "";
   root.appendChild(frag);
+  delete root.dataset.lazy;
 }
 
 let observer = null;

--- a/web/dist/assets/markdown.js
+++ b/web/dist/assets/markdown.js
@@ -12,7 +12,8 @@
 // this file and it is the reason it is hand written rather than pulled in.
 
 import { h } from "./dom.js";
-import { highlight } from "./highlight.js";
+import { highlight, rows } from "./highlight.js";
+import { current } from "./marks.js";
 import { frame } from "./table.js";
 
 /**
@@ -259,20 +260,36 @@ function table(rows, options) {
   );
 }
 
+// A file longer than this is shown without a gutter.
+//
+// Every numbered line is two more elements and the whole file is built in one
+// go, so this is where the one screen in the interface that could jank would
+// be. It is well past what anybody reads in a preview, the copy button still
+// hands over all of it, and a generated file of a hundred thousand lines is not
+// worth making every other file wait for.
+const NUMBERED_MAX = 4000;
+
 /**
- * codeBlock renders a fenced block, with its language named and a copy button.
+ * codeBlock renders a block of code, with its language named and a copy button.
  *
  * The head is only drawn when there is something to put in it, so a two line
  * snippet does not grow a bar of chrome taller than the code inside it.
+ *
+ * options.numbers draws the gutter, and only the shape that is a whole file
+ * passes it. A fenced block inside a document is an excerpt somebody quoted and
+ * its first line is not line one of anything, so a number beside it would be a
+ * fact about the code block rather than about the file it came from.
  */
-export function codeBlock(source, lang) {
-  const code = h("code", { class: "code__text" }, highlight(source, lang));
+export function codeBlock(source, lang, options = {}) {
+  const lines = source.split("\n");
+  const numbered = Boolean(options.numbers) && lines.length <= NUMBERED_MAX;
+  const code = h("code", { class: "code__text" }, numbered ? gutter(source, lang) : highlight(source, lang));
   // A code block scrolls sideways when a line is long, and a region that
   // scrolls has to be reachable by keyboard or the only way to read the end of
   // that line is a mouse.
   const pre = h("pre", { class: "code__pre", tabindex: "0" }, code);
-  const long = source.split("\n").length > 6;
-  if (!lang && !long) return h("div", { class: "code" }, pre);
+  const long = lines.length > 6;
+  if (!lang && !long && !numbered) return h("div", { class: "code" }, pre);
 
   const copy = h(
     "button",
@@ -296,10 +313,45 @@ export function codeBlock(source, lang) {
   );
   return h(
     "div",
-    { class: "code" },
+    { class: numbered ? "code code--file" : "code" },
     h("div", { class: "code__head" }, h("span", { class: "code__lang" }, lang || "text"), copy),
     pre,
   );
+}
+
+/**
+ * gutter is the file, one line at a time, each with its number beside it.
+ *
+ * The number is a link to itself. That is the whole of the feature: a line
+ * somebody wants to talk about has an address, and pasting that address opens
+ * the file there. The click is handled rather than followed because this
+ * document was painted after a fetch, so by the time the browser would have
+ * jumped to the fragment there was nothing on the page to jump to.
+ */
+function gutter(source, lang) {
+  const out = document.createDocumentFragment();
+  rows(source, lang).forEach((text, i) => {
+    const at = String(i + 1);
+    const number = h(
+      "a",
+      {
+        class: "line__no",
+        href: `#L${at}`,
+        "aria-label": `Line ${at}`,
+        onClick: (e) => {
+          e.preventDefault();
+          // replace rather than push, because reading down a file and tapping
+          // numbers as you go should not fill the back button with lines.
+          history.replaceState(null, "", `#L${at}`);
+          const line = e.currentTarget.closest(".line");
+          current(line.closest(".code"), line);
+        },
+      },
+      at,
+    );
+    out.appendChild(h("span", { class: "line", "data-line": at }, number, text));
+  });
+  return out;
 }
 
 // Inline ------------------------------------------------------------------

--- a/web/dist/assets/marks.js
+++ b/web/dist/assets/marks.js
@@ -1,0 +1,161 @@
+// Finding the words somebody typed inside the document they opened.
+//
+// This is a different claim from the one a result row makes. The snippet on a
+// row is the server's answer to why that document came back, and the runs
+// marked in it are the ones the analyzer that built the index said matched.
+// That answer belongs to the server and is never guessed at here.
+//
+// What this does is answer a reader's question instead: where in the page in
+// front of me are the words I asked for. It is the browser's job because the
+// body is already in the browser, and asking the server to find a word in a
+// document it has just finished sending is a second request for something that
+// takes a millisecond here.
+//
+// The two can disagree. A search for cache matches a document that only says
+// caching, because the index stems and this does not. A word ending may follow
+// a term for that reason and nothing else is allowed to, so when the two
+// disagree the marks are missing rather than wrong, and a document with no
+// marks in it opens at the top the way it always did.
+
+import { h } from "./dom.js";
+
+// The most marks worth drawing. A one word query against a file that repeats
+// that word on every line is a thousand elements nobody is going to look at,
+// and the first one is the only one that decides where the page opens.
+const MAX = 400;
+
+// Two characters, because a single letter appears in every document ever
+// written and marking all of it marks nothing.
+const MIN = 2;
+
+// Words in a query that are the query language rather than the words somebody
+// is looking for.
+const OPERATORS = new Set(["AND", "OR", "NOT"]);
+
+// Where a word is not a word. A line number is a coordinate, so a search for 42
+// must not paint the gutter, and a block waiting to be highlighted is about to
+// have its contents replaced.
+const SKIP = "mark, .line__no, .code__head, [data-lazy]";
+
+/**
+ * terms picks the words out of a query that are worth looking for in a body.
+ *
+ * A quoted phrase stays whole, because somebody who asked for "index format"
+ * meant the pair. A field filter and a negated word are dropped: neither is
+ * text to find, and marking the word somebody asked not to see is the opposite
+ * of what they asked for.
+ */
+export function terms(query) {
+  const found = [];
+  const rest = String(query || "").replace(/"([^"]+)"/g, (_, phrase) => {
+    found.push(phrase);
+    return " ";
+  });
+  for (const word of rest.split(/\s+/)) {
+    if (!word || word.includes(":") || word.startsWith("-")) continue;
+    if (OPERATORS.has(word.toUpperCase())) continue;
+    found.push(word);
+  }
+
+  const out = [];
+  for (const term of found) {
+    const clean = term.trim().replace(/[*?]/g, "").toLowerCase();
+    if (clean.length < MIN || out.includes(clean)) continue;
+    out.push(clean);
+  }
+  // A query longer than this is a sentence somebody pasted, and marking every
+  // word of a sentence marks the whole document.
+  return out.slice(0, 8);
+}
+
+/**
+ * mark wraps every occurrence of those words in the tree, and returns how many.
+ *
+ * The text nodes are collected before any of them is replaced. Walking and
+ * mutating at the same time means walking into the nodes just built, which
+ * finds the same word again inside the mark that was drawn around it.
+ */
+export function mark(root, words) {
+  if (!words.length) return 0;
+  const pattern = new RegExp(`\\b(${words.map(escape).join("|")})\\w*`, "gi");
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    if (!node.nodeValue.trim()) continue;
+    if (node.parentElement && node.parentElement.closest(SKIP)) continue;
+    nodes.push(node);
+  }
+
+  let count = 0;
+  for (const node of nodes) {
+    if (count >= MAX) break;
+    const text = node.nodeValue;
+    const out = document.createDocumentFragment();
+    let at = 0;
+    pattern.lastIndex = 0;
+    for (let hit = pattern.exec(text); hit && count < MAX; hit = pattern.exec(text)) {
+      if (hit.index > at) out.appendChild(document.createTextNode(text.slice(at, hit.index)));
+      out.appendChild(h("mark", { class: "hit" }, hit[0]));
+      at = hit.index + hit[0].length;
+      count++;
+    }
+    if (!at) continue;
+    if (at < text.length) out.appendChild(document.createTextNode(text.slice(at)));
+    node.parentNode.replaceChild(out, node);
+  }
+  return count;
+}
+
+/**
+ * reveal moves a document to the part of it somebody came for.
+ *
+ * A line in the address wins over a word in the query, because a link to line
+ * forty two was written by a person who meant line forty two, and the query it
+ * carries is only how they found the file.
+ *
+ * Nothing moves when there is neither, which is the case for every document
+ * opened from the rail or from a link with nothing on the end of it, and the
+ * top of a document is where reading starts.
+ */
+export function reveal(root, hash = location.hash) {
+  const line = toLine(root, hash);
+  const target = line || root.querySelector("mark.hit");
+  if (!target) return null;
+  // center rather than the default, so a match on the last line of a file is
+  // not left one pixel above the fold with nothing around it to read.
+  if (!line) target.scrollIntoView({ block: "center", inline: "nearest" });
+  return target;
+}
+
+/**
+ * toLine moves to the line an address names and says whether there was one.
+ *
+ * This is the half of reveal that an address arriving on a page already open
+ * is allowed to do. A line is a place somebody asked for. The first match is
+ * only where reading starts, and going back to it because somebody followed a
+ * link to the top of the page would move them away from what they were reading.
+ */
+export function toLine(root, hash = location.hash) {
+  const line = lineOf(root, hash);
+  if (!line) return null;
+  current(root, line);
+  line.scrollIntoView({ block: "center", inline: "nearest" });
+  return line;
+}
+
+/** lineOf finds the line an address names, if it names one that is there. */
+export function lineOf(root, hash = location.hash) {
+  const at = /^#L(\d+)$/.exec(String(hash || ""));
+  return at ? root.querySelector(`[data-line="${at[1]}"]`) : null;
+}
+
+/** current marks one line as the one being pointed at, and unmarks the rest. */
+export function current(root, line) {
+  for (const was of root.querySelectorAll(".line--current")) was.classList.remove("line--current");
+  if (line) line.classList.add("line--current");
+}
+
+function escape(term) {
+  return term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/web/dist/assets/page.js
+++ b/web/dist/assets/page.js
@@ -25,6 +25,7 @@ import {
   copyable,
 } from "./format.js";
 import { body as renderBody, shapeOf, detailOf } from "./content.js";
+import { reveal, toLine } from "./marks.js";
 import { documentPath } from "./state.js";
 
 export class Page {
@@ -32,6 +33,7 @@ export class Page {
     this.onBack = onBack;
     this.onSay = onSay || (() => {});
     this.currentKey = "";
+    this.query = "";
 
     this.back = h("div", { class: "page__back" });
     this.meta = h("div", { class: "page__meta" });
@@ -49,7 +51,8 @@ export class Page {
     );
   }
 
-  async show(id) {
+  async show(id, query = "") {
+    this.query = query;
     const k = cache.key("document", { id });
     if (this.currentKey === k) return;
     this.currentKey = k;
@@ -75,6 +78,19 @@ export class Page {
       if (err.name === "AbortError") return;
       if (!painted && this.currentKey === k) this.renderError(err);
     }
+  }
+
+  /**
+   * toLine moves to a line named by an address that arrived while this page was
+   * already open.
+   *
+   * Following a link to a line in the file being read is not a navigation as far
+   * as the browser is concerned. The path does not change, so nothing is fetched
+   * and nothing is painted, and without this the page would sit exactly where it
+   * was while the address bar claimed otherwise.
+   */
+  toLine() {
+    toLine(this.content);
   }
 
   /**
@@ -143,14 +159,20 @@ export class Page {
     );
 
     this.content.dataset.shape = shapeOf(d);
-    replace(this.content, renderBody(d));
+    replace(this.content, renderBody(d, { query: this.query }));
     replace(this.foot, actions(d, this.onSay));
 
     // Focus goes to the heading rather than to the first control, because this
     // is a document somebody came to read and the top of it is where reading
     // starts. It carries tabindex="-1" so it can take focus without joining the
     // tab order.
-    this.title.focus();
+    //
+    // Without preventScroll it would also put the top of the document on the
+    // screen, which is the one place a page opened at line four hundred must
+    // not be. Focus and the scroll position are two different questions here:
+    // reading starts at the heading and the eye starts at the match.
+    this.title.focus({ preventScroll: true });
+    if (!reveal(this.content)) this.el.scrollIntoView({ block: "start" });
   }
 
   /**

--- a/web/dist/assets/rows.js
+++ b/web/dist/assets/rows.js
@@ -18,6 +18,18 @@ import { tile, cover } from "./content.js";
 import { copies } from "./clipboard.js";
 import * as urlState from "./state.js";
 
+/**
+ * asked is the words in the address bar.
+ *
+ * A row does not hold a query and is not about to start. It reads the address
+ * when it builds a link, which is the same thing every other reader of this
+ * state does: the address bar is the state, and a copy of it kept in here would
+ * be a copy that could disagree.
+ */
+function asked() {
+  return urlState.read().q;
+}
+
 export class RowList {
   constructor({ onOpen, onHover, onSay, onCursor, label: name } = {}) {
     this.onOpen = onOpen || (() => {});
@@ -153,7 +165,7 @@ export class RowList {
         "a",
         {
           class: "cell__title",
-          href: urlState.documentPath(hit.id),
+          href: urlState.documentPath(hit.id, asked()),
           title: hit.title || hit.id,
           onClick: (e) => {
             if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
@@ -218,7 +230,7 @@ export class RowList {
         "a",
         {
           class: "result__title",
-          href: urlState.documentPath(hit.id),
+          href: urlState.documentPath(hit.id, asked()),
           onClick: (e) => {
             if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
             e.preventDefault();

--- a/web/dist/assets/state.js
+++ b/web/dist/assets/state.js
@@ -11,9 +11,11 @@ const LIST_KEYS = ["source", "kind", "container", "author", "owner"];
 //
 // A document is the thing somebody pastes into a message, so it gets an address
 // that survives being read out loud and does not carry the state of whoever
-// found it. Recent is a path because it is not a view of a search: it answers
-// what has been going on rather than what matches, and a rail entry that ran a
-// recency sorted search was answering the wrong question with the right rows.
+// found it. The words they searched for are the one exception, and the reason
+// is written on documentPath below. Recent is a path because it is not a view
+// of a search: it answers what has been going on rather than what matches, and
+// a rail entry that ran a recency sorted search was answering the wrong
+// question with the right rows.
 const DOCUMENT = "/d/";
 export const RECENT = "/recent";
 
@@ -30,9 +32,22 @@ export function route(pathname = location.pathname) {
   return id ? { name: "document", id } : { name: "search", id: "" };
 }
 
-/** documentPath is the address of one document as a page of its own. */
-export function documentPath(id) {
-  return DOCUMENT + encodeURIComponent(id);
+/**
+ * documentPath is the address of one document as a page of its own.
+ *
+ * The words somebody searched for are the one piece of the state around a
+ * result that belongs on this address, and every link on a result row carries
+ * them. They are not how that person found the document, which is what this
+ * address deliberately leaves out: no filters, no sort, no page and no cursor.
+ * They are where in the document to start reading, and a middle click on a
+ * result has to land in the same place a plain click does.
+ *
+ * Nothing that offers this address to be copied passes them, because a link
+ * somebody sends is about the document rather than about the search behind it.
+ */
+export function documentPath(id, q = "") {
+  const path = DOCUMENT + encodeURIComponent(id);
+  return q ? `${path}?q=${encodeURIComponent(q)}` : path;
 }
 
 // A path somebody typed or a link somebody mangled can hold a percent sign that


### PR DESCRIPTION
Closes #108.

The previous pull request covered the shapes.
This one covers the last two boxes on that issue, which are both about landing in the right place inside a file rather than at the top of it.

## Line numbers

A file rendered as code now shows a number on every line, and each number is a link to that line.
The numbers are real text in a gutter rather than a CSS counter, because a counter cannot be an anchor, and they carry `user-select: none` so that selecting the code does not take the numbers along with it.
An address like `#L42` opens the file at line 42 and marks which line it is.
The mark is a class on the line rather than a browser fragment jump, because the page paints after a fetch and the browser would look for the line before it exists.
Line numbers stay off fenced blocks inside prose, since the first line of an excerpt is not line one of anything.

## Opening at the match

Every link on a result row now carries the words that were searched for, so a document opened from a result marks them in the body and opens at the first one.
An address that names a line wins over the words, because a link to line 42 was written by somebody who meant line 42.
Nothing that offers the address to be copied passes the words, because a link somebody sends is about the document rather than about the search behind it.

This is a different claim from the snippet on a result row.
The snippet is the server's answer to why a document came back and is never guessed at on the client.
These marks answer where the reader's words are on the page, and where the index stems a word and this does not, the marks are missing rather than wrong.

Following a line link inside the file already on screen is not a navigation as far as the browser is concerned, so the shell listens for the address changing and moves to the line itself.

## Along the way

Highlighting had to learn to scan a whole file in one pass and then cut the result into lines.
Doing it a line at a time ended a block comment, a raw string and a docstring at the first newline in them.

Marking skips a block that is waiting on the lazy highlighter, because that block is about to have its contents replaced and any mark drawn in it first would disappear without a trace.

## Bounds

Whole file line numbers stop at 4000 lines and marking stops at 400 marks, both to keep the node count of a large file sane.
The gzipped script budget is 82867 bytes of 184320.

## Checks

`make fmt`, `make vet`, `make lint`, `make race`, the asset budget test, and `make ui-gate` with 39 keyboard assertions, 17 rendering assertions and axe over six screens with no violations.
Lighthouse reports performance 88, accessibility 100 and best practices 100.

One keyboard assertion changed.
It used to say that no link on a document page is a document address with any parameter on the end, which was written to catch a rail entry written as a bare query string.
A link to a line is a fragment, so it keeps the address it sits on and the words with it, and the assertion now rules out every parameter but those words.