### PR TITLE
Audit the states rather than the layouts

### DIFF
--- a/scripts/budget-check.mjs
+++ b/scripts/budget-check.mjs
@@ -1,0 +1,112 @@
+// The budgets, counted rather than timed.
+//
+// There is no build step, so the files on disk are the files on the wire and a
+// Go test can weigh them. What it cannot see is how many of them a screen
+// actually asks for and how much markup the interface builds once they arrive,
+// and those are the two numbers that decide whether a page stays quick on a
+// laptop that is not new.
+//
+// Everything here is a count. A count does not move when the runner is busy,
+// which is why these fail a build and the Lighthouse score next to them does
+// not.
+
+import { available, evaluate, launch, reporter, visit } from "./chrome.mjs";
+
+const BASE = process.argv[2] || "http://127.0.0.1:8123";
+const ID = process.argv[3] || "";
+
+const why = available();
+if (why) {
+  console.log(`budget-check: ${why}, so the budgets that need a browser cannot run`);
+  process.exit(0);
+}
+
+// The wire budgets are the same numbers web/web_test.go holds the files on disk
+// to. They are repeated rather than shared because they are two different
+// claims: that what is committed is small, and that a screen asks for all of it
+// and nothing else.
+const BUDGETS = {
+  script: 180 << 10,
+  style: 40 << 10,
+  requests: 40,
+  // A results page of twenty, which is the default page size, and the same page
+  // with a document open in the preview. The second is larger by a whole
+  // document, and for a source file that is a highlighted span per token, which
+  // is the largest thing the interface builds anywhere.
+  results: 1200,
+  preview: 3000,
+};
+
+// What the browser recorded about what it fetched. encodedBodySize is the body
+// as it came off the wire, so a compressed response counts what was actually
+// sent rather than what it turned into.
+const ASSETS = `(() => {
+  const entries = performance.getEntriesByType('resource');
+  const bytes = (ext) => entries
+    .filter((r) => new URL(r.name).pathname.endsWith(ext))
+    .reduce((n, r) => n + (r.encodedBodySize || 0), 0);
+  return {
+    requests: entries.length,
+    script: bytes('.js'),
+    style: bytes('.css'),
+  };
+})()`;
+
+const { state, check } = reporter("budget-check");
+const browser = await launch();
+try {
+  await run(browser.session);
+} catch (err) {
+  console.error(`budget-check: ${err.message}`);
+  state.failures++;
+} finally {
+  browser.stop();
+}
+process.exit(state.failures ? 1 : 0);
+
+async function run(session) {
+  await visit(session, `${BASE}/?q=cache`, "document.querySelectorAll('.result').length > 0");
+
+  const assets = await evaluate(session, ASSETS);
+  console.log(
+    `budget-check: ${assets.requests} requests, ${assets.script} bytes of script of ${BUDGETS.script}, ${assets.style} bytes of style of ${BUDGETS.style}`,
+  );
+  await check(
+    session,
+    `the scripts a screen asks for are under ${BUDGETS.script} bytes on the wire`,
+    `(${ASSETS}).script <= ${BUDGETS.script}`,
+  );
+  await check(
+    session,
+    `the styles a screen asks for are under ${BUDGETS.style} bytes on the wire`,
+    `(${ASSETS}).style <= ${BUDGETS.style}`,
+  );
+  // A module per file means a request per file, and a screen that quietly grows
+  // to a hundred of them is slow in a way no byte count shows.
+  await check(
+    session,
+    `a screen asks for no more than ${BUDGETS.requests} files`,
+    `(${ASSETS}).requests <= ${BUDGETS.requests}`,
+  );
+
+  const results = await evaluate(session, "document.getElementsByTagName('*').length");
+  console.log(`budget-check: ${results} nodes on a page of twenty results, of ${BUDGETS.results}`);
+  await check(
+    session,
+    `a page of twenty results is under ${BUDGETS.results} nodes`,
+    `document.getElementsByTagName('*').length <= ${BUDGETS.results}`,
+  );
+
+  if (!ID) {
+    console.log("budget-check: no document id was passed, so the preview is not counted");
+    return;
+  }
+  await visit(session, `${BASE}/?q=cache&open=${ID}`, "Boolean(document.querySelector('.preview'))");
+  const preview = await evaluate(session, "document.getElementsByTagName('*').length");
+  console.log(`budget-check: ${preview} nodes with a document open, of ${BUDGETS.preview}`);
+  await check(
+    session,
+    `a results page with a document open is under ${BUDGETS.preview} nodes`,
+    `document.getElementsByTagName('*').length <= ${BUDGETS.preview}`,
+  );
+}

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -328,6 +328,32 @@ async function walk(session) {
       new URLSearchParams(location.search).get('cursor') === '0'`,
   );
 
+  // Five presses down the list. Moving the cursor is a move through an answer
+  // the page already has, so nothing on screen is asked for a second time. Two
+  // requests are allowed to go out and both are ahead of where somebody is: the
+  // document under the cursor, which is why the preview opens instantly, and
+  // the next page of results, which is why the end of the list is not a wait.
+  await evaluate(
+    session,
+    `(() => {
+      window.__walk = { searches: [] };
+      const sent = window.fetch;
+      window.fetch = function (input) {
+        const url = String((input && input.url) || input);
+        if (url.includes('/api/v1/search')) window.__walk.searches.push(url);
+        return sent.apply(this, arguments);
+      };
+      return true;
+    })()`,
+  );
+  for (let i = 0; i < 5; i++) await press(session, "ArrowDown", "ArrowDown", 40);
+  await check(
+    session,
+    "five presses down land on the sixth result and ask again for nothing already on screen",
+    `document.activeElement.dataset.index === '5' &&
+      window.__walk.searches.every((u) => Number(new URL(u).searchParams.get('offset') || 0) > 0)`,
+  );
+
   await press(session, "End", "End", 35);
   await check(
     session,

--- a/scripts/latency-report.mjs
+++ b/scripts/latency-report.mjs
@@ -1,0 +1,126 @@
+// The cold latency report.
+//
+// Fifty distinct queries against whatever corpus the gate is pointed at, timed
+// from the client. Distinct because a repeated query is answered from a cache
+// and measures the cache, and the number worth watching is what somebody gets
+// when they type something nobody has typed before.
+//
+// It prints and it does not fail, until #55 lands and the query stops being
+// linear in the size of the match set. It prints anyway, because a number
+// nobody prints is a number nobody watches, and that is exactly how a fifth of
+// a second on a first query went unnoticed for as long as it did. Set
+// GENBA_LATENCY_STRICT=1 to have it fail against the budget.
+
+const BASE = process.argv[2] || "http://127.0.0.1:8123";
+const TENANT = process.argv[3] || "demo";
+const BUDGET = Number(process.env.GENBA_LATENCY_BUDGET || 10);
+const STRICT = process.env.GENBA_LATENCY_STRICT === "1";
+
+// Fifty words, spelled out rather than sampled, so that two runs measure the
+// same thing and a change in the number is a change in the server. They are
+// words this repository is made of, because this repository is the corpus.
+const QUERIES = [
+  "cache",
+  "ranker",
+  "posting",
+  "tenant",
+  "facet",
+  "snippet",
+  "connector",
+  "postgres",
+  "sqlite",
+  "migration",
+  "keyboard",
+  "preview",
+  "drawer",
+  "thumbnail",
+  "notebook",
+  "markdown",
+  "highlight",
+  "permission",
+  "subject",
+  "group",
+  "identity",
+  "crawl",
+  "bucket",
+  "signature",
+  "retry",
+  "backoff",
+  "watcher",
+  "reconcile",
+  "checkpoint",
+  "cursor",
+  "budget",
+  "baseline",
+  "calibration",
+  "percentile",
+  "histogram",
+  "counter",
+  "decode",
+  "candidate",
+  "corpus",
+  "vocabulary",
+  "analyzer",
+  "token",
+  "stemming",
+  "suggest",
+  "correction",
+  "recency",
+  "boost",
+  "scoring",
+  "pagination",
+  "throughput",
+];
+
+const headers = {
+  "X-Genba-Tenant": TENANT,
+  "X-Genba-Subject": "dev@example.com",
+  "X-Genba-Groups": "everyone",
+};
+
+const timings = [];
+let empty = 0;
+for (const q of QUERIES) {
+  const url = `${BASE}/api/v1/search?q=${encodeURIComponent(q)}&limit=20`;
+  const started = performance.now();
+  let res;
+  try {
+    res = await fetch(url, { headers });
+  } catch (err) {
+    console.log(`latency-report: ${q} did not answer: ${err.message}`);
+    process.exit(0);
+  }
+  const body = await res.json();
+  const took = performance.now() - started;
+  if (!res.ok) {
+    console.log(`latency-report: ${q} answered ${res.status}, so there is nothing to measure`);
+    process.exit(0);
+  }
+  if (!body.total) empty++;
+  timings.push({ q, took });
+}
+
+timings.sort((a, b) => a.took - b.took);
+const at = (p) => timings[Math.min(timings.length - 1, Math.floor((p / 100) * timings.length))];
+const p50 = at(50);
+const p95 = at(95);
+const p99 = at(99);
+const slowest = timings[timings.length - 1];
+
+const ms = (n) => `${n.toFixed(1)}ms`;
+console.log(
+  `latency-report: ${timings.length} distinct queries, p50 ${ms(p50.took)}, p95 ${ms(p95.took)}, p99 ${ms(p99.took)}, budget ${ms(BUDGET)}`,
+);
+console.log(`latency-report: slowest was ${slowest.q} at ${ms(slowest.took)}`);
+// A word that is in no document is answered from an empty posting list, which
+// is the fastest path there is. Too many of them and the percentiles above are
+// a measurement of nothing, so the count is printed next to them.
+if (empty) console.log(`latency-report: ${empty} of them matched nothing in this corpus`);
+
+if (p95.took <= BUDGET) process.exit(0);
+if (!STRICT) {
+  console.log(`latency-report: over the budget, which is advisory until #55 lands`);
+  process.exit(0);
+}
+console.error(`latency-report: p95 is ${ms(p95.took)}, over the budget of ${ms(BUDGET)}`);
+process.exit(1);

