### PR TITLE
Offer the spelling that would have worked

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,13 @@ linters:
           - noctx
           - prealloc
 
+      # The correction is code about misspelled words, so it is full of them on
+      # purpose. Every one is a documented example or a test case, and there is
+      # no version of this that the spell checker is happy with.
+      - path: spell(_test)?\.go
+        linters:
+          - misspell
+
 formatters:
   enable:
     - gofmt

--- a/api/api.go
+++ b/api/api.go
@@ -235,6 +235,12 @@ type searchResponse struct {
 	TookMS  float64            `json:"took_ms"`
 	Hits    []searchHit        `json:"hits"`
 	Facets  map[string][]facet `json:"facets"`
+
+	// Correction is a spelling of the query that would have found something. It
+	// is only ever present on a search that found nothing, and it has already
+	// been run as the person asking, so it is a query they can run rather than
+	// a word somebody else's documents contain.
+	Correction string `json:"correction,omitempty"`
 }
 
 // searchFilters echoes the parsed query back. A shareable URL and a typed
@@ -300,14 +306,15 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 	s.metrics.observeSearch(res.Took, res.Candidates, res.Total)
 
 	out := searchResponse{
-		Query:   r.URL.Query().Get("q"),
-		Text:    query.Text,
-		Filters: filtersOf(query),
-		Total:   res.Total,
-		Partial: res.Truncated,
-		TookMS:  float64(res.Took.Microseconds()) / 1000,
-		Facets:  facets(res.Facets),
-		Hits:    []searchHit{},
+		Query:      r.URL.Query().Get("q"),
+		Text:       query.Text,
+		Filters:    filtersOf(query),
+		Total:      res.Total,
+		Partial:    res.Truncated,
+		TookMS:     float64(res.Took.Microseconds()) / 1000,
+		Facets:     facets(res.Facets),
+		Hits:       []searchHit{},
+		Correction: res.Correction,
 	}
 	for _, h := range res.Hits {
 		hit := hitOf(h.Document)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -103,9 +103,10 @@ func TestSearchWithoutACredentialIsRejected(t *testing.T) {
 }
 
 type searchBody struct {
-	Query string `json:"query"`
-	Total int    `json:"total"`
-	Hits  []struct {
+	Query      string `json:"query"`
+	Total      int    `json:"total"`
+	Correction string `json:"correction"`
+	Hits       []struct {
 		ID      string  `json:"id"`
 		Title   string  `json:"title"`
 		Snippet string  `json:"snippet"`
@@ -131,6 +132,32 @@ func TestSearchReturnsOnlyWhatTheCallerMayRead(t *testing.T) {
 	}
 	if strings.Contains(w.Body.String(), "Globex") {
 		t.Fatal("the response leaked a document the caller may not read")
+	}
+}
+
+// A correction rides on the search that found nothing, so the interface has it
+// at the moment it has to draw an empty screen rather than a request later.
+func TestSearchOffersACorrectionOnTheAnswerThatFoundNothing(t *testing.T) {
+	h := newServer(t)
+
+	w := request(t, h, http.MethodGet, "/api/v1/search?q=paymnets", engineer())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body)
+	}
+	body := decode[searchBody](t, w)
+	if body.Total != 0 {
+		t.Fatalf("paymnets matched %d documents, so there is nothing to correct", body.Total)
+	}
+	if body.Correction != "payments" {
+		t.Fatalf("correction = %q, want payments", body.Correction)
+	}
+
+	// And a query that worked carries no correction at all, rather than an
+	// empty one, because a client that reads a field that is always there ends
+	// up drawing an empty offer.
+	w = request(t, h, http.MethodGet, "/api/v1/search?q=payments", engineer())
+	if strings.Contains(w.Body.String(), "correction") {
+		t.Fatalf("a search that found results carried a correction: %s", w.Body)
 	}
 }
 

--- a/index/counters_test.go
+++ b/index/counters_test.go
@@ -63,6 +63,13 @@ func rowBudget(pool, terms, hits int) int64 {
 	rows += facetRows
 	// The corpus row and one row per term of statistics.
 	rows += 1 + terms
+	// A search that found nothing looks for a spelling that would have found
+	// something, which reads four windows of the term table per word it does
+	// not recognise and then confirms the corrected query as the asker. That
+	// confirmation is a candidate cut for a single row.
+	if hits == 0 {
+		rows += terms*4*sqlitestore.NearWindow + 1
+	}
 	// And the page that is actually returned.
 	return int64(rows + hits)
 }

--- a/index/index.go
+++ b/index/index.go
@@ -164,6 +164,16 @@ type Results struct {
 	// start moving together is the day the first phase stopped cutting.
 	Candidates int
 
+	// Correction is a spelling of the query that would have found something,
+	// and is empty when there is none or when the query found results of its
+	// own. It is a query rather than a word so that the interface has something
+	// to link to rather than a hint to assemble.
+	//
+	// It has already been run as the person asking, so offering it cannot tell
+	// them that a word exists in a document they may not read. See
+	// [Searcher.correct].
+	Correction string
+
 	// Took is how long the search ran for. It is reported rather than logged
 	// because the interface shows it, and a number a user can see is a number
 	// somebody will keep honest.
@@ -305,6 +315,11 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 		Candidates: len(found.cands),
 	}
 	if len(found.cands) == 0 {
+		// Nothing matched, which is the only place a correction is worth looking
+		// for and the only place one is allowed to appear.
+		if res.Correction, err = s.correct(ctx, p, q, req.Terms, found.corpus); err != nil {
+			return Results{}, err
+		}
 		res.Took = s.now().Sub(start)
 		return res, nil
 	}

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -50,31 +50,7 @@ func newSearcher(t *testing.T, fixtures []fixture, opts ...index.Option) *index.
 	st := memstore.New()
 	t.Cleanup(func() { _ = st.Close() })
 
-	docs := make([]doc.Document, 0, len(fixtures))
-	for _, f := range fixtures {
-		if f.source == "" {
-			f.source = "gdrive"
-		}
-		if f.kind == "" {
-			f.kind = doc.KindPage
-		}
-		var props map[string]string
-		if f.media != "" {
-			props = map[string]string{doc.MediaType: f.media}
-		}
-		docs = append(docs, doc.Document{
-			ID:          f.id,
-			Tenant:      "acme",
-			Source:      f.source,
-			Kind:        f.kind,
-			Title:       f.title,
-			Body:        f.body,
-			ModifiedAt:  f.modified,
-			Permissions: f.perm,
-			Properties:  props,
-		})
-	}
-	if err := st.Put(t.Context(), docs...); err != nil {
+	if err := st.Put(t.Context(), documents(fixtures)...); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 

--- a/index/spell.go
+++ b/index/spell.go
@@ -1,0 +1,113 @@
+package index
+
+import (
+	"context"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// correctionWords is the longest query a correction is offered for.
+//
+// A query of two or three words that found nothing is usually one word typed
+// wrong. A query of nine words that found nothing is usually a sentence
+// somebody pasted, and there is no spelling of it that would have worked, so
+// the offer would be noise on top of a screen that already says nothing
+// matched.
+const correctionWords = 4
+
+// correctionShortest is the shortest word worth correcting. Two letters are
+// within one edit of most of the alphabet, and a suggestion drawn from that is
+// a guess rather than a correction.
+const correctionShortest = 3
+
+// correct is the "did you mean" on a search that found nothing.
+//
+// It runs only on the empty result, only on a short query, and only for terms
+// the corpus does not have at all, which is what keeps it from second guessing a
+// query that is spelled fine and simply matched nothing this week. The document
+// frequencies it reads for that were already fetched to score the query, so
+// deciding whether to try costs no reads.
+//
+// The security rule is the interesting part, and it belongs to this function
+// rather than to the driver. A vocabulary is a fact about the tenant, and the
+// person asking may not read every document in the tenant, so a term taken
+// straight out of the index and shown would answer "does the word incident
+// appear anywhere in this company" for somebody with access to nothing. The
+// corrected query is therefore run as the asker before it is offered, asking
+// for a single row, and it is dropped unless it found one. What is shown is
+// then a query that person can run and get results from, which is the only
+// thing a correction was ever supposed to be.
+func (s *Searcher) correct(ctx context.Context, p *acl.Principal, q Query, terms []string, corpus store.Corpus) (string, error) {
+	sp, ok := s.store.(store.Speller)
+	if !ok || q.Text == "" || len(terms) == 0 || len(terms) > correctionWords {
+		return "", nil
+	}
+
+	swap := make(map[string]string, len(terms))
+	for _, t := range terms {
+		if corpus.DocFreq[t] > 0 || utf8.RuneCountInString(t) < correctionShortest {
+			continue
+		}
+		near, err := sp.Near(ctx, p, t, 1)
+		if err != nil {
+			return "", err
+		}
+		if len(near) > 0 {
+			swap[t] = near[0]
+		}
+	}
+	if len(swap) == 0 {
+		return "", nil
+	}
+
+	text := replaceTerms(q.Text, swap)
+	if text == q.Text {
+		return "", nil
+	}
+
+	// The confirmation. Same filters, because the offer has to lead to the page
+	// the person is looking at, and one row, because whether there is a result
+	// is the whole question.
+	confirm := q
+	confirm.Text = text
+	found, err := s.collect(ctx, p, confirm.Request(), store.Selection{Limit: 1})
+	if err != nil {
+		return "", err
+	}
+	if len(found.cands) == 0 {
+		return "", nil
+	}
+	return text, nil
+}
+
+// replaceTerms rewrites the words of a query that were corrected and leaves
+// every other character where it was.
+//
+// It works on the analyzer's own spans rather than on a string replacement,
+// which is what keeps it from touching the cache inside caching, and what keeps
+// the quotes, the filters and the capitalisation of the words that were spelled
+// right exactly as they were typed.
+func replaceTerms(text string, swap map[string]string) string {
+	var (
+		out  strings.Builder
+		last int
+	)
+	for _, span := range doc.Analyze(text) {
+		to, ok := swap[span.Term]
+		if !ok {
+			continue
+		}
+		out.WriteString(text[last:span.Start])
+		out.WriteString(to)
+		last = span.End
+	}
+	if last == 0 {
+		return text
+	}
+	out.WriteString(text[last:])
+	return out.String()
+}

--- a/index/spell_test.go
+++ b/index/spell_test.go
@@ -1,0 +1,129 @@
+package index_test
+
+import (
+	"testing"
+
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// The corpus a correction is drawn from. The words that matter are the ones in
+// the bodies: what is offered has to come from the index rather than from a
+// dictionary, and northwind is not a word a dictionary of English has.
+var misspelt = []fixture{
+	{id: "d1", title: "Payments failover runbook", body: "Invalidate the payments cache before the failover.", perm: openTo("eng@acme.com")},
+	{id: "d2", title: "Weekly engineering notes", body: "The cache was cold for an hour.", perm: openTo("eng@acme.com")},
+	{id: "d3", title: "Board deck", body: "Acquisition of northwind, unannounced.", perm: openTo("board@acme.com")},
+}
+
+// plainStore is a driver with none of its optional capabilities showing. Only
+// the methods of [store.Store] are promoted through the embedded interface, so
+// what the searcher sees is a driver that cannot name a word.
+type plainStore struct{ store.Store }
+
+func TestSearchOffersASpellingThatWouldHaveWorked(t *testing.T) {
+	s := newSearcher(t, misspelt)
+	p := principal("gdrive:eng@acme.com")
+
+	res := search(t, s, p, index.Query{Text: "cahce"})
+	if len(res.Hits) != 0 {
+		t.Fatalf("cahce matched %d documents, so there is nothing to correct", len(res.Hits))
+	}
+	if res.Correction != "cache" {
+		t.Fatalf("Correction = %q, want cache", res.Correction)
+	}
+
+	// And the correction is a query rather than a word, so what the interface
+	// links to is what was confirmed.
+	if got := search(t, s, p, index.Query{Text: res.Correction}); len(got.Hits) == 0 {
+		t.Fatal("the correction that was offered returns nothing when it is run")
+	}
+}
+
+func TestSearchCorrectsTheWordAndLeavesTheRestOfTheQueryAlone(t *testing.T) {
+	s := newSearcher(t, misspelt)
+
+	// Everything that was not the misspelled word comes back exactly as it was
+	// typed, capitals and punctuation included, because what is offered is the
+	// query somebody meant to type rather than a rewrite of it.
+	res := search(t, s, principal("gdrive:eng@acme.com"), index.Query{Text: "The cahce."})
+	if res.Correction != "The cache." {
+		t.Fatalf("Correction = %q, want The cache.", res.Correction)
+	}
+}
+
+func TestSearchOffersNothingWhenTheQueryWorked(t *testing.T) {
+	s := newSearcher(t, misspelt)
+
+	res := search(t, s, principal("gdrive:eng@acme.com"), index.Query{Text: "cache"})
+	if len(res.Hits) == 0 {
+		t.Fatal("cache matched nothing, so this proves nothing")
+	}
+	if res.Correction != "" {
+		t.Fatalf("Correction = %q on a search that found results", res.Correction)
+	}
+}
+
+// The one that is not about spelling.
+//
+// A vocabulary is a fact about the tenant and results are not, so a correction
+// taken out of the index and shown would tell somebody that a word appears in a
+// document they may not read. Northwind appears once, in the board deck, and
+// nobody outside the board gets to learn that by mistyping it.
+func TestSearchNeverCorrectsTowardsADocumentTheAskerCannotRead(t *testing.T) {
+	s := newSearcher(t, misspelt)
+
+	res := search(t, s, principal("gdrive:eng@acme.com"), index.Query{Text: "northwnd"})
+	if res.Correction != "" {
+		t.Fatalf("Correction = %q, drawn from a document this reader may not open", res.Correction)
+	}
+
+	// The same query from somebody who may read it is corrected, which is what
+	// makes the case above a permission decision rather than a driver that
+	// found nothing.
+	res = search(t, s, principal("gdrive:board@acme.com"), index.Query{Text: "northwnd"})
+	if res.Correction != "northwind" {
+		t.Fatalf("Correction = %q for a reader of the board deck, want northwind", res.Correction)
+	}
+}
+
+func TestSearchCorrectsUnderTheFiltersThatAreOn(t *testing.T) {
+	s := newSearcher(t, misspelt)
+
+	// A correction that leads to a page with nothing on it is a second dead
+	// end, so the confirmation carries the filters that are on. The cache is
+	// only in gdrive pages, and this asks for it in salesforce.
+	res := search(t, s, principal("gdrive:eng@acme.com"), index.Query{Text: "cahce", Sources: []string{"salesforce"}})
+	if res.Correction != "" {
+		t.Fatalf("Correction = %q, which finds nothing under the filters that are on", res.Correction)
+	}
+}
+
+func TestSearchOffersNothingForALongQuery(t *testing.T) {
+	s := newSearcher(t, misspelt)
+
+	// Six words that found nothing is a sentence somebody pasted rather than a
+	// typo, and there is no spelling of it that would have worked.
+	res := search(t, s, principal("gdrive:eng@acme.com"), index.Query{Text: "invalidate payments cahce before failover please"})
+	if res.Correction != "" {
+		t.Fatalf("Correction = %q for a query of six words", res.Correction)
+	}
+}
+
+func TestSearchOffersNothingWhenTheStoreCannotSpell(t *testing.T) {
+	// A driver without the capability is not an error, it is a search with no
+	// correction on it. This is the reference driver with the capability hidden,
+	// which is what a driver that never had one looks like from here.
+	mem := memstore.New()
+	t.Cleanup(func() { _ = mem.Close() })
+	if err := mem.Put(t.Context(), documents(misspelt)...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	s := index.New(plainStore{Store: mem}, index.WithClock(clock))
+
+	res := search(t, s, principal("gdrive:eng@acme.com"), index.Query{Text: "cahce"})
+	if res.Correction != "" {
+		t.Fatalf("Correction = %q from a driver that cannot name a word", res.Correction)
+	}
+}

--- a/scripts/state-check.mjs
+++ b/scripts/state-check.mjs
@@ -3,8 +3,9 @@
 // Everything the gate looks at elsewhere is the happy path, and most of what
 // decides whether somebody trusts a search product is not. This drives the
 // states: a search that is slow, a search that is very slow, a check that
-// failed behind an answer, a query that matched nothing because of a filter, an
-// index with nothing in it, and a document that is either missing or forbidden.
+// failed behind an answer, a query that matched nothing because of a filter or
+// because of a typo, an index with nothing in it, and a document that is either
+// missing or forbidden.
 //
 // Four of those need a request that does not answer, so this one holds the
 // search endpoint open from the browser side rather than asking the server for
@@ -190,6 +191,26 @@ async function run(session) {
     session,
     "clearing the filters from that page brings the results back",
     "Boolean(document.querySelector('.result'))",
+  );
+
+  // Nothing matched because of a typo, which is the one empty screen that has a
+  // way out that is not a filter. The word comes from the index of this
+  // repository rather than from a dictionary, and the server has already run it
+  // as this reader, so what is on screen is a search that works.
+  await visit(session, `${BASE}/?q=serach`, "Boolean(document.querySelector('.state__correction'))");
+  await check(
+    session,
+    "a search that found nothing because of a typo offers the spelling that works",
+    "document.querySelector('.state__correction').textContent === 'search'",
+  );
+
+  await evaluate(session, "document.querySelector('.state__correction').click(), true");
+  await settle(session, "Boolean(document.querySelector('.result'))");
+  await check(
+    session,
+    "and pressing it runs that search, box and address and all",
+    `document.querySelector('.omnibox__input').value === 'search' &&
+      location.search.includes('q=search') && document.querySelectorAll('.result').length > 0`,
   );
 
   // The security assertion, and the reason both messages live in one module.

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -13,6 +13,7 @@ import (
 	"maps"
 	"slices"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/tamnd/genba"
 	"github.com/tamnd/genba/acl"
@@ -55,6 +56,7 @@ func New() *Store {
 var (
 	_ store.ContentStore = (*Store)(nil)
 	_ store.Statistician = (*Store)(nil)
+	_ store.Speller      = (*Store)(nil)
 	_ store.Notifier     = (*Store)(nil)
 )
 
@@ -251,6 +253,50 @@ func (s *Store) Statistics(ctx context.Context, p *acl.Principal, terms []string
 		}
 	}
 	return c, nil
+}
+
+// Near returns terms in the tenant that are close to the one given.
+//
+// It builds the vocabulary by walking the corpus, which is O(n) on every call
+// and is what a reference implementation should do: the driver that keeps a
+// term table maintained is checked against this. It is only ever reached on a
+// query that matched nothing, so a corpus this driver is meant to hold pays for
+// it once at the end of a search that found no results anyway.
+//
+// The tenant is applied and the reader's permissions are not, which is the
+// whole contract of [store.Speller] and the reason its documentation says what
+// the caller still has to do.
+func (s *Store) Near(ctx context.Context, p *acl.Principal, term string, limit int) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, genba.ErrClosed
+	}
+
+	// Only terms that could be within the bound, which keeps the map small on a
+	// corpus with a large vocabulary. A term more than that many characters
+	// longer or shorter cannot be reached in that many edits.
+	bound := store.MaxEdits(term)
+	typed := utf8.RuneCountInString(term)
+	docs := make(map[string]int)
+	for _, d := range s.docs {
+		if !d.Queryable() || d.Tenant != p.Tenant {
+			continue
+		}
+		for t := range d.Analyze().Terms {
+			if n := utf8.RuneCountInString(t); n < typed-bound || n > typed+bound {
+				continue
+			}
+			docs[t]++
+		}
+	}
+	return store.Nearest(term, docs, limit), nil
 }
 
 // Stats reports what the store holds.

--- a/store/memstore/memstore_test.go
+++ b/store/memstore/memstore_test.go
@@ -28,6 +28,13 @@ func TestRanking(t *testing.T) {
 	storetest.RunRanker(t, newStore)
 }
 
+// The vocabulary a correction is drawn from, which this driver builds by
+// walking the corpus. It is the answer the driver with a term table is checked
+// against.
+func TestSpelling(t *testing.T) {
+	storetest.RunSpeller(t, newStore)
+}
+
 func TestClosedStoreRefusesWork(t *testing.T) {
 	s := memstore.New()
 	if err := s.Close(); err != nil {

--- a/store/pgstore/pgstore_test.go
+++ b/store/pgstore/pgstore_test.go
@@ -123,6 +123,12 @@ func TestRetrieverConformance(t *testing.T) {
 	storetest.RunRetriever(t, newStore)
 }
 
+// This driver has no [store.Speller], so every case here skips. The call is
+// left in so that the day it grows one, the suite is already pointed at it.
+func TestSpellerConformance(t *testing.T) {
+	storetest.RunSpeller(t, newStore)
+}
+
 func TestRankerConformance(t *testing.T) {
 	storetest.RunRanker(t, newStore)
 }

--- a/store/spell.go
+++ b/store/spell.go
@@ -1,0 +1,171 @@
+package store
+
+import (
+	"context"
+	"sort"
+	"unicode/utf8"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// Speller is the optional capability of a driver that can name terms its own
+// index holds near a term it does not.
+//
+// It exists so that a correction offered to somebody who mistyped comes from
+// the corpus rather than from a dictionary of English. A dictionary knows that
+// recieve is receive and does not know that kubectl, genbad or the name of a
+// service are words at all, and in a corpus of runbooks and code most of the
+// words worth correcting to are of the second kind.
+//
+// # What it does not do
+//
+// Near applies the tenant and nothing else. There is no permission filter on a
+// vocabulary and there cannot usefully be one: a term is carried by many
+// documents, the asker may read some of them, and a per asker term list is an
+// aggregate over the corpus on a query that has already found nothing.
+//
+// So the rule is on the caller, and it is not optional. Nothing derived from
+// Near may be shown to anybody until the corrected query has been run as that
+// person and returned at least one hit. That confirmation is one search of a
+// single row, it is only ever reached on a query that matched nothing, and it
+// is what keeps a correction from telling somebody that a word appears in a
+// document they cannot read. [index.Searcher] does exactly this, and a caller
+// that skips it has built an oracle for the contents of the corpus.
+type Speller interface {
+	// Near returns terms in the principal's tenant that are close to the given
+	// term, nearest first and commonest among equals, and at most limit of
+	// them. The term itself is never returned. A driver that finds nothing
+	// returns an empty slice rather than an error.
+	//
+	// What comes back is what the driver can afford to find rather than
+	// everything that is within reach. A driver whose vocabulary is a table
+	// reads a range of it and leaves the rest, because a correction is offered
+	// on a query that already found nothing and is not worth more time than
+	// the query it follows. So a term that is close may be missing, and the
+	// caller treats an empty answer as no correction rather than as proof that
+	// there is none.
+	Near(ctx context.Context, p *acl.Principal, term string, limit int) ([]string, error)
+}
+
+// Edits is the edit distance between two terms, and is at most one past the
+// bound it is given.
+//
+// It is the Damerau version, which counts a transposition as one edit rather
+// than two, because a transposition is what a pair of hands produces and the
+// difference decides whether teh reaches the. Anything further away than bound
+// is reported as one past it rather than measured, which is what makes the
+// bound the point of the function: the rows scanned to find a correction are
+// mostly rows that are nothing like the word, and each one costs a prefix of
+// the matrix instead of all of it.
+func Edits(a, b string, bound int) int {
+	if a == b {
+		return 0
+	}
+	x, y := []rune(a), []rune(b)
+	// A length difference is a lower bound on the distance, so a candidate that
+	// cannot possibly be close enough is answered without any work at all.
+	if d := len(x) - len(y); d > bound || -d > bound {
+		return bound + 1
+	}
+	if len(x) > len(y) {
+		x, y = y, x
+	}
+
+	// Two rows of the matrix rather than all of it, plus the row before them,
+	// which is the row a transposition reaches back to.
+	prev := make([]int, len(x)+1)
+	cur := make([]int, len(x)+1)
+	before := make([]int, len(x)+1)
+	for i := range prev {
+		prev[i] = i
+	}
+
+	for j := 1; j <= len(y); j++ {
+		cur[0] = j
+		best := cur[0]
+		for i := 1; i <= len(x); i++ {
+			cost := 1
+			if x[i-1] == y[j-1] {
+				cost = 0
+			}
+			d := min(prev[i]+1, cur[i-1]+1, prev[i-1]+cost)
+			if i > 1 && j > 1 && x[i-1] == y[j-2] && x[i-2] == y[j-1] {
+				d = min(d, before[i-2]+1)
+			}
+			cur[i] = d
+			best = min(best, d)
+		}
+		// Every distance from here on is at least the best on this row, so a row
+		// with nothing under the bound on it is the end of the measurement.
+		if best > bound {
+			return bound + 1
+		}
+		before, prev, cur = prev, cur, before
+	}
+	if prev[len(x)] > bound {
+		return bound + 1
+	}
+	return prev[len(x)]
+}
+
+// MaxEdits is how far a term may be from what somebody typed and still be
+// offered as what they meant.
+//
+// Two for an ordinary word and one for a short one, because two edits on a four
+// letter word is not a correction, it is a different word: from cat to cot is a
+// typo and from cat to dog would be a suggestion nobody asked for. It is a
+// function rather than a constant so that the drivers and the ranking cannot
+// disagree about where the line is.
+func MaxEdits(term string) int {
+	if utf8.RuneCountInString(term) <= 4 {
+		return 1
+	}
+	return 2
+}
+
+// Nearest ranks candidate terms against the one somebody typed, which is the
+// half of a correction that is the same in every driver.
+//
+// candidates maps a term to how many documents carry it. Nearer wins, and among
+// equals the term more of the corpus uses wins, because the common spelling of
+// a word is what somebody meant far more often than the rare one. The term
+// itself is dropped: a query that matched nothing was not spelled that way.
+func Nearest(term string, candidates map[string]int, limit int) []string {
+	if limit <= 0 || term == "" {
+		return nil
+	}
+	bound := MaxEdits(term)
+
+	type scored struct {
+		term string
+		docs int
+		dist int
+	}
+	near := make([]scored, 0, 8)
+	for cand, docs := range candidates {
+		if cand == term || docs <= 0 {
+			continue
+		}
+		d := Edits(term, cand, bound)
+		if d > bound {
+			continue
+		}
+		near = append(near, scored{term: cand, docs: docs, dist: d})
+	}
+
+	sort.Slice(near, func(i, j int) bool {
+		if near[i].dist != near[j].dist {
+			return near[i].dist < near[j].dist
+		}
+		if near[i].docs != near[j].docs {
+			return near[i].docs > near[j].docs
+		}
+		return near[i].term < near[j].term
+	})
+
+	out := make([]string, 0, min(limit, len(near)))
+	for _, n := range near[:min(limit, len(near))] {
+		out = append(out, n.term)
+	}
+	return out
+}

--- a/store/spell_test.go
+++ b/store/spell_test.go
@@ -1,0 +1,104 @@
+package store_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/store"
+)
+
+func TestEditsMeasuresWhatHandsDo(t *testing.T) {
+	cases := []struct {
+		a, b string
+		max  int
+		want int
+	}{
+		{"cache", "cache", 2, 0},
+		{"cahce", "cache", 2, 1}, // the transposition, which is one edit and not two
+		{"teh", "the", 2, 1},     // and the one everybody types
+		{"recieve", "receive", 2, 1},
+		{"cache", "caches", 2, 1}, // an insertion
+		{"caches", "cache", 2, 1}, // and a deletion, which is the same edit read backwards
+		{"cache", "cachet", 2, 1},
+		// Two words that look alike to a person and are three edits apart, so
+		// neither is offered as the other.
+		{"kubectl", "kubelet", 2, 3},
+		{"cat", "dog", 2, 3},            // nothing like it, reported as over the bound
+		{"cache", "invalidation", 2, 3}, // and a length difference is answered without work
+		{"日本語", "日本", 2, 1},             // runes rather than bytes, or this would be three
+		{"ünicode", "unicode", 2, 1},
+	}
+	for _, c := range cases {
+		if got := store.Edits(c.a, c.b, c.max); got != c.want {
+			t.Errorf("Edits(%q, %q, %d) = %d, want %d", c.a, c.b, c.max, got, c.want)
+		}
+		// Distance is symmetric, and a version that is not has an off by one in
+		// the row it reuses.
+		if got := store.Edits(c.b, c.a, c.max); got != c.want {
+			t.Errorf("Edits(%q, %q, %d) = %d, want %d", c.b, c.a, c.max, got, c.want)
+		}
+	}
+}
+
+func TestEditsStopsAtTheBound(t *testing.T) {
+	// Anything further away is max+1 rather than the real distance, which is
+	// what lets the measurement stop early. Asking for the real number is not
+	// something a correction ever needs.
+	if got := store.Edits("cache", "dog", 1); got != 2 {
+		t.Errorf("Edits(cache, dog, 1) = %d, want 2", got)
+	}
+	if got := store.Edits("cache", "dog", 4); got != 5 {
+		t.Errorf("Edits(cache, dog, 4) = %d, want 5", got)
+	}
+}
+
+func TestMaxEditsIsStricterOnShortWords(t *testing.T) {
+	for _, term := range []string{"cat", "cost", "四文字です"[:6]} {
+		if got := store.MaxEdits(term); got > 2 {
+			t.Errorf("MaxEdits(%q) = %d", term, got)
+		}
+	}
+	if got := store.MaxEdits("cost"); got != 1 {
+		t.Errorf("MaxEdits(cost) = %d, want 1: two edits on a four letter word is a different word", got)
+	}
+	if got := store.MaxEdits("caches"); got != 2 {
+		t.Errorf("MaxEdits(caches) = %d, want 2", got)
+	}
+}
+
+func TestNearestPrefersTheNearerThenTheCommoner(t *testing.T) {
+	got := store.Nearest("cahce", map[string]int{
+		"cache":  3,   // one edit
+		"caches": 900, // two, and much commoner, and still second
+		"cage":   40,  // two
+		"cahce":  5,   // the word itself, which is never an answer
+		"dog":    900, // nothing like it
+		"cached": 0,   // carried by nothing, so it is not a place to send anybody
+	}, 3)
+	want := []string{"cache", "caches", "cage"}
+	if !slices.Equal(got, want) {
+		t.Errorf("Nearest = %v, want %v", got, want)
+	}
+}
+
+func TestNearestBreaksTiesOnTheWord(t *testing.T) {
+	// Same distance and same document count. Something has to decide, and it
+	// has to decide the same way twice or the correction offered for one query
+	// changes between two runs of it.
+	got := store.Nearest("cachs", map[string]int{"cache": 7, "cacho": 7, "cachy": 7}, 2)
+	if want := []string{"cache", "cacho"}; !slices.Equal(got, want) {
+		t.Errorf("Nearest = %v, want %v", got, want)
+	}
+}
+
+func TestNearestAnswersNothingWhenThereIsNothingToAsk(t *testing.T) {
+	if got := store.Nearest("", map[string]int{"cache": 3}, 3); got != nil {
+		t.Errorf("Nearest with no word = %v", got)
+	}
+	if got := store.Nearest("cahce", map[string]int{"cache": 3}, 0); got != nil {
+		t.Errorf("Nearest with no limit = %v", got)
+	}
+	if got := store.Nearest("cahce", nil, 3); len(got) != 0 {
+		t.Errorf("Nearest with no candidates = %v", got)
+	}
+}

--- a/store/sqlitestore/spell.go
+++ b/store/sqlitestore/spell.go
@@ -1,0 +1,165 @@
+package sqlitestore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Speller = (*Store)(nil)
+
+// NearWindow is how far a correction reads in each direction from the word it
+// is correcting, in rows of the term table.
+//
+// It is exported because the counter test spends it: a search that found
+// nothing is allowed this many rows for its correction and not one more, and a
+// budget written as a number in two places is a budget that stops agreeing with
+// itself. There are four windows in a correction, two ranges read outwards from
+// the middle, so this is a quarter of what one misspelled word costs.
+const NearWindow = 100
+
+// Near returns terms in the tenant that are close to the one given.
+//
+// The vocabulary is term_stat, which is maintained on every write for BM25 and
+// happens to be exactly the table this needs: a term, the tenant it belongs to,
+// and how many documents carry it. Nothing is stored for spelling that ranking
+// was not already storing.
+//
+// What it reads is a window of the primary key around the word itself rather
+// than the tenant's whole vocabulary, because a correction is offered after a
+// query that found nothing and must not cost more than the query did. The
+// window works because a word one edit away is a word that sorts next to it:
+// change a letter near the end and the two are neighbours, change one in the
+// middle and there are a few hundred words in between. So the scan starts at
+// the typed word and walks outwards, which spends its rows on the candidates
+// instead of on everything that starts with the same letter.
+//
+// Two things follow from that, and both are the price of not keeping a second
+// index. A word whose first two letters are wrong is not corrected, because the
+// window is inside the range those two letters name. The second range is those
+// two letters the other way round, which is the transposition, and that is the
+// common half of the cases the first range misses. And a word with a very
+// crowded neighbourhood, a corpus of identifiers with a shared prefix say, can
+// have its correction sitting just outside the window.
+//
+// The tenant is applied and the reader's permissions are not, which is the
+// contract of [store.Speller]. See it for what the caller still owes.
+func (s *Store) Near(ctx context.Context, p *acl.Principal, term string, limit int) ([]string, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if term == "" || limit <= 0 {
+		return nil, nil
+	}
+
+	bound := store.MaxEdits(term)
+	typed := utf8.RuneCountInString(term)
+	docs := make(map[string]int)
+	if err := s.near(ctx, p.Tenant, windows(term), typed-bound, typed+bound, docs); err != nil {
+		return nil, err
+	}
+	return store.Nearest(term, docs, limit), nil
+}
+
+// window is one range of the term table and where in it to start reading.
+type window struct {
+	lo, hi string
+	pivot  string
+}
+
+func (s *Store) near(ctx context.Context, tenant string, windows []window, shortest, longest int, docs map[string]int) error {
+	if len(windows) == 0 {
+		return nil
+	}
+
+	// One statement rather than one per window. The windows are small and the
+	// statement count is a budget of its own, and a correction that ran four
+	// queries would be the largest part of the search that produced it.
+	//
+	// length() counts characters on a text value, which is the unit the
+	// distance is measured in, so a word that cannot be reached in the allowed
+	// number of edits is dropped by SQLite rather than carried into Go.
+	const forward = `SELECT term, documents FROM (
+		SELECT term, documents FROM term_stat
+		WHERE tenant = ? AND term >= ? AND term < ? AND documents > 0
+			AND length(term) BETWEEN ? AND ?
+		ORDER BY term LIMIT ?)`
+	const backward = `SELECT term, documents FROM (
+		SELECT term, documents FROM term_stat
+		WHERE tenant = ? AND term >= ? AND term < ? AND documents > 0
+			AND length(term) BETWEEN ? AND ?
+		ORDER BY term DESC LIMIT ?)`
+
+	var (
+		parts = make([]string, 0, 2*len(windows))
+		args  = make([]any, 0, 12*len(windows))
+	)
+	for _, w := range windows {
+		parts = append(parts, forward, backward)
+		args = append(args, tenant, w.pivot, w.hi, shortest, longest, NearWindow)
+		args = append(args, tenant, w.lo, w.pivot, shortest, longest, NearWindow)
+	}
+
+	rows, err := s.query(ctx, strings.Join(parts, "\nUNION ALL\n"), args...)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: near: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var (
+			term string
+			n    int
+		)
+		if err := rows.Scan(&term, &n); err != nil {
+			return fmt.Errorf("sqlitestore: near: %w", err)
+		}
+		s.counters.rows.Add(1)
+		docs[term] = n
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("sqlitestore: near: %w", err)
+	}
+	return nil
+}
+
+// windows is where the scan reads: around the word itself, and around the word
+// with its first two letters swapped.
+func windows(term string) []window {
+	first, size := utf8.DecodeRuneInString(term)
+	if first == utf8.RuneError {
+		return nil
+	}
+	second, next := utf8.DecodeRuneInString(term[size:])
+	if second == utf8.RuneError || next == 0 {
+		lo, hi := prefixRange(string(first))
+		return []window{{lo: lo, hi: hi, pivot: term}}
+	}
+
+	lo, hi := prefixRange(term[:size+next])
+	out := make([]window, 0, 2)
+	out = append(out, window{lo: lo, hi: hi, pivot: term})
+	if second == first {
+		return out
+	}
+	swapped := string(second) + string(first) + term[size+next:]
+	lo, hi = prefixRange(swapped[:size+next])
+	return append(out, window{lo: lo, hi: hi, pivot: swapped})
+}
+
+// prefixRange turns a prefix into the half open range of terms that start with
+// it. The upper bound is the next code point, which is the next byte string
+// too, because UTF-8 sorts the same way the code points do and the column is
+// compared as bytes.
+func prefixRange(prefix string) (lo, hi string) {
+	last, size := utf8.DecodeLastRuneInString(prefix)
+	return prefix, prefix[:len(prefix)-size] + string(last+1)
+}

--- a/store/sqlitestore/sqlitestore_test.go
+++ b/store/sqlitestore/sqlitestore_test.go
@@ -38,6 +38,10 @@ func TestRetrieverConformance(t *testing.T) {
 	storetest.RunRetriever(t, newStore)
 }
 
+func TestSpellerConformance(t *testing.T) {
+	storetest.RunSpeller(t, newStore)
+}
+
 func TestRankerConformance(t *testing.T) {
 	storetest.RunRanker(t, newStore)
 }

--- a/store/storetest/spell.go
+++ b/store/storetest/spell.go
@@ -1,0 +1,157 @@
+package storetest
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// RunSpeller checks [store.Speller], the capability behind a correction.
+//
+// It is optional, so it skips for a driver that does not have it. What it will
+// not let a driver do is answer with a word from another tenant, or with a word
+// nothing carries any more, because a correction is offered to somebody who is
+// stuck and a correction that leads nowhere is worse than none.
+//
+// What is deliberately not checked here is recall. A driver is allowed to miss
+// a word it could have found: the two that exist read a window of an index
+// rather than all of it, on purpose, and a suite that pinned the exact set
+// would be pinning the size of that window. See [store.Speller].
+func RunSpeller(t *testing.T, newStore Factory) {
+	t.Helper()
+	for _, c := range spellCases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newStore(t)
+			t.Cleanup(func() { _ = s.Close() })
+			c.run(t, s)
+		})
+	}
+}
+
+type spellCase struct {
+	name string
+	run  func(t *testing.T, s store.Store)
+}
+
+var spellCases = []spellCase{
+	{"a word one edit away is offered", testNearOneEdit},
+	{"the word itself is never offered back", testNearNotItself},
+	{"a word of another tenant is never offered", testNearTenant},
+	{"a quarantined document lends no words", testNearQuarantine},
+	{"a deleted document takes its words with it", testNearDelete},
+	{"the limit is a limit", testNearLimit},
+	{"a nil principal is corrected nothing", testNearNilPrincipal},
+}
+
+// speller skips a case for a driver that cannot name the words it holds.
+func speller(t *testing.T, s store.Store) store.Speller {
+	t.Helper()
+	sp, ok := s.(store.Speller)
+	if !ok {
+		t.Skip("driver does not implement store.Speller")
+	}
+	return sp
+}
+
+// worded is a document whose body is the given words, so that a case can say
+// what vocabulary the corpus has in one line.
+func worded(id, words string) doc.Document {
+	d := document(id, readable())
+	d.Body = words
+	return d
+}
+
+func near(t *testing.T, sp store.Speller, p *acl.Principal, term string, limit int) []string {
+	t.Helper()
+	out, err := sp.Near(t.Context(), p, term, limit)
+	if err != nil {
+		t.Fatalf("Near(%q): %v", term, err)
+	}
+	return out
+}
+
+func testNearOneEdit(t *testing.T, s store.Store) {
+	sp := speller(t, s)
+	mustPut(t, s, worded("d1", "the cache invalidation runbook"))
+
+	got := near(t, sp, reader(), "cahce", 5)
+	if !slices.Contains(got, "cache") {
+		t.Errorf("Near(%q) = %v, which does not offer cache", "cahce", got)
+	}
+}
+
+func testNearNotItself(t *testing.T, s store.Store) {
+	sp := speller(t, s)
+	mustPut(t, s, worded("d1", "cache caches cached"))
+
+	// A word the corpus has is not a word to correct, and a driver that hands
+	// it back makes the caller show "did you mean cache" under a search for
+	// cache.
+	if got := near(t, sp, reader(), "cache", 5); slices.Contains(got, "cache") {
+		t.Errorf("Near(%q) = %v, which offers the word itself", "cache", got)
+	}
+}
+
+func testNearTenant(t *testing.T, s store.Store) {
+	sp := speller(t, s)
+	other := worded("d1", "cache")
+	other.Tenant = "globex"
+	mustPut(t, s, other, worded("d2", "runbook"))
+
+	// The whole reason [store.Speller] documents what the caller owes: this is
+	// the one filter a driver does apply, and a driver that skips it turns a
+	// correction into a question about somebody else's corpus.
+	if got := near(t, sp, reader(), "cahce", 5); len(got) != 0 {
+		t.Errorf("Near(%q) = %v, which are words of another tenant", "cahce", got)
+	}
+}
+
+func testNearQuarantine(t *testing.T, s store.Store) {
+	sp := speller(t, s)
+	held := worded("d1", "cache")
+	held.Permissions = acl.Permissions{
+		Mode:        acl.ModeUnknown,
+		Source:      "gdrive",
+		AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}},
+	}
+	mustPut(t, s, held)
+
+	if got := near(t, sp, reader(), "cahce", 5); len(got) != 0 {
+		t.Errorf("Near(%q) = %v, from a document nobody may read", "cahce", got)
+	}
+}
+
+func testNearDelete(t *testing.T, s store.Store) {
+	sp := speller(t, s)
+	mustPut(t, s, worded("d1", "cache"))
+	if err := s.Delete(t.Context(), "d1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if got := near(t, sp, reader(), "cahce", 5); len(got) != 0 {
+		t.Errorf("Near(%q) = %v, from a document that is gone", "cahce", got)
+	}
+}
+
+func testNearLimit(t *testing.T, s store.Store) {
+	sp := speller(t, s)
+	mustPut(t, s, worded("d1", "cache caches cached cacher caged"))
+
+	if got := near(t, sp, reader(), "cachs", 2); len(got) > 2 {
+		t.Errorf("Near(%q) with a limit of 2 returned %d: %v", "cachs", len(got), got)
+	}
+}
+
+func testNearNilPrincipal(t *testing.T, s store.Store) {
+	sp := speller(t, s)
+	mustPut(t, s, worded("d1", "cache"))
+
+	if _, err := sp.Near(t.Context(), nil, "cahce", 5); !errors.Is(err, genba.ErrNoPrincipal) {
+		t.Errorf("Near with a nil principal returned %v, want %v", err, genba.ErrNoPrincipal)
+	}
+}

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -2123,6 +2123,22 @@ h6.prose__h {
   font-size: var(--text-small);
 }
 
