### PR TITLE
Count the facets over a bounded pool

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -228,13 +228,20 @@ type searchResponse struct {
 	// Text is what was left of the query after the operators were parsed out of
 	// it, so the interface can show which part of what somebody typed became a
 	// filter rather than a search term.
-	Text    string             `json:"text"`
-	Filters searchFilters      `json:"filters"`
-	Total   int                `json:"total"`
-	Partial bool               `json:"partial,omitempty"`
-	TookMS  float64            `json:"took_ms"`
-	Hits    []searchHit        `json:"hits"`
-	Facets  map[string][]facet `json:"facets"`
+	Text    string        `json:"text"`
+	Filters searchFilters `json:"filters"`
+	Total   int           `json:"total"`
+	Partial bool          `json:"partial,omitempty"`
+	TookMS  float64       `json:"took_ms"`
+	Hits    []searchHit   `json:"hits"`
+
+	Facets map[string][]facet `json:"facets"`
+
+	// FacetsPartial says each facet count is a lower bound, because the counting
+	// stopped at [index.FacetPool] documents rather than reading every matching
+	// one. It is the same claim partial makes about the total, about the other
+	// number on the screen, and the interface writes both the same way.
+	FacetsPartial bool `json:"facets_partial,omitempty"`
 
 	// Correction is a spelling of the query that would have found something. It
 	// is only ever present on a search that found nothing, and it has already
@@ -306,13 +313,15 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 	s.metrics.observeSearch(res.Took, res.Candidates, res.Total)
 
 	out := searchResponse{
-		Query:      r.URL.Query().Get("q"),
-		Text:       query.Text,
-		Filters:    filtersOf(query),
-		Total:      res.Total,
-		Partial:    res.Truncated,
-		TookMS:     float64(res.Took.Microseconds()) / 1000,
-		Facets:     facets(res.Facets),
+		Query:         r.URL.Query().Get("q"),
+		Text:          query.Text,
+		Filters:       filtersOf(query),
+		Total:         res.Total,
+		Partial:       res.Truncated,
+		TookMS:        float64(res.Took.Microseconds()) / 1000,
+		Facets:        facets(res.Facets),
+		FacetsPartial: res.Approximate,
+
 		Hits:       []searchHit{},
 		Correction: res.Correction,
 	}

--- a/index/cache.go
+++ b/index/cache.go
@@ -358,6 +358,14 @@ func writeRequest(key *strings.Builder, r store.Request, sel store.Selection) {
 	key.WriteString(strconv.Itoa(sel.Limit))
 	key.WriteByte('|')
 	key.WriteString(strconv.FormatBool(sel.Recent))
+	key.WriteByte('|')
+	// The counting is part of the key because it is part of the value. An entry
+	// produced for a screen that wanted no counts holds a zero total and no
+	// facets, and serving it to a search would draw a page of results above the
+	// words "0 results".
+	key.WriteString(strconv.FormatBool(sel.Counts))
+	key.WriteByte('|')
+	key.WriteString(strconv.Itoa(sel.Facets))
 }
 
 func kindStrings(kinds []doc.Kind) []string {

--- a/index/counters_test.go
+++ b/index/counters_test.go
@@ -1,6 +1,7 @@
 package index_test
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -34,16 +35,17 @@ import (
 const counterCorpus = 4_000
 
 const (
-	// maxStatements is the statement budget for one search. Four queries do the
-	// work: the candidate cut, the counts and facets, the corpus statistics and
-	// the fetch of the page. The budget is a little above that so an extra
-	// lookup is allowed, and far below one statement per result, which is the
-	// shape of every N plus one regression.
-	maxStatements = 8
+	// maxStatements is the statement budget for one search. The candidate cut,
+	// the term frequencies for the candidates, the total, the facet counts, two
+	// of corpus statistics and the fetch of the page. The budget is a little
+	// above that so an extra lookup is allowed, and far below one statement per
+	// result, which is the shape of every N plus one regression.
+	maxStatements = 9
 
-	// facetRows is the rows the facet counts return: four fields, each capped
-	// at the number of values a facet reports, and the total.
-	facetRows = 4*store.MaxFacetValues + 1
+	// countRows is the rows the counting returns: the total, then the size of
+	// the pool the facets were counted over and four fields each capped at the
+	// number of values a facet reports.
+	countRows = 1 + 1 + 4*store.MaxFacetValues
 )
 
 // rowBudget is every row one search is allowed to read, by where it is read.
@@ -59,8 +61,9 @@ func rowBudget(pool, terms, hits int) int64 {
 	// grows with the query: one row per candidate per term it carries.
 	rows += pool * terms
 	// The total and the facet counts, which are aggregates, so the rows are the
-	// values reported and not the documents behind them.
-	rows += facetRows
+	// values reported and not the documents behind them. What those aggregates
+	// read is counted separately: see [store.Counters.Faceted].
+	rows += countRows
 	// The corpus row and one row per term of statistics.
 	rows += 1 + terms
 	// A search that found nothing looks for a spelling that would have found
@@ -144,6 +147,12 @@ func TestSearchCounters(t *testing.T) {
 				if most := rowBudget(int(pool), len(query.Request().Terms), len(res.Hits)); c.Rows > most {
 					t.Errorf("Search(%q) read %d rows, at most %d", q.Text, c.Rows, most)
 				}
+
+				// The facet counts, which the rows counter cannot see because an
+				// aggregate returns the same handful of rows whatever it read.
+				if c.Faceted > int64(index.FacetPool) {
+					t.Errorf("Search(%q) counted facets over %d documents, the bound is %d", q.Text, c.Faceted, index.FacetPool)
+				}
 			}
 		})
 	}
@@ -170,11 +179,67 @@ func TestSearchCounters(t *testing.T) {
 			if c.Candidates != 0 || c.Decodes != 0 {
 				t.Errorf("Search(%q) ranked %d candidates and decoded %d documents for a reader who may see nothing", q.Text, c.Candidates, c.Decodes)
 			}
-			if c.Rows > facetRows {
+			if c.Rows > countRows {
 				t.Errorf("Search(%q) read %d rows for a reader who may see nothing", q.Text, c.Rows)
 			}
 		}
 	})