--- a/scripts/render-check.mjs
+++ b/scripts/render-check.mjs
@@ -193,6 +193,46 @@ async function run(session) {
     `),
   );
 
+  // The sixth shape. A row and a grid cell ask for two different pictures and
+  // neither of them is the file: a photograph off a phone is four megabytes and
+  // the box it goes in is fifty six pixels across, so a list of twenty of them
+  // downloaded as they are is eighty megabytes to draw a page.
+  await check(
+    session,
+    "a picture in a row and a picture in a grid cell are thumbnails of two sizes, not the file",
+    expr(`
+      const { tile, cover, TILE, CELL } = await import('genba/content.js');
+      const { api } = await import('genba/api.js');
+      const hit = { id: 'repo:shot.png', media_type: 'image/png', kind: 'image', title: 'shot.png', modified_at: '7' };
+      const asked = [];
+      const sent = window.fetch;
+      window.fetch = function (input) { asked.push(String((input && input.url) || input)); return sent.apply(this, arguments); };
+      try {
+        document.body.append(tile(hit), cover(hit));
+        await new Promise((done) => setTimeout(done, 400));
+      } finally {
+        window.fetch = sent;
+      }
+      const thumbs = asked.filter((u) => u.includes('/thumbnail?size='));
+      return thumbs.some((u) => u.includes('size=' + TILE)) &&
+        thumbs.some((u) => u.includes('size=' + CELL)) &&
+        thumbs.every((u) => u.includes('v=7')) &&
+        !asked.some((u) => /\\/documents\\/[^/]+\\/content/.test(u)) &&
+        TILE < CELL;
+    `),
+  );
+
+  await check(
+    session,
+    "a document that is not a picture gets the icon for its kind rather than a hole in the grid",
+    expr(`
+      const { tile, cover } = await import('genba/content.js');
+      const hit = { id: 'repo:notes.md', media_type: 'text/markdown', kind: 'document', source: 'repo' };
+      return Boolean(tile(hit).querySelector('svg')) && !tile(hit).querySelector('.image') &&
+        cover(hit).classList.contains('cover--icon');
+    `),
+  );
+
   await check(
     session,
     "a recording is its transcript, with a player that has not loaded anything yet",

--- a/scripts/state-check.mjs
+++ b/scripts/state-check.mjs
@@ -21,6 +21,11 @@
 import { available, evaluate, launch, reporter, settle, sleep, visit } from "./chrome.mjs";
 
 const BASE = process.argv[2] || "http://127.0.0.1:8123";
+// A second server holding nothing, when the gate started one. The empty index
+// is rendered from a module below like the other states, and this is the same
+// screen reached the way somebody reaches it, which is the only way to find out
+// whether the count of documents survives the trip.
+const EMPTY = process.argv[3] || "";
 
 const why = available();
 if (why) {
@@ -319,6 +324,35 @@ async function run(session) {
         refused.querySelector('.state__title').textContent === 'That request was refused' &&
         !unreachable.querySelector('.state__actions');
     `),
