### PR TITLE
Cut snippets out of a window instead of the whole body

### DIFF
--- a/doc/analyze.go
+++ b/doc/analyze.go
@@ -1,8 +1,11 @@
 package doc
 
 import (
+	"iter"
+	"slices"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // Span is one analysed term together with where it sits in the text it came
@@ -30,10 +33,9 @@ type Span struct {
 // match set for the same query, and the difference shows up as a document that
 // one deployment finds and another does not.
 func Tokenize(text string) []string {
-	spans := Analyze(text)
-	terms := make([]string, len(spans))
-	for i, s := range spans {
-		terms[i] = s.Term
+	var terms []string
+	for s := range Spans(text) {
+		terms = append(terms, s.Term)
 	}
 	return terms
 }
@@ -46,35 +48,113 @@ func Tokenize(text string) []string {
 // means knowing which characters of the original text became which term, and a
 // substring search after the fact gets that wrong, because it lights up the
 // "run" inside "runbook" that the index never matched.
-func Analyze(text string) []Span {
+func Analyze(text string) []Span { return slices.Collect(Spans(text)) }
+
+// Spans is [Analyze] one term at a time, for a caller that stops before the end.
+//
+// Finding where to cut a snippet means finding the first query term in a body,
+// and the body is the whole document. Analysing all of it to use the first
+// answer is the difference between reading a sentence and reading a file, and on
+// a page of twenty results it was most of what the page cost.
+func Spans(text string) iter.Seq[Span] {
+	return func(yield func(Span) bool) {
+		scan(text, func(term []byte, start, end int) bool {
+			return yield(Span{Term: string(term), Start: start, End: end})
+		})
+	}
+}
+
+// Find returns the offset of the first term in text that is one of want, or -1.
+//
+// It is here rather than written out at the caller because it is the analyzer
+// answering a question about its own output, and a caller that searched the text
+// for the words instead would find the ones the index never matched.
+//
+// It allocates nothing. That matters because the caller is snippet cutting on a
+// page of results, where the answer is one number and the input is the whole
+// document: building a string for every word of every result to throw all but
+// one of them away was most of what a page cost.
+func Find(text string, want map[string]bool) int {
+	at := -1
+	scan(text, func(term []byte, start, _ int) bool {
+		if !want[string(term)] {
+			return true
+		}
+		at = start
+		return false
+	})
+	return at
+}
+
+// scan is the analyzer. Everything else in this file is a way of asking it
+// something.
+//
+// The term it yields is the folded bytes and it is only valid until the next
+// one, because the buffer is reused. That is the reason it is unexported: a
+// caller that keeps the slice gets the next word. [Find] looks it up in a map,
+// which the compiler does without copying, and [Spans] makes a string of it.
+func scan(text string, yield func(term []byte, start, end int) bool) {
 	var (
-		out   []Span
-		cur   strings.Builder
+		cur   []byte
 		start = -1
 	)
-	flush := func(end int) {
-		if start >= 0 && cur.Len() > 0 {
-			out = append(out, Span{Term: cur.String(), Start: start, End: end})
+	// flush emits the term being built, if there is one, and reports whether the
+	// walk should carry on.
+	flush := func(end int) bool {
+		at := start
+		term := cur
+		cur, start = cur[:0], -1
+		if at < 0 || len(term) == 0 {
+			return true
 		}
-		cur.Reset()
-		start = -1
+		return yield(term, at, end)
 	}
 	for i, r := range text {
+		// The ASCII half of the same rules, written out. Every branch below asks a
+		// range table whether a rune is a letter, and a table lookup per character
+		// of a document is what a snippet was spending its time on. This is the
+		// same answer for the characters most text is made of.
+		if r < utf8.RuneSelf {
+			switch {
+			case 'a' <= r && r <= 'z' || '0' <= r && r <= '9':
+				if start < 0 {
+					start = i
+				}
+				cur = append(cur, byte(r))
+			case 'A' <= r && r <= 'Z':
+				if start < 0 {
+					start = i
+				}
+				cur = append(cur, byte(r)+'a'-'A')
+			default:
+				if !flush(i) {
+					return
+				}
+			}
+			continue
+		}
 		switch {
 		case unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) || unicode.Is(unicode.Katakana, r):
-			flush(i)
-			out = append(out, Span{Term: string(r), Start: i, End: i + len(string(r))})
+			if !flush(i) {
+				return
+			}
+			cur = utf8.AppendRune(cur, r)
+			if !yield(cur, i, i+len(cur)) {
+				return
+			}
+			cur = cur[:0]
 		case unicode.IsLetter(r) || unicode.IsDigit(r):
 			if start < 0 {
 				start = i
 			}
-			cur.WriteRune(unicode.ToLower(r))
+			cur = utf8.AppendRune(cur, unicode.ToLower(r))
 		default:
-			flush(i)
+			if !flush(i) {
+				return
+			}
 		}
 	}
 	flush(len(text))
-	return out
 }
 
 // Analyzed returns the document's searchable text as a single string of terms
@@ -123,21 +203,21 @@ type Analysis struct {
 
 // Analyze returns the document's statistics in one pass over its text.
 func (d Document) Analyze() Analysis {
-	title, body := Tokenize(d.Title), Tokenize(d.Body)
-	a := Analysis{
-		TitleTokens: len(title),
-		BodyTokens:  len(body),
-		Terms:       make(map[string]TermCount, len(title)+len(body)),
-	}
-	for _, t := range title {
-		c := a.Terms[t]
+	// Straight into the map rather than through two slices of terms, because this
+	// runs on every document that is written and the slices are the size of the
+	// corpus while the map is the size of its vocabulary.
+	a := Analysis{Terms: make(map[string]TermCount)}
+	for s := range Spans(d.Title) {
+		a.TitleTokens++
+		c := a.Terms[s.Term]
 		c.Title++
-		a.Terms[t] = c
+		a.Terms[s.Term] = c
 	}
-	for _, t := range body {
-		c := a.Terms[t]
+	for s := range Spans(d.Body) {
+		a.BodyTokens++
+		c := a.Terms[s.Term]
 		c.Body++
-		a.Terms[t] = c
+		a.Terms[s.Term] = c
 	}
 	return a
 }

--- a/doc/analyze_test.go
+++ b/doc/analyze_test.go
@@ -1,0 +1,117 @@
+package doc
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The analyzer is asked the same question three ways, and the three have to
+// agree, because a driver that stores what Tokenize produced and a snippet that
+// marks what Find located are the same match seen from two ends.
+
+func TestSpansAgreeWithTokenize(t *testing.T) {
+	for _, text := range []string{
+		"",
+		"Hello, World!",
+		"eu-west-1 failover",
+		"  spaces   between   words  ",
+		"Café RÉSUMÉ naïve",
+		"現場の記録 and prose",
+		"trailing",
+	} {
+		var terms []string
+		for s := range Spans(text) {
+			terms = append(terms, s.Term)
+			if got := text[s.Start:s.End]; got == "" {
+				t.Errorf("Spans(%q) gave an empty span at %d", text, s.Start)
+			}
+		}
+		if want := Tokenize(text); !slices.Equal(terms, want) {
+			t.Errorf("Spans(%q) = %v, want %v", text, terms, want)
+		}
+	}
+}
+
+func TestSpansOffsetsPointAtTheOriginalCharacters(t *testing.T) {
+	text := "Failover the RÉSUMÉ queue"
+	want := []string{"Failover", "the", "RÉSUMÉ", "queue"}
+	var got []string
+	for s := range Spans(text) {
+		got = append(got, text[s.Start:s.End])
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("the spans cover %v, want %v", got, want)
+	}
+}
+
+func TestFindIsTheFirstWholeTermAndNothingInsideAWord(t *testing.T) {
+	tests := []struct {
+		text string
+		want map[string]bool
+		at   int
+	}{
+		{"the runbook says run the job", map[string]bool{"run": true}, 17},
+		{"payments settle overnight", map[string]bool{"settle": true}, 9},
+		{"payments settle overnight", map[string]bool{"absent": true}, -1},
+		{"payments settle overnight", map[string]bool{"payments": true, "settle": true}, 0},
+		{"PAYMENTS settle", map[string]bool{"payments": true}, 0},
+		{"", map[string]bool{"payments": true}, -1},
+		{"現場の記録", map[string]bool{"記": true}, 9},
+	}
+	for _, tt := range tests {
+		if got := Find(tt.text, tt.want); got != tt.at {
+			t.Errorf("Find(%q, %v) = %d, want %d", tt.text, tt.want, got, tt.at)
+		}
+	}
+}
+
+// Find has to give the same answer as walking every span, since the whole point
+// of it is that it is the cheap way to ask the analyzer the same question.
+func TestFindAgreesWithSpans(t *testing.T) {
+	want := map[string]bool{"queue": true, "記": true}
+	for _, text := range []string{
+		"the queue drains",
+		"nothing here at all",
+		"a queueing theory queue",
+		"現場の記録",
+		"Café queue",
+	} {
+		at := -1
+		for s := range Spans(text) {
+			if want[s.Term] {
+				at = s.Start
+				break
+			}
+		}
+		if got := Find(text, want); got != at {
+			t.Errorf("Find(%q) = %d, want the first matching span at %d", text, got, at)
+		}
+	}
+}
+
+func TestAnalyzeCountsTitleAndBodySeparately(t *testing.T) {
+	d := Document{Title: "Payments runbook", Body: "The payments queue drains. Payments settle."}
+	a := d.Analyze()
+
+	if a.TitleTokens != 2 {
+		t.Errorf("counted %d title tokens, want 2", a.TitleTokens)
+	}
+	if a.BodyTokens != 6 {
+		t.Errorf("counted %d body tokens, want 6", a.BodyTokens)
+	}
+	if got, want := a.Terms["payments"], (TermCount{Title: 1, Body: 2}); got != want {
+		t.Errorf("payments counted %+v, want %+v", got, want)
+	}
+}
+
+func BenchmarkFind(b *testing.B) {
+	text := strings.Repeat("The ledger closes overnight and the queue drains. ", 400)
+	want := map[string]bool{"absent": true}
+	b.ReportAllocs()
+	for b.Loop() {
+		if Find(text, want) != -1 {
+			b.Fatal("the term is not in the text")
+		}
+	}
+}

--- a/index/bench_test.go
+++ b/index/bench_test.go
@@ -1,6 +1,7 @@
 package index_test
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -83,6 +84,26 @@ func BenchmarkSearchDeepPage(b *testing.B) {
 		q.Offset = 200
 		return q
 	})
+}
+
+// BenchmarkSearchPage measures the same query at four page sizes, which is the
+// measurement that separates the cost of finding the results from the cost of
+// assembling them.
+//
+// Everything before the page is work over the match set and does not move when
+// the page grows, so whatever the difference between one result and fifty is,
+// that is what a result costs to put on a page. It was 0.7ms each, which on the
+// default page of twenty spent more than the whole search budget before
+// retrieval had done anything.
+func BenchmarkSearchPage(b *testing.B) {
+	for _, size := range []int{1, 5, 20, 50} {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			run(b, benchcorpus.ClassCommon, func(q index.Query) index.Query {
+				q.Limit = size
+				return q
+			})
+		})
+	}
 }
 
 // BenchmarkSearchByRecency ranks on the date instead of the score, which takes

--- a/index/index.go
+++ b/index/index.go
@@ -37,6 +37,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/cache"
@@ -382,7 +383,7 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 			continue
 		}
 		hit := Result{Document: full, Score: r.score}
-		hit.Snippet, hit.Passages = snippet(readable(full), req.Terms)
+		hit.Snippet, hit.Passages = snippet(full, req.Terms)
 		res.Hits = append(res.Hits, hit)
 	}
 	res.Took = s.now().Sub(start)
@@ -563,30 +564,79 @@ func (s *Searcher) recency(modified, now time.Time) float64 {
 // SnippetWidth is roughly how many characters of body a snippet shows.
 const SnippetWidth = 260
 
-// snippet returns a passage of the body around the first query match, and the
-// same passage split at the matches so the interface can mark them.
-func snippet(body string, terms []string) (string, []Passage) {
-	if body == "" {
+// snippet returns a passage of the document around the first query match, and
+// the same passage split at the matches so the interface can mark them.
+//
+// It works twice: once over the source, to find a window worth reading, and once
+// over that window, to cut the snippet itself. The second pass is what a reader
+// sees, since taking the markup out of a markdown document moves every offset in
+// it, and it is cheap because the window is a few hundred characters.
+//
+// The alternative is one pass over readable text for the whole document, which
+// is what this did. That meant rewriting a document to show two lines of it, per
+// result, on every page.
+func snippet(d doc.Document, terms []string) (string, []Passage) {
+	raw := d.Body
+	if raw == "" {
 		return "", nil
 	}
-	runes := []rune(body)
-	start := 0
-	if idx := firstMatch(body, terms); idx > 0 {
-		start = max(0, len([]rune(body[:idx]))-SnippetWidth/3)
-	}
-	end := min(start+SnippetWidth, len(runes))
 
-	text := strings.TrimSpace(collapse(string(runes[start:end])))
-	passages := mark(text, terms)
-	if start > 0 {
-		text = "..." + text
+	// Wide enough that a window whose markup is removed is still longer than the
+	// snippet, and anchored far enough back that the match does not land on the
+	// first character of it.
+	from := 0
+	if at := firstMatch(raw, terms); at > 0 {
+		from = back(raw, at, SnippetWidth)
+	}
+	to := forward(raw, from, 3*SnippetWidth)
+
+	text := raw[from:to]
+	if d.Properties[doc.MediaType] == "text/markdown" {
+		text = plainText(text)
+	}
+	text = collapse(text)
+
+	head := 0
+	if at := firstMatch(text, terms); at > 0 {
+		head = back(text, at, SnippetWidth/3)
+	}
+	tail := forward(text, head, SnippetWidth)
+
+	out := strings.TrimSpace(text[head:tail])
+	passages := mark(out, terms)
+	if from > 0 || head > 0 {
+		out = "..." + out
 		passages = append([]Passage{{Text: "..."}}, passages...)
 	}
-	if end < len(runes) {
-		text += "..."
+	if to < len(raw) || tail < len(text) {
+		out += "..."
 		passages = append(passages, Passage{Text: "..."})
 	}
-	return text, passages
+	return out, passages
+}
+
+// back is the byte offset n characters before at, and forward is the byte offset
+// n characters after it.
+//
+// Byte offsets rather than a rune slice of the body, because the window is a few
+// hundred characters and the body is a document. Converting the whole thing to
+// runes to take three lines out of the middle allocated four bytes per character
+// of every result on the page, which on a page of twenty was most of what
+// building the page cost.
+func back(s string, at, n int) int {
+	for ; n > 0 && at > 0; n-- {
+		_, size := utf8.DecodeLastRuneInString(s[:at])
+		at -= size
+	}
+	return at
+}
+
+func forward(s string, at, n int) int {
+	for ; n > 0 && at < len(s); n-- {
+		_, size := utf8.DecodeRuneInString(s[at:])
+		at += size
+	}
+	return at
 }
 
 // collapse turns runs of whitespace into single spaces. A snippet lifted out of
@@ -628,15 +678,13 @@ func mark(text string, terms []string) []Passage {
 }
 
 // firstMatch returns the byte offset of the first query term in body, or -1.
+//
+// It stops at the first one and allocates nothing on the way, which is the
+// difference between reading a sentence and rewriting a document. See [doc.Find].
 func firstMatch(body string, terms []string) int {
 	want := make(map[string]bool, len(terms))
 	for _, t := range terms {
 		want[t] = true
 	}
-	for _, s := range doc.Analyze(body) {
-		if want[s.Term] {
-			return s.Start
-		}
-	}
-	return -1
+	return doc.Find(body, want)
 }

--- a/index/plain.go
+++ b/index/plain.go
@@ -1,29 +1,16 @@
 package index
 
-import (
-	"strings"
-
-	"github.com/tamnd/genba/doc"
-)
-
-// readable is the text a snippet is cut out of.
-//
-// For most documents that is the body as it was indexed. For a markdown
-// document it is the body with the syntax taken out, because two lines of a
-// result row is a small budget and a snippet that spends it on hashes, asterisks
-// and table pipes has spent it on nothing. The person reading wants the sentence
-// somebody wrote.
-//
-// Only markdown is treated this way. A source file is not markdown, and stripping
-// what looks like syntax out of code would be lying about the file.
-func readable(d doc.Document) string {
-	if d.Properties[doc.MediaType] != "text/markdown" {
-		return d.Body
-	}
-	return plainText(d.Body)
-}
+import "strings"
 
 // plainText removes markdown syntax and keeps the words.
+//
+// A snippet is cut out of what this returns, because two lines of a result row
+// is a small budget and one spent on hashes, asterisks and table pipes has been
+// spent on nothing. The person reading wants the sentence somebody wrote.
+//
+// Only markdown is treated this way, and see [snippet] for where that is
+// decided. A source file is not markdown, and stripping what looks like syntax
+// out of code would be lying about the file.
 //
 // It is a line pass and then an inline pass, which is enough for a snippet and
 // deliberately less than a renderer. It never reorders text: a term at the start

--- a/index/snippet_test.go
+++ b/index/snippet_test.go
@@ -1,0 +1,132 @@
+package index
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/doc"
+)
+
+// A snippet is cut out of a window of the source rather than out of the whole
+// document, and for markdown the syntax is removed from the window rather than
+// from the document. These are the properties that has to keep.
+
+func markdown(body string) doc.Document {
+	return doc.Document{Body: body, Properties: map[string]string{doc.MediaType: "text/markdown"}}
+}
+
+func TestSnippetFindsAMatchPastTheWindow(t *testing.T) {
+	body := strings.Repeat("Nothing relevant here. ", 400) +
+		"The payments queue drains through the replica during a failover."
+	got, _ := snippet(doc.Document{Body: body}, []string{"replica"})
+
+	if !strings.Contains(got, "replica") {
+		t.Fatalf("the matched term is not in the snippet:\n%s", got)
+	}
+	if !strings.HasPrefix(got, "...") {
+		t.Errorf("a snippet from the middle of a body does not say so:\n%s", got)
+	}
+	if len(got) > 2*SnippetWidth {
+		t.Errorf("the snippet is %d bytes, which is not a snippet:\n%s", len(got), got)
+	}
+}
+
+func TestSnippetOfMarkdownReadsAsProse(t *testing.T) {
+	body := strings.Repeat("# Heading\n\nSome filler prose here.\n\n", 60) +
+		"The **payments** queue drains through the `replica` during a failover.\n"
+	got, _ := snippet(markdown(body), []string{"replica"})
+
+	if !strings.Contains(got, "replica") {
+		t.Fatalf("the matched term is not in the snippet:\n%s", got)
+	}
+	for _, syntax := range []string{"**", "`", "# "} {
+		if strings.Contains(got, syntax) {
+			t.Errorf("the snippet carries %q markup:\n%s", syntax, got)
+		}
+	}
+}
+
+// The window is taken from the source and the snippet is cut from the window
+// after the markup has gone, so a document that is more markup than words still
+// produces a full snippet rather than a few words and an ellipsis.
+func TestSnippetIsFullEvenWhenTheSourceIsMostlyMarkup(t *testing.T) {
+	body := strings.Repeat("| a | b | c |\n|---|---|---|\n", 40) +
+		"payments settle overnight and the ledger is closed the following morning by the on call engineer\n"
+	got, _ := snippet(markdown(body), []string{"payments"})
+
+	words := len(strings.Fields(strings.ReplaceAll(got, "...", " ")))
+	if words < 10 {
+		t.Errorf("the snippet is %d words, so the window was too narrow:\n%s", words, got)
+	}
+}
+
+func TestSnippetWithoutAMatchStartsAtTheBeginning(t *testing.T) {
+	body := "The ledger closes overnight. " + strings.Repeat("More prose. ", 200)
+	got, _ := snippet(doc.Document{Body: body}, []string{"absent"})
+
+	if !strings.HasPrefix(got, "The ledger closes overnight.") {
+		t.Errorf("a body with no match does not start at the top:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("a snippet that stops short of the end does not say so:\n%s", got)
+	}
+}
+
+func TestSnippetOfAShortBodyHasNoEllipsis(t *testing.T) {
+	got, _ := snippet(doc.Document{Body: "The payments queue drains overnight."}, []string{"payments"})
+	if strings.Contains(got, "...") {
+		t.Errorf("a body shorter than a snippet was reported as cut:\n%s", got)
+	}
+}
+
+func TestPassagesJoinToTheSnippet(t *testing.T) {
+	body := strings.Repeat("Nothing relevant here. ", 100) +
+		"The payments queue drains through the replica.\n"
+	got, passages := snippet(markdown(body), []string{"payments", "replica"})
+
+	var rebuilt strings.Builder
+	var marked int
+	for _, p := range passages {
+		rebuilt.WriteString(p.Text)
+		if p.Match {
+			marked++
+		}
+	}
+	if rebuilt.String() != got {
+		t.Fatalf("the passages join to %q, want the snippet %q", rebuilt.String(), got)
+	}
+	if marked != 2 {
+		t.Errorf("marked %d passages, want the two terms that matched:\n%s", marked, got)
+	}
+}
+
+// The cost of a result on a page. It used to be the cost of the document,
+// because finding where to cut meant analysing the whole body and taking the
+// markup out meant rewriting the whole body. See #112.
+func BenchmarkSnippet(b *testing.B) {
+	prose := strings.Repeat("The ledger closes overnight and the queue drains. ", 400)
+	late := prose + "The payments queue drains through the replica during a failover."
+	terms := []string{"replica"}
+
+	b.Run("plain", func(b *testing.B) {
+		d := doc.Document{Body: late}
+		b.ReportAllocs()
+		for b.Loop() {
+			_, _ = snippet(d, terms)
+		}
+	})
+	b.Run("markdown", func(b *testing.B) {
+		d := markdown(strings.Repeat("# Heading\n\n"+prose+"\n\n", 4) + "\nThe `replica` drains.\n")
+		b.ReportAllocs()
+		for b.Loop() {
+			_, _ = snippet(d, terms)
+		}
+	})
+	b.Run("early", func(b *testing.B) {
+		d := doc.Document{Body: "The replica drains overnight. " + prose}
+		b.ReportAllocs()
+		for b.Loop() {
+			_, _ = snippet(d, terms)
+		}
+	})
+}


### PR DESCRIPTION
Closes #112.

Building a result row used to read the document twice.
Finding where to cut ran the analyzer over the entire body and used the offset of the first match, and for markdown the syntax was stripped from the entire body before anything was cut.
Both are corpus sized work for an answer that is two lines long, and on a page of twenty results it was most of what the page cost.

## What changed

The analyzer in `doc` now has one internal scanner and three ways of asking it something.
`Tokenize` and `Analyze` behave exactly as before and are now written in terms of it.
`Spans` yields one term at a time so a caller can stop early, and `Find` answers "where is the first of these terms" without building a string for every word it walks past.
The scanner spells out the ASCII rules rather than asking a range table per character, which is the same answer for the characters most text is made of.

Snippet cutting is two passes now.
The first takes a window of a few snippet widths around the match, out of the raw body.
The second removes markdown from that window, collapses it, and cuts the snippet out of the result.
Taking the window before the markup goes means a document that is mostly table pipes still yields a full snippet rather than four words and an ellipsis, and cutting after it goes means the snippet is made of words rather than syntax.
`readable` is gone, because with the window in place there is nothing left for it to do.

## Measurements

All on the five thousand document reference corpus, on this machine, `-benchtime 60x -count=2`.

A page of results, the number is the page size:

| page | before | after | bytes before | bytes after |
| --- | --- | --- | --- | --- |
| 1 | 13.9ms | 13.7ms | 737KB | 714KB |
| 5 | 14.0ms | 13.8ms | 975KB | 791KB |
| 20 | 16.0ms | 14.5ms | 1.96MB | 1.09MB |
| 50 | 19.0ms | 17.3ms | 4.51MB | 1.79MB |

Assembling a page of twenty is 0.85ms rather than 2.2ms, and a result costs 22KB rather than 77KB.
The remaining 13.7ms is the query itself and is what #55 is about, not this.

One snippet, from `BenchmarkSnippet`:

| body | before | after | allocations |
| --- | --- | --- | --- |
| plain prose | 277us | 60us | 3686 to 35 |
| markdown | 1086us | 325us | 3686 to 35 |
| match near the top | | 7us | |

Indexing picked up the same scanner and the streaming `Analyze`, so `BenchmarkPutBatch` went from 697 documents a second to 750, allocating 103MB rather than 165MB.

`make bench-gate` passes.
Within it the filter class is 31% and multi is 21% above their recorded baselines, both inside the 35% tolerance, and both are classes whose cost is the drill down facet counting from #104 rather than anything here.
Pathological is 18% and rare is 39% below.
Rare now runs in 2.0ms, which puts it inside its 3.0ms budget for the first time.

Nothing is stored that was not stored before.
The issue offered a choice between keeping match offsets in the index and keeping a precomputed lede, and asked for the index size increase to be recorded.
Neither turned out to be needed, so the answer is zero.

## Tests

`index/snippet_test.go` is new and covers the properties the two passes have to keep: a match past the window is still found, markdown reads as prose, a body that is mostly markup still gives a full snippet, a body with no match starts at the top, a short body has no ellipsis, and the passages join back to the snippet.

`doc/analyze_test.go` is new, the package had no test file before.
It pins the three ways of asking the analyzer to the same answers, checks that the span offsets point at the original characters with their case and accents intact, and checks that `Find` matches whole terms so the "run" inside "runbook" is not a hit.

## Gates

`make fmt`, `make vet`, `make lint`, `make race`, `make build`, `make bench-counters` and `make bench-gate` all pass locally.
`make ui-gate` is green apart from the axe steps, which fail on this machine only because its ChromeDriver is 152 and its Chrome is 151.
CI runs the full gate.