+}
+
+// TestFacetCounters holds the sidebar to the facet pool, and holds the total to
+// the truth.
+//
+// The two are separate on purpose. A total is one count over the predicate and
+// there is no reason for it to be anything other than exact. The facets are four
+// grouped counts over four display strings of every matching document, which is
+// the one part of a search with no bound on it at all, so they get one and say
+// they got one. A search that reports approximate counts as though they were
+// counts is worse than either.
+func TestFacetCounters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("generating the corpus takes a few seconds the first time")
+	}
+	s, p, st := counters(t)
+
+	byClass := benchcorpus.ByClass(benchcorpus.Queries())
+	queries := append(slices.Clone(byClass[benchcorpus.ClassCommon][:12]), byClass[benchcorpus.ClassPathological][:4]...)
+
+	var bounded int
+	for _, q := range queries {
+		st.ResetCounters()
+		res, err := s.Search(t.Context(), p, index.Parse(q.Text))
+		if err != nil {
+			t.Fatalf("Search(%q): %v", q.Text, err)
+		}
+		c := st.Counters()
+
+		if res.Total <= index.FacetPool {
+			// The match set fits, so the counts are the real ones and saying
+			// otherwise would teach everybody to ignore the flag.
+			if res.Approximate {
+				t.Errorf("Search(%q) matched %d documents and called its facets approximate", q.Text, res.Total)
+			}
+			if c.Faceted != int64(res.Total) {
+				t.Errorf("Search(%q) counted facets over %d of %d matching documents", q.Text, c.Faceted, res.Total)
+			}
+			continue
+		}
+		bounded++
+		if !res.Approximate {
+			t.Errorf("Search(%q) counted %d of %d matching documents and did not say the facets are a lower bound",
+				q.Text, c.Faceted, res.Total)
+		}
+		if c.Faceted != int64(index.FacetPool) {
+			t.Errorf("Search(%q) counted facets over %d documents, the pool is %d", q.Text, c.Faceted, index.FacetPool)
+		}
+	}
+
+	// Without this the assertions above are a bound nothing in the query set has
+	// ever reached, which is a test that passes on the implementation it was
+	// written to catch.
+	if bounded == 0 {
+		t.Fatalf("no query matched more than the facet pool of %d, so the bound was never exercised", index.FacetPool)
+	}
 }
 
 // TestDeepPageCounters holds the tenth page to the same bounds as the first.

--- a/index/index.go
+++ b/index/index.go
@@ -152,9 +152,15 @@ type Results struct {
 	Total     int
 	Truncated bool
 
-	// Facets are counted over the whole match set, not over the page, which is
-	// what makes them usable as filters.
+	// Facets are counted over the match set, not over the page, which is what
+	// makes them usable as filters.
 	Facets map[string][]Facet
+
+	// Approximate says the facet counts were counted over the first [FacetPool]
+	// documents of the match set rather than over all of them, so each one is a
+	// lower bound. Total is exact either way, and an interface showing the
+	// counts is expected to say which of the two it is showing.
+	Approximate bool
 
 	// Candidates is how many documents were ranked to produce this page.
 	//
@@ -295,7 +301,12 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 	req := q.Request()
 	// A search shows a total and a facet sidebar, so it asks for the counts. See
 	// [Searcher.Recent] for the read that does not.
-	sel := store.Selection{Limit: CandidatePool(q.Offset, limit), Recent: q.Sort == ByRecent, Counts: true}
+	sel := store.Selection{
+		Limit:  CandidatePool(q.Offset, limit),
+		Recent: q.Sort == ByRecent,
+		Counts: true,
+		Facets: FacetPool,
+	}
 
 	// Phase one. Which documents are worth ranking, how many matched, and what
 	// the facet counts are, all under the permission rule and none of it
@@ -309,10 +320,11 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 	}
 
 	res := Results{
-		Total:      found.total,
-		Truncated:  found.truncated,
-		Facets:     found.facets,
-		Candidates: len(found.cands),
+		Total:       found.total,
+		Truncated:   found.truncated,
+		Facets:      found.facets,
+		Approximate: found.approximate,
+		Candidates:  len(found.cands),
 	}
 	if len(found.cands) == 0 {
 		// Nothing matched, which is the only place a correction is worth looking

--- a/index/score.go
+++ b/index/score.go
@@ -65,6 +65,27 @@ func CandidatePool(offset, limit int) int {
 	return min(max(CandidateFloor, (offset+limit)*CandidateFactor), MaxMatches)
 }
 
+// FacetPool is how many matching documents the facet counts are counted over.
+//
+// The sidebar is read as an ordering and as a set of proportions. Which sources
+// a query is finding things in, which of them has most of them, and whether
+// ticking one is going to leave anything: all three are settled by the first
+// thousand documents of a match set and none of them move when the other fifty
+// thousand are counted as well. What counting the rest costs is a read of four
+// columns of every matching document, which on a term most of the corpus
+// carries is a pass over most of the corpus, on every keystroke, for a number
+// nobody reads past its first two digits.
+//
+// So the counts stop here and say so. A count past the bound is a lower bound
+// rather than a count, [Results.Approximate] carries that up, and the interface
+// writes it as 1,000+ in the same place it already writes a truncated total.
+// The total itself is exact, because it is one count over the predicate and
+// costs nothing to be right about.
+//
+// Twice the candidate floor, so that the sidebar always describes more
+// documents than the page was ranked from.
+const FacetPool = 2 * CandidateFloor
+
 // pool is one query's retrieval: the candidates worth scoring, the counts over
 // the whole match set, and the corpus statistics the scorer needs.
 //
@@ -75,11 +96,12 @@ func CandidatePool(offset, limit int) int {
 // hundred thousand bodies is hundreds of megabytes of text that only the page's
 // worth is ever read from.
 type pool struct {
-	cands     []store.Candidate
-	total     int
-	truncated bool
-	facets    map[string][]Facet
-	corpus    store.Corpus
+	cands       []store.Candidate
+	total       int
+	truncated   bool
+	facets      map[string][]Facet
+	approximate bool
+	corpus      store.Corpus
 }
 
 // collect asks the driver for the candidates, using the best capability it has.
@@ -113,10 +135,11 @@ func (s *Searcher) collect(ctx context.Context, p *acl.Principal, r store.Reques
 			return pool{}, err
 		}
 		return pool{
-			cands:     ranked.Candidates,
-			total:     ranked.Total,
-			truncated: ranked.Truncated,
-			facets:    facetsFrom(ranked.Facets),
+			cands:       ranked.Candidates,
+			total:       ranked.Total,
+			truncated:   ranked.Truncated,
+			facets:      facetsFrom(ranked.Facets),
+			approximate: ranked.Approximate,
 		}, nil
 	}
 
@@ -157,6 +180,9 @@ func (s *Searcher) collect(ctx context.Context, p *acl.Principal, r store.Reques
 	out.cands = seen
 	out.total = len(seen)
 	out.facets = facetsOf(seen)
+	// Exact, unless [MaxMatches] stopped the walk, in which case the counts are
+	// over what was walked and are a lower bound like a driver's bounded ones.
+	out.approximate = out.truncated
 	return out, nil
 }
 

--- a/store/pgstore/pgstore.go
+++ b/store/pgstore/pgstore.go
@@ -80,6 +80,7 @@ type counters struct {
 	statements atomic.Int64
 	decodes    atomic.Int64
 	candidates atomic.Int64
+	faceted    atomic.Int64
 }
 
 // Counters reports the work this store has done since it was opened or last
@@ -90,6 +91,7 @@ func (s *Store) Counters() store.Counters {
 		Statements: s.counters.statements.Load(),
 		Decodes:    s.counters.decodes.Load(),
 		Candidates: s.counters.candidates.Load(),
+		Faceted:    s.counters.faceted.Load(),
 	}
 }
 