+  );
+
+  if (!EMPTY) {
+    console.log("state-check: no empty server was passed, so the first run is only checked from the module");
+    return;
+  }
+
+  // The same screen as the two assertions above, reached the way somebody
+  // reaches it on the day they install this. The module can be told there are
+  // no documents; only the server can be empty.
+  await visit(session, `${EMPTY}/`, "Boolean(document.querySelector('.state'))");
+  await check(
+    session,
+    "a server with an empty index opens on how to fill it",
+    `(() => {
+      const state = document.querySelector('.state--first');
+      return Boolean(state) && state.textContent.includes('Nothing indexed yet') &&
+        state.querySelector('.state__command').textContent.includes('-corpus');
+    })()`,
+  );
+  // Searching an empty index is not an unlucky query and is not written as one.
+  await visit(session, `${EMPTY}/?q=anything`, "Boolean(document.querySelector('.state'))");
+  await check(
+    session,
+    "and searching it says the same thing rather than that nothing matched",
+    `(() => {
+      const state = document.querySelector('.state--first');
+      return Boolean(state) && state.textContent.includes('Nothing indexed yet');
+    })()`,
   );
 }
 

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -2,42 +2,55 @@
 # The browser half of the performance gate.
 #
 # It starts the real binary over a real corpus, which is this repository, and
