### PR TITLE
Serve the interface the way a bundler would, without one

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ Every filter, the sort, the page and the open document live in the address bar, 
 The identity switcher at the bottom of the rail sends a different subject, tenant and set of groups with every request.
 It is there because the permission model is the part of this system worth checking by hand, and the fastest way to check it is to run the same query as two different people and watch the results change.
 
+The whole interface is hand written HTML, CSS and ES modules, committed exactly as they are served, so a clone builds a working interface with the Go toolchain and nothing else.
+There is no bundler and there is not going to be one, since the graph is twenty five modules of our own with no third party dependency anywhere in it.
+What a bundler would have bought is done by the server instead.
+Every file is hashed as it is read and served under a second name that says what is in it, cacheable for a year, and the document is rewritten on the way out so that its import map and its preload list point at those names.
+Bodies are compressed with brotli and gzip once at startup rather than once per request.
+`web/graph_test.go` walks the import graph on every build, so a module added without a preload fails the build instead of costing every visitor a round trip.
+
 ## HTTP API
 
 Everything the interface does is an HTTP call, and there is nothing it can reach that a client cannot.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tamnd/genba
 go 1.26.6
 
 require (
+	github.com/andybalholm/brotli v1.2.2
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/jackc/pgx/v5 v5.10.0
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
+github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -32,6 +34,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -90,7 +90,7 @@ async function walk(session) {
   await check(
     session,
     "images are a vertical, and an empty index has none at all",
-    `import('/assets/results.js').then(({ verticalsFor }) => {
+    `import('genba/results.js').then(({ verticalsFor }) => {
       const withImages = verticalsFor([
         { value: 'page', count: 4 },
         { value: 'image', count: 912 },

--- a/scripts/render-check.mjs
+++ b/scripts/render-check.mjs
@@ -92,7 +92,7 @@ async function run(session) {
     session,
     "every media type in the corpus lands on a renderer that suits it",
     expr(`
-      const { shapeOf } = await import('/assets/content.js');
+      const { shapeOf } = await import('genba/content.js');
       const of = (media, id) => shapeOf({ media_type: media, id: id || 'repo:x' });
       return of('image/png') === 'image' &&
         of('audio/mpeg') === 'media' && of('video/mp4') === 'media' &&
@@ -110,7 +110,7 @@ async function run(session) {
     session,
     "nothing that can run survives the HTML renderer",
     expr(`
-      const { render } = await import('/assets/html.js');
+      const { render } = await import('genba/html.js');
       const box = document.createElement('div');
       box.appendChild(render(${JSON.stringify(HOSTILE)}));
       const has = (sel) => Boolean(box.querySelector(sel));
@@ -126,7 +126,7 @@ async function run(session) {
     session,
     "everything in that page that was a document survives it",
     expr(`
-      const { render } = await import('/assets/html.js');
+      const { render } = await import('genba/html.js');
       const box = document.createElement('div');
       box.appendChild(render(${JSON.stringify(HOSTILE)}));
       const link = box.querySelector('a[href="https://example.com/detail"]');
@@ -146,7 +146,7 @@ async function run(session) {
     session,
     "a PDF is prose with its length beside it rather than a wall of text",
     expr(`
-      const { body, detailOf } = await import('/assets/content.js');
+      const { body, detailOf } = await import('genba/content.js');
       const out = body({
         id: 'repo:report.pdf',
         media_type: 'application/pdf',
@@ -166,7 +166,7 @@ async function run(session) {
     session,
     "a notebook is prose and code cells with the outputs it produced",
     expr(`
-      const { body } = await import('/assets/content.js');
+      const { body } = await import('genba/content.js');
       const out = body({
         id: 'repo:analysis.ipynb',
         media_type: 'application/x-ipynb+json',
@@ -187,7 +187,7 @@ async function run(session) {
     session,
     "a notebook that is not valid JSON falls back to being shown as it is",
     expr(`
-      const { body } = await import('/assets/content.js');
+      const { body } = await import('genba/content.js');
       const out = body({ id: 'repo:broken.ipynb', media_type: 'application/x-ipynb+json', body: '{oops' });
       return Boolean(out.querySelector('.plain')) && out.textContent.includes('{oops');
     `),
@@ -197,7 +197,7 @@ async function run(session) {
     session,
     "a recording is its transcript, with a player that has not loaded anything yet",
     expr(`
-      const { body } = await import('/assets/content.js');
+      const { body } = await import('genba/content.js');
       const out = body({
         id: 'repo:standup.mp3',
         media_type: 'audio/mpeg',
@@ -216,7 +216,7 @@ async function run(session) {
     session,
     "a recording with nothing transcribed says so rather than looking empty",
     expr(`
-      const { body } = await import('/assets/content.js');
+      const { body } = await import('genba/content.js');
       const out = body({ id: 'repo:clip.mp4', media_type: 'video/mp4', body: '' });
       return out.querySelector('.preview__empty').textContent.includes('Nothing was transcribed') &&
         out.querySelector('.media__bar button').textContent === 'Play the video';
@@ -227,7 +227,7 @@ async function run(session) {
     session,
     "code is highlighted with its language named, and everything else is shown plainly",
     expr(`
-      const { body } = await import('/assets/content.js');
+      const { body } = await import('genba/content.js');
       const code = body({ id: 'repo:main.go', media_type: 'text/x-go', body: 'package main\\n' });
       const plain = body({ id: 'repo:data.bin', media_type: 'application/octet-stream', body: 'raw\\nbytes' });
       return code.querySelector('.code__lang').textContent === 'go' &&
@@ -240,7 +240,7 @@ async function run(session) {
     session,
     "a long table is folded to a screenful in a region the keyboard can scroll",
     expr(`
-      const { body } = await import('/assets/content.js');
+      const { body } = await import('genba/content.js');
       const out = body({ id: 'repo:notes.md', media_type: 'text/markdown', body: ${JSON.stringify(TABLE)} });
       const region = out.querySelector('.prose__scroll');
       const shown = () => [...out.querySelectorAll('tbody tr')].filter((r) => !r.hidden).length;
@@ -255,7 +255,7 @@ async function run(session) {
     session,
     "a file shows a number on every line and each one is a link to that line",
     expr(`
-      const { body } = await import('/assets/content.js');
+      const { body } = await import('genba/content.js');
       const out = body({ id: 'repo:main.go', media_type: 'text/x-go', body: 'package main\\n\\nfunc main() {}\\n' });
       const numbers = [...out.querySelectorAll('.line__no')];
       return numbers.length === 4 &&
@@ -273,7 +273,7 @@ async function run(session) {
     session,
     "a comment that runs over several lines is one comment on all of them",
     expr(`
-      const { rows } = await import('/assets/highlight.js');
+      const { rows } = await import('genba/highlight.js');
       const lines = rows('/*\\n one\\n two\\n*/\\nfunc main() {}', 'go');
       return lines.length === 5 &&
         lines.slice(0, 4).every((line) => line.querySelector('.tok--comment')) &&
@@ -285,8 +285,8 @@ async function run(session) {
     session,
     "an address that names a line opens the file at it and marks which one",
     expr(`
-      const { body } = await import('/assets/content.js');
-      const { reveal } = await import('/assets/marks.js');
+      const { body } = await import('genba/content.js');
+      const { reveal } = await import('genba/marks.js');
       const source = Array.from({ length: 60 }, (_, i) => 'line ' + i).join('\\n');
       const out = body({ id: 'repo:main.go', media_type: 'text/x-go', body: source });
       const at = reveal(out, '#L42');
@@ -302,8 +302,8 @@ async function run(session) {
     session,
     "a line address that arrives on an open file moves to that line and no further",
     expr(`
-      const { body } = await import('/assets/content.js');
-      const { reveal, toLine } = await import('/assets/marks.js');
+      const { body } = await import('genba/content.js');
+      const { reveal, toLine } = await import('genba/marks.js');
       const source = Array.from({ length: 60 }, (_, i) => 'line ' + i).join('\\n');
       const out = body({ id: 'repo:main.go', media_type: 'text/x-go', body: source });
       reveal(out, '#L42');
@@ -319,8 +319,8 @@ async function run(session) {
     session,
     "a document opened from a search opens at the first of the words somebody typed",
     expr(`
-      const { body } = await import('/assets/content.js');
-      const { reveal, terms } = await import('/assets/marks.js');
+      const { body } = await import('genba/content.js');
+      const { reveal, terms } = await import('genba/marks.js');
       const out = body(
         {
           id: 'repo:notes.md',
@@ -342,7 +342,7 @@ async function run(session) {
     session,
     "a search for a number marks the code and not the line numbers",
     expr(`
-      const { body } = await import('/assets/content.js');
+      const { body } = await import('genba/content.js');
       const lines = Array.from({ length: 60 }, () => 'const x = 1');
       lines[2] = 'const limit = 42';
       const out = body(
@@ -359,7 +359,7 @@ async function run(session) {
     session,
     "a body the extractor could not read to the end says which half is missing",
     expr(`
-      const { body } = await import('/assets/content.js');
+      const { body } = await import('genba/content.js');
       const out = body({
         id: 'repo:big.pdf',
         media_type: 'application/pdf',

--- a/scripts/state-check.mjs
+++ b/scripts/state-check.mjs
@@ -140,7 +140,7 @@ async function run(session) {
   await evaluate(
     session,
     expr(`
-      const { cache } = await import('/assets/cache.js');
+      const { cache } = await import('genba/cache.js');
       cache.invalidate('');
       window.dispatchEvent(new PopStateEvent('popstate'));
       return true;
@@ -221,7 +221,7 @@ async function run(session) {
     session,
     "a document that is not there and one nobody may read are the same page",
     expr(`
-      const { Page } = await import('/assets/page.js');
+      const { Page } = await import('genba/page.js');
       const drawn = (status, code, message) => {
         const page = new Page({ onBack: () => ({ href: '/', title: 'Search', go() {} }) });
         page.renderError({ status, code, message });
@@ -240,7 +240,7 @@ async function run(session) {
     session,
     "and the same two are the same preview",
     expr(`
-      const { Drawer } = await import('/assets/drawer.js');
+      const { Drawer } = await import('genba/drawer.js');
       const drawn = (status, message) => {
         const drawer = new Drawer({ onClose() {} });
         drawer.renderError({ status, message });
@@ -260,7 +260,7 @@ async function run(session) {
     session,
     "an index with nothing in it says how to fill it rather than that nothing matched",
     expr(`
-      const { nothingMatched } = await import('/assets/states.js');
+      const { nothingMatched } = await import('genba/states.js');
       const out = nothingMatched({ q: 'anything' }, () => {}, { documents: 0 });
       return out.classList.contains('state--first') &&
         out.textContent.includes('Nothing indexed yet') &&
@@ -272,7 +272,7 @@ async function run(session) {
     session,
     "and home is that screen too, rather than a dashboard reading zero in three places",
     expr(`
-      const { Home } = await import('/assets/home.js');
+      const { Home } = await import('genba/home.js');
       const home = new Home({ onQuery() {}, onOpen() {}, onVisit() {} });
       home.paint({ subject: 'dev' }, null, { documents: 0 });
       const first = Boolean(home.el.querySelector('.state--first')) && !home.el.querySelector('.panel');
@@ -285,7 +285,7 @@ async function run(session) {
     session,
     "the filters on a zero result page are the ones above the list, and clearing them keeps the words",
     expr(`
-      const { nothingMatched } = await import('/assets/states.js');
+      const { nothingMatched } = await import('genba/states.js');
       const chip = document.createElement('span');
       chip.textContent = 'Type: image';
       let cleared = null;
@@ -307,7 +307,7 @@ async function run(session) {
     session,
     "a request that failed says what kind of failure it was, with the request id and a way to try again",
     expr(`
-      const { failed } = await import('/assets/states.js');
+      const { failed } = await import('genba/states.js');
       let again = 0;
       const answered = failed({ status: 503, message: 'the server returned 503', requestID: 'r-1234' }, () => { again++; });
       answered.querySelector('.state__actions button').click();

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -5,21 +5,21 @@
 // rather than reaching back in here, which is what keeps a change to the result
 // row from being a change to routing.
 
-import { h, replace, svg } from "./dom.js";
-import { api, identity, setIdentity, ApiError } from "./api.js";
-import { cache } from "./cache.js";
-import { Live } from "./live.js";
-import { copies, copy } from "./clipboard.js";
-import * as urlState from "./state.js";
-import { followable, icon, initials, label, number, sourceColor, when } from "./format.js";
-import { Omnibox, modifierLabel, shortcutLabel } from "./omnibox.js";
-import { Results, VERTICALS, verticalsFor } from "./results.js";
-import { Drawer } from "./drawer.js";
-import { Page } from "./page.js";
-import { Home } from "./home.js";
-import { Recent } from "./recent.js";
-import { forget, remember } from "./queries.js";
-import { failed } from "./states.js";
+import { h, replace, svg } from "genba/dom.js";
+import { api, identity, setIdentity, ApiError } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { Live } from "genba/live.js";
+import { copies, copy } from "genba/clipboard.js";
+import * as urlState from "genba/state.js";
+import { followable, icon, initials, label, number, sourceColor, when } from "genba/format.js";
+import { Omnibox, modifierLabel, shortcutLabel } from "genba/omnibox.js";
+import { Results, VERTICALS, verticalsFor } from "genba/results.js";
+import { Drawer } from "genba/drawer.js";
+import { Page } from "genba/page.js";
+import { Home } from "genba/home.js";
+import { Recent } from "genba/recent.js";
+import { forget, remember } from "genba/queries.js";
+import { failed } from "genba/states.js";
 
 const THEME_KEY = "genba.theme";
 const DENSITY_KEY = "genba.density";

--- a/web/dist/assets/clipboard.js
+++ b/web/dist/assets/clipboard.js
@@ -5,8 +5,8 @@
 // nothing is a copy somebody does twice, and a spoken one, because a tick
 // appearing is not something a screen reader announces.
 
-import { replace, svg } from "./dom.js";
-import { icon } from "./format.js";
+import { replace, svg } from "genba/dom.js";
+import { icon } from "genba/format.js";
 
 // How long the tick stays. Long enough to be seen after the eye has moved back
 // to the button, short enough that the control is itself again before anybody

--- a/web/dist/assets/content.js
+++ b/web/dist/assets/content.js
@@ -6,14 +6,14 @@
 // Everything downstream of that decision is presentation, so adding a media
 // type is a line in a table here rather than a branch in three views.
 
-import { h, svg } from "./dom.js";
-import { api } from "./api.js";
-import { render as markdown, codeBlock } from "./markdown.js";
-import { render as htmlDocument } from "./html.js";
-import { parse as parseNotebook, render as notebookCells } from "./notebook.js";
-import { player } from "./media.js";
-import { terms, mark } from "./marks.js";
-import { kindIcon, sourceColor, bytes as formatBytes } from "./format.js";
+import { h, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { render as markdown, codeBlock } from "genba/markdown.js";
+import { render as htmlDocument } from "genba/html.js";
+import { parse as parseNotebook, render as notebookCells } from "genba/notebook.js";
+import { player } from "genba/media.js";
+import { terms, mark } from "genba/marks.js";
+import { kindIcon, sourceColor, bytes as formatBytes } from "genba/format.js";
 
 // Media types the interface knows how to draw as code, and the language each
 // one is highlighted as. A type that is not here and is not an image is drawn

--- a/web/dist/assets/drawer.js
+++ b/web/dist/assets/drawer.js
@@ -7,15 +7,15 @@
 // It is a modal dialog as far as assistive technology is concerned: focus goes
 // in, Tab stays inside, Escape closes it and focus goes back where it was.
 
-import { h, replace, svg } from "./dom.js";
-import { api } from "./api.js";
-import { cache } from "./cache.js";
-import { copies } from "./clipboard.js";
-import { icon, label, sourceColor, when, exact, followable, copyable } from "./format.js";
-import { body as renderBody, shapeOf, detailOf } from "./content.js";
-import { reveal } from "./marks.js";
-import { NOT_AVAILABLE, NO_ACCESS } from "./states.js";
-import { documentPath } from "./state.js";
+import { h, replace, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { copies } from "genba/clipboard.js";
+import { icon, label, sourceColor, when, exact, followable, copyable } from "genba/format.js";
+import { body as renderBody, shapeOf, detailOf } from "genba/content.js";
+import { reveal } from "genba/marks.js";
+import { NOT_AVAILABLE, NO_ACCESS } from "genba/states.js";
+import { documentPath } from "genba/state.js";
 
 export class Drawer {
   constructor({ onClose, onSay }) {

--- a/web/dist/assets/highlight.js
+++ b/web/dist/assets/highlight.js
@@ -10,7 +10,7 @@
 // correct answer rather than a failure. Highlighting the wrong thing is worse
 // than highlighting nothing.
 
-import { h } from "./dom.js";
+import { h } from "genba/dom.js";
 
 // Blocks under this many characters are highlighted as they are built. Anything
 // longer waits until it is near the viewport, so a document holding a thousand

--- a/web/dist/assets/home.js
+++ b/web/dist/assets/home.js
@@ -7,13 +7,13 @@
 // page uses, so nothing here can show a document the person could not have found
 // by searching for it.
 
-import { h, replace } from "./dom.js";
-import { api } from "./api.js";
-import { cache } from "./cache.js";
-import { queries } from "./queries.js";
-import { LIMIT as RECENT_LIMIT } from "./recent.js";
-import { label, sourceColor, when, number, initials } from "./format.js";
-import { firstRun } from "./states.js";
+import { h, replace } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { queries } from "genba/queries.js";
+import { LIMIT as RECENT_LIMIT } from "genba/recent.js";
+import { label, sourceColor, when, number, initials } from "genba/format.js";
+import { firstRun } from "genba/states.js";
 
 // How many rows a panel on this screen carries. Home is a summary and the whole
 // answer is one click away, so six is a panel somebody reads rather than one

--- a/web/dist/assets/html.js
+++ b/web/dist/assets/html.js
@@ -18,9 +18,9 @@
 // second sanitiser sitting beside this one, and two sanitisers that disagree is
 // a worse position than one that is tested everywhere.
 
-import { h } from "./dom.js";
-import { codeBlock, safeURL } from "./markdown.js";
-import { frame } from "./table.js";
+import { h } from "genba/dom.js";
+import { codeBlock, safeURL } from "genba/markdown.js";
+import { frame } from "genba/table.js";
 
 // The elements that survive, and what each becomes. Presentational tags are
 // folded into the one element that means what they meant, so b and strong are

--- a/web/dist/assets/live.js
+++ b/web/dist/assets/live.js
@@ -11,7 +11,7 @@
 // arrives while nobody is looking marks the cache stale, and the refresh
 // happens when somebody looks.
 
-import { api } from "./api.js";
+import { api } from "genba/api.js";
 
 // INTERVAL is the ceiling on how stale a visible page can get with nothing
 // else happening. Sixty seconds because that is the point at which somebody

--- a/web/dist/assets/markdown.js
+++ b/web/dist/assets/markdown.js
@@ -11,10 +11,10 @@
 // containing the text of a script tag. That is the whole security argument for
 // this file and it is the reason it is hand written rather than pulled in.
 
-import { h } from "./dom.js";
-import { highlight, rows } from "./highlight.js";
-import { current } from "./marks.js";
-import { frame } from "./table.js";
+import { h } from "genba/dom.js";
+import { highlight, rows } from "genba/highlight.js";
+import { current } from "genba/marks.js";
+import { frame } from "genba/table.js";
 
 /**
  * render turns markdown into nodes.

--- a/web/dist/assets/marks.js
+++ b/web/dist/assets/marks.js
@@ -17,7 +17,7 @@
 // disagree the marks are missing rather than wrong, and a document with no
 // marks in it opens at the top the way it always did.
 
-import { h } from "./dom.js";
+import { h } from "genba/dom.js";
 
 // The most marks worth drawing. A one word query against a file that repeats
 // that word on every line is a thousand elements nobody is going to look at,

--- a/web/dist/assets/media.js
+++ b/web/dist/assets/media.js
@@ -11,9 +11,9 @@
 // means the whole file. Starting that automatically would spend two hundred
 // megabytes to show somebody a page they opened to read one sentence of.
 
-import { h, replace } from "./dom.js";
-import { api } from "./api.js";
-import { bytes as formatBytes } from "./format.js";
+import { h, replace } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { bytes as formatBytes } from "genba/format.js";
 
 /**
  * player is the control that fetches a recording and plays it.

--- a/web/dist/assets/notebook.js
+++ b/web/dist/assets/notebook.js
@@ -12,8 +12,8 @@
 // notebook emitted is a preview that renders whatever anybody put in a
 // notebook.
 
-import { h } from "./dom.js";
-import { render as markdown, codeBlock } from "./markdown.js";
+import { h } from "genba/dom.js";
+import { render as markdown, codeBlock } from "genba/markdown.js";
 
 // Image outputs that are drawn. They are decoded by the browser as pictures and
 // cannot be anything else, which is not true of the fifth entry every notebook

--- a/web/dist/assets/omnibox.js
+++ b/web/dist/assets/omnibox.js
@@ -8,10 +8,10 @@
 // that people drive with the keyboard and a screen reader has to be told what
 // the arrow keys are doing.
 
-import { h, replace, svg } from "./dom.js";
-import { api } from "./api.js";
-import { cache } from "./cache.js";
-import { icon } from "./format.js";
+import { h, replace, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { icon } from "genba/format.js";
 
 // DEBOUNCE is how long the box waits before asking the server. The suggestion
 // budget is 80ms at the server, and this is the other half of feeling instant:

--- a/web/dist/assets/page.js
+++ b/web/dist/assets/page.js
@@ -11,10 +11,10 @@
 // primary target on a row behave like a link on the web rather than like a
 // widget that happens to look like one.
 
-import { h, replace, svg } from "./dom.js";
-import { api } from "./api.js";
-import { cache } from "./cache.js";
-import { copies } from "./clipboard.js";
+import { h, replace, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { copies } from "genba/clipboard.js";
 import {
   icon,
   label,
@@ -23,11 +23,11 @@ import {
   exact,
   followable,
   copyable,
-} from "./format.js";
-import { body as renderBody, shapeOf, detailOf } from "./content.js";
-import { reveal, toLine } from "./marks.js";
-import { notPermitted, failedBody, failureTitle, NOT_AVAILABLE } from "./states.js";
-import { documentPath } from "./state.js";
+} from "genba/format.js";
+import { body as renderBody, shapeOf, detailOf } from "genba/content.js";
+import { reveal, toLine } from "genba/marks.js";
+import { notPermitted, failedBody, failureTitle, NOT_AVAILABLE } from "genba/states.js";
+import { documentPath } from "genba/state.js";
 
 export class Page {
   constructor({ onBack, onSay }) {

--- a/web/dist/assets/recent.js
+++ b/web/dist/assets/recent.js
@@ -10,11 +10,11 @@
 // inside the storage driver like everything else, so a document somebody lost
 // access to leaves this screen silently.
 
-import { h, replace, svg } from "./dom.js";
-import { api } from "./api.js";
-import { cache } from "./cache.js";
-import { icon } from "./format.js";
-import { RowList } from "./rows.js";
+import { h, replace, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { icon } from "genba/format.js";
+import { RowList } from "genba/rows.js";
 
 // LIMIT is how many rows each half carries, and it is the server's own default.
 // Twenty is a screen of them, and this list is read at a glance rather than

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -1,11 +1,11 @@
 // The results view: verticals, active filters, result rows and facets.
 
-import { h, replace, svg } from "./dom.js";
-import { label, number, duration, icon } from "./format.js";
-import { shapeOf } from "./content.js";
-import { RowList } from "./rows.js";
-import { nothingMatched, slow, stopped } from "./states.js";
-import * as urlState from "./state.js";
+import { h, replace, svg } from "genba/dom.js";
+import { label, number, duration, icon } from "genba/format.js";
+import { shapeOf } from "genba/content.js";
+import { RowList } from "genba/rows.js";
+import { nothingMatched, slow, stopped } from "genba/states.js";
+import * as urlState from "genba/state.js";
 
 /**
  * VERTICALS are the tabs above the results.

--- a/web/dist/assets/rows.js
+++ b/web/dist/assets/rows.js
@@ -12,11 +12,11 @@
 // query in here, no paging, no facets and no empty state, because those are
 // different questions on every screen that uses this one.
 
-import { h, replace, svg } from "./dom.js";
-import { kindIcon, sourceColor, label, when, exact, icon, followable, copyable } from "./format.js";
-import { tile, cover } from "./content.js";
-import { copies } from "./clipboard.js";
-import * as urlState from "./state.js";
+import { h, replace, svg } from "genba/dom.js";
+import { kindIcon, sourceColor, label, when, exact, icon, followable, copyable } from "genba/format.js";
+import { tile, cover } from "genba/content.js";
+import { copies } from "genba/clipboard.js";
+import * as urlState from "genba/state.js";
 
 /**
  * asked is the words in the address bar.

--- a/web/dist/assets/states.js
+++ b/web/dist/assets/states.js
@@ -11,9 +11,9 @@
 // not read are the same words, and the only way to keep them the same words is
 // for there to be one copy of them.
 
-import { h, svg } from "./dom.js";
-import { icon, label, number } from "./format.js";
-import * as urlState from "./state.js";
+import { h, svg } from "genba/dom.js";
+import { icon, label, number } from "genba/format.js";
+import * as urlState from "genba/state.js";
 
 /**
  * NO_ACCESS is what a 403 and a 404 on a document both say.

--- a/web/dist/assets/table.js
+++ b/web/dist/assets/table.js
@@ -10,7 +10,7 @@
 // preview is showing somebody the spreadsheet instead of telling them whether
 // it is the one they wanted.
 
-import { h } from "./dom.js";
+import { h } from "genba/dom.js";
 
 // How much of a long table the preview shows, and the length at which it counts
 // as long. A table of thirty rows is read in one go and folding it would be an

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -9,9 +9,80 @@
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%234f46e5'/%3E%3Ctext x='16' y='22' font-family='system-ui,sans-serif' font-size='18' font-weight='700' fill='white' text-anchor='middle'%3EG%3C/text%3E%3C/svg%3E" />
     <link rel="stylesheet" href="/assets/tokens.css" />
     <link rel="stylesheet" href="/assets/app.css" />
+    <!--
+      Every module by name, so that an importer says genba/dom.js and never says
+      where dom.js lives. The server rewrites these targets to the content
+      addressed name of each file as it serves this document, which is how a
+      module gets a URL that can be cached for a year without a build step and
+      without a hash appearing anywhere in the source.
+
+      The prefix at the end is the fallback for a module with no entry of its
+      own. It resolves, it is simply not addressed by content, and graph_test.go
+      fails the build when one turns up.
+    -->
+    <script type="importmap">
+      {
+        "imports": {
+          "genba/api.js": "/assets/api.js",
+          "genba/app.js": "/assets/app.js",
+          "genba/cache.js": "/assets/cache.js",
+          "genba/clipboard.js": "/assets/clipboard.js",
+          "genba/content.js": "/assets/content.js",
+          "genba/dom.js": "/assets/dom.js",
+          "genba/drawer.js": "/assets/drawer.js",
+          "genba/format.js": "/assets/format.js",
+          "genba/highlight.js": "/assets/highlight.js",
+          "genba/home.js": "/assets/home.js",
+          "genba/html.js": "/assets/html.js",
+          "genba/live.js": "/assets/live.js",
+          "genba/markdown.js": "/assets/markdown.js",
+          "genba/marks.js": "/assets/marks.js",
+          "genba/media.js": "/assets/media.js",
+          "genba/notebook.js": "/assets/notebook.js",
+          "genba/omnibox.js": "/assets/omnibox.js",
+          "genba/page.js": "/assets/page.js",
+          "genba/queries.js": "/assets/queries.js",
+          "genba/recent.js": "/assets/recent.js",
+          "genba/results.js": "/assets/results.js",
+          "genba/rows.js": "/assets/rows.js",
+          "genba/state.js": "/assets/state.js",
+          "genba/states.js": "/assets/states.js",
+          "genba/table.js": "/assets/table.js",
+          "genba/": "/assets/"
+        }
+      }
+    </script>
+    <!--
+      The whole module graph, flattened. Without this the browser learns about
+      markdown.js only after content.js has arrived, which is four levels deep
+      on a graph that is twenty five files wide. graph_test.go computes the
+      closure from app.js and fails if this list is not exactly it.
+    -->
     <link rel="modulepreload" href="/assets/api.js" />
+    <link rel="modulepreload" href="/assets/app.js" />
     <link rel="modulepreload" href="/assets/cache.js" />
+    <link rel="modulepreload" href="/assets/clipboard.js" />
+    <link rel="modulepreload" href="/assets/content.js" />
     <link rel="modulepreload" href="/assets/dom.js" />
+    <link rel="modulepreload" href="/assets/drawer.js" />
+    <link rel="modulepreload" href="/assets/format.js" />
+    <link rel="modulepreload" href="/assets/highlight.js" />
+    <link rel="modulepreload" href="/assets/home.js" />
+    <link rel="modulepreload" href="/assets/html.js" />
+    <link rel="modulepreload" href="/assets/live.js" />
+    <link rel="modulepreload" href="/assets/markdown.js" />
+    <link rel="modulepreload" href="/assets/marks.js" />
+    <link rel="modulepreload" href="/assets/media.js" />
+    <link rel="modulepreload" href="/assets/notebook.js" />
+    <link rel="modulepreload" href="/assets/omnibox.js" />
+    <link rel="modulepreload" href="/assets/page.js" />
+    <link rel="modulepreload" href="/assets/queries.js" />
+    <link rel="modulepreload" href="/assets/recent.js" />
+    <link rel="modulepreload" href="/assets/results.js" />
+    <link rel="modulepreload" href="/assets/rows.js" />
+    <link rel="modulepreload" href="/assets/state.js" />
+    <link rel="modulepreload" href="/assets/states.js" />
+    <link rel="modulepreload" href="/assets/table.js" />
     <script>
       // The theme and the density are read before the first paint. Doing it in
       // the module would put a white frame in front of somebody who chose a

--- a/web/embed.go
+++ b/web/embed.go
@@ -3,9 +3,14 @@
 package web
 
 import (
+	"bytes"
+	"compress/gzip"
 	"embed"
 	"io/fs"
+	"path"
 	"sync"
+
+	"github.com/andybalholm/brotli"
 )
 
 //go:embed all:dist
@@ -25,3 +30,85 @@ var assets = sync.OnceValues(func() (fs.FS, bool) {
 	}
 	return sub, true
 })
+
+// The size under which compressing is not worth the trouble. A body this small
+// arrives in the same packet either way, and a browser still has to run a
+// decompressor over it.
+const worthCompressing = 512
+
+// How much smaller a compressed form has to be to be kept at all. A file that
+// barely compresses is one somebody already compressed.
+const worthKeeping = 0.9
+
+// squeeze is every encoding worth sending a file in instead of sending the file.
+//
+// It runs once per asset, at startup, because the alternative is compressing
+// the same twenty five modules again for every visitor. Both encoders are asked
+// for their best: this is paid once for the life of the process, and what it
+// buys is paid for on every cold load anybody ever has.
+func squeeze(name string, body []byte) map[string][]byte {
+	if len(body) < worthCompressing || !compressible(name) {
+		return nil
+	}
+
+	out := map[string][]byte{}
+	var wg sync.WaitGroup
+	var gz, br []byte
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		gz = gzipped(body)
+	}()
+	go func() {
+		defer wg.Done()
+		br = brotlied(body)
+	}()
+	wg.Wait()
+
+	for encoding, encoded := range map[string][]byte{"gzip": gz, "br": br} {
+		if len(encoded) > 0 && float64(len(encoded)) < worthKeeping*float64(len(body)) {
+			out[encoding] = encoded
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func gzipped(body []byte) []byte {
+	var buf bytes.Buffer
+	w, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if err != nil {
+		return nil
+	}
+	if _, err := w.Write(body); err != nil {
+		return nil
+	}
+	if err := w.Close(); err != nil {
+		return nil
+	}
+	return buf.Bytes()
+}
+
+func brotlied(body []byte) []byte {
+	var buf bytes.Buffer
+	w := brotli.NewWriterLevel(&buf, brotli.BestCompression)
+	if _, err := w.Write(body); err != nil {
+		return nil
+	}
+	if err := w.Close(); err != nil {
+		return nil
+	}
+	return buf.Bytes()
+}
+
+// compressible is the text in the tree. An image or a font is already
+// compressed and running a second pass over one costs time to make it larger.
+func compressible(name string) bool {
+	switch path.Ext(name) {
+	case ".js", ".css", ".html", ".json", ".svg", ".txt", ".map":
+		return true
+	}
+	return false
+}

--- a/web/graph_test.go
+++ b/web/graph_test.go
@@ -1,0 +1,327 @@
+package web_test
+
+import (
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/web"
+)
+
+// The piece of a bundler this repository actually needs.
+//
+// There is no build step, which is a promise rather than an accident, and the
+// price of it is that nothing walks the module graph on the way to the browser.
+// So the graph is walked here instead. What that catches is a module added
+// without a preload, a preload left behind by a module that was deleted, an
+// importer that reached for a path instead of going through the map, and a
+// cycle. All four look perfectly fine in review and none of them fails anything
+// else in the tree.
+
+const entry = "app.js"
+
+var (
+	importing = regexp.MustCompile(`(?m)(?:from|import)\s*\(?\s*"([^"]+)"`)
+	preloaded = regexp.MustCompile(`<link rel="modulepreload" href="([^"]+)"`)
+	inMap     = regexp.MustCompile(`(?s)<script type="importmap">(.*?)</script>`)
+	addressed = regexp.MustCompile(`/assets/([a-z]+)\.([0-9a-f]{8})\.(js|css)`)
+)
+
+func TestTheDocumentPreloadsTheWholeGraph(t *testing.T) {
+	graph := imports(t)
+
+	// Everything reachable from the entry point, which is everything the first
+	// paint waits on however deep it sits.
+	want := map[string]bool{}
+	var walk func(string)
+	walk = func(module string) {
+		if want[module] {
+			return
+		}
+		want[module] = true
+		for _, next := range graph[module] {
+			walk(next)
+		}
+	}
+	walk(entry)
+
+	got := map[string]bool{}
+	for _, m := range preloaded.FindAllStringSubmatch(document(t), 1000) {
+		got[strings.TrimPrefix(m[1], "/assets/")] = true
+	}
+
+	for module := range want {
+		if !got[module] {
+			t.Errorf("%s is in the graph and is not preloaded, so the browser finds it a round trip late", module)
+		}
+	}
+	for module := range got {
+		if !want[module] {
+			t.Errorf("%s is preloaded and nothing imports it, so every visitor downloads it for nothing", module)
+		}
+	}
+}
+
+func TestEveryModuleImportsThroughTheMap(t *testing.T) {
+	body := document(t)
+	found := inMap.FindStringSubmatch(body)
+	if found == nil {
+		t.Fatal("the document has no import map, so a bare specifier resolves to nothing")
+	}
+
+	var parsed struct {
+		Imports map[string]string `json:"imports"`
+	}
+	if err := json.Unmarshal([]byte(found[1]), &parsed); err != nil {
+		t.Fatalf("the import map is not valid JSON, which fails silently in a browser: %v", err)
+	}
+	if parsed.Imports["genba/"] != "/assets/" {
+		t.Errorf("the prefix entry is %q, want /assets/", parsed.Imports["genba/"])
+	}
+
+	for module, specifiers := range imports(t) {
+		for _, target := range specifiers {
+			if _, ok := parsed.Imports["genba/"+target]; !ok {
+				t.Errorf("%s imports %s and the map has no entry for it, so it is not addressed by content", module, target)
+			}
+		}
+	}
+
+	// A module that says where another module lives is a module that has to be
+	// edited when one moves, and it is a module that would carry a hash in its
+	// source if it were addressed by content.
+	for name, body := range modules(t) {
+		for _, m := range importing.FindAllStringSubmatch(body, -1) {
+			if !strings.HasPrefix(m[1], "genba/") {
+				t.Errorf("%s imports %q rather than a genba/ specifier", name, m[1])
+			}
+		}
+	}
+}
+
+func TestTheModuleGraphHasNoCycles(t *testing.T) {
+	graph := imports(t)
+
+	// Modules do load in a cycle, which is exactly the problem: it works until
+	// one of the two reads something from the other while it is still being
+	// evaluated, and then it is undefined at a line that has not changed.
+	const (
+		open = 1
+		done = 2
+	)
+	seen := map[string]int{}
+	var walk func(string, []string)
+	walk = func(module string, path []string) {
+		if seen[module] == done {
+			return
+		}
+		if seen[module] == open {
+			t.Errorf("import cycle: %s", strings.Join(append(path, module), " -> "))
+			return
+		}
+		seen[module] = open
+		for _, next := range graph[module] {
+			walk(next, append(path, module))
+		}
+		seen[module] = done
+	}
+	for module := range graph {
+		walk(module, nil)
+	}
+}
+
+func TestAnAssetIsServedByContentAndKeptForAYear(t *testing.T) {
+	h := web.Handler()
+	if h == nil {
+		t.Skip("this build carries no interface")
+	}
+
+	// The served document names the addressed URLs, and those are the ones a
+	// browser asks for, so this reads them out of it rather than computing a
+	// hash of its own and checking the server against itself.
+	shell := httptest.NewRecorder()
+	h.ServeHTTP(shell, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+	names := addressed.FindAllString(shell.Body.String(), -1)
+	if len(names) == 0 {
+		t.Fatal("the document names no addressed asset, so nothing is cached for longer than a minute")
+	}
+
+	for _, name := range names {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, name, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s returned %d, and it is what the document asks for", name, w.Code)
+		}
+		if got := w.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+			t.Errorf("%s Cache-Control = %q, want a year and immutable", name, got)
+		}
+	}
+
+	// The plain name still answers, because a page that is open when the binary
+	// is upgraded goes on asking for what it already knows about, and because
+	// the checks in scripts/ import modules by path.
+	plain := addressed.ReplaceAllString(names[0], "/assets/$1.$3")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, plain, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("%s returned %d, want the same file under its own name", plain, w.Code)
+	}
+	if got := w.Header().Get("Cache-Control"); !strings.Contains(got, "must-revalidate") {
+		t.Errorf("%s Cache-Control = %q, a name that does not say what is in it must be revalidated", plain, got)
+	}
+
+	// The address of a file from a build that is no longer running. It is
+	// missing, and it says so, because the alternative is handing a browser the
+	// document where it asked for a module and failing on the MIME type three
+	// steps later.
+	stale := httptest.NewRecorder()
+	h.ServeHTTP(stale, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/assets/app.deadbeef.js", nil))
+	if stale.Code != http.StatusNotFound {
+		t.Errorf("an asset from an older build returned %d, want 404", stale.Code)
+	}
+}
+
+func TestTheDocumentIsNeverCachedAndNamesNothingPlain(t *testing.T) {
+	h := web.Handler()
+	if h == nil {
+		t.Skip("this build carries no interface")
+	}
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+	if got := w.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("the document Cache-Control = %q, and it is the one file that must not be held", got)
+	}
+
+	// Every asset the served document names carries a hash. Missing one means a
+	// file that a browser revalidates on every load for the life of a build.
+	body := w.Body.String()
+	for _, m := range regexp.MustCompile(`/assets/[a-z]+\.(js|css)`).FindAllString(body, -1) {
+		t.Errorf("the served document still names %s without a hash", m)
+	}
+	if !strings.Contains(body, `"genba/": "/assets/"`) {
+		t.Error("the prefix entry did not survive the rewrite, so a module with no entry of its own stops resolving")
+	}
+}
+
+func TestBodiesArePrecompressedAndNegotiated(t *testing.T) {
+	h := web.Handler()
+	if h == nil {
+		t.Skip("this build carries no interface")
+	}
+
+	ask := func(accept string) *httptest.ResponseRecorder {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/assets/app.js", nil)
+		if accept != "" {
+			r.Header.Set("Accept-Encoding", accept)
+		}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		return w
+	}
+
+	plain := ask("")
+	if plain.Header().Get("Content-Encoding") != "" {
+		t.Errorf("a request that asked for no encoding got %q", plain.Header().Get("Content-Encoding"))
+	}
+	if plain.Header().Get("Vary") != "Accept-Encoding" {
+		t.Error("a negotiated response that does not vary on Accept-Encoding poisons every cache in front of it")
+	}
+
+	for accept, want := range map[string]string{
+		"gzip":                    "gzip",
+		"br, gzip":                "br",
+		"gzip, deflate, br, zstd": "br",
+		"gzip;q=0, br":            "br",
+		"br;q=0, gzip":            "gzip",
+		"br;q=0, gzip;q=0":        "",
+	} {
+		got := ask(accept).Header().Get("Content-Encoding")
+		if got != want {
+			t.Errorf("Accept-Encoding %q was answered with %q, want %q", accept, got, want)
+		}
+	}
+
+	if compressed, uncompressed := ask("br").Body.Len(), plain.Body.Len(); compressed >= uncompressed {
+		t.Errorf("the brotli body is %d bytes and the file is %d", compressed, uncompressed)
+	}
+
+	// A validator names a representation rather than a file, so the gzip and
+	// the file itself cannot share one. A cache that has both and one ETag
+	// hands a browser a body it cannot read.
+	if ask("gzip").Header().Get("ETag") == plain.Header().Get("ETag") {
+		t.Error("the compressed body and the file are served under the same ETag")
+	}
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/assets/app.js", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	r.Header.Set("If-None-Match", ask("gzip").Header().Get("ETag"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusNotModified {
+		t.Errorf("a browser that holds the current gzip was answered %d rather than 304", w.Code)
+	}
+}
+
+// document is the committed shell, which is what the graph is asserted against.
+// The served one has been rewritten and is read directly where that is the
+// point.
+func document(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile("dist/index.html")
+	if err != nil {
+		t.Fatalf("reading the document: %v", err)
+	}
+	return string(body)
+}
+
+// modules is every ES module in the tree, by name.
+func modules(t *testing.T) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := fs.WalkDir(os.DirFS("dist/assets"), ".", func(name string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || path.Ext(name) != ".js" {
+			return err
+		}
+		body, err := os.ReadFile(path.Join("dist/assets", name))
+		if err != nil {
+			return err
+		}
+		out[name] = string(body)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the modules: %v", err)
+	}
+	return out
+}
+
+// imports is the graph: every module, and the modules it names.
+func imports(t *testing.T) map[string][]string {
+	t.Helper()
+	out := map[string][]string{}
+	for name, body := range modules(t) {
+		var named []string
+		for _, m := range importing.FindAllStringSubmatch(body, -1) {
+			target := strings.TrimPrefix(m[1], "genba/")
+			if target == m[1] || slices.Contains(named, target) {
+				continue
+			}
+			named = append(named, target)
+		}
+		sort.Strings(named)
+		out[name] = named
+	}
+	if len(out[entry]) == 0 {
+		t.Fatalf("%s imports nothing, so the graph walked from it is not the interface", entry)
+	}
+	return out
+}

--- a/web/noembed.go
+++ b/web/noembed.go
@@ -7,3 +7,7 @@ import "io/fs"
 // assets reports that this build carries no interface. Built with the noassets
 // tag, nothing under dist reaches the binary at all.
 func assets() (fs.FS, bool) { return nil, false }
+
+// squeeze has nothing to compress in a build with no assets in it, and saying
+// so here is what keeps both compressors out of an API only binary.
+func squeeze(string, []byte) map[string][]byte { return nil }

--- a/web/web.go
+++ b/web/web.go
@@ -16,12 +16,22 @@
 // else, and the assets in the repository are the assets in the binary, which
 // makes a diff of the interface readable in a review.
 //
-// The cost is that nothing renames a file when its contents change, so the
-// usual trick of caching hashed filenames forever is not available. Every file
-// is served with an ETag of its contents instead. A browser revalidates and
-// gets a 304 for anything it already has, which costs one conditional request
-// per asset and is always correct, including the case that matters: an operator
-// upgrading the binary under a browser that has the old one cached.
+// The usual thing a build step buys is a name that changes when the contents
+// change, so a browser can be told to keep the file for a year. That does not
+// need a bundler. This package hashes each file as it reads it and serves it
+// under both names: the plain one, revalidated, and assets/app.7f3a9c2e.js,
+// immutable for a year. The document is rewritten on the way out so that its
+// stylesheet links, its module preloads and its import map all point at the
+// addressed names, which is why no hash appears anywhere in the source. The
+// document itself is never cached, so an upgraded binary is picked up on the
+// next load and every asset it names is either already held or fetched once.
+//
+// Compression is the other thing a build step usually does. Each asset is
+// compressed once when it is first read, with brotli and with gzip, and the
+// request picks between them, so a body is compressed once for the life of the
+// process rather than once per request. A form that did not come out
+// meaningfully smaller is dropped rather than kept, since sending it would cost
+// a browser a decompression for nothing.
 //
 // # What the interface holds
 //
@@ -44,54 +54,155 @@ package web
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"io/fs"
+	"mime"
 	"net/http"
 	"path"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
-	"time"
 )
 
-// file is one asset with the validator it is served under.
-type file struct {
-	name string
-	etag string
+// The encodings that may be sent instead of the file itself, best first. There
+// are two and there will not be a third: everything else a browser advertises
+// is either older than gzip or not for text.
+var encodings = []string{"br", "gzip"}
+
+// asset is one file as it is served: its bytes, the compressed forms worth
+// sending instead of them, and the validator that names this version of it.
+type asset struct {
+	ctype   string
+	etag    string
+	body    []byte
+	encoded map[string][]byte
+}
+
+// servable is an asset under one of the names it answers to. The same bytes are
+// reachable at a plain name and at a content addressed one, and which of the
+// two was asked for is the whole difference between a file a browser checks
+// every minute and a file it keeps for a year.
+type servable struct {
+	*asset
+	name      string
+	immutable bool
 }
 
 // index is built once, lazily, over the embedded tree. It is small, it never
 // changes for the life of the process, and computing it up front would make an
-// API only build pay for a frontend it does not serve.
-var index = sync.OnceValue(func() map[string]file {
+// API only build pay for a frontend it does not serve. Reading, hashing and
+// compressing all happen here, so a request does none of them.
+var index = sync.OnceValue(func() map[string]servable {
 	root, ok := assets()
 	if !ok {
 		return nil
 	}
-	out := map[string]file{}
+
+	type entry struct {
+		name string
+		body []byte
+	}
+	var files []entry
 	_ = fs.WalkDir(root, ".", func(name string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		if err != nil || d.IsDir() || name == "index.html" {
 			return err
 		}
-		b, err := fs.ReadFile(root, name)
+		body, err := fs.ReadFile(root, name)
 		if err != nil {
 			return err
 		}
-		sum := sha256.Sum256(b)
-		out[name] = file{name: name, etag: `"` + base64.RawURLEncoding.EncodeToString(sum[:12]) + `"`}
+		files = append(files, entry{name: name, body: body})
 		return nil
 	})
+
+	// One goroutine per file, because compressing twenty five modules one after
+	// another is most of the time a process spends starting up and they have
+	// nothing to say to each other.
+	built := make([]*asset, len(files))
+	var wg sync.WaitGroup
+	for i, f := range files {
+		wg.Go(func() { built[i] = read(f.name, f.body) })
+	}
+	wg.Wait()
+
+	out := map[string]servable{}
+	addressed := map[string]string{}
+	for i, f := range files {
+		addr := address(f.name, f.body)
+		out[f.name] = servable{asset: built[i], name: f.name}
+		out[addr] = servable{asset: built[i], name: addr, immutable: true}
+		addressed["/"+f.name] = "/" + addr
+	}
+
+	// The document is built last, because what it says depends on the names
+	// every other file ended up with.
+	body, err := fs.ReadFile(root, "index.html")
+	if err != nil {
+		return out
+	}
+	out["index.html"] = servable{asset: read("index.html", point(body, addressed)), name: "index.html"}
 	return out
 })
+
+// read turns bytes into the asset they are served as.
+func read(name string, body []byte) *asset {
+	sum := sha256.Sum256(body)
+	return &asset{
+		ctype:   contentType(name),
+		etag:    `"` + base64.RawURLEncoding.EncodeToString(sum[:12]) + `"`,
+		body:    body,
+		encoded: squeeze(name, body),
+	}
+}
+
+// address is the name a file is cached under for a year. Eight hex characters
+// of the hash of the contents is four thousand million buckets, which is more
+// than enough to tell two versions of a twenty kilobyte module apart, and short
+// enough to read in a network panel.
+func address(name string, body []byte) string {
+	sum := sha256.Sum256(body)
+	ext := path.Ext(name)
+	return strings.TrimSuffix(name, ext) + "." + hex.EncodeToString(sum[:4]) + ext
+}
+
+// point rewrites the document so that every asset it names is named by its
+// content addressed URL instead. The committed document is written with plain
+// URLs and works as it stands, which is what keeps it reviewable, and this is a
+// substitution rather than a parse because the thing being replaced is a
+// filename and there is exactly one spelling of each.
+func point(body []byte, addressed map[string]string) []byte {
+	if len(addressed) == 0 {
+		return body
+	}
+	names := make([]string, 0, len(addressed))
+	for from := range addressed {
+		names = append(names, from)
+	}
+	// Longest first, so that a name which is a prefix of another cannot claim
+	// the match. Nothing in the tree is named that way today and nothing should
+	// have to remember that when adding a file.
+	sort.Slice(names, func(i, j int) bool {
+		if len(names[i]) != len(names[j]) {
+			return len(names[i]) > len(names[j])
+		}
+		return names[i] < names[j]
+	})
+	pairs := make([]string, 0, 2*len(names))
+	for _, from := range names {
+		pairs = append(pairs, from, addressed[from])
+	}
+	return []byte(strings.NewReplacer(pairs...).Replace(string(body)))
+}
 
 // Handler serves the interface, or nil when the binary was built without it.
 // Callers should check for nil rather than assume: an API only build is a
 // supported build, not a broken one.
 func Handler() http.Handler {
-	root, ok := assets()
-	if !ok {
+	if _, ok := assets(); !ok {
 		return nil
 	}
 	files := index()
-	server := http.FileServerFS(root)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		name := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
@@ -100,29 +211,109 @@ func Handler() http.Handler {
 		}
 		f, ok := files[name]
 		if !ok {
-			// An unknown path is a client route, not a missing file. The shell
-			// loads and the client decides what the path meant.
-			serveIndex(w, r, root, files)
-			return
+			// An asset that is not there is missing, and saying so is the
+			// useful answer. This is the address of a file from a build that is
+			// no longer running, and answering it with the document would hand
+			// a browser a page where it asked for a module.
+			if strings.HasPrefix(name, "assets/") {
+				http.NotFound(w, r)
+				return
+			}
+			// Anything else is a client route rather than a missing file. The
+			// shell loads and the client decides what the path meant.
+			f, ok = files["index.html"]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
 		}
-
-		w.Header().Set("ETag", f.etag)
-		w.Header().Set("Cache-Control", cacheControl(name))
-		if match(r, f.etag) {
-			w.WriteHeader(http.StatusNotModified)
-			return
-		}
-		server.ServeHTTP(w, r)
+		serve(w, r, f)
 	})
 }
 
-// cacheControl lets a browser hold an asset briefly without asking, and never
-// lets it hold the document that names the assets.
-func cacheControl(name string) string {
-	if strings.HasPrefix(name, "assets/") {
-		return "public, max-age=60, must-revalidate"
+// serve writes one asset in whichever encoding the request allows.
+func serve(w http.ResponseWriter, r *http.Request, f servable) {
+	encoding, body := f.pick(r.Header.Get("Accept-Encoding"))
+	etag := f.etag
+	if encoding != "" {
+		// A compressed body is a different representation of the same file, so
+		// it gets a validator of its own. A browser that held the gzip and then
+		// asked without it must not be told that what it holds is current.
+		etag = strings.TrimSuffix(f.etag, `"`) + "+" + encoding + `"`
 	}
-	return "no-cache"
+
+	h := w.Header()
+	h.Set("ETag", etag)
+	h.Set("Cache-Control", f.cacheControl())
+	h.Set("Vary", "Accept-Encoding")
+	h.Set("Content-Type", f.ctype)
+	if encoding != "" {
+		h.Set("Content-Encoding", encoding)
+	}
+	if match(r, etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	h.Set("Content-Length", strconv.Itoa(len(body)))
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	_, _ = w.Write(body)
+}
+
+// pick is the encoding to send and the bytes to send in it.
+func (f servable) pick(accept string) (encoding string, body []byte) {
+	for _, candidate := range encodings {
+		encoded, ok := f.encoded[candidate]
+		if ok && accepts(accept, candidate) {
+			return candidate, encoded
+		}
+	}
+	return "", f.body
+}
+
+// cacheControl lets a browser keep a file forever when the name it asked for
+// says what is in it, keep it briefly when the name does not, and never keep
+// the document that names the rest.
+func (f servable) cacheControl() string {
+	switch {
+	case f.immutable:
+		return "public, max-age=31536000, immutable"
+	case strings.HasPrefix(f.name, "assets/"):
+		return "public, max-age=60, must-revalidate"
+	default:
+		return "no-cache"
+	}
+}
+
+// accepts reports whether a request allows an encoding. A quality of zero is a
+// refusal, which is how a client asks for a file as it is without saying so.
+func accepts(header, encoding string) bool {
+	for part := range strings.SplitSeq(header, ",") {
+		token, params, _ := strings.Cut(part, ";")
+		if !strings.EqualFold(strings.TrimSpace(token), encoding) {
+			continue
+		}
+		return quality(params) > 0
+	}
+	return false
+}
+
+func quality(params string) float64 {
+	for param := range strings.SplitSeq(params, ";") {
+		key, value, ok := strings.Cut(param, "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(key), "q") {
+			continue
+		}
+		q, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		if err != nil {
+			return 0
+		}
+		return q
+	}
+	return 1
 }
 
 func match(r *http.Request, etag string) bool {
@@ -134,26 +325,30 @@ func match(r *http.Request, etag string) bool {
 	return false
 }
 
+// contentType is stated rather than sniffed. The tree holds text, the extension
+// says which kind, and a module served as anything but JavaScript is a page
+// that does not load at all.
+func contentType(name string) string {
+	switch path.Ext(name) {
+	case ".js":
+		return "text/javascript; charset=utf-8"
+	case ".css":
+		return "text/css; charset=utf-8"
+	case ".html":
+		return "text/html; charset=utf-8"
+	case ".json":
+		return "application/json"
+	case ".svg":
+		return "image/svg+xml"
+	}
+	if ctype := mime.TypeByExtension(path.Ext(name)); ctype != "" {
+		return ctype
+	}
+	return "application/octet-stream"
+}
+
 // Enabled reports whether the binary carries the interface.
 func Enabled() bool {
 	_, ok := assets()
 	return ok
-}
-
-func serveIndex(w http.ResponseWriter, r *http.Request, root fs.FS, files map[string]file) {
-	b, err := fs.ReadFile(root, "index.html")
-	if err != nil {
-		http.NotFound(w, r)
-		return
-	}
-	if f, ok := files["index.html"]; ok {
-		w.Header().Set("ETag", f.etag)
-		if match(r, f.etag) {
-			w.WriteHeader(http.StatusNotModified)
-			return
-		}
-	}
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-cache")
-	http.ServeContent(w, r, "index.html", time.Time{}, strings.NewReader(string(b)))
 }


### PR DESCRIPTION
Closes #111.

The decision in that issue is to keep shipping unbundled modules, and it is only defensible with the three things around it that did not exist yet.
This is all three, plus the test that keeps them true.

### The waterfall

`index.html` preloaded three modules out of twenty five, so the browser discovered the rest one level at a time and learned about `markdown.js` only after `content.js` had arrived.
It now preloads the whole transitive closure from `app.js`, which takes the graph from four levels deep to one.

`web/graph_test.go` is the part that makes that safe.
It reads the import statements out of every module, computes the closure, and fails if the preload list is not exactly that set.
That catches a module added without a preload, a preload left behind after a module was deleted, an importer that reached for a path instead of going through the map, and an import cycle.
All four look fine in review and none of them fails anything else in the tree.
About a hundred lines of Go and no toolchain.

### The import map

Every module now says `import { h } from "genba/dom.js"` rather than `"./dom.js"`, resolved by an inline import map.
The map has an entry per module and the `genba/` prefix as a fallback, and the test fails when a module is imported without an entry of its own.

That is what makes content addressing possible without a build step.

### Names that say what is in them

Each file is hashed as it is read and served under two names: the plain one, revalidated, and `/assets/app.936deffc.js`, `public, max-age=31536000, immutable`.
The document is rewritten on the way out so that its import map, its preload list and its stylesheet links all point at the addressed names, which is why no hash appears anywhere in the source and the committed `index.html` still works exactly as it reads.

The document itself is never cached, so an operator upgrading the binary under a browser holding the old assets is picked up on the next load.
A repeat visit costs one request instead of twenty eight conditional ones.
The plain names keep answering, because a page that was open across an upgrade goes on asking for them, and because the checks in `scripts/` import modules by name.

An asset that is not found is now a 404 rather than the shell.
The address of a file from a build that is no longer running should not be answered with a page that then fails on its MIME type three steps later.

### Compression

Brotli and gzip, computed once per file at startup and negotiated per request, so a body is never compressed twice.
It costs 96ms of startup, in parallel across files, and it is paid once for the life of the process.

| | bytes on a cold load |
| --- | --- |
| as committed | 331254 |
| gzip | 109637 |
| brotli | 91737 |

Both compressors sit behind the `noassets` tag with the assets, so an API only binary carries neither.
`go tool nm` on a headless build finds zero brotli symbols.

`github.com/andybalholm/brotli` is the one new dependency, MIT, pure Go, no cgo.
The alternative was gzip only, which is 18 KB worse on this tree for every cold load anybody ever has.

### Measurements

Same machine, same corpus, two runs of `make ui-gate` about twenty minutes apart.
Lighthouse performance went from 86 to 99, accessibility stayed at 100.
Lighthouse is noisy so I would not read the exact number, but the direction is what the preload flattening and the immutable caching are for.

### Gates

`make fmt`, `make vet`, `make race`, `make lint`, `make build`, `go build -tags noassets ./...`, `go test -tags noassets ./...` and the full `make ui-gate` are green, axe clean on all seven screens.