@@ -99,6 +101,7 @@ func (s *Store) ResetCounters() {
 	s.counters.statements.Store(0)
 	s.counters.decodes.Store(0)
 	s.counters.candidates.Store(0)
+	s.counters.faceted.Store(0)
 }
 
 // query and queryRow are the only two ways this driver reads, so that the

--- a/store/pgstore/rank.go
+++ b/store/pgstore/rank.go
@@ -24,10 +24,10 @@ import (
 // read out of columns rather than derived from text, and nothing on the path is
 // proportional to the corpus outside the index walk Postgres does for itself.
 //
-// Three statements: the candidates, their term frequencies, and one that
-// carries the total and every facet count over the same predicate. The third
-// runs only for a caller that asked for the counts, because it is the only one
-// of the three whose cost follows the match set rather than the page.
+// Four statements: the candidates, their term frequencies, the total, and the
+// facet counts. The last two run only for a caller that asked for the counts,
+// because they are the two whose cost follows the match set rather than the
+// page, and the facets are bounded on top of that. See [Store.counts].
 func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel store.Selection) (store.Ranked, error) {
 	if err := s.ready(ctx); err != nil {
 		return store.Ranked{}, err
@@ -78,17 +78,29 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 			}
 		}
 		if !sel.Counts {
-			// The counts are the one statement here whose cost follows the match
-			// set, so a caller that shows neither a total nor a sidebar does not
-			// run it.
+			// The counting is the part here whose cost follows the match set, so
+			// a caller that shows neither a total nor a sidebar does not run it.
 			out = store.Ranked{Candidates: cands}
 			return nil
 		}
-		total, facets, err := s.counts(ctx, c)
+		total, err := s.total(ctx, c)
 		if err != nil {
 			return err
 		}