-# audits the screens somebody actually looks at: the home page, a results page,
-# a results page with the document drawer open, a document on a page of its own,
-# a grid of pictures, the recent screen and a search that matched nothing.
-# Auditing a static fixture would audit the fixture, and every accessibility bug
-# this is meant to catch lives in the markup the interface builds after a fetch.
+# audits nine screens: the home page, the home page over an index holding
+# nothing, a results page, a results page with the document drawer open, a
+# search that matched nothing, a filter that matched nothing, a grid of
+# pictures, a document on a page of its own and the recent screen. They are
+# states rather than layouts, because a layout is looked at every day and a
+# state is looked at once. Auditing a static fixture would audit the fixture,
+# and every accessibility bug this is meant to catch lives in the markup the
+# interface builds after a fetch.
 #
-# The keyboard walk, the rendering check, the states check and axe are the parts
-# that fail a build. axe reports violations of a standard rather than an
-# opinion, it does not move when the runner is busy, and a violation is a person
-# who cannot use the page. The walk presses the keys and clicks the links a
-# person would and asserts where each one led, which is the half axe cannot see:
-# markup can describe itself perfectly and still go nowhere when you click it.
-# The states check drives the screens that are not the happy path, which is
-# where an interface either has a way out or does not.
+# The keyboard walk, the rendering check, the states check, the budgets and axe
+# are the parts that fail a build. axe reports violations of a standard rather
+# than an opinion, it does not move when the runner is busy, and a violation is
+# a person who cannot use the page. The walk presses the keys and clicks the
+# links a person would and asserts where each one led, which is the half axe
+# cannot see: markup can describe itself perfectly and still go nowhere when you
+# click it. The states check drives the screens that are not the happy path,
+# which is where an interface either has a way out or does not. The budgets are
+# counts, of files fetched and nodes built, and a count does not flake.
 #