+/* The spelling that would have found something. It reads as a sentence with a
+   link in it, which is what it is, so the word is set in the colour a link is
+   set in and the button around it is given none of a button's furniture. */
+.state__suggest {
+  color: var(--text);
+}
+
+.state__correction {
+  color: var(--text-link);
+  font-weight: var(--weight-semibold);
+}
+
+.state__correction:hover {
+  text-decoration: underline;
+}
+
 /* The filters that are the reason a search came back with nothing, offered
    where somebody is looking rather than only above the list they are not. */
 .state__filters {

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -234,9 +234,10 @@ export class Results {
     this.query = query;
     this.res = res;
     // What the filters removed was measured against the previous query, so it
-    // is dropped here rather than carried. What the index holds is a fact about
-    // the corpus and survives.
-    this.context = { ...this.context, removed: null };
+    // is dropped here rather than carried. The spelling that would have worked
+    // belongs to this answer for the same reason. What the index holds is a
+    // fact about the corpus and survives.
+    this.context = { ...this.context, removed: null, correction: res.correction || null };
     this.hits = res.hits || [];
     // Kept because the paging keys have to know where the last page ends, and
     // the pager itself is rebuilt from the response every time.

--- a/web/dist/assets/states.js
+++ b/web/dist/assets/states.js
@@ -86,7 +86,7 @@ export function firstRun(command = "genbad -corpus ~/notes -corpus-name notes") 
  * that was never connected, and saying which is better than a shrug.
  */
 export function nothingMatched(query, onQuery, context = {}) {
-  const { removed = null, documents = null, sources = [], chips = [] } = context;
+  const { removed = null, documents = null, sources = [], chips = [], correction = null } = context;
 
   if (documents === 0) return firstRun();
 
@@ -118,6 +118,7 @@ export function nothingMatched(query, onQuery, context = {}) {
             `Your filters removed ${number(removed)} ${removed === 1 ? "result" : "results"}.`,
           )
         : h("p", { class: "state__body" }, "The filters below are the reason. Remove one, or clear them all."),
+      didYouMean(query, correction, onQuery),
       // The controls are the ones above the list rather than a second set that
       // reads the same query, because two sets of filter chips are two chances
       // to disagree about what is on.
@@ -139,6 +140,7 @@ export function nothingMatched(query, onQuery, context = {}) {
     { class: "state" },
     h("span", { class: "state__icon" }, svg(icon("search"), 40)),
     h("p", { class: "state__title" }, `Nothing found for ${quoted(query)}`),
+    didYouMean(query, correction, onQuery),
     h("p", { class: "state__body" }, "Try fewer words, or a word that would be written down rather than spoken."),
     sources.length
       ? h(
@@ -254,6 +256,34 @@ export function notPermitted(back) {
           h("button", { class: "button button--primary", type: "button", onClick: back.go }, back.title),
         )
       : null,
+  );
+}
+
+/**
+ * didYouMean is the spelling that would have worked, offered as something to
+ * press rather than as advice.
+ *
+ * The server only sends one after running it as this person and getting a
+ * result, so it is a query that leads somewhere rather than a guess. It goes
+ * above the sentence about trying fewer words, because a correction is the
+ * likelier answer and the advice is what is left when there is none.
+ */
+function didYouMean(query, correction, onQuery) {
+  if (!correction || correction === query.q) return null;
+  return h(
+    "p",
+    { class: "state__body state__suggest" },
+    "Did you mean ",
+    h(
+      "button",
+      {
+        class: "state__correction",
+        type: "button",
+        onClick: () => onQuery({ ...query, q: correction, offset: 0, cursor: -1 }),
+      },
+      correction,
+    ),
+    "?",
   );
 }
 


### PR DESCRIPTION
Closes the last of #110.

A search that found nothing is the one screen with no way forward on it, and the commonest reason for one is a typo.
This offers the query somebody meant to type.

The words come from the index rather than from a dictionary.
A dictionary knows that recieve is receive and has never heard of kubectl or genbad, and in a corpus of runbooks and code most of the words worth correcting to are of the second kind.

### How it is paid for

`store.Speller` is a new optional capability, discovered by type assertion like the rest.
The sqlite driver answers it out of `term_stat`, which is already maintained on every write for BM25, so nothing is stored for spelling that ranking was not already storing.

It reads a window of that table around the word itself rather than the tenant's whole vocabulary: a hundred rows outwards in each direction, plus the same window on the word with its first two letters swapped, which is the transposition.
That is one statement and about two hundred rows for a whole query, which is less than the search that failed.
A correction is only looked for when a search returned nothing, only for queries of four words or fewer, and only for words the statistics already fetched for scoring say are in no document at all, so deciding whether to try costs no reads.

`index/counters_test.go` names that cost, so a correction that starts reading more than its window fails the gate rather than quietly getting slower.

The price of not keeping a second index is written down in the driver: a word whose first two letters are both wrong is not corrected, and a word in a very crowded neighbourhood can have its correction sitting just outside the window.
The conformance suite deliberately does not assert recall for that reason.

### The security half

A vocabulary is a fact about the tenant and results are not.
`Near` applies the tenant and nothing else, and there is no useful permission filter on a term list, so a correction shown straight out of the index would tell somebody that a word appears in a document they may not read.

So the rule is on the caller and it is not optional.
The searcher runs the corrected query as the person who asked, cut to a single row, and drops the offer unless something comes back.
There is a test that a reader outside the board group is never offered northwind while a board reader is, and the interface doc says that a caller who skips the confirmation has built an oracle for the contents of the corpus.

### What it looks like

The empty state grows a line that reads as a sentence with a link in it, because that is what it is.
Pressing the word runs that search, and the box and the address follow.
The offered query keeps the capitals, the punctuation and the operators somebody typed, since only the analyzer's spans are rewritten.

`scripts/state-check.mjs` now visits a typo, presses the correction and checks that the search it runs finds something, which is two more assertions and fifteen in that script.

### Gates

`make fmt`, `make vet`, `make race`, `make lint`, `make build`, `make bench-counters` and the full `make ui-gate` are green, axe clean on all seven screens, lighthouse 86 performance and 100 accessibility.

One thing left over: pgstore does not grow the capability here, so every case in its conformance run skips.
The call is wired in for the day it does, and I will open an issue for it.