-		out = store.Ranked{Candidates: cands, Total: total, Facets: facets, Truncated: total > len(cands)}
+		counted, facets, err := s.counts(ctx, c, sel.Facets)
+		if err != nil {
+			return err
+		}
+		out = store.Ranked{
+			Candidates: cands,
+			Total:      total,
+			Facets:     facets,
+			// Counted rather than the bound, because what makes the counts a
+			// lower bound is the statement having stopped early, and the
+			// statement is the only thing that knows whether it did.
+			Approximate: counted < total,
+			Truncated:   total > len(cands),
+		}
 		return nil
 	})
 	if err != nil {
@@ -181,24 +193,56 @@ func (s *Store) frequencies(ctx context.Context, cands []store.Candidate, terms 
 	return rows.Err()
 }
 
-// counts is the total and every facet, over the same predicate, in one
-// statement.
+// total is how many documents matched, in one statement over the predicate.
 //
-// One rather than five, because the predicate is the expensive part and the
-// common table expression is materialised so it is evaluated once. Five
-// statements would apply the permission rule to the match set five times over
-// to answer five questions about the same rows. MATERIALIZED is spelled out
+// It is a plain count and it reads no columns, so Postgres answers it from the
+// index scan the predicate needs anyway. The same number used to come out of the
+// common table expression below, which meant a query for a common word wrote
+// every matching row into a work table to count them.
+func (s *Store) total(ctx context.Context, c *clause) (int, error) {
+	var n int
+	if err := s.queryRow(ctx, `SELECT count(*) FROM document d WHERE `+c.where(), c.args...).Scan(&n); err != nil {
+		return 0, err
+	}
+	s.counters.rows.Add(1)
+	return n, nil
+}
+
+// counts is every facet over the same predicate, in one statement, and returns
+// how many documents it counted over.
+//
+// One statement rather than four, because the predicate is the expensive part
+// and the common table expression is materialised so it is evaluated once. Four
+// statements would apply the permission rule to the match set four times over
+// to answer four questions about the same rows. MATERIALIZED is spelled out
 // because Postgres inlines a common table expression referenced more than once
 // only when it is cheap to, and it has no way of knowing that this one is not.
-func (s *Store) counts(ctx context.Context, c *clause) (total int, facets map[string][]store.Facet, err error) {
+//
+// The bound is the LIMIT inside the expression, and it is what keeps this from
+// being proportional to the match set: the four columns are read for the first
+// bound documents and the scan stops there. They are the first in the order the
+// planner produces rather than the best matching, because ordering by the score
+// would mean reading those four columns of every matching document to find out
+// which ones to keep, which is the cost being removed. A sample of the match set
+// is what the sidebar gets, the number of documents behind it comes back so the
+// caller can say the counts are a lower bound, and the total above is exact.
+func (s *Store) counts(ctx context.Context, c *clause, bound int) (counted int, facets map[string][]store.Facet, err error) {
 	const fields = `
-		SELECT 'total'::text AS field, ''::text AS value, count(*) AS n FROM m
+		SELECT 'counted'::text AS field, ''::text AS value, count(*) AS n FROM m
 		UNION ALL SELECT * FROM (SELECT 'source'::text, source, count(*) FROM m WHERE source <> '' GROUP BY source ORDER BY 3 DESC, 2 LIMIT ?) f1
 		UNION ALL SELECT * FROM (SELECT 'kind'::text, kind, count(*) FROM m WHERE kind <> '' GROUP BY kind ORDER BY 3 DESC, 2 LIMIT ?) f2
 		UNION ALL SELECT * FROM (SELECT 'container'::text, container, count(*) FROM m WHERE container <> '' GROUP BY container ORDER BY 3 DESC, 2 LIMIT ?) f3
 		UNION ALL SELECT * FROM (SELECT 'author'::text, author, count(*) FROM m WHERE author <> '' GROUP BY author ORDER BY 3 DESC, 2 LIMIT ?) f4`
 
+	// No bound means no LIMIT rather than a limit large enough to stand in for
+	// one, because the exact answer is what a selection without a bound asked
+	// for and a very large number is not the same claim.
+	limit := ``
 	args := append([]any{}, c.args...)
+	if bound > 0 {
+		limit = ` LIMIT ?`
+		args = append(args, bound)
+	}
 	for range 4 {
 		args = append(args, store.MaxFacetValues)
 	}
@@ -206,7 +250,7 @@ func (s *Store) counts(ctx context.Context, c *clause) (total int, facets map[st
 	rows, err := s.query(ctx, `
 		WITH m AS MATERIALIZED (
 			SELECT d.source AS source, d.kind AS kind, d.container AS container, d.author_name AS author
-			FROM document d WHERE `+c.where()+`
+			FROM document d WHERE `+c.where()+limit+`
 		)`+fields, args...)
 	if err != nil {
 		return 0, nil, err
@@ -223,13 +267,17 @@ func (s *Store) counts(ctx context.Context, c *clause) (total int, facets map[st
 			return 0, nil, err
 		}
 		s.counters.rows.Add(1)
-		if field == "total" {
-			total = n
+		if field == "counted" {
+			counted = n
+			// The documents the aggregate read, which no other counter can see:
+			// see [store.Counters.Faceted] for why it is counted separately from
+			// the rows the statement returned.
+			s.counters.faceted.Add(int64(n))
 			continue
 		}
 		facets[field] = append(facets[field], store.Facet{Value: value, Count: n})
 	}
-	return total, facets, rows.Err()
+	return counted, facets, rows.Err()
 }
 
 // Statistics reads the corpus numbers the scorer needs, in two key lookups.

--- a/store/rank.go
+++ b/store/rank.go
@@ -52,6 +52,23 @@ type Selection struct {
 	// it, which is visible. Defaulting the other way would mean a caller who
 	// forgets gets the slow query, which is not.
 	Counts bool
+
+	// Facets bounds how many matching documents the facet counts are counted
+	// over. Zero counts every one of them.
+	//
+	// The total and the facets are asked for together and they are not the same
+	// question. A total is one number and a driver answers it with a count over
+	// the predicate. The facets are four grouped counts over four display
+	// strings, so answering them exactly means reading four columns of every
+	// matching document, and on a term that most of the corpus carries that is
+	// a pass over most of the corpus to draw a sidebar.
+	//
+	// Past the bound the counts are a lower bound rather than a count, and
+	// [Ranked.Approximate] says which of the two came back. Zero is kept as the
+	// exact answer because a driver has to be able to produce it: the
+	// conformance suite checks a driver's arithmetic against the same counts
+	// computed in Go, and it can only do that against an exact one.
+	Facets int
 }
 
 // Ranked is one query's retrieval: the candidates worth scoring and the counts
@@ -69,10 +86,17 @@ type Ranked struct {
 	// nothing to compare the pool against, so it is false.
 	Truncated bool
 
-	// Facets are counted over the whole match set, which is what makes them
-	// usable as filters rather than as a description of the current page. They
-	// are empty when the selection did not ask for the counts.
+	// Facets are counted over the match set rather than over the page, which is
+	// what makes them usable as filters rather than as a description of what is
+	// on screen. They are empty when the selection did not ask for the counts,
+	// and bounded by [Selection.Facets] when it set a bound.
 	Facets map[string][]Facet
+
+	// Approximate reports that the facets were counted over the first
+	// [Selection.Facets] documents of the match set rather than over all of
+	// them, so each count is a lower bound on the true one. Total is exact
+	// either way, and a caller showing the counts is expected to say so.
+	Approximate bool
 }
 
 // Candidate is what a ranker needs to score a document without reading it.

--- a/store/sqlitestore/rank.go
+++ b/store/sqlitestore/rank.go
@@ -23,10 +23,10 @@ import (
 // read out of columns rather than derived from text, and nothing on the path is
 // proportional to the corpus outside the index walk SQLite does for itself.
 //
-// Three statements: the candidates, their term frequencies, and one that
-// carries the total and every facet count over the same predicate. The third
-// runs only for a caller that asked for the counts, because it is the only one
-// of the three whose cost follows the match set rather than the page.
+// Four statements: the candidates, their term frequencies, the total, and the
+// facet counts. The last two run only for a caller that asked for the counts,
+// because they are the two whose cost follows the match set rather than the
+// page, and the facets are bounded on top of that. See [Store.counts].
 func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel store.Selection) (store.Ranked, error) {
 	if err := s.ready(ctx); err != nil {
 		return store.Ranked{}, err
@@ -93,13 +93,22 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 		}
 	}
 	if !sel.Counts {
-		// The counts are the one statement here whose cost follows the match set,
-		// so a caller that shows neither a total nor a sidebar does not run it.
+		// The counting is the part here whose cost follows the match set, so a
+		// caller that shows neither a total nor a sidebar does not run it.
 		return out, nil
 	}
-	if out.Total, out.Facets, err = s.counts(ctx, from, c); err != nil {
+	if out.Total, err = s.total(ctx, from, c); err != nil {
 		return store.Ranked{}, err
 	}
+	counted, facets, err := s.counts(ctx, from, c, sel.Facets)
+	if err != nil {
+		return store.Ranked{}, err
+	}
+	out.Facets = facets
+	// Counted rather than the bound, because what makes the counts a lower
+	// bound is the statement having stopped early, and the statement is the only
+	// thing that knows whether it did.
+	out.Approximate = counted < out.Total
 	out.Truncated = out.Total > len(cands)
 	return out, nil
 }
@@ -194,22 +203,55 @@ func (s *Store) frequencies(ctx context.Context, cands []store.Candidate, rowids
 	return rows.Err()
 }
 
-// counts is the total and every facet, over the same predicate, in one
-// statement.
+// total is how many documents matched, in one statement over the predicate.
 //
-// One rather than five, because the predicate is the expensive part and the
-// common table expression is materialised so it is evaluated once. Five
-// statements would apply the permission rule to the match set five times over
-// to answer five questions about the same rows.
-func (s *Store) counts(ctx context.Context, from string, c *clause) (total int, facets map[string][]store.Facet, err error) {
+// It is a plain count and it reads no columns, so SQLite answers it out of the
+// index walk it is doing anyway and nothing is written down on the way. The
+// same number used to come out of the common table expression below, which
+// meant a query for a common word copied every matching row into a temporary
+// b-tree to count them.
+func (s *Store) total(ctx context.Context, from string, c *clause) (int, error) {
+	var n int
+	if err := s.queryRow(ctx, `SELECT count(*) FROM `+from+` WHERE `+c.where(), c.args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("sqlitestore: rank: %w", err)
+	}
+	s.counters.rows.Add(1)
+	return n, nil
+}
+
+// counts is every facet over the same predicate, in one statement, and returns
+// how many documents it counted over.
+//
+// One statement rather than four, because the predicate is the expensive part
+// and the common table expression is materialised so it is evaluated once. Four
+// statements would apply the permission rule to the match set four times over
+// to answer four questions about the same rows.
+//
+// The bound is the LIMIT inside the expression, and it is what keeps this from
+// being proportional to the match set: the four columns are read for the first
+// bound documents and the walk stops there. They are the first in the order the
+// planner produces rather than the best matching, because ordering by the score
+// would mean reading those four columns of every matching document to find out
+// which ones to keep, which is the cost being removed. A sample of the match set
+// is what the sidebar gets, the number of documents behind it comes back so the
+// caller can say the counts are a lower bound, and the total above is exact.
+func (s *Store) counts(ctx context.Context, from string, c *clause, bound int) (counted int, facets map[string][]store.Facet, err error) {
 	const fields = `
-		SELECT 'total' AS field, '' AS value, count(*) AS n FROM m
+		SELECT 'counted' AS field, '' AS value, count(*) AS n FROM m
 		UNION ALL SELECT * FROM (SELECT 'source', source, count(*) FROM m WHERE source <> '' GROUP BY source ORDER BY 3 DESC, 2 LIMIT ?)
 		UNION ALL SELECT * FROM (SELECT 'kind', kind, count(*) FROM m WHERE kind <> '' GROUP BY kind ORDER BY 3 DESC, 2 LIMIT ?)
 		UNION ALL SELECT * FROM (SELECT 'container', container, count(*) FROM m WHERE container <> '' GROUP BY container ORDER BY 3 DESC, 2 LIMIT ?)
 		UNION ALL SELECT * FROM (SELECT 'author', author, count(*) FROM m WHERE author <> '' GROUP BY author ORDER BY 3 DESC, 2 LIMIT ?)`
 
+	// No bound means no LIMIT rather than a limit large enough to stand in for
+	// one, because the exact answer is what a selection without a bound asked
+	// for and a very large number is not the same claim.
+	limit := ``
 	args := append([]any{}, c.args...)
+	if bound > 0 {
+		limit = ` LIMIT ?`
+		args = append(args, bound)
+	}
 	for range 4 {
 		args = append(args, store.MaxFacetValues)
 	}
@@ -217,7 +259,7 @@ func (s *Store) counts(ctx context.Context, from string, c *clause) (total int, 
 	rows, err := s.query(ctx, `
 		WITH m AS MATERIALIZED (
 			SELECT d.source AS source, d.kind AS kind, d.container AS container, d.author_name AS author
-			FROM `+from+` WHERE `+c.where()+`
+			FROM `+from+` WHERE `+c.where()+limit+`
 		)`+fields, args...)
 	if err != nil {
 		return 0, nil, fmt.Errorf("sqlitestore: rank: %w", err)
@@ -234,8 +276,12 @@ func (s *Store) counts(ctx context.Context, from string, c *clause) (total int, 
 			return 0, nil, fmt.Errorf("sqlitestore: rank: %w", err)
 		}
 		s.counters.rows.Add(1)
-		if field == "total" {
-			total = n
+		if field == "counted" {
+			counted = n
+			// The documents the aggregate read, which no other counter can see:
+			// see [store.Counters.Faceted] for why it is counted separately from
+			// the rows the statement returned.
+			s.counters.faceted.Add(int64(n))
 			continue
 		}
 		facets[field] = append(facets[field], store.Facet{Value: value, Count: n})
@@ -243,7 +289,7 @@ func (s *Store) counts(ctx context.Context, from string, c *clause) (total int, 
 	if err := rows.Err(); err != nil {
 		return 0, nil, fmt.Errorf("sqlitestore: rank: %w", err)
 	}
-	return total, facets, nil
+	return counted, facets, nil
 }
 
 // Statistics reads the corpus numbers the scorer needs, in two key lookups.

--- a/store/sqlitestore/sqlitestore.go
+++ b/store/sqlitestore/sqlitestore.go
@@ -79,6 +79,7 @@ type counters struct {
 	statements atomic.Int64
 	decodes    atomic.Int64
 	candidates atomic.Int64
+	faceted    atomic.Int64
 }
 
 // Counters reports the work this store has done since it was opened or last
@@ -89,6 +90,7 @@ func (s *Store) Counters() store.Counters {
 		Statements: s.counters.statements.Load(),
 		Decodes:    s.counters.decodes.Load(),
 		Candidates: s.counters.candidates.Load(),
+		Faceted:    s.counters.faceted.Load(),
 	}
 }
 
@@ -98,6 +100,7 @@ func (s *Store) ResetCounters() {
 	s.counters.statements.Store(0)
 	s.counters.decodes.Store(0)
 	s.counters.candidates.Store(0)
+	s.counters.faceted.Store(0)
 }
 
 // query and queryRow are the only two ways this driver reads, so that the

--- a/store/store.go
+++ b/store/store.go
@@ -123,6 +123,18 @@ type Counters struct {
 	// candidate pool rather than by the match set, which is the whole point of
 	// two phase retrieval.
 	Candidates int64
+
+	// Faceted is the documents the facet counts were counted over. It is
+	// bounded by [Selection.Facets] rather than by the match set.
+	//
+	// It counts rows the database read on the driver's behalf rather than rows
+	// it handed back, which is the one place the two have to be told apart. An
+	// aggregate returns the same handful of rows whether it counted fifty
+	// documents or fifty thousand, so Rows cannot see the difference and the
+	// regression this exists to catch is invisible in it: a facet count that
+	// goes back to walking the whole match set costs a second on a common term
+	// and looks free in every other counter here.
+	Faceted int64
 }
 
 // Counted is a store that reports the work it has done.

--- a/store/storetest/rank.go
+++ b/store/storetest/rank.go
@@ -44,6 +44,7 @@ var rankCases = []rankCase{
 	{"the total counts the match set and not the pool", testRankTotal},
 	{"truncated says whether the ranking saw everything", testRankTruncated},
 	{"facets are counted over the match set and not over the pool", testRankFacets},
+	{"a facet bound counts a sample and says the counts are a lower bound", testRankFacetBound},
 	{"a selection with no counts ranks the same documents", testRankWithoutCounts},
 	{"the principal is applied inside rank", testRankPermission},
 	{"a nil principal ranks nothing", testRankNilPrincipal},
@@ -225,6 +226,55 @@ func testRankFacets(t *testing.T, s store.Store) {
 		if !maps.EqualFunc(got, want, maps.Equal) {
 			t.Fatalf("facets for a pool of %d are %v, expected %v", sel.Limit, got, want)
 		}
+	}
+}
+
+// A facet bound is what a search sets, so this is the shape a driver actually
+// runs. The counts stop at the bound, which is what keeps a query for a common
+// word from reading four columns of every document that matched, and what comes
+// back has to admit that it stopped: a sidebar showing a sample as though it
+// were a count is a number somebody will subtract two others from.
+//
+// The total is checked in the same case because it is the number that must not
+// have been bounded along with them. It is one count over the predicate and it
+// is cheap to be exact about, and a driver that answers it out of the same
+// bounded pool would report four hundred results for a query that found forty
+// thousand.
+func testRankFacetBound(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	matched := len(wantIDs(t, s, reader(), store.Request{}))
+	const bound = 2
+	got := mustRank(t, rk, reader(), store.Request{}, store.Selection{Limit: 100, Counts: true, Facets: bound})
+	if !got.Approximate {
+		t.Fatal("Approximate is not set for facets counted over a bound smaller than the match set")
+	}
+	if got.Total != matched {
+		t.Fatalf("Total = %d under a facet bound, the match set has %d documents in it", got.Total, matched)
+	}
+	if n := len(got.Candidates); n != matched {
+		t.Fatalf("the facet bound cut the candidate pool to %d of %d", n, matched)
+	}
+	for field, values := range got.Facets {
+		var counted int
+		for _, v := range values {
+			counted += v.Count
+		}
+		if counted > bound {
+			t.Fatalf("the %s facet counts %d documents under a bound of %d: %v", field, counted, bound, values)
+		}
+	}
+
+	// And a bound the match set fits inside is the exact answer, unflagged,
+	// because a search that says its counts are a sample when they are not
+	// teaches everybody to ignore the flag.
+	full := mustRank(t, rk, reader(), store.Request{}, store.Selection{Limit: 100, Counts: true, Facets: 100})
+	if full.Approximate {
+		t.Fatal("Approximate is set for facets counted over a bound larger than the match set")
+	}
+	if want := wantFacets(t, s, reader(), store.Request{}); !maps.EqualFunc(gotFacets(t, full), want, maps.Equal) {
+		t.Fatalf("facets under a bound larger than the match set are %v, expected %v", gotFacets(t, full), want)
 	}
 }
 

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -21,7 +21,12 @@ import * as urlState from "genba/state.js";
 export const VERTICALS = [
   { id: "all", title: "All", icon: "rows", kinds: [] },
   { id: "documents", title: "Documents", icon: "doc", kinds: ["page", "file"] },
-  { id: "messages", title: "Messages", icon: "chat", kinds: ["message", "email"] },
+  {
+    id: "messages",
+    title: "Messages",
+    icon: "chat",
+    kinds: ["message", "email"],
+  },
   { id: "tickets", title: "Tickets", icon: "ticket", kinds: ["ticket"] },
   { id: "code", title: "Code", icon: "code", kinds: ["code"] },
   { id: "images", title: "Images", icon: "image", kinds: ["image", "video"] },
@@ -48,7 +53,9 @@ export const VERTICALS = [
  */
 export function verticalsFor(kinds) {
   const counts = new Map((kinds || []).map((k) => [k.value, k.count]));
-  const held = VERTICALS.filter((v) => v.kinds.some((k) => (counts.get(k) || 0) > 0));
+  const held = VERTICALS.filter((v) =>
+    v.kinds.some((k) => (counts.get(k) || 0) > 0),
+  );
   return held.length > 1 ? [VERTICALS[0], ...held] : [];
 }
 
@@ -158,7 +165,13 @@ export class Results {
     this.hits = [];
     this.rows.skeleton();
     replace(this.chips);
-    replace(this.head, h("div", { class: "skeleton", style: { width: "180px", height: "16px" } }));
+    replace(
+      this.head,
+      h("div", {
+        class: "skeleton",
+        style: { width: "180px", height: "16px" },
+      }),
+    );
     replace(this.aside);
     replace(this.facets);
   }
@@ -237,7 +250,11 @@ export class Results {
     // is dropped here rather than carried. The spelling that would have worked
     // belongs to this answer for the same reason. What the index holds is a
     // fact about the corpus and survives.
-    this.context = { ...this.context, removed: null, correction: res.correction || null };
+    this.context = {
+      ...this.context,
+      removed: null,
+      correction: res.correction || null,
+    };
     this.hits = res.hits || [];
     // Kept because the paging keys have to know where the last page ends, and
     // the pager itself is rebuilt from the response every time.
@@ -256,6 +273,10 @@ export class Results {
       this.verticals.map((v) => {
         const active = (query.tab || "all") === v.id;
         const count = res ? countFor(res, v) : null;
+        // All is the total and the rest are added up out of the kind facet, so
+        // which of the two numbers is a lower bound depends on the tab.
+        const partial =
+          res && (v.kinds.length ? res.facets_partial : res.partial);
         return h(
           "button",
           {
@@ -263,10 +284,13 @@ export class Results {
             role: "tab",
             type: "button",
             "aria-selected": String(active),
-            onClick: () => this.onQuery({ ...query, tab: v.id, kind: [], offset: 0 }),
+            onClick: () =>
+              this.onQuery({ ...query, tab: v.id, kind: [], offset: 0 }),
           },
           v.title,
-          count !== null && count !== undefined && h("span", { class: "tab__count" }, number(count)),
+          count !== null &&
+            count !== undefined &&
+            h("span", { class: "tab__count" }, atLeast(count, partial)),
         );
       }),
     );
@@ -287,7 +311,8 @@ export class Results {
     // fraction and never reaches the far end exactly, so each end gets a pixel.
     const before = this.tabs.scrollLeft > 1;
     const after = room > 1 && this.tabs.scrollLeft < room - 1;
-    const state = before && after ? "both" : before ? "start" : after ? "end" : "none";
+    const state =
+      before && after ? "both" : before ? "start" : after ? "end" : "none";
     if (this.tabs.dataset.scroll !== state) this.tabs.dataset.scroll = state;
   }
 
@@ -299,7 +324,11 @@ export class Results {
       active.length > 0 &&
         h(
           "button",
-          { class: "chip", type: "button", onClick: () => this.onQuery(urlState.clear(query)) },
+          {
+            class: "chip",
+            type: "button",
+            onClick: () => this.onQuery(urlState.clear(query)),
+          },
           "Clear all",
         ),
     );
@@ -325,10 +354,15 @@ export class Results {
           "select",
           {
             class: "sort",
-            onChange: (e) => this.onQuery({ ...query, sort: e.target.value, offset: 0 }),
+            onChange: (e) =>
+              this.onQuery({ ...query, sort: e.target.value, offset: 0 }),
           },
           h("option", { value: "", selected: !query.sort }, "Most relevant"),
-          h("option", { value: "recent", selected: query.sort === "recent" }, "Most recent"),
+          h(
+            "option",
+            { value: "recent", selected: query.sort === "recent" },
+            "Most recent",
+          ),
         ),
       ),
     );
@@ -379,7 +413,10 @@ export class Results {
    */
   viewFor(query) {
     if (query.view) return query.view;
-    return this.hits.length > 0 && this.hits.every((hit) => shapeOf(hit) === "image") ? "grid" : "list";
+    return this.hits.length > 0 &&
+      this.hits.every((hit) => shapeOf(hit) === "image")
+      ? "grid"
+      : "list";
   }
 
   // The list holds results and nothing else. A list that also holds its own
@@ -387,8 +424,14 @@ export class Results {
   // item, so a reader on a screen reader is told there are twenty one results
   // and the last one is a pair of buttons.
   renderList(query, res) {
-    this.rows.render(this.hits, { view: this.viewFor(query), cursor: query.cursor });
-    replace(this.aside, this.hits.length ? pager(query, res, this.onQuery) : this.empty(query));
+    this.rows.render(this.hits, {
+      view: this.viewFor(query),
+      cursor: query.cursor,
+    });
+    replace(
+      this.aside,
+      this.hits.length ? pager(query, res, this.onQuery) : this.empty(query),
+    );
   }
 
   /** empty is why there is nothing here, with everything known so far in it. */
@@ -398,7 +441,9 @@ export class Results {
     // rather than a chip. On a page with nothing on it, a tab holding the whole
     // answer back while the state lists the filters and does not mention it is
     // the same dead end with better manners.
-    const vertical = this.verticals.find((v) => v.id === query.tab && v.id !== "all");
+    const vertical = this.verticals.find(
+      (v) => v.id === query.tab && v.id !== "all",
+    );
     if (vertical) chips.push(tabChip(vertical, query, this.onQuery));
     return nothingMatched(query, this.onQuery, { ...this.context, chips });
   }
@@ -427,11 +472,24 @@ export class Results {
                   class: "facet__item",
                   type: "button",
                   "aria-pressed": String(on),
-                  onClick: () => this.onQuery(urlState.toggle(query, key, v.value)),
+                  onClick: () =>
+                    this.onQuery(urlState.toggle(query, key, v.value)),
                 },
-                h("span", { class: "facet__box" }, on ? svg(icon("check"), 12) : null),
-                h("span", { class: "facet__label", title: v.value }, titled ? label(v.value) : v.value),
-                h("span", { class: "facet__count" }, number(v.count)),
+                h(
+                  "span",
+                  { class: "facet__box" },
+                  on ? svg(icon("check"), 12) : null,
+                ),
+                h(
+                  "span",
+                  { class: "facet__label", title: v.value },
+                  titled ? label(v.value) : v.value,
+                ),
+                h(
+                  "span",
+                  { class: "facet__count" },
+                  atLeast(v.count, res.facets_partial),
+                ),
               ),
             );
           }),
@@ -478,6 +536,20 @@ export class Results {
   }
 }
 
+/**
+ * atLeast writes a count, and says so when it is only a lower bound.
+ *
+ * The server counts the facets over the first thousand documents that matched
+ * rather than over all of them, because counting four fields of every matching
+ * document is the one part of a search with no bound on it. Past that the number
+ * under a filter is at least this many rather than exactly this many, and the
+ * plus is how the result count already says the same thing about a total it
+ * stopped counting.
+ */
+function atLeast(n, partial) {
+  return partial ? `${number(n)}+` : number(n);
+}
+
 function countFor(res, vertical) {
   if (!vertical.kinds.length) return res.total;
   const kinds = (res.facets && res.facets.kind) || [];
@@ -490,7 +562,11 @@ function countFor(res, vertical) {
 }
 
 function labelFor(field) {
-  return { source: "Source", kind: "Type", container: "In", author: "Person" }[field] || field;
+  return (
+    { source: "Source", kind: "Type", container: "In", author: "Person" }[
+      field
+    ] || field
+  );
 }
 
 function pager(query, res, onQuery) {
@@ -509,7 +585,8 @@ function pager(query, res, onQuery) {
         class: "button",
         type: "button",
         disabled: !hasPrev,
-        onClick: () => onQuery({ ...query, offset: Math.max(0, offset - limit) }),
+        onClick: () =>
+          onQuery({ ...query, offset: Math.max(0, offset - limit) }),
       },
       "Previous",
     ),


### PR DESCRIPTION
Closes #69.

`counts` materialised the whole match set and read it five times, once for the total and once for each of the four facet fields.
On a term most of the corpus carries that is a pass over most of the corpus on every keystroke, and it was the one part of a search with no bound on it at all.

This follows the shape the issue suggests.

## The total

A plain `count(*)` over the predicate, no CTE, nothing materialised.
It stays exact, because it is one count and there is no reason for it to be anything else.
A bounded total would report four hundred results for a query that found forty thousand, which is a worse answer than a slow one.

## The facets

Counted over the first `FacetPool` documents of the match set.
The bound sits next to `CandidatePool` in `index/score.go` and is twice the candidate floor, so the sidebar always describes more documents than the page was ranked from.

Which sources a query is finding things in, which of them has most of them, and whether ticking one is going to leave anything are all settled by the first thousand documents of a match set.
None of the three move when the other fifty thousand are counted as well.
What counting the rest costs is a read of four columns of every matching document, for a number nobody reads past its first two digits.

Past the bound each count is a lower bound and the response says so.
`Ranked.Approximate` carries it out of the driver, `Results.Approximate` out of the index, `facets_partial` out of the API, and the interface writes `1,000+` in the same place it already writes a truncated total.
The All tab reads the total and the rest are added up out of the kind facet, so which of the two numbers is a lower bound depends on the tab.

`Selection.Facets` of zero still means count every one of them, because the conformance suite needs an exact answer to check a driver's arithmetic against.

## The assertion

The rows counter cannot see this regression.
An aggregate hands back the same handful of rows whether it counted fifty documents or fifty thousand, so a facet count that goes back to walking the whole match set costs a second on a common term and looks free in every counter we had.

The counting statement now returns its own pool size as a row and the drivers record it in a new `Counters.Faceted`, which counts rows the database read on the driver's behalf rather than rows it handed back.
`TestFacetCounters` runs twelve common and four pathological queries and holds each one to it: under the bound the counts are exact and the flag is off, over it the counts stopped at exactly the bound and the flag is on.
It fails if no query in the set reaches the bound at all, so the assertions cannot quietly become a bound nothing touches.

## Measurement

On the twenty thousand document fixture, best of five, each column adding one statement to the one before it:

| query | hits | cut | plus total | plus bounded facets | before |
| --- | --- | --- | --- | --- | --- |
| bababa | 12,396 | 58.5ms | 86.2ms | 90.3ms | 139.6ms |
| nixtenba | 4,170 | 17.0ms | 27.9ms | 32.5ms | 45.5ms |
| falfalba | 3,182 | 13.7ms | 22.8ms | 26.9ms | 36.4ms |
| ronixba | 2,594 | 11.3ms | 18.8ms | 23.2ms | 30.4ms |

Facet counting went from about 53ms to about 4ms on the largest query and is now flat in the hit count.
The cut and the total are still proportional to the match set, which is the part #104 and #55 are about.

## Also

The ranked cache key did not name `sel.Counts`.
An entry produced for a screen that asked for no counts holds a zero total and no facets, and serving it to a search would draw a page of results above the words "0 results".
Both `Counts` and `Facets` are in the key now.

## Gates

`make build`, `make fmt`, `make vet`, `go test ./...`, `make race`, `make lint`, `make bench-counters`, `make bench-gate` and `make headless` all pass.
`make ui-gate` passes lighthouse at 99 performance and 100 accessibility, and axe does not run on this machine because the local chromedriver is a major version ahead of the installed Chrome. CI runs it.
The pgstore half is covered by the same conformance suite and runs in CI with `GENBA_TEST_POSTGRES`.