-# Lighthouse is advisory here and enforced on the nightly run, because a
-# Lighthouse performance score on a shared runner moves by ten points between
-# two runs of the same commit. Set GENBA_UI_STRICT=1 to have it fail.
+# Lighthouse and the cold latency report are advisory. A Lighthouse performance
+# score on a shared runner moves by ten points between two runs of the same
+# commit, and Lighthouse is enforced on the nightly run instead. Set
+# GENBA_UI_STRICT=1 to have it fail. The latency report is advisory for the
+# other reason: it is over its budget on purpose, and it prints so that the
+# number is watched while the work that fixes it is done.
 set -eu
 
 BIN=${BIN:-bin/genbad}
 PORT=${PORT:-8123}
 BASE="http://127.0.0.1:$PORT"
+# The second server holds nothing, because an index with nothing in it is a
+# state somebody sees on their first day and it cannot be reached from a server
+# that has a corpus.
+EMPTY_PORT=$((PORT + 1))
+EMPTY="http://127.0.0.1:$EMPTY_PORT"
 TENANT=demo
 LIGHTHOUSE_MIN=${LIGHTHOUSE_MIN:-95}
 SERVER=
+BLANK=
 # Where the pictures go. It is inside the corpus because the corpus is this
 # directory, it is gitignored, and it is not a dotted name because the file
 # connector skips anything that starts with a dot and would index none of it.
 IMAGES=${IMAGES:-gate-images}
 
 cleanup() {
-	if [ -n "$SERVER" ]; then
-		kill "$SERVER" 2>/dev/null || true
-		wait "$SERVER" 2>/dev/null || true
-	fi
+	for pid in $SERVER $BLANK; do
+		kill "$pid" 2>/dev/null || true
+		wait "$pid" 2>/dev/null || true
+	done
 	rm -rf "$IMAGES"
 }
 trap cleanup EXIT INT TERM
@@ -57,10 +70,30 @@ fi
 # pages to the audit, while our server exits because it could not bind. The
 # failure that produces blames the corpus, which is a long way from the truth,
 # so the port is checked before anything is started.
-if curl -fsS -o /dev/null "$BASE/healthz" 2>/dev/null; then
-	echo "ui-gate: something is already listening on $PORT, set PORT to a free one" >&2
-	exit 1
-fi
+for url in "$BASE" "$EMPTY"; do
+	if curl -fsS -o /dev/null "$url/healthz" 2>/dev/null; then
+		echo "ui-gate: something is already listening on $url, set PORT to a free one" >&2
+		exit 1
+	fi
+done
+
+# ready waits for a server to answer its health check, and gives up if the
+# process it is waiting for is no longer there.
+ready() {
+	i=0
+	until curl -fsS "$1/healthz" >/dev/null 2>&1; do
+		if ! kill -0 "$2" 2>/dev/null; then
+			echo "ui-gate: the server on $1 exited before it was ready" >&2
+			exit 1
+		fi
+		i=$((i + 1))
+		if [ "$i" -gt 100 ]; then
+			echo "ui-gate: the server on $1 never became healthy" >&2
+			exit 1
+		fi
+		sleep 0.2
+	done
+}
 
 # The repository holds no images, so the grid and the thumbnail endpoint would
 # have nothing to audit. Two dozen generated pictures are written into the corpus
