### PR TITLE
Facet counts describe the choice rather than the current state

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -270,6 +270,17 @@ type searchFilters struct {
 type facet struct {
 	Value string `json:"value"`
 	Count int    `json:"count"`
+
+	// Selected says the query already narrows to this value, so the interface
+	// draws it ticked.
+	//
+	// The server says it rather than the client working it out, because working
+	// it out means comparing a filter somebody typed against a display string a
+	// connector produced, and the comparison that decided whether the document
+	// matched has already been made once, down in the store. A client that
+	// compared them a second time and got a different answer would draw a box
+	// unticked next to a count that only makes sense because it is ticked.
+	Selected bool `json:"selected,omitempty"`
 }
 
 type searchHit struct {
@@ -319,7 +330,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 		Total:         res.Total,
 		Partial:       res.Truncated,
 		TookMS:        float64(res.Took.Microseconds()) / 1000,
-		Facets:        facets(res.Facets),
+		Facets:        facets(res.Facets, query.Request()),
 		FacetsPartial: res.Approximate,
 
 		Hits:       []searchHit{},
@@ -773,16 +784,58 @@ func (s *Server) cacheStats() map[string]cache.Stats {
 	return out
 }
 
-func facets(in map[string][]index.Facet) map[string][]facet {
+// facets is the sidebar on the wire, with the values the query already narrows
+// to marked.
+//
+// The counts here are not all counted over the same set of documents. A field
+// the query narrows is counted with its own filter lifted, so its values say
+// what choosing them instead would find, and the value already chosen says what
+// is on the screen. Which of the two a number is depends entirely on the flag
+// next to it, which is why the flag is on the wire rather than inferred.
+func facets(in map[string][]index.Facet, r store.Request) map[string][]facet {
 	out := make(map[string][]facet, len(in))
 	for name, values := range in {
+		chosen := chosenValues(r, name)
 		fs := make([]facet, 0, len(values))
 		for _, v := range values {
-			fs = append(fs, facet{Value: v.Value, Count: v.Count})
+			fs = append(fs, facet{Value: v.Value, Count: v.Count, Selected: contains(chosen, v.Value)})
 		}
 		out[name] = fs
 	}
 	return out
+}
+
+// chosenValues is what the query narrows the field to, and nothing for a field
+// it leaves alone.
+func chosenValues(r store.Request, field string) []string {
+	switch field {
+	case "source":
+		return r.Sources
+	case "kind":
+		kinds := make([]string, 0, len(r.Kinds))
+		for _, k := range r.Kinds {
+			kinds = append(kinds, string(k))
+		}
+		return kinds
+	case "container":
+		return r.Containers
+	case "author":
+		return r.Authors
+	}
+	return nil
+}
+
+// contains compares the way the filters themselves compare, through
+// [store.Fold], so a link somebody typed in a different case still ticks the box
+// it filtered by.
+func contains(values []string, value string) bool {
+	folded := store.Fold(value)
+	for _, v := range values {
+		if store.Fold(v) == folded {
+			return true
+		}
+	}
+	return false
 }
 
 func intParam(v string) (int, error) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -113,8 +113,9 @@ type searchBody struct {
 		Score   float64 `json:"score"`
 	} `json:"hits"`
 	Facets map[string][]struct {
-		Value string `json:"value"`
-		Count int    `json:"count"`
+		Value    string `json:"value"`
+		Count    int    `json:"count"`
+		Selected bool   `json:"selected"`
 	} `json:"facets"`
 }
 
@@ -335,6 +336,78 @@ func TestSearchReadsOperatorsFromTheQuery(t *testing.T) {
 	}
 	if len(typed.Hits) != 1 || typed.Hits[0].ID != "d1" {
 		t.Fatalf("app:gdrive returned %v, want only the drive document", typed.Hits)
+	}
+}
+
+// A filter panel is a set of questions about what would happen if you chose
+// something else, and the answer to all of them used to be zero. Counting a
+// field with its own filter applied leaves the value that was ticked reporting
+// its own count and every sibling reporting nothing, so the one moment somebody
+// needs to know whether unticking is worth it is the moment the panel goes
+// blank.
+func TestSearchCountsAFacetWithItsOwnFilterLifted(t *testing.T) {
+	h := engineerWithBothGroups()
+	body := decode[searchBody](t, request(t, newServer(t), http.MethodGet,
+		"/api/v1/search?q=payments&kind=page", h))
+
+	if body.Total != 1 {
+		t.Fatalf("total = %d, the filtered match set is one page", body.Total)
+	}
+	kinds := map[string]int{}
+	for _, v := range body.Facets["kind"] {
+		kinds[v.Value] = v.Count
+	}
+	if kinds["page"] != 1 || kinds["ticket"] != 1 {
+		t.Fatalf("the kind facet is %v, and there is a page and a ticket to be found", kinds)
+	}
+
+	// The other fields keep the filter, because they are a different question.
+	// How many results there are in Drive given that you are looking at pages is
+	// useful. How many there are with the query's filters ignored is a fact about
+	// the corpus rather than about the search.
+	sources := map[string]int{}
+	for _, v := range body.Facets["source"] {
+		sources[v.Value] = v.Count
+	}
+	if len(sources) != 1 || sources["gdrive"] != 1 {
+		t.Fatalf("the source facet is %v, and only the drive document is a page", sources)
+	}
+}
+
+// Which values are ticked is the server's answer rather than the client's,
+// because a count that was computed with a filter lifted only makes sense next
+// to the flag that says the filter is there.
+func TestSearchSaysWhichFacetValuesAreChosen(t *testing.T) {
+	h := engineerWithBothGroups()
+	srv := newServer(t)
+
+	body := decode[searchBody](t, request(t, srv, http.MethodGet, "/api/v1/search?q=payments&kind=page", h))
+	for _, v := range body.Facets["kind"] {
+		if want := v.Value == "page"; v.Selected != want {
+			t.Errorf("the kind facet reports %q as selected=%v", v.Value, v.Selected)
+		}
+	}
+	// A different field, untouched by the query, has nothing chosen in it.
+	for _, v := range body.Facets["source"] {
+		if v.Selected {
+			t.Errorf("the source facet reports %q as chosen and the query does not narrow by source", v.Value)
+		}
+	}
+
+	// A typed operator is the same filter as a ticked box, so it ticks the box.
+	typed := decode[searchBody](t, request(t, srv, http.MethodGet,
+		"/api/v1/search?q="+url.QueryEscape("payments app:gdrive"), h))
+	var chosen int
+	for _, v := range typed.Facets["source"] {
+		if v.Selected {
+			chosen++
+			if v.Value != "gdrive" {
+				t.Errorf("app:gdrive ticked %q", v.Value)
+			}
+		}
+	}
+	if chosen != 1 {
+		t.Errorf("app:gdrive ticked %d values in the source facet", chosen)
 	}
 }
 

--- a/index/counters_test.go
+++ b/index/counters_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/benchcorpus"
+	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/index"
 	"github.com/tamnd/genba/store"
 	"github.com/tamnd/genba/store/sqlitestore"
@@ -34,19 +35,43 @@ import (
 // minute.
 const counterCorpus = 4_000
 
-const (
-	// maxStatements is the statement budget for one search. The candidate cut,
-	// the term frequencies for the candidates, the total, the facet counts, two
-	// of corpus statistics and the fetch of the page. The budget is a little
-	// above that so an extra lookup is allowed, and far below one statement per
-	// result, which is the shape of every N plus one regression.
-	maxStatements = 9
+// maxStatements is the statement budget for one search. The candidate cut, the
+// term frequencies for the candidates, the total, the facet counts, two of
+// corpus statistics and the fetch of the page. The budget is a little above that
+// so an extra lookup is allowed, and far below one statement per result, which
+// is the shape of every N plus one regression.
+//
+// It does not move with the filters. Every facet, lifted or not, is counted in
+// the same statement, and a filtered search running one statement per ticked box
+// is the regression this number is here to catch.
+const maxStatements = 9
 
-	// countRows is the rows the counting returns: the total, then the size of
-	// the pool the facets were counted over and four fields each capped at the
-	// number of values a facet reports.
-	countRows = 1 + 1 + 4*store.MaxFacetValues
-)
+// countRows is the rows the counting returns for a request that constrains the
+// given number of facet fields: the total, then one pool per expression the
+// statement declares and one capped group of values per field it counts.
+//
+// A field somebody has ticked is counted twice, once with its own filter lifted
+// and once over the match set, and the lifted count needs an expression of its
+// own. So a search with two boxes ticked returns rather more rows than one with
+// none, and writing that out is how the growth stays something somebody chose
+// rather than something that happened.
+func countRows(constrained int) int {
+	pools := 1 + constrained
+	groups := len(store.FacetFields) + constrained
+	return 1 + pools + groups*store.MaxFacetValues
+}
+
+// constrained is how many facet fields the request narrows, which is what the
+// counting statement grows with.
+func constrained(r store.Request) int {
+	var n int
+	for _, field := range store.FacetFields {
+		if r.Constrains(field) {
+			n++
+		}
+	}
+	return n
+}
 
 // rowBudget is every row one search is allowed to read, by where it is read.
 //
@@ -54,7 +79,7 @@ const (
 // a bound somebody chose, and a search that goes over one of them has broken
 // the thing that bound was protecting, which is a more useful failure than
 // "slower than it was".
-func rowBudget(pool, terms, hits int) int64 {
+func rowBudget(pool, terms, hits, constrained int) int64 {
 	// Phase one hands back at most the pool.
 	rows := pool
 	// The term frequencies for those candidates, which is the one part that
@@ -63,7 +88,7 @@ func rowBudget(pool, terms, hits int) int64 {
 	// The total and the facet counts, which are aggregates, so the rows are the
 	// values reported and not the documents behind them. What those aggregates
 	// read is counted separately: see [store.Counters.Faceted].
-	rows += countRows
+	rows += countRows(constrained)
 	// The corpus row and one row per term of statistics.
 	rows += 1 + terms
 	// A search that found nothing looks for a spelling that would have found
@@ -123,6 +148,7 @@ func TestSearchCounters(t *testing.T) {
 				}
 				c := st.Counters()
 				pool := int64(index.CandidatePool(query.Offset, index.DefaultLimit))
+				filters := constrained(query.Request())
 
 				// Decoding is the expensive part of returning a result, because
 				// it is JSON, so a search decodes the page it is about to
@@ -144,14 +170,20 @@ func TestSearchCounters(t *testing.T) {
 
 				// And the rows, which is the counter that catches a count being
 				// done by reading the rows and adding them up in Go.
-				if most := rowBudget(int(pool), len(query.Request().Terms), len(res.Hits)); c.Rows > most {
+				if most := rowBudget(int(pool), len(query.Request().Terms), len(res.Hits), filters); c.Rows > most {
 					t.Errorf("Search(%q) read %d rows, at most %d", q.Text, c.Rows, most)
 				}
 
 				// The facet counts, which the rows counter cannot see because an
 				// aggregate returns the same handful of rows whatever it read.
-				if c.Faceted > int64(index.FacetPool) {
-					t.Errorf("Search(%q) counted facets over %d documents, the bound is %d", q.Text, c.Faceted, index.FacetPool)
+				//
+				// The bound is per expression and there is one of those for the
+				// match set plus one per ticked box, because a field counted with
+				// its own filter lifted is counted over a different set of
+				// documents and each of them stops at the same bound. Four boxes
+				// is five bounded walks and never a walk of the match set.
+				if most := int64(index.FacetPool) * int64(1+filters); c.Faceted > most {
+					t.Errorf("Search(%q) counted facets over %d documents, the bound is %d", q.Text, c.Faceted, most)
 				}
 			}
 		})
@@ -179,7 +211,7 @@ func TestSearchCounters(t *testing.T) {
 			if c.Candidates != 0 || c.Decodes != 0 {
 				t.Errorf("Search(%q) ranked %d candidates and decoded %d documents for a reader who may see nothing", q.Text, c.Candidates, c.Decodes)
 			}
-			if c.Rows > countRows {
+			if c.Rows > int64(countRows(0)) {
 				t.Errorf("Search(%q) read %d rows for a reader who may see nothing", q.Text, c.Rows)
 			}
 		}
@@ -240,6 +272,94 @@ func TestFacetCounters(t *testing.T) {
 	if bounded == 0 {
 		t.Fatalf("no query matched more than the facet pool of %d, so the bound was never exercised", index.FacetPool)
 	}
+}
+
+// A filtered search counts more documents than it matched, on purpose. A field
+// somebody has ticked is counted a second time with its own filter lifted, so
+// that the values nobody ticked still carry the number of results choosing them
+// would find, which is the one thing worth knowing at the moment somebody is
+// looking at a filter they have already applied.
+//
+// What that must not become is unbounded. The bound applies to each of those
+// walks separately, so the work grows by a factor of the boxes somebody ticked,
+// which is at most five walks, and never with the size of the match set.
+func TestFilteredFacetCounters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("generating the corpus takes a few seconds the first time")
+	}
+	s, p, st := counters(t)
+
+	byClass := benchcorpus.ByClass(benchcorpus.Queries())
+	queries := append(slices.Clone(byClass[benchcorpus.ClassFilter][:8]), byClass[benchcorpus.ClassTermFilter][:8]...)
+
+	var siblings, exact int
+	for _, q := range queries {
+		query := index.Parse(q.Text)
+		r := query.Request()
+		filters := constrained(r)
+		if filters == 0 {
+			t.Fatalf("%q is meant to be a filtered query and narrows no facet", q.Text)
+		}
+
+		st.ResetCounters()
+		res, err := s.Search(t.Context(), p, query)
+		if err != nil {
+			t.Fatalf("Search(%q): %v", q.Text, err)
+		}
+		if most := int64(index.FacetPool) * int64(1+filters); st.Counters().Faceted > most {
+			t.Errorf("Search(%q) counted facets over %d documents, the bound is %d",
+				q.Text, st.Counters().Faceted, most)
+		}
+
+		for _, field := range store.FacetFields {
+			if !r.Constrains(field) {
+				continue
+			}
+			var ticked, other int
+			for _, v := range res.Facets[field] {
+				if chosen(r, field, v.Value) {
+					ticked = v.Count
+					continue
+				}
+				other++
+			}
+			siblings += other
+			// The value somebody ticked reports the results they are looking at,
+			// which is the total. Under the bound it is a lower bound like every
+			// other count, so the check is on the queries small enough to be exact.
+			if res.Approximate || res.Total > index.FacetPool {
+				continue
+			}
+			exact++
+			if ticked != res.Total {
+				t.Errorf("Search(%q) ticked %s and its own count is %d of %d results",
+					q.Text, field, ticked, res.Total)
+			}
+		}
+	}
+
+	// The point of all of it. If every ticked field reported nothing but itself
+	// the assertions above would still pass, and the sidebar would be a list of
+	// one thing somebody already knows.
+	if siblings == 0 {
+		t.Fatal("no filtered query offered a single alternative to the value it had ticked")
+	}
+	if exact == 0 {
+		t.Fatal("every filtered query was counted under the bound, so nothing checked a ticked count against the total")
+	}
+}
+
+// chosen reports whether the request already narrows the field to this value.
+func chosen(r store.Request, field, value string) bool {
+	switch field {
+	case "source":
+		return slices.Contains(r.Sources, value)
+	case "kind":
+		return slices.Contains(r.Kinds, doc.Kind(value))
+	case "container":
+		return slices.Contains(r.Containers, value)
+	}
+	return false
 }
 
 // TestDeepPageCounters holds the tenth page to the same bounds as the first.

--- a/index/driver_test.go
+++ b/index/driver_test.go
@@ -89,6 +89,15 @@ func TestDriversAgree(t *testing.T) {
 		{"an author filter", p, index.Query{Authors: []string{"mei@acme.com"}}},
 		{"an owner filter", p, index.Query{Owners: []string{"mei@acme.com"}}},
 		{"a term and a filter", p, index.Query{Text: "payments", Sources: []string{"gdrive"}}},
+		// A filtered query is where the two ways of counting a facet can differ
+		// without the results differing at all: each field is counted with its own
+		// filter lifted, so the sidebar describes documents the page does not
+		// contain. One driver does that in SQL and the other in Go, and a
+		// disagreement here is a sidebar that changes when a deployment switches
+		// storage.
+		{"two filters", p, index.Query{Sources: []string{"gdrive"}, Kinds: []doc.Kind{doc.KindPage}}},
+		{"a filter matching nothing", p, index.Query{Sources: []string{"jira"}, Authors: []string{"mei@acme.com"}}},
+		{"a term and two filters", p, index.Query{Text: "payments", Sources: []string{"gdrive", "slack"}, Containers: []string{"Platform"}}},
 		{"a lower time bound", p, index.Query{Since: epoch.AddDate(0, 0, -30)}},
 		{"an upper time bound", p, index.Query{Until: epoch.AddDate(0, 0, -30)}},
 		{"a window", p, index.Query{Since: epoch.AddDate(0, 0, -60), Until: epoch.AddDate(0, 0, -10)}},

--- a/index/score.go
+++ b/index/score.go
@@ -143,27 +143,42 @@ func (s *Searcher) collect(ctx context.Context, p *acl.Principal, r store.Reques
 		}, nil
 	}
 
+	// The walk is over the request with the facet constraints lifted, and the
+	// constraints are applied here instead. A document that fails exactly one of
+	// them is not a result and is still a count: it is what ticking that value
+	// instead would have found, which is the number the sidebar exists to show.
+	// See [store.Request.Without].
+	base := r.WithoutFacets()
 	var (
-		out  pool
-		seen []store.Candidate
+		out    pool
+		seen   []store.Candidate
+		counts = newDrill(r)
+		walked int
 	)
 	take := func(d doc.Document) bool {
-		if len(seen) >= MaxMatches {
+		// The cap is on the walk rather than on the match set, because the walk
+		// is the work. A query that reaches it has stopped counting, and
+		// truncated is how that is admitted.
+		if walked >= MaxMatches {
 			out.truncated = true
 			return false
 		}
-		seen = append(seen, candidateOf(d, r.Terms))
+		walked++
+		if counts.add(d) {
+			seen = append(seen, candidateOf(d, r.Terms))
+		}
 		return true
 	}
 
 	var err error
 	if rt, ok := s.store.(store.Retriever); ok {
-		// The driver has already applied the terms and the filters, so every
-		// document it yields is in the match set.
-		err = rt.Retrieve(ctx, p, r, take)
+		// The driver has already applied the terms and everything that is not a
+		// facet, so what it yields is the match set plus the documents one
+		// ticked box away from it.
+		err = rt.Retrieve(ctx, p, base, take)
 	} else {
 		err = s.store.Scan(ctx, p, func(d doc.Document) bool {
-			if !r.Matches(d) {
+			if !base.Matches(d) {
 				return true
 			}
 			return take(d)
@@ -179,11 +194,82 @@ func (s *Searcher) collect(ctx context.Context, p *acl.Principal, r store.Reques
 	// scoring instead: see [Searcher.Search].
 	out.cands = seen
 	out.total = len(seen)
-	out.facets = facetsOf(seen)
+	out.facets = counts.facets()
 	// Exact, unless [MaxMatches] stopped the walk, in which case the counts are
 	// over what was walked and are a lower bound like a driver's bounded ones.
 	out.approximate = out.truncated
 	return out, nil
+}
+
+// drill counts the facets the way a filter panel has to be counted: each field
+// with its own constraint lifted, and every other constraint applied.
+//
+// This is the Go side of what a driver does in SQL, and the two produce the same
+// sidebar for the same query, which is what store/storetest holds a driver to. A
+// document is offered to it once and lands in one of three places. In the match
+// set, where it counts towards all four fields. One constraint short of it,
+// where it counts towards that field and nothing else, because it is a result
+// that ticking that value would produce. Two or more short, where it counts
+// towards nothing: it is not reachable by changing one answer, and a count that
+// included it would be a count of a page nobody can get to.
+type drill struct {
+	r      store.Request
+	counts map[string]map[string]int
+}
+
+func newDrill(r store.Request) *drill {
+	d := &drill{r: r, counts: make(map[string]map[string]int, len(store.FacetFields))}
+	for _, field := range store.FacetFields {
+		d.counts[field] = map[string]int{}
+	}
+	return d
+}
+
+// add records one document and reports whether it is in the match set.
+func (dr *drill) add(d doc.Document) bool {
+	missing := ""
+	for _, field := range store.FacetFields {
+		if dr.r.Passes(field, d) {
+			continue
+		}
+		if missing != "" {
+			return false
+		}
+		missing = field
+	}
+	if missing != "" {
+		dr.counts[missing][valueOf(missing, d)]++
+		return false
+	}
+	for _, field := range store.FacetFields {
+		dr.counts[field][valueOf(field, d)]++
+	}
+	return true
+}
+
+func (dr *drill) facets() map[string][]Facet {
+	out := make(map[string][]Facet, len(dr.counts))
+	for field, counts := range dr.counts {
+		out[field] = sortedFacets(counts)
+	}
+	return out
+}
+
+// valueOf is the display string a facet counts a document under. It is the same
+// string a driver reads out of its own column, because both of them are what a
+// person sees on the row and clicks to filter by.
+func valueOf(field string, d doc.Document) string {
+	switch field {
+	case "source":
+		return d.Source
+	case "kind":
+		return string(d.Kind)
+	case "container":
+		return d.Container
+	case "author":
+		return d.Author.Display()
+	}
+	return ""
 }
 
 // candidateOf is a document reduced to what the ranking reads.
@@ -272,26 +358,6 @@ func score(c store.Candidate, terms []string, corpus store.Corpus) float64 {
 		total += idf * tf * (bm25K1 + 1) / (tf + norm)
 	}
 	return total
-}
-
-// facetsOf counts the facets over a match set the caller holds in full.
-func facetsOf(cands []store.Candidate) map[string][]Facet {
-	bySource := map[string]int{}
-	byKind := map[string]int{}
-	byContainer := map[string]int{}
-	byAuthor := map[string]int{}
-	for _, c := range cands {
-		bySource[c.Source]++
-		byKind[string(c.Kind)]++
-		byContainer[c.Container]++
-		byAuthor[c.Author]++
-	}
-	return map[string][]Facet{
-		"source":    sortedFacets(bySource),
-		"kind":      sortedFacets(byKind),
-		"container": sortedFacets(byContainer),
-		"author":    sortedFacets(byAuthor),
-	}
 }
 
 // facetsFrom carries a driver's counts across, in the same order the Go side

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -100,6 +100,39 @@ async function walk(session) {
     })`,
   );
 
+  // Facet labels, asked of the function for the same reason. The corpus the
+  // gate indexes has whatever paths it has, and the case worth pinning is the
+  // one where two of them would read identically.
+  await check(
+    session,
+    "a facet value reads as its last segment, and a collision grows one",
+    `import('genba/format.js').then(({ facetLabels }) => {
+      const out = facetLabels([
+        'team/alpha/docs',
+        'team/beta/docs',
+        '/Users/mei/notes/Spec/2121',
+      ]);
+      return out[0].label === 'alpha/docs' && out[1].label === 'beta/docs' &&
+        out[0].context === 'team' &&
+        out[2].label === '2121' &&
+        out[2].context === 'Users / mei / notes / Spec';
+    })`,
+  );
+
+  await check(
+    session,
+    "a filter row shows the end of the value rather than the start",
+    `(() => {
+      const items = [...document.querySelectorAll('.facet__item')];
+      return items.length > 0 && items.every((el) => {
+        const value = el.querySelector('.facet__text').title;
+        const shown = el.querySelector('.facet__label').textContent.trim().toLowerCase();
+        const last = (value.split('/').filter(Boolean).pop() || value).toLowerCase();
+        return shown.endsWith(last);
+      });
+    })()`,
+  );
+
   await press(session, "j", "KeyJ", 74);
   await check(
     session,
@@ -543,6 +576,24 @@ async function walk(session) {
     })()`,
   );
 
+  // The wide half of the one filter surface rule. The panel is the surface, so
+  // the button that would open it somewhere else is not on the page at all. The
+  // width is set rather than assumed, because a headless window opens at 800 and
+  // every rule here is about which side of 960 we are on.
+  await narrow(session, 1280, 900);
+  await visit(session, `${BASE}/?q=cache`, "document.querySelectorAll('.facet__item').length > 0");
+  await check(
+    session,
+    "the panel is the only filter surface where there is room for it",
+    `(() => {
+      const panel = document.querySelector('.facets');
+      const toggle = document.querySelector('.filterbar__toggle');
+      return panel.getBoundingClientRect().height > 0 &&
+        toggle.offsetParent === null &&
+        panel.getAttribute('aria-modal') === null;
+    })()`,
+  );
+
   // Last, because it changes the viewport for everything after it. 390 is the
   // narrowest phone worth drawing for, and it is the width at which the strip
   // used to shrink its tabs to fit instead of scrolling, so the last one read
@@ -559,6 +610,34 @@ async function walk(session) {
       );
       return whole && tabs.scrollWidth > tabs.clientWidth && tabs.dataset.scroll === 'end';
     })()`,
+  );
+
+  // The narrow half of the one filter surface rule. The same panel comes up as
+  // a sheet, and the button that raised it goes, so there is never a Filters
+  // button sitting next to an open panel of filters.
+  await settle(session, "document.querySelectorAll('.facet__item').length > 0");
+  await evaluate(session, "document.querySelector('.filterbar__toggle').click()");
+  await check(
+    session,
+    "at 390 pixels the filters are a sheet and the button that opened it is gone",
+    `(() => {
+      const panel = document.querySelector('.facets');
+      const toggle = document.querySelector('.filterbar__toggle');
+      return panel.dataset.open === 'true' &&
+        panel.getBoundingClientRect().height > 0 &&
+        panel.getAttribute('aria-modal') === 'true' &&
+        toggle.offsetParent === null &&
+        panel.contains(document.activeElement);
+    })()`,
+  );
+
+  await press(session, "Escape", "Escape", 27);
+  await check(
+    session,
+    "Escape closes the sheet and puts focus back on the button",
+    `document.querySelector('.facets').dataset.open === 'false' &&
+      document.querySelector('.scrim--filters').hidden &&
+      document.activeElement === document.querySelector('.filterbar__toggle')`,
   );
 
   // At this width the drawer is the window and there is nothing behind it to

--- a/store/pgstore/rank.go
+++ b/store/pgstore/rank.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -39,8 +41,19 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 		return store.Ranked{}, errors.New("pgstore: rank: no candidate limit")
 	}
 
-	c := visible(p)
-	filters(r, c)
+	// The predicate for a request, built the same way whatever is being asked
+	// about. The counting asks about a request with one facet constraint lifted,
+	// and building that by hand somewhere else is how two predicates that are
+	// meant to be the same drift apart.
+	pred := func(r store.Request) *clause {
+		c := visible(p)
+		filters(r, c)
+		if q, ok := tsquery(r.Terms); ok {
+			c.add(`d.terms @@ ?::tsquery`, q)
+		}
+		return c
+	}
+	c := pred(r)
 
 	// The cut order. Ties break on the id so that two runs of the same query
 	// return the same page, which a client paging through results depends on and
@@ -53,7 +66,6 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 		order = `d.modified_at DESC NULLS LAST, d.id`
 	}
 	if q, ok := tsquery(r.Terms); ok {
-		c.add(`d.terms @@ ?::tsquery`, q)
 		if !sel.Recent {
 			// ts_rank descending is best first. It is only the cut, not the
 			// ranking: the score that orders the results is computed in Go over
@@ -87,7 +99,7 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 		if err != nil {
 			return err
 		}
-		counted, facets, err := s.counts(ctx, c, sel.Facets)
+		counted, stopped, facets, err := s.counts(ctx, r, pred, sel.Facets)
 		if err != nil {
 			return err
 		}
@@ -97,8 +109,10 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 			Facets:     facets,
 			// Counted rather than the bound, because what makes the counts a
 			// lower bound is the statement having stopped early, and the
-			// statement is the only thing that knows whether it did.
-			Approximate: counted < total,
+			// statement is the only thing that knows whether it did. A lifted
+			// count has no total to be compared against, so stopped carries the
+			// same claim for those.
+			Approximate: counted < total || stopped,
 			Truncated:   total > len(cands),
 		}
 		return nil
@@ -208,76 +222,147 @@ func (s *Store) total(ctx context.Context, c *clause) (int, error) {
 	return n, nil
 }
 
-// counts is every facet over the same predicate, in one statement, and returns
-// how many documents it counted over.
+// counts is every facet, in one statement, and returns how many documents it
+// counted the match set over and whether any of the counting stopped at the
+// bound.
 //
-// One statement rather than four, because the predicate is the expensive part
-// and the common table expression is materialised so it is evaluated once. Four
-// statements would apply the permission rule to the match set four times over
-// to answer four questions about the same rows. MATERIALIZED is spelled out
+// One statement rather than one per field, because the predicate is the
+// expensive part and a materialised common table expression is evaluated once.
+// Four statements would apply the permission rule to the match set four times
+// over to answer four questions about the same rows. MATERIALIZED is spelled out
 // because Postgres inlines a common table expression referenced more than once
 // only when it is cheap to, and it has no way of knowing that this one is not.
 //
-// The bound is the LIMIT inside the expression, and it is what keeps this from
+// A field with a constraint on it gets a second expression with that constraint
+// lifted, because a count under its own filter is the number that made the
+// sidebar useless: tick one type and every other type reports zero. See
+// [store.Request.Without]. That is one extra expression per field somebody has
+// actually ticked, which is nearly always none or one, and never more than four.
+//
+// The bound is the LIMIT inside each expression, and it is what keeps this from
 // being proportional to the match set: the four columns are read for the first
 // bound documents and the scan stops there. They are the first in the order the
 // planner produces rather than the best matching, because ordering by the score
 // would mean reading those four columns of every matching document to find out
-// which ones to keep, which is the cost being removed. A sample of the match set
-// is what the sidebar gets, the number of documents behind it comes back so the
-// caller can say the counts are a lower bound, and the total above is exact.
-func (s *Store) counts(ctx context.Context, c *clause, bound int) (counted int, facets map[string][]store.Facet, err error) {
-	const fields = `
-		SELECT 'counted'::text AS field, ''::text AS value, count(*) AS n FROM m
-		UNION ALL SELECT * FROM (SELECT 'source'::text, source, count(*) FROM m WHERE source <> '' GROUP BY source ORDER BY 3 DESC, 2 LIMIT ?) f1
-		UNION ALL SELECT * FROM (SELECT 'kind'::text, kind, count(*) FROM m WHERE kind <> '' GROUP BY kind ORDER BY 3 DESC, 2 LIMIT ?) f2
-		UNION ALL SELECT * FROM (SELECT 'container'::text, container, count(*) FROM m WHERE container <> '' GROUP BY container ORDER BY 3 DESC, 2 LIMIT ?) f3
-		UNION ALL SELECT * FROM (SELECT 'author'::text, author, count(*) FROM m WHERE author <> '' GROUP BY author ORDER BY 3 DESC, 2 LIMIT ?) f4`
+// which ones to keep, which is the cost being removed. A sample is what the
+// sidebar gets, and the total above is exact.
+//
+// The values somebody has ticked are counted twice, once in the lifted
+// expression and once over the match set itself, and the second is the one that
+// is kept. Both are counts of the same documents, since a lifted field's bucket
+// for a ticked value is the match set, and the one taken over the smaller set is
+// the one the bound is less likely to have cut short.
+func (s *Store) counts(ctx context.Context, r store.Request, pred func(store.Request) *clause, bound int) (counted int, stopped bool, facets map[string][]store.Facet, err error) {
+	const columns = `SELECT d.source AS source, d.kind AS kind, d.container AS container, d.author_name AS author`
 
-	// No bound means no LIMIT rather than a limit large enough to stand in for
-	// one, because the exact answer is what a selection without a bound asked
-	// for and a very large number is not the same claim.
-	limit := ``
-	args := append([]any{}, c.args...)
-	if bound > 0 {
-		limit = ` LIMIT ?`
-		args = append(args, bound)
+	var (
+		ctes  []string
+		parts []string
+		args  []any
+		caps  []any
+	)
+	// pool declares one expression and the row that says how many documents it
+	// was allowed to see. No bound means no LIMIT rather than a limit large
+	// enough to stand in for one, because the exact answer is what a selection
+	// without a bound asked for and a very large number is not the same claim.
+	pool := func(name string, r store.Request) {
+		c := pred(r)
+		limit := ``
+		if bound > 0 {
+			limit = ` LIMIT ?`
+		}
+		ctes = append(ctes, name+` AS MATERIALIZED (`+columns+` FROM document d WHERE `+c.where()+limit+`)`)
+		args = append(args, c.args...)
+		if bound > 0 {
+			args = append(args, bound)
+		}
+		parts = append(parts, `SELECT 'counted:`+name+`'::text AS field, ''::text AS value, count(*) AS n FROM `+name)
 	}
-	for range 4 {
-		args = append(args, store.MaxFacetValues)
+	// The subquery is named because Postgres requires it, and the name is the
+	// position so that two counts of the same field are still two names.
+	group := func(label, name, column string) {
+		parts = append(parts, `SELECT * FROM (SELECT '`+label+`'::text, `+column+`, count(*) FROM `+name+
+			` WHERE `+column+` <> '' GROUP BY `+column+` ORDER BY 3 DESC, 2 LIMIT ?) f`+strconv.Itoa(len(caps)))
+		caps = append(caps, store.MaxFacetValues)
 	}
 
-	rows, err := s.query(ctx, `
-		WITH m AS MATERIALIZED (
-			SELECT d.source AS source, d.kind AS kind, d.container AS container, d.author_name AS author
-			FROM document d WHERE `+c.where()+limit+`
-		)`+fields, args...)
+	// The match set first, so that its counted row is the one carrying the
+	// column names the rest of the union inherits.
+	pool("m", r)
+	for _, field := range store.FacetFields {
+		over := "m"
+		if r.Constrains(field) {
+			over = "m_" + field
+			pool(over, r.Without(field))
+			// The ticked values, counted over the match set, which override the
+			// lifted counts of the same values below.
+			group(field+"!", "m", field)
+		}
+		group(field, over, field)
+	}
+
+	rows, err := s.query(ctx, `WITH `+strings.Join(ctes, `, `)+"\n"+
+		strings.Join(parts, "\nUNION ALL "), append(args, caps...)...)
 	if err != nil {
-		return 0, nil, err
+		return 0, false, nil, err
 	}
 	defer rows.Close()
 
-	facets = map[string][]store.Facet{}
+	var (
+		lifted  = map[string][]store.Facet{}
+		ticked  = map[string]map[string]int{}
+		scanned = map[string]int{}
+	)
 	for rows.Next() {
 		var (
 			field, value string
 			n            int
 		)
 		if err := rows.Scan(&field, &value, &n); err != nil {
-			return 0, nil, err
+			return 0, false, nil, err
 		}
 		s.counters.rows.Add(1)
-		if field == "counted" {
-			counted = n
+		switch {
+		case strings.HasPrefix(field, "counted:"):
+			scanned[strings.TrimPrefix(field, "counted:")] = n
 			// The documents the aggregate read, which no other counter can see:
 			// see [store.Counters.Faceted] for why it is counted separately from
 			// the rows the statement returned.
 			s.counters.faceted.Add(int64(n))
-			continue
+		case strings.HasSuffix(field, "!"):
+			field = strings.TrimSuffix(field, "!")
+			if ticked[field] == nil {
+				ticked[field] = map[string]int{}
+			}
+			ticked[field][value] = n
+		default:
+			lifted[field] = append(lifted[field], store.Facet{Value: value, Count: n})
 		}
-		facets[field] = append(facets[field], store.Facet{Value: value, Count: n})
 	}
-	return counted, facets, rows.Err()
+	if err := rows.Err(); err != nil {
+		return 0, false, nil, err
+	}
+
+	facets = make(map[string][]store.Facet, len(lifted))
+	for field, values := range lifted {
+		for i, v := range values {
+			if n, ok := ticked[field][v.Value]; ok {
+				values[i].Count = n
+			}
+		}
+		facets[field] = values
+	}
+	// A lifted expression counts over a larger set than the match set and there
+	// is no total to compare it against, so reaching the bound is what stands in
+	// for having stopped early. It says approximate on a count that landed
+	// exactly on the bound and was in fact exact, which is the harmless way to be
+	// wrong about it.
+	for name, n := range scanned {
+		if name != "m" && bound > 0 && n >= bound {
+			stopped = true
+		}
+	}
+	return scanned["m"], stopped, facets, nil
 }
 
 // Statistics reads the corpus numbers the scorer needs, in two key lookups.

--- a/store/rank.go
+++ b/store/rank.go
@@ -90,12 +90,24 @@ type Ranked struct {
 	// what makes them usable as filters rather than as a description of what is
 	// on screen. They are empty when the selection did not ask for the counts,
 	// and bounded by [Selection.Facets] when it set a bound.
+	//
+	// Each field is counted with its own constraint lifted and every other
+	// constraint applied: see [Request.Without]. A value somebody has already
+	// ticked is counted over the match set itself, because that is the same
+	// number arrived at from a smaller set and therefore the more accurate of
+	// the two under a bound.
 	Facets map[string][]Facet
 
 	// Approximate reports that the facets were counted over the first
 	// [Selection.Facets] documents of the match set rather than over all of
 	// them, so each count is a lower bound on the true one. Total is exact
 	// either way, and a caller showing the counts is expected to say so.
+	//
+	// A field counted with its own constraint lifted is counted over a larger
+	// set than the match set, so it reaches the bound sooner. When a driver
+	// cannot tell whether such a count stopped early it says approximate, which
+	// overstates the doubt on an exact count rather than understating it on an
+	// inexact one.
 	Approximate bool
 }
 

--- a/store/retrieve.go
+++ b/store/retrieve.go
@@ -72,6 +72,67 @@ type Request struct {
 	Until time.Time
 }
 
+// FacetFields are the fields a sidebar is drawn from, in the order it shows
+// them.
+//
+// They are the four request fields somebody ticks rather than types, which is
+// why they are named here and the dates and the owner are not: a facet count is
+// a claim about what ticking a box would do, and nothing draws a box for a date
+// range. Both drivers and the Go fallback count exactly these, so the sidebar
+// does not depend on which driver answered.
+var FacetFields = []string{"source", "kind", "container", "author"}
+
+// Constrains reports whether the request restricts the given facet field.
+func (r Request) Constrains(field string) bool {
+	switch field {
+	case "source":
+		return len(r.Sources) > 0
+	case "kind":
+		return len(r.Kinds) > 0
+	case "container":
+		return len(r.Containers) > 0
+	case "author":
+		return len(r.Authors) > 0
+	}
+	return false
+}
+
+// Without is the request with one facet field's own constraint lifted, and
+// every other constraint left exactly where it was.
+//
+// This is what a facet count is counted over, and it is the whole of why a
+// sidebar is worth reading. Counted over the request as it stands, a ticked
+// type reports its own count and zero for every other type, which destroys the
+// one thing somebody needs in order to decide whether to untick it. Counted
+// with its own field lifted, each value answers the question the box is asking:
+// how many results there would be if this were what you had chosen.
+//
+// The other fields stay applied, because they are different questions. How many
+// pages there are is a useful answer; how many pages there are with every filter
+// in the query ignored is a fact about the corpus rather than about the search.
+func (r Request) Without(field string) Request {
+	switch field {
+	case "source":
+		r.Sources = nil
+	case "kind":
+		r.Kinds = nil
+	case "container":
+		r.Containers = nil
+	case "author":
+		r.Authors = nil
+	}
+	return r
+}
+
+// WithoutFacets is the request with all four facet constraints lifted, which is
+// the widest set any facet count is counted over.
+func (r Request) WithoutFacets() Request {
+	for _, field := range FacetFields {
+		r = r.Without(field)
+	}
+	return r
+}
+
 // Empty reports whether the request narrows anything at all.
 func (r Request) Empty() bool {
 	return len(r.Terms) == 0 && len(r.Sources) == 0 && len(r.Kinds) == 0 &&
@@ -113,6 +174,29 @@ func (r Request) Filters(d doc.Document) bool {
 	}
 	if !r.Until.IsZero() && d.ModifiedAt.After(r.Until) {
 		return false
+	}
+	return true
+}
+
+// Passes reports whether the document satisfies one facet field's constraint,
+// ignoring every other part of the request.
+//
+// It is [Request.Filters] taken apart, and it is here so that a caller counting
+// facets in Go can ask which single constraint a document failed. A document
+// that fails exactly one of them is what a drill down count is made of: it is
+// not in the match set, and it is in the match set that ticking that value
+// instead would produce. A field the request does not constrain is passed by
+// everything.
+func (r Request) Passes(field string, d doc.Document) bool {
+	switch field {
+	case "source":
+		return len(r.Sources) == 0 || slices.Contains(r.Sources, d.Source)
+	case "kind":
+		return len(r.Kinds) == 0 || slices.Contains(r.Kinds, d.Kind)
+	case "container":
+		return len(r.Containers) == 0 || containsFold(r.Containers, d.Container)
+	case "author":
+		return len(r.Authors) == 0 || matchesPerson(r.Authors, d.Author)
 	}
 	return true
 }

--- a/store/sqlitestore/rank.go
+++ b/store/sqlitestore/rank.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/tamnd/genba"
 	"github.com/tamnd/genba/acl"
@@ -38,8 +39,19 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 		return store.Ranked{}, errors.New("sqlitestore: rank: no candidate limit")
 	}
 
-	c := visible(p)
-	filters(r, c)
+	// The predicate for a request, built the same way whatever is being asked
+	// about. The counting asks about a request with one facet constraint lifted,
+	// and building that by hand somewhere else is how two predicates that are
+	// meant to be the same drift apart.
+	pred := func(r store.Request) *clause {
+		c := visible(p)
+		filters(r, c)
+		if q, ok := match(r.Terms); ok {
+			c.add(`document_fts MATCH ?`, q)
+		}
+		return c
+	}
+	c := pred(r)
 
 	// The full text table leads the join for the same reason it does in
 	// Retrieve: it is the most selective thing in the statement on any real
@@ -68,9 +80,8 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 		// slow. See document_recent in schema.go for the index this walks.
 		order = `d.modified_at DESC, d.id`
 	}
-	if q, ok := match(r.Terms); ok {
+	if _, ok := match(r.Terms); ok {
 		from = `document_fts CROSS JOIN document d ON d.rowid = document_fts.rowid`
-		c.add(`document_fts MATCH ?`, q)
 		if !sel.Recent {
 			// bm25 returns a smaller number for a better match, so ascending is
 			// best first. It is only the cut, not the ranking: the score that
@@ -100,15 +111,16 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 	if out.Total, err = s.total(ctx, from, c); err != nil {
 		return store.Ranked{}, err
 	}
-	counted, facets, err := s.counts(ctx, from, c, sel.Facets)
+	counted, stopped, facets, err := s.counts(ctx, from, r, pred, sel.Facets)
 	if err != nil {
 		return store.Ranked{}, err
 	}
 	out.Facets = facets
 	// Counted rather than the bound, because what makes the counts a lower
 	// bound is the statement having stopped early, and the statement is the only
-	// thing that knows whether it did.
-	out.Approximate = counted < out.Total
+	// thing that knows whether it did. A lifted count has no total to be compared
+	// against, so stopped carries the same claim for those.
+	out.Approximate = counted < out.Total || stopped
 	out.Truncated = out.Total > len(cands)
 	return out, nil
 }
@@ -219,77 +231,143 @@ func (s *Store) total(ctx context.Context, from string, c *clause) (int, error) 
 	return n, nil
 }
 
-// counts is every facet over the same predicate, in one statement, and returns
-// how many documents it counted over.
+// counts is every facet, in one statement, and returns how many documents it
+// counted the match set over and whether any of the counting stopped at the
+// bound.
 //
-// One statement rather than four, because the predicate is the expensive part
-// and the common table expression is materialised so it is evaluated once. Four
-// statements would apply the permission rule to the match set four times over
-// to answer four questions about the same rows.
+// One statement rather than one per field, because the predicate is the
+// expensive part and a materialised common table expression is evaluated once.
+// Four statements would apply the permission rule to the match set four times
+// over to answer four questions about the same rows.
 //
-// The bound is the LIMIT inside the expression, and it is what keeps this from
+// A field with a constraint on it gets a second expression with that constraint
+// lifted, because a count under its own filter is the number that made the
+// sidebar useless: tick one type and every other type reports zero. See
+// [store.Request.Without]. That is one extra expression per field somebody has
+// actually ticked, which is nearly always none or one, and never more than four.
+//
+// The bound is the LIMIT inside each expression, and it is what keeps this from
 // being proportional to the match set: the four columns are read for the first
 // bound documents and the walk stops there. They are the first in the order the
 // planner produces rather than the best matching, because ordering by the score
 // would mean reading those four columns of every matching document to find out
-// which ones to keep, which is the cost being removed. A sample of the match set
-// is what the sidebar gets, the number of documents behind it comes back so the
-// caller can say the counts are a lower bound, and the total above is exact.
-func (s *Store) counts(ctx context.Context, from string, c *clause, bound int) (counted int, facets map[string][]store.Facet, err error) {
-	const fields = `
-		SELECT 'counted' AS field, '' AS value, count(*) AS n FROM m
-		UNION ALL SELECT * FROM (SELECT 'source', source, count(*) FROM m WHERE source <> '' GROUP BY source ORDER BY 3 DESC, 2 LIMIT ?)
-		UNION ALL SELECT * FROM (SELECT 'kind', kind, count(*) FROM m WHERE kind <> '' GROUP BY kind ORDER BY 3 DESC, 2 LIMIT ?)
-		UNION ALL SELECT * FROM (SELECT 'container', container, count(*) FROM m WHERE container <> '' GROUP BY container ORDER BY 3 DESC, 2 LIMIT ?)
-		UNION ALL SELECT * FROM (SELECT 'author', author, count(*) FROM m WHERE author <> '' GROUP BY author ORDER BY 3 DESC, 2 LIMIT ?)`
+// which ones to keep, which is the cost being removed. A sample is what the
+// sidebar gets, and the total above is exact.
+//
+// The values somebody has ticked are counted twice, once in the lifted
+// expression and once over the match set itself, and the second is the one that
+// is kept. Both are counts of the same documents, since a lifted field's bucket
+// for a ticked value is the match set, and the one taken over the smaller set is
+// the one the bound is less likely to have cut short.
+func (s *Store) counts(ctx context.Context, from string, r store.Request, pred func(store.Request) *clause, bound int) (counted int, stopped bool, facets map[string][]store.Facet, err error) {
+	const columns = `SELECT d.source AS source, d.kind AS kind, d.container AS container, d.author_name AS author`
 
-	// No bound means no LIMIT rather than a limit large enough to stand in for
-	// one, because the exact answer is what a selection without a bound asked
-	// for and a very large number is not the same claim.
-	limit := ``
-	args := append([]any{}, c.args...)
-	if bound > 0 {
-		limit = ` LIMIT ?`
-		args = append(args, bound)
+	var (
+		ctes  []string
+		parts []string
+		args  []any
+		caps  []any
+	)
+	// pool declares one expression and the row that says how many documents it
+	// was allowed to see. No bound means no LIMIT rather than a limit large
+	// enough to stand in for one, because the exact answer is what a selection
+	// without a bound asked for and a very large number is not the same claim.
+	pool := func(name string, r store.Request) {
+		c := pred(r)
+		limit := ``
+		if bound > 0 {
+			limit = ` LIMIT ?`
+		}
+		ctes = append(ctes, name+` AS MATERIALIZED (`+columns+` FROM `+from+` WHERE `+c.where()+limit+`)`)
+		args = append(args, c.args...)
+		if bound > 0 {
+			args = append(args, bound)
+		}
+		parts = append(parts, `SELECT 'counted:`+name+`' AS field, '' AS value, count(*) AS n FROM `+name)
 	}
-	for range 4 {
-		args = append(args, store.MaxFacetValues)
+	group := func(label, name, column string) {
+		parts = append(parts, `SELECT * FROM (SELECT '`+label+`', `+column+`, count(*) FROM `+name+
+			` WHERE `+column+` <> '' GROUP BY `+column+` ORDER BY 3 DESC, 2 LIMIT ?)`)
+		caps = append(caps, store.MaxFacetValues)
 	}
 
-	rows, err := s.query(ctx, `
-		WITH m AS MATERIALIZED (
-			SELECT d.source AS source, d.kind AS kind, d.container AS container, d.author_name AS author
-			FROM `+from+` WHERE `+c.where()+limit+`
-		)`+fields, args...)
+	// The match set first, so that its counted row is the one carrying the
+	// column names the rest of the union inherits.
+	pool("m", r)
+	for _, field := range store.FacetFields {
+		over := "m"
+		if r.Constrains(field) {
+			over = "m_" + field
+			pool(over, r.Without(field))
+			// The ticked values, counted over the match set, which override the
+			// lifted counts of the same values below.
+			group(field+"!", "m", field)
+		}
+		group(field, over, field)
+	}
+
+	rows, err := s.query(ctx, `WITH `+strings.Join(ctes, `, `)+"\n"+
+		strings.Join(parts, "\nUNION ALL "), append(args, caps...)...)
 	if err != nil {
-		return 0, nil, fmt.Errorf("sqlitestore: rank: %w", err)
+		return 0, false, nil, fmt.Errorf("sqlitestore: rank: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	facets = map[string][]store.Facet{}
+	var (
+		lifted  = map[string][]store.Facet{}
+		ticked  = map[string]map[string]int{}
+		scanned = map[string]int{}
+	)
 	for rows.Next() {
 		var (
 			field, value string
 			n            int
 		)
 		if err := rows.Scan(&field, &value, &n); err != nil {
-			return 0, nil, fmt.Errorf("sqlitestore: rank: %w", err)
+			return 0, false, nil, fmt.Errorf("sqlitestore: rank: %w", err)
 		}
 		s.counters.rows.Add(1)
-		if field == "counted" {
-			counted = n
+		switch {
+		case strings.HasPrefix(field, "counted:"):
+			scanned[strings.TrimPrefix(field, "counted:")] = n
 			// The documents the aggregate read, which no other counter can see:
 			// see [store.Counters.Faceted] for why it is counted separately from
 			// the rows the statement returned.
 			s.counters.faceted.Add(int64(n))
-			continue
+		case strings.HasSuffix(field, "!"):
+			field = strings.TrimSuffix(field, "!")
+			if ticked[field] == nil {
+				ticked[field] = map[string]int{}
+			}
+			ticked[field][value] = n
+		default:
+			lifted[field] = append(lifted[field], store.Facet{Value: value, Count: n})
 		}
-		facets[field] = append(facets[field], store.Facet{Value: value, Count: n})
 	}
 	if err := rows.Err(); err != nil {
-		return 0, nil, fmt.Errorf("sqlitestore: rank: %w", err)
+		return 0, false, nil, fmt.Errorf("sqlitestore: rank: %w", err)
 	}
-	return counted, facets, nil
+
+	facets = make(map[string][]store.Facet, len(lifted))
+	for field, values := range lifted {
+		for i, v := range values {
+			if n, ok := ticked[field][v.Value]; ok {
+				values[i].Count = n
+			}
+		}
+		facets[field] = values
+	}
+	// A lifted expression counts over a larger set than the match set and there
+	// is no total to compare it against, so reaching the bound is what stands in
+	// for having stopped early. It says approximate on a count that landed
+	// exactly on the bound and was in fact exact, which is the harmless way to be
+	// wrong about it.
+	for name, n := range scanned {
+		if name != "m" && bound > 0 && n >= bound {
+			stopped = true
+		}
+	}
+	return scanned["m"], stopped, facets, nil
 }
 
 // Statistics reads the corpus numbers the scorer needs, in two key lookups.

--- a/store/storetest/rank.go
+++ b/store/storetest/rank.go
@@ -44,6 +44,7 @@ var rankCases = []rankCase{
 	{"the total counts the match set and not the pool", testRankTotal},
 	{"truncated says whether the ranking saw everything", testRankTruncated},
 	{"facets are counted over the match set and not over the pool", testRankFacets},
+	{"a facet count lifts its own filter and applies the others", testRankDrillDown},
 	{"a facet bound counts a sample and says the counts are a lower bound", testRankFacetBound},
 	{"a selection with no counts ranks the same documents", testRankWithoutCounts},
 	{"the principal is applied inside rank", testRankPermission},
@@ -117,28 +118,66 @@ func pool() store.Selection { return store.Selection{Limit: 100, Counts: true} }
 
 // wantFacets counts the facets the slow way, from the documents the principal
 // can actually read.
+//
+// Each field is counted with its own constraint lifted and every other
+// constraint applied, which is the contract in [store.Ranked.Facets]. A
+// document in the match set counts towards all four fields. One that fails
+// exactly one constraint counts towards that field alone, because it is a
+// result that ticking that value instead would have found. One that fails two
+// or more counts towards nothing: no single change to the query reaches it.
 func wantFacets(t *testing.T, s store.Store, p *acl.Principal, r store.Request) map[string]map[string]int {
 	t.Helper()
 	out := map[string]map[string]int{
 		"source": {}, "kind": {}, "container": {}, "author": {},
 	}
-	count := func(field, value string) {
-		if value != "" {
-			out[field][value]++
+	count := func(field string, d doc.Document) {
+		if v := facetValue(field, d); v != "" {
+			out[field][v]++
 		}
 	}
+	base := r.WithoutFacets()
 	if err := s.Scan(t.Context(), p, func(d doc.Document) bool {
-		if r.Matches(d) {
-			count("source", d.Source)
-			count("kind", string(d.Kind))
-			count("container", d.Container)
-			count("author", d.Author.Display())
+		if !base.Matches(d) {
+			return true
+		}
+		missing := ""
+		for _, field := range store.FacetFields {
+			if r.Passes(field, d) {
+				continue
+			}
+			if missing != "" {
+				return true
+			}
+			missing = field
+		}
+		if missing != "" {
+			count(missing, d)
+			return true
+		}
+		for _, field := range store.FacetFields {
+			count(field, d)
 		}
 		return true
 	}); err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
 	return out
+}
+
+// facetValue is the display string a facet counts a document under, which is
+// the string on the row somebody clicks to filter by.
+func facetValue(field string, d doc.Document) string {
+	switch field {
+	case "source":
+		return d.Source
+	case "kind":
+		return string(d.Kind)
+	case "container":
+		return d.Container
+	case "author":
+		return d.Author.Display()
+	}
+	return ""
 }
 
 // gotFacets turns a driver's answer into the same shape, which is also where a
@@ -225,6 +264,58 @@ func testRankFacets(t *testing.T, s store.Store) {
 		got := gotFacets(t, mustRank(t, rk, reader(), store.Request{}, sel))
 		if !maps.EqualFunc(got, want, maps.Equal) {
 			t.Fatalf("facets for a pool of %d are %v, expected %v", sel.Limit, got, want)
+		}
+	}
+}
+
+// A sidebar is only worth reading if the values nobody has ticked still carry
+// counts. Counted over the request as it stands, a ticked source reports its own
+// count and zero for every other source, and the one question somebody has at
+// that point, whether unticking it is going to find anything, has no answer on
+// the screen.
+//
+// So each field is counted with its own filter lifted and the rest applied, and
+// the three things checked here are that the driver's arithmetic agrees with the
+// same rule computed in Go, that the ticked value still reports the fully
+// constrained count, and that Total was left alone. Total is the one number that
+// does describe the current state, and a driver that lifted a filter out of it
+// as well would report more results than the page it is sitting above.
+func testRankDrillDown(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	for _, r := range []store.Request{
+		{Sources: []string{"gdrive"}},
+		{Kinds: []doc.Kind{doc.KindPage, doc.KindFile}},
+		{Containers: []string{"Platform"}},
+		{Authors: []string{"mei@acme.com"}},
+		{Sources: []string{"gdrive"}, Kinds: []doc.Kind{doc.KindPage}},
+		{Terms: []string{"payments"}, Sources: []string{"gdrive", "slack"}},
+		{Sources: []string{"gdrive"}, Authors: []string{"kenji"}},
+	} {
+		ranked := mustRank(t, rk, reader(), r, pool())
+		got, want := gotFacets(t, ranked), wantFacets(t, s, reader(), r)
+		if !maps.EqualFunc(got, want, maps.Equal) {
+			t.Fatalf("facets for %+v are %v, expected %v", r, got, want)
+		}
+		if total := len(wantIDs(t, s, reader(), r)); ranked.Total != total {
+			t.Fatalf("Total = %d for %+v, the match set has %d documents in it", ranked.Total, r, total)
+		}
+		if ranked.Approximate {
+			t.Fatalf("Approximate is set for %+v, which was counted with no bound", r)
+		}
+	}
+
+	// The counts a lifted filter produces have to be the ones somebody would get
+	// by making that choice, so the sidebar is checked against the searches it is
+	// promising. Ticking a value that is already ticked changes nothing, which is
+	// how the ticked value's own count is pinned to the fully constrained one.
+	r := store.Request{Sources: []string{"gdrive"}}
+	for _, v := range mustRank(t, rk, reader(), r, pool()).Facets["source"] {
+		next := r
+		next.Sources = []string{v.Value}
+		if want := len(wantIDs(t, s, reader(), next)); v.Count != want {
+			t.Fatalf("the source facet promises %d results for %q and searching for it finds %d", v.Count, v.Value, want)
 		}
 	}
 }

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -555,8 +555,19 @@ time {
   font-weight: var(--weight-normal);
 }
 
-.filterbar__toggle {
+/* Two classes rather than one, because the button carries .button as well and
+   the rule that gives .button a display of its own is further down the file.
+   One class each and the later one wins, which put a Filters button next to the
+   open panel of filters at every width above the breakpoint. */
+.filterbar .filterbar__toggle {
   display: none;
+}
+
+/* Louder than the rule that brings it back below the breakpoint, because a
+   display of its own beats the hidden attribute and the button would come back
+   underneath the open sheet. */
+.filterbar__toggle[hidden] {
+  display: none !important;
 }
 
 /* Chips ------------------------------------------------------------------ */
@@ -1094,10 +1105,32 @@ mark.hit--current::after {
   display: none;
 }
 
+.facets__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
 .facets__title {
   font-size: var(--text-title);
   font-weight: var(--weight-semibold);
   line-height: var(--leading-title);
+}
+
+/* The sheet's way out, and only the sheet's. Above the breakpoint the panel is
+   a column on the page with nothing covering it, so there is nothing to
+   dismiss and a close button would be a control that removes the filters from
+   a window wide enough to hold them. */
+.facets__done {
+  display: none;
+}
+
+/* The panel is the surface where there is room for it, and the sheet where
+   there is not, and the two are never on screen together. This is the half
+   that keeps the scrim off a window that has no sheet in it. */
+.scrim--filters {
+  display: none;
 }
 
 .facet__title {
@@ -1114,8 +1147,11 @@ mark.hit--current::after {
   align-items: center;
   gap: var(--space-3);
   width: 100%;
-  height: 40px;
-  padding: 0 var(--space-2);
+  /* A minimum rather than a height. A value with a context under it is two
+     lines, and a row that was fixed at one clipped the line that made the
+     first one readable. */
+  min-height: 40px;
+  padding: var(--space-2);
   border-radius: var(--radius-sm);
   color: var(--text);
   font-size: var(--text-body);
@@ -1148,12 +1184,35 @@ mark.hit--current::after {
   color: var(--text-inverse);
 }
 
-.facet__label {
+.facet__text {
   flex: 1;
   min-width: 0;
+}
+
+.facet__label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/*
+ * Where the value came from, cut at the front rather than at the end.
+ *
+ * A column of paths truncated on the right is a column of identical rows: the
+ * shared prefix is what fits and the part that tells them apart is what got
+ * dropped. Reversing the direction of the box moves the ellipsis to the start,
+ * and the bdi inside it keeps the text itself running left to right so the
+ * separators stay where they were written.
+ */
+.facet__context {
+  display: block;
+  direction: rtl;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-size: var(--text-small);
 }
 
 .facet__count {
@@ -2572,30 +2631,64 @@ h6.prose__h {
     );
   }
 
-  .filterbar__toggle {
+  .filterbar .filterbar__toggle {
     display: inline-flex;
     flex: none;
     margin-left: auto;
     align-self: center;
   }
 
+  /*
+   * The panel becomes a sheet.
+   *
+   * It is the same element and the same counts, moved rather than duplicated,
+   * because a second copy of the filters for narrow windows is a second list to
+   * keep in step with the first and the way that goes wrong is that one of them
+   * is a query out of date.
+   *
+   * Over the results rather than above them, which is what makes it one filter
+   * surface: while it is open it covers the bar that opened it, so there is
+   * never a Filters button next to an open panel of filters.
+   */
   .facets {
-    position: static;
-    max-height: none;
-    overflow: visible;
+    position: fixed;
+    inset: auto 0 0 0;
+    z-index: var(--z-drawer);
     display: none;
+    max-height: 80vh;
+    padding: var(--space-6) var(--gutter) var(--space-8);
+    background: var(--bg);
+    border-top: 1px solid var(--border);
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    animation: sheet-up var(--dur-fast) var(--ease);
   }
 
   .facets[data-open="true"] {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: var(--space-8);
-    padding-bottom: var(--space-6);
-    border-bottom: 1px solid var(--border);
+    align-content: start;
   }
 
-  .facets__title {
+  .facets__head {
     grid-column: 1 / -1;
+  }
+
+  .facets__done {
+    display: inline-flex;
+  }
+
+  .scrim--filters {
+    display: block;
+  }
+}
+
+@keyframes sheet-up {
+  from {
+    transform: translateY(8px);
+    opacity: 0;
   }
 }
 

--- a/web/dist/assets/format.js
+++ b/web/dist/assets/format.js
@@ -115,6 +115,70 @@ export function label(value) {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+/**
+ * facetLabels is what a filter row shows for each value in one facet.
+ *
+ * A facet value is an identity. It goes in the URL, it goes in the request and
+ * it is what the count was counted against, so it is never changed. What it is
+ * not is something to read: a container on a file corpus is an absolute path,
+ * and a column of them truncated on the right is a column of identical rows
+ * ending in an ellipsis, distinguished only by the part that was cut off.
+ *
+ * So a value has three forms. The value itself, a label, which is the last
+ * segment, because the end of a path is the part that identifies it, and a
+ * context, which is everything in front of it and is elided from the left when
+ * it does not fit.
+ *
+ * Where two values in the same facet would produce the same label, both grow a
+ * segment, and they keep growing until they differ. Four folders called en-US
+ * under four different books are four rows that all read en-US, which is worse
+ * than a truncated path because it reads as a bug rather than as a truncation.
+ * Growing is per collision rather than per facet, so one pair of deep duplicates
+ * does not lengthen every other row in the list.
+ *
+ * It is done here rather than on the server because it is a display decision,
+ * and the server has no idea how wide the window is.
+ */
+export function facetLabels(values) {
+  const parts = values.map((v) => String(v || "").split("/").filter(Boolean));
+  const depth = parts.map(() => 1);
+  // Terminates because a round only ever deepens a value that has a segment
+  // left to give, and a value that has run out is left where it is: two paths
+  // that differ only above their common root end up identical and readable,
+  // which is the truthful answer rather than a loop.
+  for (;;) {
+    const groups = new Map();
+    parts.forEach((segments, i) => {
+      const key = segments.slice(segments.length - depth[i]).join("/");
+      const group = groups.get(key);
+      if (group) group.push(i);
+      else groups.set(key, [i]);
+    });
+    let grew = false;
+    for (const group of groups.values()) {
+      if (group.length < 2) continue;
+      for (const i of group) {
+        if (depth[i] >= parts[i].length) continue;
+        depth[i]++;
+        grew = true;
+      }
+    }
+    if (!grew) break;
+  }
+  return values.map((value, i) => {
+    const segments = parts[i];
+    if (!segments.length) return { value, label: String(value || ""), context: "" };
+    const at = Math.max(segments.length - depth[i], 0);
+    return {
+      value,
+      label: segments.slice(at).join("/"),
+      // Spaced, because this is being read rather than pasted, and a spaced
+      // separator is where a long one is allowed to wrap or to be cut.
+      context: segments.slice(0, at).join(" / "),
+    };
+  });
+}
+
 const RELATIVE = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
 const ABSOLUTE = new Intl.DateTimeFormat(undefined, {
   year: "numeric",

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -1,7 +1,7 @@
 // The results view: verticals, active filters, result rows and facets.
 
 import { h, replace, svg } from "genba/dom.js";
-import { label, number, duration, icon } from "genba/format.js";
+import { label, number, duration, icon, facetLabels } from "genba/format.js";
 import { shapeOf } from "genba/content.js";
 import { RowList } from "genba/rows.js";
 import { nothingMatched, slow, stopped } from "genba/states.js";
@@ -71,6 +71,12 @@ const FACETS = [
 
 const FACET_VISIBLE = 8;
 
+// The width at which the filter panel stops being a margin column and becomes a
+// sheet. It is the same number as the layout breakpoint in app.css, and it is
+// the line between a panel sitting beside the results and a dialog sitting over
+// them, which decides whether Tab is allowed to leave it.
+const SHEET = "(max-width: 960px)";
+
 export class Results {
   constructor({ onQuery, onOpen, onHover, onSay, onCursor }) {
     this.onQuery = onQuery;
@@ -108,26 +114,56 @@ export class Results {
     if (typeof ResizeObserver === "function") {
       new ResizeObserver(() => this.edges()).observe(this.tabs);
     }
-    this.facets = h("aside", { class: "facets", "aria-label": "Filters" });
+    this.facets = h("aside", {
+      class: "facets",
+      "aria-label": "Filters",
+      tabindex: "-1",
+      onKeydown: (e) => this.trapFilters(e),
+    });
+    // Behind the sheet and never behind the column, which is what closes it by
+    // clicking away from it on the one width where there is an away.
+    this.scrim = h("div", {
+      class: "scrim scrim--filters",
+      hidden: true,
+      onClick: () => this.showFilters(false),
+    });
 
-    // The facet column becomes a disclosure below the medium breakpoint, where
-    // there is no room for a margin column. The button is hidden by CSS above
-    // it rather than by a resize listener, so nothing recomputes on drag.
+    // The facet column becomes a sheet below the medium breakpoint, where there
+    // is no room for a margin column. The button is hidden by CSS above it
+    // rather than by a resize listener, so nothing recomputes on drag.
     this.toggle = h(
       "button",
       {
         class: "button button--ghost filterbar__toggle",
         type: "button",
         "aria-expanded": "false",
-        onClick: () => {
-          const open = this.facets.dataset.open === "true";
-          this.facets.dataset.open = String(!open);
-          this.toggle.setAttribute("aria-expanded", String(!open));
-        },
+        "aria-controls": "filters",
+        onClick: () => this.showFilters(true),
       },
       svg(icon("slider"), 18),
       "Filters",
     );
+    this.facets.id = "filters";
+    // The sheet's own way out. Below the breakpoint the button that opened it is
+    // behind the scrim, and a panel with no visible control to dismiss it is a
+    // panel somebody closes by reloading the page.
+    this.done = h(
+      "button",
+      {
+        class: "icon-button facets__done",
+        type: "button",
+        "aria-label": "Close filters",
+        onClick: () => this.showFilters(false),
+      },
+      svg(icon("close"), 20),
+    );
+
+    // A window dragged back across the breakpoint while the sheet is open turns
+    // it into the margin column, and a margin column that still claims to be a
+    // modal dialog makes the results beside it unreachable.
+    window.matchMedia(SHEET).addEventListener("change", () => {
+      if (!window.matchMedia(SHEET).matches) this.showFilters(false, { focus: false });
+    });
 
     this.filterbar = h("div", { class: "filterbar" }, this.tabs, this.toggle);
     this.progress = h("div", { class: "progress", hidden: true });
@@ -145,10 +181,71 @@ export class Results {
       h(
         "div",
         { class: "results" },
+        this.scrim,
         this.facets,
         h("div", { class: "results__main" }, this.head, this.list, this.aside),
       ),
     );
+  }
+
+  /**
+   * showFilters opens and closes the sheet, and is a no-op above the breakpoint
+   * where the panel is simply on the page.
+   *
+   * The two are the same panel, which is the point of it. A second copy of the
+   * filters for narrow windows is a second list of counts to keep in step with
+   * the first, and the way those go wrong is that one of them is a query old.
+   */
+  showFilters(open, opts = {}) {
+    const sheet = window.matchMedia(SHEET).matches;
+    this.facets.dataset.open = String(open);
+    this.toggle.setAttribute("aria-expanded", String(open));
+    this.scrim.hidden = !open;
+    // One surface. While the sheet is up, the button that opened it goes, and
+    // the sheet's own close button is the only filter control on the screen.
+    // Leaving it there is how the narrow layout ends up with a Filters button
+    // sitting next to an open panel of filters.
+    this.toggle.hidden = open && sheet;
+    if (open && sheet) {
+      // A dialog only while it is one. Above the breakpoint this is a
+      // complementary region beside the results and saying it is modal would
+      // take the results away from a screen reader.
+      this.facets.setAttribute("role", "dialog");
+      this.facets.setAttribute("aria-modal", "true");
+      this.facets.focus();
+      return;
+    }
+    this.facets.removeAttribute("role");
+    this.facets.removeAttribute("aria-modal");
+    if (!open && opts.focus !== false && this.toggle.offsetParent !== null) {
+      this.toggle.focus();
+    }
+  }
+
+  /**
+   * trapFilters keeps Tab inside the sheet while the sheet is what is on
+   * screen, and lets it out where the panel is a column beside the results.
+   */
+  trapFilters(e) {
+    if (this.facets.dataset.open !== "true" || !window.matchMedia(SHEET).matches) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      this.showFilters(false);
+      return;
+    }
+    if (e.key !== "Tab") return;
+    const focusable = this.facets.querySelectorAll("button:not([disabled])");
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
   }
 
   /**
@@ -453,6 +550,10 @@ export class Results {
       const values = (res.facets && res.facets[field]) || [];
       if (!values.length) return null;
       const expanded = this.expanded.has(field);
+      // Over the whole facet rather than over the eight that are showing, so
+      // that a label does not change under somebody the moment they press Show
+      // all and a ninth value collides with one already on screen.
+      const named = facetLabels(values.map((v) => v.value));
       const shown = expanded ? values : values.slice(0, FACET_VISIBLE);
       return h(
         "section",
@@ -461,8 +562,14 @@ export class Results {
         h(
           "ul",
           {},
-          shown.map((v) => {
-            const on = (query[key] || []).includes(v.value);
+          shown.map((v, i) => {
+            // The server says which values the query narrows to, because it made
+            // that comparison already to answer the query and a person typing
+            // from:mei@acme.com has not typed the display name the row carries.
+            // The query is still consulted, so a facet arriving without the flag
+            // still draws its ticks.
+            const on = v.selected === true || (query[key] || []).includes(v.value);
+            const { label: text, context } = named[i];
             return h(
               "li",
               {},
@@ -482,8 +589,16 @@ export class Results {
                 ),
                 h(
                   "span",
-                  { class: "facet__label", title: v.value },
-                  titled ? label(v.value) : v.value,
+                  { class: "facet__text", title: v.value },
+                  h(
+                    "span",
+                    { class: "facet__label" },
+                    titled ? label(text) : text,
+                  ),
+                  // Isolated, so that the right to left trick that elides the
+                  // front of the line does not reorder the slashes inside it.
+                  context &&
+                    h("span", { class: "facet__context" }, h("bdi", {}, context)),
                 ),
                 h(
                   "span",
@@ -513,7 +628,14 @@ export class Results {
 
     replace(
       this.facets,
-      groups.length ? h("h2", { class: "facets__title" }, "Filters") : null,
+      groups.length
+        ? h(
+            "div",
+            { class: "facets__head" },
+            h("h2", { class: "facets__title" }, "Filters"),
+            this.done,
+          )
+        : null,
       groups.length ? groups : null,
     );
   }
@@ -521,18 +643,17 @@ export class Results {
   /**
    * focusFilters is the f key.
    *
-   * The first filter where the panel is on screen, and the disclosure that
-   * opens the panel where it is not, because below the medium breakpoint the
-   * facets are behind a button and focusing something inside a collapsed panel
-   * is focusing nothing.
+   * The first filter where the panel is on screen, and below the breakpoint the
+   * sheet, opened, because the panel is behind a button there and focusing
+   * something inside a closed one is focusing nothing.
    */
   focusFilters() {
-    const first = this.facets.querySelector("button");
+    const first = this.facets.querySelector(".facet__item");
     if (first && first.offsetParent !== null) {
       first.focus();
       return;
     }
-    if (this.toggle.offsetParent !== null) this.toggle.focus();
+    if (this.toggle.offsetParent !== null) this.showFilters(true);
   }
 }
 


### PR DESCRIPTION
Closes #104.

## What this does

**Counts survive a choice.** Every facet is counted with its own constraint lifted and every other constraint applied.
Ticking `Type: page` now still shows how many tickets and how many images there are, which is the number somebody needs in order to decide the filter was a mistake.
`total` is untouched and still means the fully constrained count.

It is one extra bounded pool per field somebody has ticked, inside the same statement the counts already ran in, so the predicate is evaluated once per pool rather than once per field.
Nearly always that is none or one, and never more than four.

A ticked value gets counted twice, once in the lifted pool and once over the match set, and the match set count is the one kept.
Both are counts of the same documents, and the one taken over the smaller set is less likely to have been cut short by the bound.

**Values read.** A facet value now has a label, which is its last path segment, and a context, which is everything in front of it, elided from the left.

```
2121                          14
notes / Spec

2024                           9
notes / Spec
```

Where two labels in the same list would collide, both grow a segment until they differ.
That is per collision rather than per facet, so one deep pair does not lengthen every other row.
The value itself is never changed: it goes in the URL, in the request, and it is what the count was counted against.

**One filter surface.** Below 960 pixels the panel comes up as a sheet over the results and the button that raised it is hidden while it is up.
Above it the panel is the surface and the button is not on the page at all.
It is the same element and the same counts moved rather than duplicated, so there is no second list of filters to keep in step.

That last one was a real bug rather than a missing feature.
The rule hiding the button above the breakpoint carries one class, and the rule that gives every `.button` a display of its own carries one class too and sits further down the file, so the later rule won and the button was visible at every width.

## Where the rule lives

The conformance suite in `store/storetest` states it once, so both drivers are held to the same rule: a document in the match set counts towards all four fields, one failing exactly one facet constraint counts towards that field only, and one failing two or more counts towards nothing.
`TestDriversAgree` now runs filtered queries, so the Go path in `index` and the SQL path in `sqlitestore` are checked against each other rather than each against my reading of the rule.

The response carries `selected` on each facet value rather than leaving the client to work it out.
The server folded the value when it matched, so the client would have to fold it the same way to agree, and there is no reason for two implementations of that.

## Measurements

`make bench-counters` passes with budgets that grow with the number of constrained fields rather than being loosened, so a query that ticks nothing costs exactly what it did before.

`make bench-gate` passes. The filter class moved from 17.3ms to 23.1ms normalised, which is +33% against a tolerance of 35%, and that is the second pool being paid for.
Every other class moved down: common -16%, pathological -13%, term-filter -23%.
I have not recorded a new baseline here, since a baseline that arrives with the change it measures is one nobody can review, but the filter class is now close enough to the tolerance that it is worth watching on the next change that touches counting.

`perf/01_budgets.md` has been updated to say what the counts and facets line actually buys.

## Gates

`make fmt vet race lint build bench-counters bench-gate` all pass.

`make ui-gate` passes its Go tests, the keyboard walk, the rendering check and the states check, and Lighthouse reports performance 99, accessibility 100, best practices 100.
The axe steps do not run on my machine: the installed ChromeDriver is 152 and the installed Chrome is 151, which axe refuses to drive.
That is my environment rather than the change, and CI runs the full gate.

New walk assertions:

- a facet value reads as its last segment, and a collision grows one
- a filter row shows the end of the value rather than the start
- the panel is the only filter surface where there is room for it
- at 390 pixels the filters are a sheet and the button that opened it is gone
- Escape closes the sheet and puts focus back on the button