### PR TITLE
Build the settings screen

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/tamnd/genba"
@@ -67,6 +68,19 @@ type Server struct {
 	// started is when the process came up, reported by the health endpoint.
 	started time.Time
 	now     func() time.Time
+
+	// driver names the storage this process was started with. It is passed in
+	// rather than derived from the store, because the name an operator knows is
+	// the one they typed on the command line and a Go type name is not it.
+	driver string
+
+	// indexed is when the store last reported a committed write, as Unix
+	// nanoseconds, and zero until one happens.
+	//
+	// It is not persisted and it is not asked of the driver. A process that has
+	// just started has not seen a sync, and saying so is more honest than
+	// reporting one it was not there for.
+	indexed atomic.Int64
 
 	// heartbeat is how often an idle event stream sends a comment.
 	heartbeat time.Duration
@@ -113,6 +127,13 @@ func WithClock(now func() time.Time) Option {
 	}
 }
 
+// WithDriver names the storage driver this process was started with, for the
+// stats endpoint to report. Without it the server says nothing about its
+// storage, which is what an embedder that never chose a driver name should say.
+func WithDriver(name string) Option {
+	return func(s *Server) { s.driver = name }
+}
+
 // WithHeartbeat sets how often an idle event stream sends a comment. It exists
 // so that a test does not have to wait [HeartbeatInterval] to see one.
 func WithHeartbeat(d time.Duration) Option {
@@ -144,6 +165,13 @@ func New(st store.Store, searcher *index.Searcher, auth Authenticator, opts ...O
 	// what the counters read and both arrive with the server rather than with
 	// the registry.
 	s.metrics = newMetrics(s)
+	// A driver that reports its writes is how this process knows a sync
+	// happened. The unsubscribe is dropped on purpose: a server is built once
+	// and lives as long as the process does, so there is no point in the life
+	// of one where this should stop listening.
+	if n, ok := st.(store.Notifier); ok {
+		n.OnChange(func(store.Change) { s.indexed.Store(s.now().UnixNano()) })
+	}
 	return s
 }
 
@@ -198,6 +226,7 @@ type healthResponse struct {
 	Status  string `json:"status"`
 	Version string `json:"version"`
 	Commit  string `json:"commit"`
+	Built   string `json:"built"`
 	Uptime  string `json:"uptime"`
 }
 
@@ -206,6 +235,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 		Status:  "ok",
 		Version: genba.Version,
 		Commit:  genba.Commit,
+		Built:   genba.Date,
 		Uptime:  time.Since(s.started).Round(time.Second).String(),
 	})
 }
@@ -456,6 +486,13 @@ type meResponse struct {
 	Tenant  string   `json:"tenant"`
 	Roles   []string `json:"roles,omitempty"`
 
+	// Groups is what the principal is a member of, as the authenticator
+	// resolved it. It is on the wire because the first question somebody asks
+	// when a document says they may not read it is which groups they are in,
+	// and the answer they need is the server's rather than whatever the browser
+	// last sent. Absent where the principal is in none.
+	Groups []string `json:"groups,omitempty"`
+
 	// View names what this principal can see, and is the same fingerprint the
 	// server keys its own caches by.
 	//
@@ -484,6 +521,7 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request, p *acl.Princip
 		Subject: p.Subject,
 		Tenant:  p.Tenant,
 		Roles:   p.Roles,
+		Groups:  p.Groups.Members,
 		View:    acl.Fingerprint(p),
 		Sources: []facet{},
 		Kinds:   []facet{},
@@ -741,6 +779,17 @@ type statsResponse struct {
 	Documents   int                    `json:"documents"`
 	Quarantined int                    `json:"quarantined"`
 	Cache       map[string]cache.Stats `json:"cache,omitempty"`
+
+	// Driver is the storage this process was started with, and IndexedAt is
+	// when it last committed a write, in RFC 3339. Both are empty where there
+	// is nothing true to say: an embedder that named no driver, and a process
+	// that has not seen the corpus move since it came up.
+	//
+	// They are here rather than on the health endpoint because that one is
+	// unauthenticated, and what a deployment runs on is not something to hand
+	// to anybody who can reach the port.
+	Driver    string `json:"driver,omitempty"`
+	IndexedAt string `json:"indexed_at,omitempty"`
 }
 
 // handleStats reports the corpus and the cache counters.
@@ -766,7 +815,19 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request, _ *acl.Prin
 		Documents:   st.Documents,
 		Quarantined: st.Quarantined,
 		Cache:       s.cacheStats(),
+		Driver:      s.driver,
+		IndexedAt:   s.indexedAt(),
 	})
+}
+
+// indexedAt is when the corpus last moved, or empty if it has not moved since
+// this process came up.
+func (s *Server) indexedAt() string {
+	ns := s.indexed.Load()
+	if ns == 0 {
+		return ""
+	}
+	return time.Unix(0, ns).UTC().Format(time.RFC3339)
 }
 
 // cacheStats is every cache the process runs, under one name each.

--- a/api/settings_test.go
+++ b/api/settings_test.go
@@ -1,0 +1,130 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// The facts the settings screen prints about the deployment. They are asserted
+// here rather than left to the browser gate because the split between them is a
+// decision rather than a layout: what a deployment runs on is on the endpoint
+// that asks for a credential, and what this build is is on the one that does
+// not.
+
+func newNamedServer(t *testing.T, driver string, now func() time.Time) (http.Handler, *memstore.Store) {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	opts := []api.Option{api.WithDriver(driver)}
+	if now != nil {
+		opts = append(opts, api.WithClock(now))
+	}
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}, opts...)
+	return s.Handler(), st
+}
+
+type statsBody struct {
+	Driver    string `json:"driver"`
+	IndexedAt string `json:"indexed_at"`
+}
+
+func TestStatsNameTheStoreThisProcessWasStartedWith(t *testing.T) {
+	h, _ := newNamedServer(t, "sqlite", nil)
+
+	w := request(t, h, http.MethodGet, "/api/v1/stats", engineer())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := decode[statsBody](t, w).Driver; got != "sqlite" {
+		t.Errorf("driver = %q, want sqlite", got)
+	}
+
+	// An embedder that named no driver says nothing rather than guessing at one
+	// from a Go type name that nobody typed on a command line.
+	h, _ = newNamedServer(t, "", nil)
+	w = request(t, h, http.MethodGet, "/api/v1/stats", engineer())
+	if got := decode[statsBody](t, w).Driver; got != "" {
+		t.Errorf("a server that was given no driver name reported %q", got)
+	}
+}
+
+// A process that has just come up has not seen a sync, and saying so is more
+// honest than reporting one it was not there for.
+func TestStatsReportTheLastSyncOnlySinceThisProcessCameUp(t *testing.T) {
+	at := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	h, st := newNamedServer(t, "memory", func() time.Time { return at })
+
+	w := request(t, h, http.MethodGet, "/api/v1/stats", engineer())
+	if got := decode[statsBody](t, w).IndexedAt; got != "" {
+		t.Fatalf("indexed_at = %q before anything was written, want empty", got)
+	}
+
+	perm := acl.Permissions{Mode: acl.ModePublicToTenant, Source: "gdrive", Version: 1}
+	d := doc.Document{
+		ID: "d1", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+		Title: "Payments failover runbook", Permissions: perm,
+	}
+	if err := st.Put(t.Context(), d); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	w = request(t, h, http.MethodGet, "/api/v1/stats", engineer())
+	if got := decode[statsBody](t, w).IndexedAt; got != at.Format(time.RFC3339) {
+		t.Errorf("indexed_at = %q, want %q", got, at.Format(time.RFC3339))
+	}
+}
+
+// The unauthenticated endpoint says what this build is and nothing about what
+// it was pointed at. Anybody who can reach the port can read it.
+func TestHealthSaysWhatThisBuildIsAndNotWhatItRunsOn(t *testing.T) {
+	h, _ := newNamedServer(t, "postgres", nil)
+
+	w := request(t, h, http.MethodGet, "/healthz", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := decode[map[string]string](t, w)
+	if _, ok := body["built"]; !ok {
+		t.Errorf("healthz said nothing about when this was built: %v", body)
+	}
+	for _, key := range []string{"driver", "indexed_at"} {
+		if v, ok := body[key]; ok {
+			t.Errorf("healthz told an anonymous caller %s = %q", key, v)
+		}
+	}
+}
+
+// The first question somebody asks when a document says they may not read it is
+// which groups they are in, and the answer has to be the server's rather than
+// whatever the browser last sent.
+func TestMeReportsTheGroupsTheAuthenticatorResolved(t *testing.T) {
+	type meBody struct {
+		Groups []string `json:"groups"`
+	}
+	h, _ := newNamedServer(t, "memory", nil)
+
+	w := request(t, h, http.MethodGet, "/api/v1/me", map[string]string{
+		api.HeaderSubject: "u_mei",
+		api.HeaderGroups:  "gdrive:eng@acme.com,gdrive:oncall@acme.com",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	got := decode[meBody](t, w).Groups
+	if len(got) != 2 || got[0] != "gdrive:eng@acme.com" || got[1] != "gdrive:oncall@acme.com" {
+		t.Errorf("groups = %v, want both groups the header carried", got)
+	}
+
+	w = request(t, h, http.MethodGet, "/api/v1/me", map[string]string{api.HeaderSubject: "u_nobody"})
+	if got := decode[meBody](t, w).Groups; len(got) != 0 {
+		t.Errorf("a principal in no groups was told they are in %v", got)
+	}
+}

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -136,6 +136,22 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		}
 	}()
 
+	opts := []api.Option{api.WithLogger(log), api.WithDriver(string(cfg.Store))}
+	if h := web.Handler(); h != nil {
+		opts = append(opts, api.WithAssets(h))
+	}
+
+	// The searcher subscribes the cache to the store's writes, so it is closed
+	// before the store is, and it holds nothing else.
+	searcher := index.New(st, searchOptions(cfg)...)
+	defer func() { _ = searcher.Close() }()
+
+	// Built before anything is indexed rather than after, because the server
+	// listens for the store's writes and the first sync is a write like any
+	// other. Building it afterwards left it reporting that nothing had been
+	// indexed since it came up while sitting on a corpus it had just loaded.
+	srv := api.New(st, searcher, api.HeaderAuth{Tenant: cfg.Tenant}, opts...)
+
 	// The first sync of each source runs here, before the listener opens, so
 	// that the server is useful the moment it says it is up. A server pointed at
 	// both indexes both, and the two are separate feeds with separate cursors
@@ -152,18 +168,6 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		return err
 	}
 	defer waitForBucket()