@@ -73,19 +106,14 @@ node scripts/gate-images.mjs "$IMAGES" 24
 "$BIN" -addr "127.0.0.1:$PORT" -store memory -tenant "$TENANT" -corpus . -corpus-name repo -log-level error &
 SERVER=$!
 
-i=0
-until curl -fsS "$BASE/healthz" >/dev/null 2>&1; do
-	if ! kill -0 "$SERVER" 2>/dev/null; then
-		echo "ui-gate: the server exited before it was ready" >&2
-		exit 1
-	fi
-	i=$((i + 1))
-	if [ "$i" -gt 100 ]; then
-		echo "ui-gate: the server never became healthy" >&2
-		exit 1
-	fi
-	sleep 0.2
-done
+# The same binary with nothing to index. It is one more process rather than a
+# fixture because the empty state is what the interface does with an answer of
+# no documents, and an answer of no documents has to come from the server.
+"$BIN" -addr "127.0.0.1:$EMPTY_PORT" -store memory -tenant "$TENANT" -log-level error &
+BLANK=$!
+
+ready "$BASE" "$SERVER"
+ready "$EMPTY" "$BLANK"
 
 # The drawer is opened by an id in the URL, so one has to be looked up. The
 # headers are what a trusted proxy would pass down, and the corpus is readable
@@ -125,9 +153,21 @@ fi
 # from the browser side to produce a slow request and a failed one, so it needs
 # nothing downloaded either and asks nothing of the server it is auditing.
 echo "ui-gate: states check"
-if ! node scripts/state-check.mjs "$BASE"; then
+if ! node scripts/state-check.mjs "$BASE" "$EMPTY"; then
 	status=1
 fi
+
+# Counts rather than timings, so they fail a build. What a screen fetches and
+# how much markup it builds are both things that grow one commit at a time and
+# are never noticed in any single one of them.
+echo "ui-gate: budgets"
+if ! node scripts/budget-check.mjs "$BASE" "$ID"; then
+	status=1
+fi
+
+# Printed on every run and advisory until #55 lands. See the script.
+echo "ui-gate: latency"
+node scripts/latency-report.mjs "$BASE" "$TENANT" || status=1
 
 if ! command -v npx >/dev/null 2>&1; then
 	echo "ui-gate: npx is not on the path, so axe and Lighthouse cannot run"
@@ -149,13 +189,31 @@ if [ -n "${CHROMEDRIVER:-}" ]; then
 	DRIVER="--chromedriver-path $CHROMEDRIVER"
 fi
 
-for path in "/" "/?q=cache" "/?q=cache&open=$ID" "/d/$ID" "/?q=gatepix" "/recent" "/?q=cache&kind=image"; do
-	echo "ui-gate: axe $path"
+# Nine screens, and they are states rather than layouts. Three of them, the
+# empty index, the query that matched nothing and the filter that matched
+# nothing, produce markup no other screen produces, and that markup is where an
+# accessibility bug survives longest: nobody looks at an empty page twice.
+#
+# The settings screen the specification lists is not among them because it does
+# not exist yet. When it does it belongs here, and until then a screen audited
+# on a corpus that has no filter left to remove is worth more than a placeholder.
+# It is #133.
+for url in \
+	"$BASE/" \
+	"$EMPTY/" \
+	"$BASE/?q=cache" \
+	"$BASE/?q=cache&open=$ID" \
+	"$BASE/?q=zzqxzzqx" \
+	"$BASE/?q=cache&kind=image" \
+	"$BASE/?q=gatepix&kind=image&view=grid" \
+	"$BASE/d/$ID" \
+	"$BASE/recent"; do
+	echo "ui-gate: axe $url"
 	# The interface renders after a fetch, so the audit waits for the first
 	# paint to have happened. Auditing an empty document passes and proves
 	# nothing.
 	# shellcheck disable=SC2086
-	if ! npx --yes @axe-core/cli "$BASE$path" \
+	if ! npx --yes @axe-core/cli "$url" \
 		--tags wcag2a,wcag2aa,wcag21a,wcag21aa \
 		--load-delay 2000 \
 		$DRIVER \


### PR DESCRIPTION
Closes #113.

The gate audited three screens in one state.
A layout is looked at every day and a state is looked at once, so a state is where an accessibility bug survives, and every state in `frontend/08_states.md` was unaudited.

## Nine screens

```
/                                 home, populated
/                                 home, empty index, on a second server
/?q=cache                         results
/?q=cache&open=ID                 results with the preview open
/?q=zzqxzzqx                      nothing matched
/?q=cache&kind=image              nothing matched because of a filter
/?q=gatepix&kind=image&view=grid  the grid
/d/ID                             the document page
/recent                           recent
```

All nine pass axe on wcag2a, wcag2aa, wcag21a and wcag21aa with zero violations.

The empty index needs a server that is empty, so the gate starts a second one with no corpus on the next port and shuts both down through the same trap.
The states check is pointed at it as well.
It already rendered the empty state from the module that draws it, and now it also opens the real screen on the real empty server, because the module can be told there are no documents and only a server can be empty.

The settings screen `frontend/09_testing.md` lists is not among the nine because it does not exist in the product.
I opened #133 for it rather than auditing a placeholder, and the ninth screen is the filter that matched nothing, which is a state the specification does list.

## Budgets, which fail the build

`scripts/budget-check.mjs` is new. Everything in it is a count, and a count does not move when the runner is busy.

| budget | measured | ceiling |
| --- | --- | --- |
| files a screen fetches | 30 | 40 |
| script on the wire | 79558 | 184320 |
| style on the wire | 16356 | 40960 |
| nodes, a page of twenty | 753 | 1200 |
| nodes, with a document open | 1773 | 3000 |

The byte budgets are the same numbers `web/web_test.go` holds the files on disk to, repeated on purpose.
They are two different claims: that what is committed is small, and that a screen asks for all of it and nothing else.
The node counts are the ones that were missing, and the second is the interesting one, because a source file in the preview is a highlighted span per token and it is the largest thing the interface builds anywhere.

## The cold latency report

`scripts/latency-report.mjs` is new. Fifty distinct queries, spelled out rather than sampled so two runs measure the same thing, timed from the client against whatever corpus the gate is pointed at.
Distinct because a repeated query is answered from a cache and would measure the cache.

On this machine against this repository:

```
latency-report: 50 distinct queries, p50 131.9ms, p95 248.9ms, p99 258.1ms, budget 10.0ms
latency-report: slowest was pagination at 258.1ms
latency-report: 3 of them matched nothing in this corpus
latency-report: over the budget, which is advisory until #55 lands
```

It prints and does not fail, and `GENBA_LATENCY_STRICT=1` makes it fail.
It prints because a number nobody prints is a number nobody watches, which is exactly how the numbers in `frontend/01_reality.md` went unnoticed for as long as they did.
The count of queries that matched nothing is printed next to the percentiles, because a word in no document is answered from an empty posting list and too many of those would make the percentiles a measurement of nothing.

## The walk and the renderers

The walk gained the five presses down the list from the issue.
It asserts the sixth row has focus and that nothing already on screen was asked for again.
Two requests do go out during those presses and both are ahead of where the person is, the document under the cursor and the next page of results, so the assertion is that every search issued is for an offset past the page rather than that no request was made at all.

The rendering check gained the sixth shape.
A row and a grid cell ask for two different sizes of thumbnail, both carry the version, and neither of them fetches the file: a photograph off a phone is four megabytes and the box it goes in is fifty six pixels across.
A document that is not a picture gets the icon for its kind rather than a hole in the grid.

## Gates

The whole gate passes locally, exit 0, 97 assertions and nine screens with no violations.
That run needed `CHROMEDRIVER` pointed at a driver matching the Chrome on this machine, because axe downloads the current one and this laptop is a release behind.
CI passes `CHROMEWEBDRIVER` for that already.
Lighthouse reports 99 performance, 100 accessibility, 100 best practices.