-
-	opts := []api.Option{api.WithLogger(log)}
-	if h := web.Handler(); h != nil {
-		opts = append(opts, api.WithAssets(h))
-	}
-
-	// The searcher subscribes the cache to the store's writes, so it is closed
-	// before the store is, and it holds nothing else.
-	searcher := index.New(st, searchOptions(cfg)...)
-	defer func() { _ = searcher.Close() }()
-
-	srv := api.New(st, searcher, api.HeaderAuth{Tenant: cfg.Tenant}, opts...)
 
 	httpSrv := &http.Server{
 		Addr:              cfg.Addr,

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -544,6 +544,62 @@ async function walk(session) {
     })()`,
   );
 
+  // The settings screen, reached the way the screen itself says it is reached.
+  // A shortcut that is printed on a list and does not work is worse than one
+  // that was never written down, so the walk presses the keys off the list.
+  await visit(session, `${BASE}/?q=cache`, "document.querySelectorAll('.result').length > 0");
+  await press(session, "g", "KeyG", 71);
+  await press(session, ",", "Comma", 188);
+  await settle(session, "location.pathname === '/settings'");
+  await check(
+    session,
+    "g then comma reaches the settings screen and the rail says so",
+    `document.querySelector('.rail__link[data-route="settings"]').getAttribute('aria-current') === 'page' &&
+      document.activeElement === document.querySelector('.settings__title')`,
+  );
+
+  // The reason keys.js exists. Both lists are drawn from the same rows, so the
+  // count on this screen is the count the sheet shows, and neither of them can
+  // be a key that nothing answers.
+  await check(
+    session,
+    "the printed list of keys is the table the handler reads",
+    `(() => {
+      const printed = [...document.querySelectorAll('.settings .shortcut')];
+      const keyed = printed.filter((row) => row.querySelectorAll('.kbd').length > 0);
+      return printed.length >= 15 && keyed.length === printed.length;
+    })()`,
+  );
+
+  await evaluate(
+    session,
+    "document.querySelector('.choice input[value=\"dark\"]').click()",
+  );
+  await check(
+    session,
+    "choosing a theme applies it at once and remembers it",
+    `document.documentElement.dataset.theme === 'dark' &&
+      localStorage.getItem('genba.theme') === 'dark'`,
+  );
+
+  await evaluate(
+    session,
+    "document.querySelector('.choice input[value=\"\"]').click()",
+  );
+  await check(
+    session,
+    "following the system again forgets the choice rather than storing one",
+    "localStorage.getItem('genba.theme') === null",
+  );
+
+  await evaluate(session, "document.querySelector('.settings .page__back-link').click()");
+  await settle(session, "location.pathname === '/'");
+  await check(
+    session,
+    "the way out leads back to the search it was opened from",
+    "location.search.includes('q=cache')",
+  );
+
   // The grid. The pictures behind this query are written into the corpus by the
   // gate before the server starts, because the repository itself holds none.
   await visit(session, `${BASE}/?q=gatepix`, "document.querySelectorAll('.cell').length > 0");

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -2,10 +2,11 @@
 # The browser half of the performance gate.
 #
 # It starts the real binary over a real corpus, which is this repository, and
-# audits nine screens: the home page, the home page over an index holding
+# audits ten screens: the home page, the home page over an index holding
 # nothing, a results page, a results page with the document drawer open, a
 # search that matched nothing, a filter that matched nothing, a grid of
-# pictures, a document on a page of its own and the recent screen. They are
+# pictures, a document on a page of its own, the recent screen and the settings
+# screen. They are
 # states rather than layouts, because a layout is looked at every day and a
 # state is looked at once. Auditing a static fixture would audit the fixture,
 # and every accessibility bug this is meant to catch lives in the markup the
@@ -189,15 +190,14 @@ if [ -n "${CHROMEDRIVER:-}" ]; then
 	DRIVER="--chromedriver-path $CHROMEDRIVER"
 fi
 
-# Nine screens, and they are states rather than layouts. Three of them, the
+# Ten screens, and they are states rather than layouts. Three of them, the
 # empty index, the query that matched nothing and the filter that matched
 # nothing, produce markup no other screen produces, and that markup is where an
 # accessibility bug survives longest: nobody looks at an empty page twice.
 #
-# The settings screen the specification lists is not among them because it does
-# not exist yet. When it does it belongs here, and until then a screen audited
-# on a corpus that has no filter left to remove is worth more than a placeholder.
-# It is #133.
+# The settings screen is the tenth. It is the only screen in the product built
+# out of form controls, and a radio group that has lost its label is the kind of
+# thing that reads perfectly to whoever wrote it and not at all to anybody else.
 for url in \
 	"$BASE/" \
 	"$EMPTY/" \
@@ -207,7 +207,8 @@ for url in \
 	"$BASE/?q=cache&kind=image" \
 	"$BASE/?q=gatepix&kind=image&view=grid" \
 	"$BASE/d/$ID" \
-	"$BASE/recent"; do
+	"$BASE/recent" \
+	"$BASE/settings"; do
 	echo "ui-gate: axe $url"
 	# The interface renders after a fetch, so the audit waits for the first
 	# paint to have happened. Auditing an empty document passes and proves

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -2494,18 +2494,147 @@ h6.prose__h {
   align-items: center;
   gap: var(--space-3);
   min-height: 40px;
-  border-top: 1px solid var(--border);
   font-size: var(--text-body);
 }
 
-.shortcut:first-of-type {
-  border-top: none;
+/* The rule goes between rows rather than above each of them, so that the list
+   reads the same under a dialog title as it does under a panel heading. */
+.shortcut + .shortcut {
+  border-top: 1px solid var(--border);
 }
 
 .shortcut__keys {
   margin-left: auto;
   display: flex;
+  align-items: center;
   gap: var(--space-1);
+}
+
+/* The word between two ways of doing the same thing, which reads as either of
+   these rather than as both of them pressed together. */
+.shortcut__or {
+  color: var(--text-muted);
+  font-size: var(--text-small);
+}
+
+/* Settings --------------------------------------------------------------- */
+
+.settings {
+  max-width: var(--page-max);
+  margin: 0 auto;
+  padding: var(--space-16) var(--gutter) var(--space-24);
+}
+
+.settings__head {
+  margin-bottom: var(--space-12);
+}
+
+.settings__title {
+  font-size: var(--text-display);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-display);
+  letter-spacing: var(--display-tracking);
+}
+
+/* The heading takes focus when the screen opens so that a screen reader starts
+   at the top of it. It is not a control, so it does not draw a ring. */
+.settings__title:focus {
+  outline: none;
+}
+
+.settings__lead {
+  max-width: var(--measure);
+  margin-top: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-lead);
+  line-height: var(--leading-lead);
+}
+
+.settings__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: var(--space-12) var(--space-16);
+  align-items: start;
+}
+
+/* A fieldset with the browser's frame taken off it. The element is here for the
+   grouping it gives a screen reader, not for the box it draws. */
+.choice {
+  margin: 0 0 var(--space-6);
+  padding: 0;
+  border: none;
+}
+
+.choice:last-child {
+  margin-bottom: 0;
+}
+
+.choice__legend {
+  padding: 0;
+  margin-bottom: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+}
+
+.choice__option {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+  cursor: pointer;
+}
+
+.choice__input {
+  flex: none;
+  width: 20px;
+  height: 20px;
+  /* On the first line of the label rather than in the middle of two lines of
+     it, which is where a hint underneath would otherwise push it. */
+  margin: 2px 0 0;
+  accent-color: var(--accent);
+}
+
+.choice__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.choice__label {
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+}
+
+.choice__hint {
+  color: var(--text-muted);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+/* A named value and its answer. Two columns while there is room for two, and
+   the name column takes what it needs rather than a fixed share, because Last
+   indexed and Up are not the same width in any language. */
+.facts {
+  display: grid;
+  grid-template-columns: minmax(0, max-content) minmax(0, 1fr);
+  gap: var(--space-2) var(--space-6);
+  margin-bottom: var(--space-4);
+}
+
+.facts__name {
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-body);
+}
+
+.facts__value {
+  margin: 0;
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  /* A commit is one long word and there is nowhere in it to break, so it is
+     told it may break anywhere rather than widening the column past the panel. */
+  overflow-wrap: anywhere;
 }
 
 /* Responsive ------------------------------------------------------------- */

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -11,18 +11,18 @@ import { cache } from "genba/cache.js";
 import { Live } from "genba/live.js";
 import { copies, copy } from "genba/clipboard.js";
 import * as urlState from "genba/state.js";
-import { followable, icon, initials, label, number, sourceColor, when } from "genba/format.js";
-import { Omnibox, modifierLabel, shortcutLabel } from "genba/omnibox.js";
+import { icon, initials, label, number, sourceColor, when } from "genba/format.js";
+import { Omnibox } from "genba/omnibox.js";
+import { CHORD, CHORD_TIMEOUT, SHORTCUTS, arms, binding, keysOf } from "genba/keys.js";
+import { apply as applyPrefs, density, setDensity, setTheme } from "genba/prefs.js";
 import { Results, VERTICALS, verticalsFor } from "genba/results.js";
 import { Drawer } from "genba/drawer.js";
 import { Page } from "genba/page.js";
 import { Home } from "genba/home.js";
 import { Recent } from "genba/recent.js";
+import { Settings } from "genba/settings.js";
 import { forget, remember } from "genba/queries.js";
 import { failed } from "genba/states.js";
-
-const THEME_KEY = "genba.theme";
-const DENSITY_KEY = "genba.density";
 
 // LOADING_DELAY is how long a search may run before the interface admits to it.
 //
@@ -79,6 +79,11 @@ class App {
     // somewhere to go back to. It is empty in a tab that opened straight onto a
     // document, which is the case the back link has to answer differently.
     this.lastSearch = "";
+    // The address the settings screen was opened from, for the same reason and
+    // with the same empty case. It is not the last search: settings is reached
+    // from every screen, and landing back on a results page from a document
+    // somebody was reading would be the wrong way out.
+    this.lastScreen = "";
 
     this.omnibox = new Omnibox({
       // Explicitly the search, because the box is on every screen and a search
@@ -117,6 +122,11 @@ class App {
     });
     this.page = new Page({
       onBack: () => this.backFromDocument(),
+      onSay: (text) => this.say(text),
+    });
+    this.settings = new Settings({
+      onBack: () => this.backFromSettings(),
+      onIdentity: () => this.switchIdentity(),
       onSay: (text) => this.say(text),
     });
 
@@ -298,6 +308,18 @@ class App {
           svg(icon("clock"), 20),
           h("span", { class: "rail__label" }, "Recent"),
         ),
+        h(
+          "a",
+          {
+            class: "rail__link",
+            href: urlState.SETTINGS,
+            title: "Settings",
+            dataset: { route: "settings" },
+            onClick: (e) => this.follow(e, urlState.SETTINGS),
+          },
+          svg(icon("slider"), 20),
+          h("span", { class: "rail__label" }, "Settings"),
+        ),
       ),
       // Both of these are filled once the session says what the corpus holds.
       // They are empty until then rather than full of guesses, because a rail
@@ -345,6 +367,12 @@ class App {
    * recent screen is a view of either.
    */
   visit(path) {
+    // Where the settings screen was opened from, taken before the address
+    // moves. No other screen needs this: the rest either carry their own state
+    // in the address or have a list behind them to go back to.
+    if (path === urlState.SETTINGS && urlState.route().name !== "settings") {
+      this.lastScreen = location.pathname + location.search;
+    }
     if (location.pathname !== path || location.search) history.pushState(null, "", path);
     this.query = urlState.read("");
     this.sync();
@@ -507,6 +535,10 @@ class App {
       this.showDocument(route.id);
       return;
     }
+    if (route.name === "settings") {
+      this.showSettings();
+      return;
+    }
 
     document.title = "genba";
     this.omnibox.value = this.query.q;
@@ -566,6 +598,48 @@ class App {
     };
   }
 
+  /**
+   * showSettings renders the preferences, the keys, and who the server says
+   * this is.
+   *
+   * It takes no arguments and asks the network for very little, so unlike every
+   * other screen there is nothing here that can fail into an error page. The
+   * two facts that come from the server are left out where they did not arrive,
+   * which the screen says by not printing them.
+   */
+  async showSettings() {
+    this.currentKey = "";
+    this.drawer.currentId = null;
+    if (this.drawer.open) this.drawer.close({ notify: false, focus: false });
+    document.title = "Settings · genba";
+    if (this.main.firstChild !== this.settings.el) replace(this.main, this.settings.el);
+    await this.settings.render(this.session);
+  }
+
+  /**
+   * backFromSettings is the way out, which is wherever this screen was opened
+   * from.
+   *
+   * A tab that opened straight onto this address has nothing behind it, and a
+   * back button that lands on whatever else was in that tab is worse than one
+   * that offers the search.
+   */
+  backFromSettings() {
+    const href = this.lastScreen || "/";
+    return {
+      href,
+      title: this.lastScreen ? "Back" : "Search",
+      // The address itself rather than history.back(), so that the link and the
+      // click agree. That costs a history entry and buys a way out that lands
+      // where it says it will, which is the same trade the document page makes.
+      go: () => {
+        history.pushState(null, "", href);
+        this.query = urlState.read(new URL(href, location.origin).search);
+        this.sync();
+      },
+    };
+  }
+
   async showHome() {
     if (this.main.firstChild !== this.home.el) replace(this.main, this.home.el);
     await this.home.render(this.session);
@@ -594,7 +668,12 @@ class App {
   markRail() {
     const searching = Boolean(this.query.q) || urlState.count(this.query) > 0 || Boolean(this.query.sort);
     const route = urlState.route();
-    const here = route.name === "recent" ? "recent" : route.name === "search" && !searching ? "home" : "";
+    const here =
+      route.name === "recent" || route.name === "settings"
+        ? route.name
+        : route.name === "search" && !searching
+          ? "home"
+          : "";
     for (const link of this.rail.querySelectorAll("[data-route]")) {
       if (link.dataset.route === here) link.setAttribute("aria-current", "page");
       else link.removeAttribute("aria-current");
@@ -913,28 +992,24 @@ class App {
     cache.invalidate(cache.key("recent", {}));
   }
 
+  /**
+   * theme is the header button: the other one of the two.
+   *
+   * It toggles what is on screen rather than what is stored, because what is
+   * stored may be nothing at all and somebody pressing this on a machine set to
+   * dark means light. The settings screen is where the three way choice lives,
+   * including the way back to following the system.
+   */
   theme() {
-    const next = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
-    document.documentElement.dataset.theme = next;
-    localStorage.setItem(THEME_KEY, next);
+    setTheme(document.documentElement.dataset.theme === "dark" ? "light" : "dark");
     this.header = this.buildHeader();
     this.build();
     this.sync();
   }
 
-  /**
-   * density is the one escape hatch in the spacing system.
-   *
-   * The restyle costs vertical space deliberately, and somebody triaging four
-   * hundred results has a different job from somebody reading one. Compact
-   * reduces the row padding and drops the body size one step. It does not
-   * reintroduce borders, change the colour system or touch the type scale
-   * above body, so it is two token overrides rather than a second theme.
-   */
+  /** density is the header button for the one escape hatch in the spacing system. */
   density() {
-    const next = document.documentElement.dataset.density === "compact" ? "comfortable" : "compact";
-    document.documentElement.dataset.density = next;
-    localStorage.setItem(DENSITY_KEY, next);
+    setDensity(density() === "compact" ? "comfortable" : "compact");
   }
 
   /**
@@ -975,27 +1050,14 @@ class App {
     location.reload();
   }
 
+  /**
+   * shortcuts is the dialog over whatever is on screen.
+   *
+   * It draws the same table the settings screen does and the same table the
+   * listener below dispatches through, so there is one answer to what a key
+   * does and three places that read it.
+   */
   shortcuts() {
-    const rows = [
-      ["Focus search", [shortcutLabel()]],
-      ["Next result", ["j"]],
-      ["Previous result", ["k"]],
-      ["First result", ["Home"]],
-      ["Last result", ["End"]],
-      ["Open preview", ["Enter"]],
-      ["Next match in the preview", ["n"]],
-      ["Previous match in the preview", ["shift", "n"]],
-      ["Open as a page, in a new tab", [modifierLabel(), "Enter"]],
-      ["Open in source", ["o"]],
-      ["Copy a link to this result", ["y"]],
-      ["Previous page", ["["]],
-      ["Next page", ["]"]],
-      ["Filters", ["f"]],
-      ["Go home", ["g", "h"]],
-      ["Recent", ["g", "s"]],
-      ["Close", ["Esc"]],
-      ["This list", ["?"]],
-    ];
     const returnTo = document.activeElement;
     const dismiss = () => {
       dialog.remove();
@@ -1023,14 +1085,7 @@ class App {
         "div",
         { class: "dialog__panel", tabindex: "-1" },
         h("h2", { class: "dialog__title" }, "Keyboard shortcuts"),
-        rows.map(([what, keys]) =>
-          h(
-            "div",
-            { class: "shortcut" },
-            what,
-            h("span", { class: "shortcut__keys" }, keys.map((k) => h("kbd", { class: "kbd" }, k))),
-          ),
-        ),
+        SHORTCUTS.map((row) => h("div", { class: "shortcut" }, row.what, keysOf(row))),
       ),
     );
     document.body.appendChild(dialog);
@@ -1066,6 +1121,16 @@ class App {
     return null;
   }
 
+  /** showingResults reports whether the search is the screen on the page. */
+  showingResults() {
+    return this.main.firstChild === this.results.el;
+  }
+
+  /** goHome is the search with nothing asked of it, which is the home screen. */
+  goHome() {
+    this.go({ ...urlState.read("") }, { path: "/" });
+  }
+
   /**
    * copyLink is the y key: a link to the result under the cursor.
    *
@@ -1093,148 +1158,32 @@ class App {
     return Boolean(rows && rows.holds());
   }
 
+  /**
+   * bindKeys is the one keyboard listener, dispatching through the table.
+   *
+   * There is no switch here on purpose. Every key and everything it does lives
+   * in keys.js, which is also what the settings screen and the shortcut sheet
+   * print, so a key cannot be handled without being written down.
+   */
   bindKeys() {
     let chord = null;
     document.addEventListener("keydown", (e) => {
-      const typing = e.target.matches("input, textarea, select");
+      // Read and clear together. A press either completes an armed sequence or
+      // ends it, and either way the next press starts from nothing.
+      const armed = chord || "";
+      chord = null;
 
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        this.omnibox.focus();
+      const row = binding(e, armed);
+      if (row) {
+        row.run(this, e);
         return;
       }
-      // The modifier means the same thing here as it does on a link: open it
-      // over there and leave me where I am.
-      if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && !typing) {
-        const rows = this.rows();
-        const hit = rows && rows.current();
-        if (!hit) return;
-        e.preventDefault();
-        window.open(urlState.documentPath(hit.id, this.query.q), "_blank", "noreferrer");
-        return;
-      }
-      if (e.key === "Escape") {
-        if (this.drawer.open) return; // the drawer handles its own Escape
-        if (typing) e.target.blur();
-        return;
-      }
-      if (typing || e.metaKey || e.ctrlKey || e.altKey) return;
 
       // A two key sequence: g then a destination. The first key arms it and it
       // disarms itself, so a stray g does nothing rather than waiting forever.
-      if (chord === "g") {
-        chord = null;
-        // s is the recent screen, which is a path rather than a query, so it
-        // is the one destination in here that is not a search.
-        if (e.key === "s") {
-          e.preventDefault();
-          this.visit(urlState.RECENT);
-          return;
-        }
-        const destinations = { h: {}, a: { tab: "all" } };
-        if (destinations[e.key]) {
-          e.preventDefault();
-          this.go({ ...urlState.read(""), ...destinations[e.key] }, { path: "/" });
-        }
-        return;
-      }
-
-      switch (e.key) {
-        case "/":
-          e.preventDefault();
-          this.omnibox.focus();
-          break;
-        case "g":
-          chord = "g";
-          setTimeout(() => (chord = null), 1200);
-          break;
-        case "j":
-        case "k": {
-          const rows = this.rows();
-          if (!rows) return;
-          e.preventDefault();
-          const delta = e.key === "j" ? 1 : -1;
-          // With the preview open these keys move the preview. Reading through
-          // five candidates used to be five open and close cycles, each of
-          // which lost the place in the list.
-          const stepping = this.drawer.open;
-          rows.move(delta, { focus: !stepping });
-          if (stepping) this.step(delta);
-          break;
-        }
-        // The matches inside the preview, in the same direction j and k move
-        // between documents. It is answered here rather than in the drawer so
-        // that it works wherever focus happens to be, which above the
-        // breakpoint is not necessarily inside the drawer.
-        case "n":
-        case "N": {
-          if (!this.drawer.open) return;
-          e.preventDefault();
-          this.drawer.toMatch(e.shiftKey ? -1 : 1);
-          break;
-        }
-        // The arrow keys move inside the list and only inside it. A page has
-        // one scrollbar and somebody reading a preview with the arrow keys is
-        // scrolling it, so these are answered where the pattern says they are:
-        // when focus is in the widget they belong to.
-        case "ArrowDown":
-        case "ArrowUp": {
-          if (!this.inList()) return;
-          const rows = this.rows();
-          if (!rows) return;
-          e.preventDefault();
-          rows.move(e.key === "ArrowDown" ? 1 : -1);
-          break;
-        }
-        case "Home":
-        case "End": {
-          const rows = this.rows();
-          if (this.drawer.open || !rows || !rows.hits.length) return;
-          e.preventDefault();
-          rows.edge(e.key === "Home" ? "first" : "last");
-          break;
-        }
-        case "Enter":
-        case "p": {
-          const rows = this.rows();
-          const hit = rows && rows.current();
-          if (!hit) return;
-          e.preventDefault();
-          this.open(hit.id);
-          break;
-        }
-        case "o": {
-          // Only where a browser would go there. Opening a file:// URL in a new
-          // tab from an HTTP page leaves somebody looking at a blank tab, which
-          // is worse than the key doing nothing.
-          const rows = this.rows();
-          const hit = rows && rows.current();
-          if (!hit || !followable(hit.url)) return;
-          e.preventDefault();
-          window.open(hit.url, "_blank", "noreferrer");
-          break;
-        }
-        case "[":
-        case "]":
-          if (this.page(e.key === "]" ? 1 : -1)) e.preventDefault();
-          break;
-        case "f":
-          // Not from inside the preview, which is modal. Moving focus behind a
-          // modal is the one way out of a focus trap that nobody asked for, and
-          // not from a screen with no filters on it either.
-          if (this.drawer.open || this.main.firstChild !== this.results.el) return;
-          e.preventDefault();
-          this.results.focusFilters();
-          break;
-        case "y":
-          if (this.copyLink()) e.preventDefault();
-          break;
-        case "?":
-          e.preventDefault();
-          this.shortcuts();
-          break;
-        default:
-          break;
+      if (!armed && arms(e)) {
+        chord = CHORD;
+        setTimeout(() => (chord = null), CHORD_TIMEOUT);
       }
     });
   }
@@ -1254,17 +1203,9 @@ function countIn(kinds, vertical) {
 }
 
 // Theme before first paint, so a dark theme does not arrive as a white flash.
-// The same block runs inline in index.html, and this one is what keeps the two
-// in step when the module loads without a cached document.
-const saved = localStorage.getItem(THEME_KEY);
-if (saved) {
-  document.documentElement.dataset.theme = saved;
-} else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-  document.documentElement.dataset.theme = "dark";
-}
-
-const density = localStorage.getItem(DENSITY_KEY);
-if (density) document.documentElement.dataset.density = density;
+// The same two preferences are applied inline in index.html, and this call is
+// what keeps the two in step when the module loads without a cached document.
+applyPrefs();
 
 const app = new App(document.getElementById("app"));
 app.start();

--- a/web/dist/assets/keys.js
+++ b/web/dist/assets/keys.js
@@ -1,0 +1,310 @@
+// The keyboard, as one table.
+//
+// Every key this interface answers is a row here: what it does, how it is
+// written down, which press reaches it and the code that runs. The shell's
+// listener dispatches through this table and both places that print a list of
+// shortcuts read the same rows, which is the whole point of the file. A list
+// kept next to the switch that implements it drifts from it in about two
+// commits, and a list of keys that is wrong about the keys is worse than no
+// list at all.
+//
+// A row's run is handed the shell and the event, and does its own guarding. A
+// key that has nothing to act on is a key the browser should still get: j on
+// the home screen is a j, not a silent no-op somewhere else, so a run that
+// finds no list returns without preventing the default.
+
+import { h } from "genba/dom.js";
+import { documentPath, RECENT, SETTINGS } from "genba/state.js";
+import { followable } from "genba/format.js";
+
+const MAC = navigator.platform.toLowerCase().includes("mac");
+
+/** modifierLabel is the key a platform holds down for its own shortcuts. */
+export function modifierLabel() {
+  return MAC ? "⌘" : "Ctrl";
+}
+
+/** shortcutLabel matches the key the platform actually uses. */
+export function shortcutLabel() {
+  return MAC ? "⌘K" : "Ctrl K";
+}
+
+/**
+ * CHORD is the key that arms a two key sequence.
+ *
+ * It arms and disarms itself, so a stray press does nothing rather than waiting
+ * forever for a second key.
+ */
+export const CHORD = "g";
+
+/** CHORD_TIMEOUT is how long an armed sequence waits for its second key. */
+export const CHORD_TIMEOUT = 1200;
+
+/**
+ * SHORTCUTS is every key, in the order the lists print them.
+ *
+ * keys is a sequence of chords, and a chord is the labels pressed together, so
+ * [["g", "h"]] is g then h and [["j"], ["↓"]] is either of two ways to do the
+ * same thing. on is the matching half: one descriptor per way in, where mod is
+ * the platform's own modifier and typing says the press is answered even when
+ * the caret is in a field.
+ */
+export const SHORTCUTS = [
+  {
+    what: "Focus search",
+    keys: [[shortcutLabel()], ["/"]],
+    on: [{ key: "k", mod: true, typing: true }, { key: "/" }],
+    run: (app, e) => {
+      e.preventDefault();
+      app.omnibox.focus();
+    },
+  },
+  {
+    what: "Next result",
+    keys: [["j"], ["↓"]],
+    on: [{ key: "j" }, { key: "ArrowDown" }],
+    run: (app, e) => move(app, e, 1),
+  },
+  {
+    what: "Previous result",
+    keys: [["k"], ["↑"]],
+    on: [{ key: "k" }, { key: "ArrowUp" }],
+    run: (app, e) => move(app, e, -1),
+  },
+  {
+    what: "First result",
+    keys: [["Home"]],
+    on: [{ key: "Home" }],
+    run: (app, e) => edge(app, e, "first"),
+  },
+  {
+    what: "Last result",
+    keys: [["End"]],
+    on: [{ key: "End" }],
+    run: (app, e) => edge(app, e, "last"),
+  },
+  {
+    what: "Open preview",
+    keys: [["Enter"], ["p"]],
+    on: [{ key: "Enter" }, { key: "p" }],
+    run: (app, e) => {
+      const hit = current(app);
+      if (!hit) return;
+      e.preventDefault();
+      app.open(hit.id);
+    },
+  },
+  {
+    what: "Next match in the preview",
+    keys: [["n"]],
+    on: [{ key: "n" }],
+    run: (app, e) => match(app, e, 1),
+  },
+  {
+    what: "Previous match in the preview",
+    keys: [["shift", "n"]],
+    on: [{ key: "N" }],
+    run: (app, e) => match(app, e, -1),
+  },
+  {
+    // The modifier means the same thing here as it does on a link: open it over
+    // there and leave me where I am.
+    what: "Open as a page, in a new tab",
+    keys: [[modifierLabel(), "Enter"]],
+    on: [{ key: "Enter", mod: true }],
+    run: (app, e) => {
+      const hit = current(app);
+      if (!hit) return;
+      e.preventDefault();
+      window.open(documentPath(hit.id, app.query.q), "_blank", "noreferrer");
+    },
+  },
+  {
+    what: "Open in source",
+    keys: [["o"]],
+    on: [{ key: "o" }],
+    run: (app, e) => {
+      // Only where a browser would go there. Opening a file:// URL in a new tab
+      // from an HTTP page leaves somebody looking at a blank tab, which is
+      // worse than the key doing nothing.
+      const hit = current(app);
+      if (!hit || !followable(hit.url)) return;
+      e.preventDefault();
+      window.open(hit.url, "_blank", "noreferrer");
+    },
+  },
+  {
+    what: "Copy a link to this result",
+    keys: [["y"]],
+    on: [{ key: "y" }],
+    run: (app, e) => {
+      if (app.copyLink()) e.preventDefault();
+    },
+  },
+  {
+    what: "Previous page",
+    keys: [["["]],
+    on: [{ key: "[" }],
+    run: (app, e) => {
+      if (app.page(-1)) e.preventDefault();
+    },
+  },
+  {
+    what: "Next page",
+    keys: [["]"]],
+    on: [{ key: "]" }],
+    run: (app, e) => {
+      if (app.page(1)) e.preventDefault();
+    },
+  },
+  {
+    what: "Filters",
+    keys: [["f"]],
+    on: [{ key: "f" }],
+    run: (app, e) => {
+      // Not from inside the preview, which is modal. Moving focus behind a
+      // modal is the one way out of a focus trap that nobody asked for, and not
+      // from a screen with no filters on it either.
+      if (app.drawer.open || !app.showingResults()) return;
+      e.preventDefault();
+      app.results.focusFilters();
+    },
+  },
+  {
+    what: "Go home",
+    keys: [["g", "h"]],
+    on: [{ key: "h", chord: CHORD }],
+    run: (app, e) => {
+      e.preventDefault();
+      app.goHome();
+    },
+  },
+  {
+    what: "Recent",
+    keys: [["g", "s"]],
+    on: [{ key: "s", chord: CHORD }],
+    run: (app, e) => {
+      e.preventDefault();
+      app.visit(RECENT);
+    },
+  },
+  {
+    what: "Settings",
+    keys: [["g", ","]],
+    on: [{ key: ",", chord: CHORD }],
+    run: (app, e) => {
+      e.preventDefault();
+      app.visit(SETTINGS);
+    },
+  },
+  {
+    // Not one action but the way out of whatever is open, which is why it is
+    // the one row that is answered while the caret is in a field.
+    what: "Close",
+    keys: [["Esc"]],
+    on: [{ key: "Escape", typing: true }],
+    run: (app, e) => {
+      if (app.drawer.open) return; // the drawer handles its own Escape
+      if (typing(e.target)) e.target.blur();
+    },
+  },
+  {
+    what: "This list",
+    keys: [["?"]],
+    on: [{ key: "?" }],
+    run: (app, e) => {
+      e.preventDefault();
+      app.shortcuts();
+    },
+  },
+];
+
+/**
+ * binding is the row a press reaches, or nothing.
+ *
+ * chord is the key already armed, if any. A row that names one is unreachable
+ * without it and a row that names none is unreachable with it, so an armed g
+ * cannot be followed by a stray j that scrolls the list.
+ */
+export function binding(e, chord = "") {
+  // Alt is the one modifier nothing here claims. It is how a keyboard produces
+  // characters this table does not know about, and swallowing those is how an
+  // interface stops working in a language it was not tested in.
+  if (e.altKey) return null;
+  const inField = typing(e.target);
+  for (const row of SHORTCUTS) {
+    for (const on of row.on) {
+      if ((on.chord || "") !== chord) continue;
+      if (Boolean(on.mod) !== Boolean(e.metaKey || e.ctrlKey)) continue;
+      if (inField && !on.typing) continue;
+      if (on.mod ? e.key.toLowerCase() !== on.key : e.key !== on.key) continue;
+      return row;
+    }
+  }
+  return null;
+}
+
+/**
+ * keysOf draws one row's keys, for whichever list is printing them.
+ *
+ * A chord is its keys side by side, which reads as press them in order, and two
+ * chords are separated by a word, which reads as either of these.
+ */
+export function keysOf(row) {
+  const out = [];
+  for (const chord of row.keys) {
+    if (out.length) out.push(h("span", { class: "shortcut__or" }, "or"));
+    for (const key of chord) out.push(h("kbd", { class: "kbd" }, key));
+  }
+  return h("span", { class: "shortcut__keys" }, out);
+}
+
+/** arms reports whether a press should start a two key sequence. */
+export function arms(e) {
+  return e.key === CHORD && !e.metaKey && !e.ctrlKey && !e.altKey && !typing(e.target);
+}
+
+/** typing reports whether the caret is somewhere a key means a character. */
+export function typing(target) {
+  return Boolean(target && target.matches && target.matches("input, textarea, select"));
+}
+
+function current(app) {
+  const rows = app.rows();
+  return (rows && rows.current()) || null;
+}
+
+// The arrow keys move inside the list and only inside it. A page has one
+// scrollbar and somebody reading a preview with the arrow keys is scrolling it,
+// so these are answered where the pattern says they are: when focus is in the
+// widget they belong to. j and k are not that, which is why they also move the
+// preview.
+function move(app, e, delta) {
+  if (e.key.startsWith("Arrow") && !app.inList()) return;
+  const rows = app.rows();
+  if (!rows) return;
+  e.preventDefault();
+  // With the preview open these keys move the preview. Reading through five
+  // candidates used to be five open and close cycles, each of which lost the
+  // place in the list.
+  const stepping = app.drawer.open && !e.key.startsWith("Arrow");
+  rows.move(delta, { focus: !stepping });
+  if (stepping) app.step(delta);
+}
+
+function edge(app, e, where) {
+  const rows = app.rows();
+  if (app.drawer.open || !rows || !rows.hits.length) return;
+  e.preventDefault();
+  rows.edge(where);
+}
+
+// The matches inside the preview, in the same direction j and k move between
+// documents. It is answered by the shell rather than by the drawer so that it
+// works wherever focus happens to be, which above the breakpoint is not
+// necessarily inside the drawer.
+function match(app, e, delta) {
+  if (!app.drawer.open) return;
+  e.preventDefault();
+  app.drawer.toMatch(delta);
+}

--- a/web/dist/assets/omnibox.js
+++ b/web/dist/assets/omnibox.js
@@ -12,6 +12,7 @@ import { h, replace, svg } from "genba/dom.js";
 import { api } from "genba/api.js";
 import { cache } from "genba/cache.js";
 import { icon } from "genba/format.js";
+import { shortcutLabel } from "genba/keys.js";
 
 // DEBOUNCE is how long the box waits before asking the server. The suggestion
 // budget is 80ms at the server, and this is the other half of feeling instant:
@@ -265,14 +266,3 @@ export class Omnibox {
   }
 }
 
-const MAC = navigator.platform.toLowerCase().includes("mac");
-
-/** modifierLabel is the key a platform holds down for its own shortcuts. */
-export function modifierLabel() {
-  return MAC ? "⌘" : "Ctrl";
-}
-
-/** shortcutLabel matches the key the platform actually uses. */
-export function shortcutLabel() {
-  return MAC ? "⌘K" : "Ctrl K";
-}

--- a/web/dist/assets/prefs.js
+++ b/web/dist/assets/prefs.js
@@ -1,0 +1,99 @@
+// The two preferences that survive a reload.
+//
+// Both belong to the person rather than to the corpus, both are local to this
+// browser, and neither is ever sent to the server. They live in a module of
+// their own because three places have to agree about them: the inline script in
+// the document, which applies them before the first paint, the shell, which
+// toggles them from the header, and the settings screen, where they are
+// actually chosen.
+//
+// The theme has three choices and only two of them are ever stored. No key at
+// all means follow the system, which is what somebody who has never opened the
+// settings screen gets and what choosing System puts back. A stored value that
+// meant the same thing would be a second way of saying nothing, and the inline
+// script would have to know about it too.
+
+export const THEME_KEY = "genba.theme";
+export const DENSITY_KEY = "genba.density";
+
+/** THEMES is the choice, in the order it is offered. */
+export const THEMES = [
+  { value: "", label: "System", hint: "Follow the appearance this device is set to" },
+  { value: "light", label: "Light", hint: "" },
+  { value: "dark", label: "Dark", hint: "" },
+];
+
+/**
+ * DENSITIES is the other one.
+ *
+ * Compact reduces the row padding and drops the body size one step. It does not
+ * reintroduce borders, change the colour system or touch the type scale above
+ * body, so it is two token overrides rather than a second theme.
+ */
+export const DENSITIES = [
+  { value: "comfortable", label: "Comfortable", hint: "Room to read one document at a time" },
+  { value: "compact", label: "Compact", hint: "More rows on screen, for triaging a long list" },
+];
+
+const dark = matchMedia("(prefers-color-scheme: dark)");
+
+/** theme is the stored choice, or empty for the system's. */
+export function theme() {
+  return read(THEME_KEY);
+}
+
+/** density is the stored choice, which has a default rather than a system. */
+export function density() {
+  return read(DENSITY_KEY) || DENSITIES[0].value;
+}
+
+/** setTheme stores a choice and applies it. An empty value is the system's. */
+export function setTheme(value) {
+  write(THEME_KEY, value);
+  apply();
+}
+
+export function setDensity(value) {
+  write(DENSITY_KEY, value === DENSITIES[0].value ? "" : value);
+  apply();
+}
+
+/**
+ * apply writes both preferences onto the root element.
+ *
+ * The theme is resolved here rather than left absent, because the header button
+ * reads what is on screen to decide which way to toggle, and an absent
+ * attribute would make it guess.
+ */
+export function apply() {
+  const root = document.documentElement;
+  root.dataset.theme = theme() || (dark.matches ? "dark" : "light");
+  root.dataset.density = density();
+}
+
+// A device that changes its mind while the tab is open, which is what happens
+// at sunset on a machine set to switch automatically. Only where nothing was
+// chosen: somebody who asked for light stays in light after dark.
+dark.addEventListener("change", () => {
+  if (!theme()) apply();
+});
+
+// Storage throws rather than returning nothing in a browser that has turned it
+// off, and a preference that cannot be saved is a preference that lasts until
+// the reload rather than a screen that fails to paint.
+function read(key) {
+  try {
+    return localStorage.getItem(key) || "";
+  } catch {
+    return "";
+  }
+}
+
+function write(key, value) {
+  try {
+    if (value) localStorage.setItem(key, value);
+    else localStorage.removeItem(key);
+  } catch {
+    // Nothing to say about it. The choice applies to this tab either way.
+  }
+}

--- a/web/dist/assets/settings.js
+++ b/web/dist/assets/settings.js
@@ -1,0 +1,266 @@
+// The settings screen.
+//
+// Four sections and nothing else: how this looks, which keys do what, who the
+// server thinks you are, and what it is running. Nothing on it writes to the
+// server. Everything it changes is local to this browser, which is what keeps
+// it a screen rather than a feature, and it is why there is no save button
+// anywhere on it: a choice applies as it is made.
+//
+// It is also where somebody is sent when a document tells them they may not
+// read it, because the first question then is which account they are and which
+// groups came with it. That answer has to be the server's rather than whatever
+// this browser last sent, so it is read from the me response rather than from
+// local storage.
+
+import { h, replace, svg } from "genba/dom.js";
+import { api, identity } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { SHORTCUTS, keysOf } from "genba/keys.js";
+import { DENSITIES, THEMES, density, setDensity, setTheme, theme } from "genba/prefs.js";
+import { exact, icon, label, number, when } from "genba/format.js";
+
+export class Settings {
+  constructor({ onBack, onIdentity, onSay }) {
+    this.onBack = onBack;
+    this.onIdentity = onIdentity;
+    this.onSay = onSay || (() => {});
+    this.session = null;
+    this.health = null;
+    this.stats = null;
+    this.title = null;
+    this.el = h("div", { class: "settings" });
+  }
+
+  /**
+   * render paints the screen and then fills in what the server says.
+   *
+   * The two halves that need a request are the last two sections, and neither
+   * is worth a skeleton: the appearance and keyboard sections are complete
+   * without the network, so the screen is useful at the first frame and the
+   * facts arrive under it a moment later.
+   */
+  async render(session) {
+    this.session = session;
+    this.paint();
+
+    const [health, stats] = await Promise.all([
+      api.health().catch(() => null),
+      cache
+        .swr(cache.key("stats", {}), (opts) => api.stats(opts), () => {})
+        .catch(() => null),
+    ]);
+    // The address bar may have moved on while those were in flight, and a
+    // screen that has been taken off the page should not be repainted under
+    // whatever replaced it.
+    if (!this.el.isConnected) return;
+    this.health = health;
+    this.stats = stats;
+    this.paint();
+  }
+
+  paint() {
+    // Whether anything on this screen already has focus, read before the paint
+    // takes it away. Arriving here from a key rather than from a click has to
+    // land somewhere, and the heading is where, but a repaint underneath
+    // somebody who is on a radio must not pull them back to the top.
+    const held = this.el.contains(document.activeElement) && document.activeElement !== this.title;
+
+    this.title = h("h1", { class: "settings__title", tabindex: "-1" }, "Settings");
+    replace(
+      this.el,
+      this.backLink(),
+      h(
+        "header",
+        { class: "settings__head" },
+        this.title,
+        h(
+          "p",
+          { class: "settings__lead" },
+          "Everything here is kept in this browser and none of it is sent to the server.",
+        ),
+      ),
+      h(
+        "div",
+        { class: "settings__grid" },
+        this.appearance(),
+        this.keyboard(),
+        this.who(),
+        this.server(),
+      ),
+    );
+    if (!held) this.title.focus();
+  }
+
+  /**
+   * backLink is the way out, which is wherever this screen was opened from.
+   *
+   * A tab that opened straight onto this address has nothing behind it, so it
+   * is offered the search rather than a button that would land on whatever else
+   * that tab was doing.
+   */
+  backLink() {
+    const to = this.onBack();
+    return h(
+      "div",
+      { class: "page__back" },
+      h(
+        "a",
+        {
+          class: "page__back-link",
+          href: to.href,
+          onClick: (e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+            e.preventDefault();
+            to.go();
+          },
+        },
+        svg(icon("arrow-left"), 16),
+        to.title,
+      ),
+    );
+  }
+
+  appearance() {
+    return h(
+      "section",
+      { class: "panel" },
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Appearance")),
+      // Nothing repaints on a pick. The radio the browser just ticked is
+      // already showing the answer, and rebuilding the screen under somebody's
+      // hand would take the focus off the control they are using.
+      this.choice("Theme", THEMES, theme(), (value) => {
+        setTheme(value);
+        this.onSay(`Theme ${labelOf(THEMES, value).toLowerCase()}`);
+      }),
+      this.choice("Density", DENSITIES, density(), (value) => {
+        setDensity(value);
+        this.onSay(`Density ${labelOf(DENSITIES, value).toLowerCase()}`);
+      }),
+    );
+  }
+
+  /**
+   * choice is one set of options, as radios.
+   *
+   * They are real radio inputs in a real fieldset rather than buttons dressed
+   * up as one, because a group of options where exactly one is chosen is what a
+   * radio group is, and the browser already knows how to walk one from the
+   * keyboard and how to say what it is.
+   */
+  choice(title, options, chosen, onPick) {
+    const name = `settings-${title.toLowerCase()}`;
+    return h(
+      "fieldset",
+      { class: "choice" },
+      h("legend", { class: "choice__legend" }, title),
+      options.map((option) =>
+        h(
+          "label",
+          { class: "choice__option" },
+          h("input", {
+            class: "choice__input",
+            type: "radio",
+            name,
+            value: option.value,
+            checked: option.value === chosen,
+            onChange: () => onPick(option.value),
+          }),
+          h(
+            "span",
+            { class: "choice__text" },
+            h("span", { class: "choice__label" }, option.label),
+            option.hint ? h("span", { class: "choice__hint" }, option.hint) : null,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * keyboard is the list of keys, generated from the table the handler reads.
+   *
+   * Not typed out again. A list of shortcuts written beside the code that
+   * implements them drifts from it in about two commits, and a list that is
+   * wrong about the keys is worse than no list.
+   */
+  keyboard() {
+    return h(
+      "section",
+      { class: "panel" },
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Keyboard")),
+      SHORTCUTS.map((row) => h("div", { class: "shortcut" }, row.what, keysOf(row))),
+    );
+  }
+
+  who() {
+    const session = this.session || {};
+    const local = identity();
+    return h(
+      "section",
+      { class: "panel" },
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Identity")),
+      facts([
+        ["Subject", session.subject || local.subject],
+        ["Tenant", session.tenant || "the single tenant deployment"],
+        ["Groups", (session.groups || []).join(", ")],
+        ["Roles", (session.roles || []).join(", ")],
+        ["Source identities", local.identities.join(", ")],
+      ]),
+      h(
+        "p",
+        { class: "meta" },
+        "This is what the server resolved from the request, and it is what decides which documents come back.",
+      ),
+      h(
+        "button",
+        { class: "button", type: "button", onClick: () => this.onIdentity() },
+        "Search as somebody else",
+      ),
+    );
+  }
+
+  server() {
+    const health = this.health || {};
+    const stats = this.stats || {};
+    return h(
+      "section",
+      { class: "panel" },
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Server")),
+      facts([
+        ["Version", health.version],
+        ["Commit", health.commit],
+        ["Built", health.built === "unknown" ? "" : exact(health.built) || health.built],
+        ["Store", stats.driver ? label(stats.driver) : ""],
+        ["Documents", this.stats ? number(stats.documents) : ""],
+        ["Held back", this.stats ? number(stats.quarantined) : ""],
+        ["Last indexed", stats.indexed_at ? when(stats.indexed_at) : "not since this process started"],
+        ["Up", health.uptime],
+      ]),
+    );
+  }
+}
+
+/**
+ * facts is a list of named values, with the ones nobody answered left out.
+ *
+ * An empty row would be a fact this screen claims to know and does not, which
+ * on the one screen somebody comes to for the truth about their session is the
+ * worst thing it could print.
+ */
+function facts(rows) {
+  return h(
+    "dl",
+    { class: "facts" },
+    rows
+      .filter(([, value]) => value)
+      .map(([name, value]) => [
+        h("dt", { class: "facts__name" }, name),
+        h("dd", { class: "facts__value" }, value),
+      ]),
+  );
+}
+
+function labelOf(options, value) {
+  const found = options.find((option) => option.value === value);
+  return found ? found.label : value;
+}

--- a/web/dist/assets/state.js
+++ b/web/dist/assets/state.js
@@ -7,7 +7,7 @@
 
 const LIST_KEYS = ["source", "kind", "container", "author", "owner"];
 
-// The two screens that are a path rather than a query string.
+// The three screens that are a path rather than a query string.
 //
 // A document is the thing somebody pastes into a message, so it gets an address
 // that survives being read out loud and does not carry the state of whoever
@@ -15,9 +15,11 @@ const LIST_KEYS = ["source", "kind", "container", "author", "owner"];
 // is written on documentPath below. Recent is a path because it is not a view
 // of a search: it answers what has been going on rather than what matches, and
 // a rail entry that ran a recency sorted search was answering the wrong
-// question with the right rows.
+// question with the right rows. Settings is a path because none of the query
+// state means anything on it.
 const DOCUMENT = "/d/";
 export const RECENT = "/recent";
+export const SETTINGS = "/settings";
 
 /**
  * route says which screen the path names.
@@ -27,6 +29,7 @@ export const RECENT = "/recent";
  */
 export function route(pathname = location.pathname) {
   if (pathname === RECENT) return { name: "recent", id: "" };
+  if (pathname === SETTINGS) return { name: "settings", id: "" };
   if (!pathname.startsWith(DOCUMENT)) return { name: "search", id: "" };
   const id = decode(pathname.slice(DOCUMENT.length));
   return id ? { name: "document", id } : { name: "search", id: "" };

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -34,6 +34,7 @@
           "genba/highlight.js": "/assets/highlight.js",
           "genba/home.js": "/assets/home.js",
           "genba/html.js": "/assets/html.js",
+          "genba/keys.js": "/assets/keys.js",
           "genba/live.js": "/assets/live.js",
           "genba/markdown.js": "/assets/markdown.js",
           "genba/marks.js": "/assets/marks.js",
@@ -41,10 +42,12 @@
           "genba/notebook.js": "/assets/notebook.js",
           "genba/omnibox.js": "/assets/omnibox.js",
           "genba/page.js": "/assets/page.js",
+          "genba/prefs.js": "/assets/prefs.js",
           "genba/queries.js": "/assets/queries.js",
           "genba/recent.js": "/assets/recent.js",
           "genba/results.js": "/assets/results.js",
           "genba/rows.js": "/assets/rows.js",
+          "genba/settings.js": "/assets/settings.js",
           "genba/state.js": "/assets/state.js",
           "genba/states.js": "/assets/states.js",
           "genba/table.js": "/assets/table.js",
@@ -55,7 +58,7 @@
     <!--
       The whole module graph, flattened. Without this the browser learns about
       markdown.js only after content.js has arrived, which is four levels deep
-      on a graph that is twenty five files wide. graph_test.go computes the
+      on a graph that is twenty eight files wide. graph_test.go computes the
       closure from app.js and fails if this list is not exactly it.
     -->
     <link rel="modulepreload" href="/assets/api.js" />
@@ -69,6 +72,7 @@
     <link rel="modulepreload" href="/assets/highlight.js" />
     <link rel="modulepreload" href="/assets/home.js" />
     <link rel="modulepreload" href="/assets/html.js" />
+    <link rel="modulepreload" href="/assets/keys.js" />
     <link rel="modulepreload" href="/assets/live.js" />
     <link rel="modulepreload" href="/assets/markdown.js" />
     <link rel="modulepreload" href="/assets/marks.js" />
@@ -76,10 +80,12 @@
     <link rel="modulepreload" href="/assets/notebook.js" />
     <link rel="modulepreload" href="/assets/omnibox.js" />
     <link rel="modulepreload" href="/assets/page.js" />
+    <link rel="modulepreload" href="/assets/prefs.js" />
     <link rel="modulepreload" href="/assets/queries.js" />
     <link rel="modulepreload" href="/assets/recent.js" />
     <link rel="modulepreload" href="/assets/results.js" />
     <link rel="modulepreload" href="/assets/rows.js" />
+    <link rel="modulepreload" href="/assets/settings.js" />
     <link rel="modulepreload" href="/assets/state.js" />
     <link rel="modulepreload" href="/assets/states.js" />
     <link rel="modulepreload" href="/assets/table.js" />

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -144,7 +144,7 @@ func TestTheCacheKeepsNothingOnDisk(t *testing.T) {
 	// typed are the whole of what may persist, and none of them is anything the
 	// corpus said. A query is the asker's own words, which is why it stays on
 	// their machine rather than being kept for them on the server.
-	persist := map[string]bool{"api.js": true, "app.js": true, "queries.js": true}
+	persist := map[string]bool{"api.js": true, "prefs.js": true, "queries.js": true}
 
 	err := fs.WalkDir(os.DirFS("dist"), ".", func(name string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || path.Ext(name) != ".js" {


### PR DESCRIPTION
Closes #133.

The specification lists four screens and the product had three.
There was nowhere to change the theme, nowhere to read which keys do what, nowhere to see who the server thinks you are and nowhere to see what it is running.

## The keyboard section is why this is three modules

A list of shortcuts written beside the switch that implements them drifts from it in about two commits, and a list that is wrong about the keys is worse than no list.
So `keys.js` is the table: what each key does, how it is written down, which press reaches it and the code that runs.
The shell dispatches through it and both places that print a list of shortcuts read the same rows.

Building it that way turned up two drifts that were already here.
`/`, `p` and the arrow keys were handled and printed nowhere.
`g a` was handled, printed nowhere and produced the same URL as `g h`.
The undocumented one is gone and the rest are on the list, which is now nineteen rows instead of the eleven the sheet used to show.

`prefs.js` holds the two preferences that survive a reload.
The theme has three choices and stores two of them, because no key at all is what following the system means, and a stored value that meant the same thing would be a second way of saying nothing that the inline pre-paint script would have to know about too.

The two appearance choices are real radios in a real fieldset rather than buttons with `aria-pressed`.
A group where exactly one option is chosen is what a radio group is, and the browser already knows how to walk one from the keyboard and how to say what it is.

## Three facts were not on the wire

The issue says all of the server facts are already in `/healthz` and the stats endpoint. They were not.

Build date goes on `/healthz`, because it is part of what this build is and that endpoint takes no credential.
Store driver and the time of the last sync go on the stats endpoint, because what a deployment runs on is not something to hand to anybody who can reach the port.
Groups go on `/api/v1/me`, since the first question somebody asks when a document says they may not read it is which groups they are in, and the answer has to be the server's rather than whatever the browser last sent.

The last sync is not persisted and is not asked of the driver.
A process that has just started has not seen one, and saying so is more honest than reporting one it was not there for.

That did mean reordering startup.
The server learns that the corpus moved by subscribing to the store, so building it after the first ingest left it reporting that nothing had been indexed since it came up while sitting on a corpus it had just loaded.
It is built before the ingest now.
The listener still opens after the first sync, which is what that ordering was for, and the feeds now drain before the searcher closes rather than after.

## Gate

The axe list is ten screens rather than nine.
The settings screen is the only one in the product built out of form controls, and a radio group that has lost its label reads perfectly to whoever wrote it and not at all to anybody else.

The keyboard walk gained five assertions and presses the keys off the printed list, so a shortcut that is written down and does nothing fails the build.

## What ran

All of it on the servers rather than locally.

On server3, go1.26.6: `gofmt -l` clean, `go vet ./...` clean, `go test ./...` all green, including four new tests in `api/settings_test.go` covering the driver name, the sync time before and after a write, that `/healthz` tells an anonymous caller nothing about the store, and that the me endpoint reports the groups the authenticator resolved.

On server2, against the real binary over this repository as the corpus:

- keyboard walk, all assertions pass, including `g` then comma reaching the screen, the printed list being the table the handler reads, a theme choice applying at once and being remembered, choosing System again forgetting the choice rather than storing one, and the way out landing on the search it was opened from
- axe over `/settings` with `wcag2a,wcag2aa,wcag21a,wcag21aa`: 0 violations
- render check and state check pass
- budgets: 33 requests of 40, 85562 bytes of script of 184320, 16892 bytes of style of 40960

The three new modules cost two requests on the screens that do not use them and the whole graph is still a long way under the script budget.