### PR TITLE
Answer before the corpus is read, and say so

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -82,6 +82,11 @@ type Server struct {
 	// reporting one it was not there for.
 	indexed atomic.Int64
 
+	// indexing is asked, on every health check and every stats request, whether
+	// a source is still being read for the first time. It is nil for an embedder
+	// that runs no connectors, and a nil one is the same answer as no.
+	indexing func() (Indexing, bool)
+
 	// heartbeat is how often an idle event stream sends a comment.
 	heartbeat time.Duration
 
@@ -132,6 +137,30 @@ func WithClock(now func() time.Time) Option {
 // storage, which is what an embedder that never chose a driver name should say.
 func WithDriver(name string) Option {
 	return func(s *Server) { s.driver = name }
+}
+
+// Indexing is one source being read for the first time.
+//
+// Done and Total count the same thing, which is documents this source will put
+// in the index, and Total is an estimate: it is what the source held when the
+// run counted it, and a source people are working in moves while it is read.
+// That is why the interface says "about" and why nothing here should be used
+// for anything but telling somebody the answer they are looking at is not the
+// whole one yet.
+type Indexing struct {
+	Source string `json:"source"`
+	Done   int    `json:"done"`
+	Total  int    `json:"total"`
+}
+
+// WithIndexing supplies the answer to whether a source is still being read.
+//
+// The caller owns the tracking, because the thing that knows is whatever is
+// running the connectors and this package deliberately does not. An embedder
+// that indexes on its own schedule passes its own function and gets the same
+// banner for free.
+func WithIndexing(fn func() (Indexing, bool)) Option {
+	return func(s *Server) { s.indexing = fn }
 }
 
 // WithHeartbeat sets how often an idle event stream sends a comment. It exists
@@ -240,16 +269,46 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
+type readyResponse struct {
+	Status string `json:"status"`
+
+	// Indexing says a source is still being read for the first time, so the
+	// answers this process gives are true and incomplete.
+	//
+	// It is a bare boolean rather than the counts the stats endpoint reports,
+	// because this endpoint is unauthenticated and how large somebody's corpus
+	// is and what their sources are called is not for anybody who can reach the
+	// port. A probe needs to know whether to wait. It does not need to know what
+	// it is waiting for.
+	Indexing bool `json:"indexing,omitempty"`
+}
+
 // handleReady reports whether the process can serve queries. It touches the
 // store, because a process that is up but cannot reach its storage is not ready
 // and a load balancer needs to know the difference.
+//
+// A process that is still reading a source for the first time is ready. It
+// answers, the answers are correct as far as they go, and holding the whole
+// deployment out of rotation until a crawl finishes is how a rolling restart
+// turns into an outage. The flag is there so that a caller who does care, which
+// in practice is a benchmark rather than a load balancer, can wait.
 func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	if _, err := s.store.Stats(r.Context()); err != nil {
 		s.log.Warn("readiness check failed", "error", err)
 		writeError(w, http.StatusServiceUnavailable, "not_ready", "storage is not available")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ready"})
+	_, indexing := s.stillIndexing()
+	writeJSON(w, http.StatusOK, readyResponse{Status: "ready", Indexing: indexing})
+}
+
+// stillIndexing asks whoever is running the connectors whether one of them is
+// still reading a source for the first time.
+func (s *Server) stillIndexing() (Indexing, bool) {
+	if s.indexing == nil {
+		return Indexing{}, false
+	}
+	return s.indexing()
 }
 
 type searchResponse struct {
@@ -790,6 +849,15 @@ type statsResponse struct {
 	// to anybody who can reach the port.
 	Driver    string `json:"driver,omitempty"`
 	IndexedAt string `json:"indexed_at,omitempty"`
+
+	// Indexing is the source being read for the first time, and is absent when
+	// nothing is, which is the ordinary case.
+	//
+	// It is a pointer so that absent means absent. The interface renders its
+	// banner on the key being there and never has to compare two numbers to
+	// work out whether a sync is running, which is what stops it flickering the
+	// banner on every refresh of a corpus that is already complete.
+	Indexing *Indexing `json:"indexing,omitempty"`
 }
 
 // handleStats reports the corpus and the cache counters.
@@ -811,12 +879,17 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request, _ *acl.Prin
 	h := w.Header()
 	h.Set("Cache-Control", cacheControl)
 	h.Set(varyHeader, varyValue)
+	var indexing *Indexing
+	if current, ok := s.stillIndexing(); ok {
+		indexing = &current
+	}
 	writeJSON(w, http.StatusOK, statsResponse{
 		Documents:   st.Documents,
 		Quarantined: st.Quarantined,
 		Cache:       s.cacheStats(),
 		Driver:      s.driver,
 		IndexedAt:   s.indexedAt(),
+		Indexing:    indexing,
 	})
 }
 

--- a/api/indexing_test.go
+++ b/api/indexing_test.go
@@ -1,0 +1,101 @@
+package api_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// What the server says while a source is still being read for the first time.
+//
+// The split is the same one the settings screen made and it is made for the
+// same reason. How much of a corpus there is and what the sources are called
+// goes to a caller who authenticated. Whether a crawl is running goes to
+// anybody, because the thing that needs to know is a readiness probe and it
+// does not carry a credential.
+
+func newIndexingServer(t *testing.T, state func() (api.Indexing, bool)) http.Handler {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}, api.WithIndexing(state))
+	return s.Handler()
+}
+
+type indexingBody struct {
+	Indexing *struct {
+		Source string `json:"source"`
+		Done   int    `json:"done"`
+		Total  int    `json:"total"`
+	} `json:"indexing"`
+}
+
+func TestStatsReportsTheSourceStillBeingRead(t *testing.T) {
+	h := newIndexingServer(t, func() (api.Indexing, bool) {
+		return api.Indexing{Source: "notes", Done: 4182, Total: 22235}, true
+	})
+
+	w := request(t, h, http.MethodGet, "/api/v1/stats", engineer())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	got := decode[indexingBody](t, w).Indexing
+	if got == nil {
+		t.Fatal("stats said nothing about the sync that is running")
+	}
+	if got.Source != "notes" || got.Done != 4182 || got.Total != 22235 {
+		t.Errorf("indexing = %+v, want the source and both numbers", *got)
+	}
+}
+
+// Absent rather than a zero object, so the interface renders its banner on the
+// key being there and never has to compare two numbers to work out whether a
+// sync is running.
+func TestStatsLeavesIndexingOutWhenNothingIsIndexing(t *testing.T) {
+	for _, state := range []func() (api.Indexing, bool){
+		nil,
+		func() (api.Indexing, bool) { return api.Indexing{}, false },
+	} {
+		h := newIndexingServer(t, state)
+		w := request(t, h, http.MethodGet, "/api/v1/stats", engineer())
+		if got := decode[indexingBody](t, w).Indexing; got != nil {
+			t.Errorf("stats reported %+v with nothing being indexed", *got)
+		}
+	}
+}
+
+// The readiness check says whether to wait and refuses to say what for. It is
+// unauthenticated, and how large somebody's corpus is and what their sources are
+// called are not facts to hand to whoever can reach the port.
+func TestReadinessSaysThatASyncIsRunningAndNotWhatItIs(t *testing.T) {
+	h := newIndexingServer(t, func() (api.Indexing, bool) {
+		return api.Indexing{Source: "payroll", Done: 12, Total: 900}, true
+	})
+
+	w := request(t, h, http.MethodGet, "/readyz", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, a process reading a source still answers", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"indexing":true`) {
+		t.Errorf("readyz did not say a sync is running: %s", body)
+	}
+	for _, leak := range []string{"payroll", "900"} {
+		if strings.Contains(body, leak) {
+			t.Errorf("readyz told an anonymous caller %q: %s", leak, body)
+		}
+	}
+}
+
+func TestReadinessIsSilentWhenNothingIsIndexing(t *testing.T) {
+	h := newIndexingServer(t, func() (api.Indexing, bool) { return api.Indexing{}, false })
+
+	w := request(t, h, http.MethodGet, "/readyz", nil)
+	if body := w.Body.String(); strings.Contains(body, "indexing") {
+		t.Errorf("readyz mentioned indexing with nothing being indexed: %s", body)
+	}
+}

--- a/cmd/genbad/bucket.go
+++ b/cmd/genbad/bucket.go
@@ -193,10 +193,10 @@ func bucketPolicyFor(c *objectsource.Client, o bucketOptions) (objectsource.Poli
 
 // ingestBucket syncs the configured bucket into the store.
 //
-// It runs on the same schedule the directory does, for the same reason: the
-// first sync finishes before the listener opens, and later ones are incremental
-// against the cursor the last one saved.
-func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant string, log *slog.Logger) (func(), error) {
+// It runs on the same schedule the directory does, for the same reason: every
+// sync including the first runs behind the listener, and later ones are
+// incremental against the cursor the last one saved.
+func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant string, track *indexing, log *slog.Logger) (func(), error) {
 	if cfg.Bucket == "" {
 		return func() {}, nil
 	}
@@ -257,6 +257,7 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 		Fields:    []any{"bucket", cfg.Bucket, "prefix", cfg.Prefix, "source", cfg.Name},
 		Report:    func() []any { return requesting(client, limiter) },
 		Policy:    policy,
+		Track:     track,
 		Release:   func() { _ = src.Close() },
 	}, log)
 }

--- a/cmd/genbad/bucket_test.go
+++ b/cmd/genbad/bucket_test.go
@@ -114,7 +114,7 @@ func TestAStartedServerAnswersQueriesAboutTheBucket(t *testing.T) {
 	)
 	defer stop()
 
-	waitForHealth(t, "http://"+addr+"/healthz")
+	waitForIndex(t, "http://"+addr)
 
 	res := searchAs(t, addr, "alice", "deploying")
 	if res.Total == 0 {
@@ -169,7 +169,7 @@ func TestAServerReadsADirectoryAndABucketTogether(t *testing.T) {
 	)
 	defer stop()
 
-	waitForHealth(t, "http://"+addr+"/healthz")
+	waitForIndex(t, "http://"+addr)
 
 	if got := searchAs(t, addr, "alice", "deploying"); got.Total == 0 {
 		t.Error("the directory was not indexed")
@@ -198,7 +198,7 @@ func TestABucketThatRefusesDoesNotStopTheServer(t *testing.T) {
 	)
 	defer stop()
 
-	waitForHealth(t, "http://"+addr+"/healthz")
+	waitForIndex(t, "http://"+addr)
 
 	if got := searchAs(t, addr, "alice", "deploying"); got.Total == 0 {
 		t.Error("a bucket that refused took the directory down with it")
@@ -225,7 +225,7 @@ func TestTheBucketCrawlStaysUnderItsRate(t *testing.T) {
 	)
 	defer stop()
 
-	waitForHealth(t, "http://"+addr+"/healthz")
+	waitForIndex(t, "http://"+addr)
 	took := time.Since(began)
 
 	hits := store.hits()

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -142,12 +142,11 @@ func policyFor(o corpusOptions) (fssource.Policy, error) {
 
 // ingestCorpus syncs the configured directory into the store.
 //
-// The first sync runs before the server listens, so that a request arriving the
-// moment the log says the server is up finds a corpus rather than an empty
-// index. Later syncs run in the background on the refresh interval, and are
-// incremental: the connector reports only what changed since the cursor the
-// last one saved.
-func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant string, log *slog.Logger) (func(), error) {
+// Every sync runs in the background, including the first, so the server answers
+// from the moment it says it is up and says on screen that the answers are
+// partial while the first read finishes. Later syncs are incremental: the
+// connector reports only what changed since the cursor the last one saved.
+func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant string, track *indexing, log *slog.Logger) (func(), error) {
 	if cfg.Dir == "" {
 		return func() {}, nil
 	}
@@ -189,6 +188,7 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 		Fields:    []any{"dir", cfg.Dir, "source", cfg.Name},
 		Report:    func() []any { return watching(watcher) },
 		Policy:    policy,
+		Track:     track,
 		Release: func() {
 			if watcher != nil {
 				_ = watcher.Close()

--- a/cmd/genbad/corpus_os_test.go
+++ b/cmd/genbad/corpus_os_test.go
@@ -65,7 +65,7 @@ func TestTheFileSystemDecidesWhatAQueryReturns(t *testing.T) {
 		}
 	}()
 
-	waitForHealth(t, "http://"+addr+"/healthz")
+	waitForIndex(t, "http://"+addr)
 
 	if got := searchAs(t, addr, me, "legacy"); got.Total == 0 {
 		t.Error("the owner of a file cannot find it")

--- a/cmd/genbad/corpus_test.go
+++ b/cmd/genbad/corpus_test.go
@@ -116,7 +116,7 @@ func TestAStartedServerAnswersQueriesAboutTheCorpus(t *testing.T) {
 		}
 	}()
 
-	waitForHealth(t, "http://"+addr+"/healthz")
+	waitForIndex(t, "http://"+addr)
 
 	res := searchAs(t, addr, "alice", "deploying")
 	if res.Total == 0 {
@@ -170,7 +170,7 @@ func TestOwnersDecideWhatAQueryReturns(t *testing.T) {
 		}
 	}()
 
-	waitForHealth(t, "http://"+addr+"/healthz")
+	waitForIndex(t, "http://"+addr)
 
 	// bob approves the guides directory and alice approves the root, which the
 	// guides OWNERS file replaced.
@@ -220,7 +220,7 @@ func TestADeletedFileStopsComingBack(t *testing.T) {
 		}
 	}()
 
-	waitForHealth(t, "http://"+addr+"/healthz")
+	waitForIndex(t, "http://"+addr)
 
 	if got := searchAs(t, addr, "alice", "deploying"); got.Total == 0 {
 		t.Fatal("the file was not indexed in the first place")
@@ -280,7 +280,7 @@ func TestAWatchedCorpusKeepsUpWithTheTree(t *testing.T) {
 		}
 	}()
 
-	waitForHealth(t, "http://"+addr+"/healthz")
+	waitForIndex(t, "http://"+addr)
 
 	if got := searchAs(t, addr, "alice", "deploying"); got.Total == 0 {
 		t.Fatal("the first sync did not index the tree")

--- a/cmd/genbad/feed.go
+++ b/cmd/genbad/feed.go
@@ -54,6 +54,11 @@ type feed struct {
 	// wanted here is the one method some of their implementations share.
 	Policy any
 
+	// Track is where the first read of this source is reported, so that the
+	// interface can say the answers it is giving are not the whole answer yet.
+	// A nil one is a feed nobody is watching.
+	Track *indexing
+
 	// Release is called once the last sync has returned, and is where a watcher
 	// and a source get closed.
 	Release func()
@@ -62,14 +67,23 @@ type feed struct {
 // runFeed syncs f once and then on its interval, and returns the function that
 // waits for it to stop.
 //
-// The first sync runs before this returns, and the caller runs it before the
-// listener opens, so that a request arriving the moment the log says the server
-// is up finds a corpus rather than an empty index.
+// The first sync runs in the background, alongside the listener, rather than in
+// front of it. Reading a real corpus takes a minute and a half, and a process
+// that refuses connections for that long is one a load balancer takes out of
+// rotation and a person watching a terminal assumes has hung. It answers from
+// the first second instead, and says on every screen that what it is answering
+// from is not all of it yet, which is what [indexing] is for.
 func runFeed(ctx context.Context, st store.Store, f feed, log *slog.Logger) (func(), error) {
 	// Checkpoints live in memory because the only storage driver that ships
 	// today does too. Restarting loses the index, so a cursor that survived the
 	// restart would skip everything the new empty index needs.
-	pipeline, err := ingest.New(st, connector.NewMemoryCheckpoints(), ingest.WithLogger(log))
+	opts := []ingest.Option{ingest.WithLogger(log)}
+	if f.Track != nil {
+		opts = append(opts, ingest.WithProgress(func(p ingest.Progress) {
+			f.Track.advance(p.Source, p.Done)
+		}))
+	}
+	pipeline, err := ingest.New(st, connector.NewMemoryCheckpoints(), opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -120,19 +134,39 @@ func runFeed(ctx context.Context, st store.Store, f feed, log *slog.Logger) (fun
 		reportMapping(f.Policy, log)
 	}
 
-	sync(ctx)
-
 	release := f.Release
 	if release == nil {
 		release = func() {}
 	}
-	if f.Refresh <= 0 {
-		return release, nil
-	}
+
+	// Said here rather than in the goroutine, so that the answer to whether this
+	// process is still reading its sources is already correct by the time the
+	// listener opens. A readiness check that arrives in the microsecond between
+	// the two would otherwise be told the crawl is over because it has not
+	// started.
+	source := f.Source.Source()
+	tracked := f.Track != nil && f.Track.expect(source)
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+		if tracked {
+			// Counted before the sync rather than during it, because the whole
+			// point of the second number is that it is there from the start. It
+			// is one metadata pass over a source that is about to get a full
+			// content pass, and it happens once per process and only on a process
+			// that came up with nothing indexed.
+			total := countSource(ctx, f.Source)
+			log.Info(f.Kind+" first read", append(slices.Clone(f.Fields), "documents", total)...)
+			f.Track.counting(source, total)
+		}
+		sync(ctx)
+		if tracked {
+			f.Track.finished(source)
+		}
+		if f.Refresh <= 0 {
+			return
+		}
 		t := time.NewTicker(f.Refresh)
 		defer t.Stop()
 		for {

--- a/cmd/genbad/first_read_test.go
+++ b/cmd/genbad/first_read_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The first ninety seconds, end to end.
+//
+// A server pointed at a corpus it has never read used to bind its port after
+// the walk finished. On a real tree that is a minute and a half of connection
+// refused, which a readiness probe reads as a failed deploy and a person reads
+// as a hang. It answers from the first second now, and the price of that is
+// that the first answers come out of an index that is still filling. So it says
+// so, on every screen, until it is done.
+
+// bigTree writes enough files that reading them takes long enough to watch. The
+// count is not arbitrary: the whole point of the test is to look at the server
+// while a first read is in flight, and a tree of eight files is read faster than
+// a request can be sent.
+func bigTree(t *testing.T, files int) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "notes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := range files {
+		name := filepath.Join(root, "notes", fmt.Sprintf("note-%04d.md", i))
+		body := fmt.Sprintf("# Note %04d\n\nOne paragraph about deploying, written so the file is worth reading and parsing.\n", i)
+		if err := os.WriteFile(name, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// startCorpus starts a server on a directory and returns its address and a
+// function that shuts it down. It deliberately does not wait for the index.
+func startCorpus(t *testing.T, root string) (string, func()) {
+	t.Helper()
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, []string{
+			"-addr", addr,
+			"-tenant", "acme",
+			"-corpus", root,
+			"-corpus-name", "handbook",
+			"-log-level", "error",
+		}, env(nil), &out, &errOut)
+	}()
+	return addr, func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			t.Error("the server did not shut down")
+		}
+	}
+}
+
+func TestTheServerAnswersBeforeTheCorpusIsReadAndSaysSo(t *testing.T) {
+	addr, stop := startCorpus(t, bigTree(t, 2000))
+	defer stop()
+
+	// This is the assertion. The health check answering at all, on a corpus that
+	// cannot have been read yet, is the behaviour the whole change is for.
+	waitForHealth(t, "http://"+addr+"/healthz")
+
+	var ready struct {
+		Status   string `json:"status"`
+		Indexing bool   `json:"indexing"`
+	}
+	body := get(t, "http://"+addr+"/readyz")
+	if body == "" {
+		t.Fatal("the readiness check did not answer on a server that is already healthy")
+	}
+	if err := json.Unmarshal([]byte(body), &ready); err != nil {
+		t.Fatalf("decoding %q: %v", body, err)
+	}
+	if ready.Status != "ready" {
+		t.Errorf("status is %q, want a server that is reading its corpus to still be ready", ready.Status)
+	}
+	if !ready.Indexing {
+		t.Fatal("a server that has not finished its first read says nothing is being indexed")
+	}
+
+	// A query is answered rather than refused or held, out of whatever has been
+	// written so far. Nothing is asserted about the number of results, because
+	// how many there are at this instant is a race by design.
+	res := searchAs(t, addr, "alice", "deploying")
+	if res.Total < 0 {
+		t.Errorf("search returned %+v", res)
+	}
+
+	// And an authenticated caller gets the numbers, which is what the interface
+	// puts in the banner.
+	stats := statsAs(t, addr, "alice")
+	if stats.Indexing == nil {
+		t.Fatal("stats said nothing about the read that is running")
+	}
+	if stats.Indexing.Source != "handbook" {
+		t.Errorf("indexing names %q, want the source from -corpus-name", stats.Indexing.Source)
+	}
+	if stats.Indexing.Done > stats.Indexing.Total && stats.Indexing.Total != 0 {
+		t.Errorf("indexing = %+v, more read than there is to read", *stats.Indexing)
+	}
+}
+
+// And it stops saying it. A banner that is still up after the corpus is read is
+// worse than never having had one, because the next time it is true nobody
+// reads it.
+func TestNothingIsReportedOnceTheCorpusIsRead(t *testing.T) {
+	addr, stop := startCorpus(t, corpusTree(t))
+	defer stop()
+
+	waitForIndex(t, "http://"+addr)
+
+	if body := get(t, "http://"+addr+"/readyz"); strings.Contains(body, "indexing") {
+		t.Errorf("readyz still mentions indexing on a corpus that is read: %s", body)
+	}
+	if got := statsAs(t, addr, "alice").Indexing; got != nil {
+		t.Errorf("stats still reports %+v on a corpus that is read", *got)
+	}
+
+	// The results are all there, which is the thing the banner was promising
+	// would arrive.
+	if res := searchAs(t, addr, "alice", "deploying"); res.Total == 0 {
+		t.Error("the first read finished and the corpus is not searchable")
+	}
+}
+
+type statsResult struct {
+	Documents int `json:"documents"`
+	Indexing  *struct {
+		Source string `json:"source"`
+		Done   int    `json:"done"`
+		Total  int    `json:"total"`
+	} `json:"indexing"`
+}
+
+func statsAs(t *testing.T, addr, subject string) statsResult {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+"/api/v1/stats", http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Genba-Subject", subject)
+	req.Header.Set("X-Genba-Tenant", "acme")
+	req.Header.Set("X-Genba-Identities", "github:"+subject)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stats returned %s", resp.Status)
+	}
+	var out statsResult
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decoding the response: %v", err)
+	}
+	return out
+}

--- a/cmd/genbad/first_read_test.go
+++ b/cmd/genbad/first_read_test.go
@@ -44,9 +44,9 @@ func bigTree(t *testing.T, files int) string {
 
 // startCorpus starts a server on a directory and returns its address and a
 // function that shuts it down. It deliberately does not wait for the index.
-func startCorpus(t *testing.T, root string) (string, func()) {
+func startCorpus(t *testing.T, root string) (addr string, stop func()) {
 	t.Helper()
-	addr := freeAddr(t)
+	addr = freeAddr(t)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)

--- a/cmd/genbad/indexing.go
+++ b/cmd/genbad/indexing.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"sync"
+
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/store"
+)
+
+// indexing is what the server answers when somebody asks whether the corpus on
+// screen is all of it.
+//
+// It only ever reports a source being read for the very first time, which is
+// the state where an answer is true and incomplete at the same time. A refresh
+// over a corpus that is already indexed is not reported, because during one of
+// those every query returns the whole answer and a banner saying otherwise
+// would be a lie that appears once a minute forever.
+type indexing struct {
+	// firstRun says this process came up on an index with nothing in it.
+	//
+	// It is decided once, before any connector starts, rather than per source.
+	// Asking the store twice would give two different answers on a server
+	// reading a directory and a bucket, because by the time the second one asks
+	// the first has already written something.
+	firstRun bool
+
+	mu sync.Mutex
+
+	// runs is the state of each source, and order is the order they were first
+	// seen in. A process reading a directory and a bucket has two, and the one
+	// that started first is the one reported, so the banner does not swap
+	// between them while both are going.
+	runs  map[string]*firstRead
+	order []string
+}
+
+// firstRead is one source being read for the first time.
+type firstRead struct {
+	// total is what the source held when it was counted, and zero until the
+	// count comes back or when the source cannot be counted at all.
+	total int
+
+	// done is how many documents the sync has stored so far.
+	done int
+
+	// over is set when the run finished, and is what keeps a source that has
+	// been read from being counted again on the next refresh.
+	over bool
+}
+
+// newIndexing decides whether this process is starting on an empty index, which
+// is the only situation any of this reports on.
+func newIndexing(ctx context.Context, st store.Store) *indexing {
+	return &indexing{firstRun: indexIsEmpty(ctx, st), runs: make(map[string]*firstRead, 2)}
+}
+
+// expect records that a source is about to be read for the first time.
+//
+// It is called before the sync starts, and before the count that fills in the
+// second number, so that the moment between a server answering and a server
+// knowing how much work it has is a moment it reports as indexing rather than
+// as done. The alternative is a readiness check that says a crawl has finished
+// because it has not begun.
+// It returns whether the source is being tracked, which is the answer to
+// whether counting it is worth a walk.
+func (i *indexing) expect(source string) bool {
+	if !i.firstRun {
+		return false
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if _, seen := i.runs[source]; seen {
+		return false
+	}
+	i.runs[source] = &firstRead{}
+	i.order = append(i.order, source)
+	return true
+}
+
+// counting fills in how much of a source there is to read. A total of zero
+// means the count failed or the source cannot be counted.
+func (i *indexing) counting(source string, total int) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if r, ok := i.runs[source]; ok {
+		r.total = total
+	}
+}
+
+// advance records how far the run on a source has got. It does nothing for a
+// source nobody is expecting, which is every refresh after the first read.
+func (i *indexing) advance(source string, done int) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if r, ok := i.runs[source]; ok {
+		r.done = done
+	}
+}
+
+// finished records that the run on a source is over, whether it succeeded or
+// not. A failed first read is still over: the banner promises that results are
+// partial until this finishes, and a sync that died has finished.
+func (i *indexing) finished(source string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if r, ok := i.runs[source]; ok {
+		r.over = true
+	}
+}
+
+// State is what the API reports, and is the function handed to
+// [api.WithIndexing].
+//
+// A source that is being read but has not been counted yet is reported with a
+// total of zero, which says a sync is running and declines to guess how long it
+// has left. Whoever renders it decides what to do with that, and the interface
+// waits for the second number before it puts a banner up.
+func (i *indexing) State() (api.Indexing, bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	for _, source := range i.order {
+		r := i.runs[source]
+		// A run that has already stored more than the count said there was has
+		// nothing left to say. That happens on a tree people are working in, and
+		// reporting 22,100 of about 22,000 would make the one number on the line
+		// the one nobody believes.
+		if r.over || (r.total > 0 && r.done >= r.total) {
+			continue
+		}
+		return api.Indexing{Source: source, Done: r.done, Total: r.total}, true
+	}
+	return api.Indexing{}, false
+}
+
+// countSource is how many documents a source holds, for the second number on
+// the banner.
+//
+// It is the enumeration the reconciliation sweep is built on, which reads
+// metadata and no content: on a filesystem that is a stat per file against a
+// read per file, and on a bucket it is one list request per thousand objects.
+// A source that cannot enumerate returns zero and gets no banner, which is the
+// right answer rather than a guess.
+func countSource(ctx context.Context, c connector.Connector) int {
+	enum, ok := c.(connector.Enumerator)
+	if !ok {
+		return 0
+	}
+	n := 0
+	if err := enum.Enumerate(ctx, func(connector.Item) bool {
+		n++
+		return true
+	}); err != nil {
+		return 0
+	}
+	return n
+}
+
+// indexIsEmpty says whether this process started on an index with nothing in
+// it, which is what makes the syncs about to run first reads rather than catch
+// ups.
+//
+// The store is asked rather than the checkpoints, because checkpoints are held
+// in memory and a restart against a SQLite file that already holds the whole
+// corpus reads it all again from a zero cursor. That run is not a first read.
+// Nothing on screen is missing while it goes, and it must not raise a banner.
+func indexIsEmpty(ctx context.Context, st store.Store) bool {
+	s, err := st.Stats(ctx)
+	if err != nil {
+		return false
+	}
+	return s.Documents == 0
+}

--- a/cmd/genbad/indexing_test.go
+++ b/cmd/genbad/indexing_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// The rules about when the server says a source is still being read.
+//
+// Every one of them is about not putting a banner up that says results are
+// partial when they are not. A caveat somebody sees while the answer is
+// complete is worse than no caveat at all, because after the second time they
+// stop reading it and it is still there the day it is true.
+
+func emptyTracker(t *testing.T) *indexing {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	return newIndexing(t.Context(), st)
+}
+
+func TestASourceIsReportedFromBeforeItHasBeenCounted(t *testing.T) {
+	track := emptyTracker(t)
+
+	if !track.expect("notes") {
+		t.Fatal("a process that came up on an empty index is not tracking its first read")
+	}
+	got, ok := track.State()
+	if !ok {
+		t.Fatal("nothing was reported between the listener opening and the count arriving")
+	}
+	if got.Source != "notes" || got.Total != 0 {
+		t.Errorf("state = %+v, want the source named and no total yet", got)
+	}
+
+	track.counting("notes", 900)
+	track.advance("notes", 500)
+	if got, _ = track.State(); got.Done != 500 || got.Total != 900 {
+		t.Errorf("state = %+v, want 500 of 900", got)
+	}
+}
+
+func TestASourceStopsBeingReportedWhenItIsRead(t *testing.T) {
+	track := emptyTracker(t)
+	track.expect("notes")
+	track.counting("notes", 900)
+
+	track.advance("notes", 900)
+	if _, ok := track.State(); ok {
+		t.Error("a source that reached its own count is still being reported")
+	}
+
+	// A tree people are working in grows while it is read, and a line saying
+	// 22,100 of about 22,000 makes the one number on it the one nobody believes.
+	track.advance("notes", 1200)
+	if _, ok := track.State(); ok {
+		t.Error("a source that overshot its own count is still being reported")
+	}
+}
+
+// A first read that failed is over. The banner promises that results are
+// partial until this finishes, and a sync that died has finished.
+func TestAFailedFirstReadStopsBeingReported(t *testing.T) {
+	track := emptyTracker(t)
+	track.expect("notes")
+	track.counting("notes", 900)
+	track.advance("notes", 12)
+
+	track.finished("notes")
+	if _, ok := track.State(); ok {
+		t.Error("a run that is over is still being reported")
+	}
+}
+
+// The one that matters most. A restart against a SQLite file that already holds
+// the whole corpus re-reads it from a zero cursor, because checkpoints are held
+// in memory. Nothing is missing from the index while that runs, so nothing is
+// partial and there is nothing to say.
+func TestAProcessThatCameUpOnAFullIndexReportsNothing(t *testing.T) {
+	st := memstore.New()
+	defer func() { _ = st.Close() }()
+
+	d := doc.Document{
+		ID: "notes:readme.md", Tenant: "acme", Source: "notes", Kind: doc.KindPage,
+		Title: "Readme", Permissions: acl.Permissions{Mode: acl.ModePublicToTenant, Source: "notes", Version: 1},
+	}
+	if err := st.Put(t.Context(), d); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	track := newIndexing(t.Context(), st)
+	if track.expect("notes") {
+		t.Fatal("a restart over a corpus that is already indexed counted its source again")
+	}
+	track.counting("notes", 900)
+	track.advance("notes", 12)
+	if _, ok := track.State(); ok {
+		t.Error("a catch up over a full index was reported as a first read")
+	}
+}
+
+// Two sources, and the banner has room for one. The one that started first is
+// the one reported, so it does not swap between them while both are going.
+func TestTheSourceThatStartedFirstIsTheOneReported(t *testing.T) {
+	track := emptyTracker(t)
+	track.expect("notes")
+	track.counting("notes", 900)
+	track.expect("objects")
+	track.counting("objects", 40)
+
+	if got, _ := track.State(); got.Source != "notes" {
+		t.Errorf("state named %q, want the source that started first", got.Source)
+	}
+
+	track.finished("notes")
+	if got, ok := track.State(); !ok || got.Source != "objects" {
+		t.Errorf("state = %+v %v, want the second source once the first is done", got, ok)
+	}
+
+	track.finished("objects")
+	if _, ok := track.State(); ok {
+		t.Error("something is still being reported with both sources read")
+	}
+}
+
+// A refresh is not a first read. Once a source has been through one, later syncs
+// over it say nothing, forever.
+func TestARefreshIsNotAFirstRead(t *testing.T) {
+	track := emptyTracker(t)
+	track.expect("notes")
+	track.counting("notes", 4)
+	track.advance("notes", 4)
+	track.finished("notes")
+
+	if track.expect("notes") {
+		t.Fatal("a refresh registered itself as a first read")
+	}
+	track.advance("notes", 1)
+	if _, ok := track.State(); ok {
+		t.Error("a refresh over a source that has been read is being reported")
+	}
+}

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -136,7 +136,17 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		}
 	}()
 
-	opts := []api.Option{api.WithLogger(log), api.WithDriver(string(cfg.Store))}
+	// Shared by the feeds, which write to it, and the server, which reads it on
+	// every stats request and every readiness check. It is built before either,
+	// because the question it answers is whether this process came up with an
+	// empty index and there is exactly one moment at which that can be asked.
+	track := newIndexing(ctx, st)
+
+	opts := []api.Option{
+		api.WithLogger(log),
+		api.WithDriver(string(cfg.Store)),
+		api.WithIndexing(track.State),
+	}
 	if h := web.Handler(); h != nil {
 		opts = append(opts, api.WithAssets(h))
 	}
@@ -152,18 +162,20 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	// indexed since it came up while sitting on a corpus it had just loaded.
 	srv := api.New(st, searcher, api.HeaderAuth{Tenant: cfg.Tenant}, opts...)
 
-	// The first sync of each source runs here, before the listener opens, so
-	// that the server is useful the moment it says it is up. A server pointed at
-	// both indexes both, and the two are separate feeds with separate cursors
-	// rather than one merged crawl, because a bucket that is refusing requests
-	// should not stop a directory being reindexed.
-	waitForCorpus, err := ingestCorpus(ctx, st, corpus, cfg.Tenant, log)
+	// Each source starts syncing here and keeps going behind the listener. What
+	// is built here and not in the background is everything that can be wrong
+	// with a flag, so a bad corpus directory or a bucket with no credentials is
+	// still an error the process exits on rather than a warning it logs a minute
+	// later. A server pointed at both indexes both, and the two are separate
+	// feeds with separate cursors rather than one merged crawl, because a bucket
+	// that is refusing requests should not stop a directory being reindexed.
+	waitForCorpus, err := ingestCorpus(ctx, st, corpus, cfg.Tenant, track, log)
 	if err != nil {
 		return err
 	}
 	defer waitForCorpus()
 
-	waitForBucket, err := ingestBucket(ctx, st, bucket, cfg.Tenant, log)
+	waitForBucket, err := ingestBucket(ctx, st, bucket, cfg.Tenant, track, log)
 	if err != nil {
 		return err
 	}

--- a/cmd/genbad/main_test.go
+++ b/cmd/genbad/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net"
 	"net/http"
@@ -147,6 +148,30 @@ func freeAddr(t *testing.T) string {
 		t.Fatalf("releasing the port: %v", err)
 	}
 	return addr
+}
+
+// waitForIndex waits until the server has finished reading its sources for the
+// first time.
+//
+// A test that asserts on what is in the index needs this and not the health
+// check. The server answers from the moment it binds, and everything a
+// connector is doing it is doing behind that, so a query sent the microsecond
+// the port opens is a query against an index that is legitimately empty.
+func waitForIndex(t *testing.T, base string) {
+	t.Helper()
+	waitForHealth(t, base+"/healthz")
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		var ready struct {
+			Indexing bool `json:"indexing"`
+		}
+		body := get(t, base+"/readyz")
+		if body != "" && json.Unmarshal([]byte(body), &ready) == nil && !ready.Indexing {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("the server was still indexing after thirty seconds")
 }
 
 func waitForHealth(t *testing.T, url string) {

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -54,6 +54,7 @@ type Pipeline struct {
 	batchSize   int
 	clock       func() time.Time
 	log         *slog.Logger
+	progress    func(Progress)
 
 	// maint is the same store when the driver can do the two things a
 	// maintenance job needs and a query path must never have: list what is
@@ -81,6 +82,25 @@ func WithLogger(l *slog.Logger) Option {
 	return func(p *Pipeline) {
 		if l != nil {
 			p.log = l
+		}
+	}
+}
+
+// WithProgress sets what to tell about a run while it is still going.
+//
+// It is called once when the run starts and again after every store write, on
+// the goroutine doing the work, so it must not block: whatever it does is time
+// the sync is not spending on documents. Handing over a snapshot rather than a
+// pointer is deliberate, since the caller is usually publishing it to a reader
+// on another goroutine.
+//
+// The alternative was to have the caller read the returned [Stats], and that
+// only ever arrives after the run is over, which is exactly when nobody needs
+// to be told how far it has got.
+func WithProgress(fn func(Progress)) Option {
+	return func(p *Pipeline) {
+		if fn != nil {
+			p.progress = fn
 		}
 	}
 }
@@ -116,6 +136,33 @@ func New(s store.Store, cp connector.Checkpoints, opts ...Option) (*Pipeline, er
 	}
 	p.maint, _ = s.(store.Maintenance)
 	return p, nil
+}
+
+// Progress is how far a run has got, reported while it is still running.
+//
+// It is a subset of [Stats] rather than the whole of it, because the numbers
+// left out are ones that are not meaningful until a run is over and would
+// invite somebody to draw a conclusion from a half finished one.
+type Progress struct {
+	// Source is the connector being synced.
+	Source string
+
+	// Tenant is whose corpus it is going into.
+	Tenant string
+
+	// Done is how many documents have been stored so far, whether they are
+	// queryable or quarantined. Both are documents this run has got through, and
+	// somebody watching a count climb is asking how far along it is rather than
+	// how many of them they will be allowed to read.
+	Done int
+
+	// Resumed says the run started from a checkpoint, so the index already held
+	// documents from this source before it began.
+	//
+	// It is the difference between a corpus being read for the first time and
+	// one being caught up, and only the first of those means the answers on
+	// screen are incomplete.
+	Resumed bool
 }
 
 // Stats is what one run did.
@@ -191,8 +238,12 @@ func (p *Pipeline) Run(ctx context.Context, tenant genba.TenantID, c connector.C
 		return Stats{}, err
 	}
 
-	run := &run{pipeline: p, tenant: string(tenant), source: source}
+	run := &run{pipeline: p, tenant: string(tenant), source: source, resumed: !from.IsZero()}
 	run.stats.Cursor = from
+	// Said before a single document has been read, so that whoever is watching
+	// learns a run has started rather than learning it half a batch later. On a
+	// source with nothing new in it this is the only report there will be.
+	run.report()
 
 	final, syncErr := c.Sync(ctx, from, run.emit)
 
@@ -268,6 +319,22 @@ type run struct {
 	// is saved only once that batch is stored.
 	pending connector.Cursor
 	stats   Stats
+
+	// resumed says this run started from a checkpoint rather than from nothing.
+	resumed bool
+}
+
+// report tells the pipeline's progress function how far this run has got.
+func (r *run) report() {
+	if r.pipeline.progress == nil {
+		return
+	}
+	r.pipeline.progress(Progress{
+		Source:  r.source,
+		Tenant:  r.tenant,
+		Done:    r.stats.Indexed + r.stats.Quarantined,
+		Resumed: r.resumed,
+	})
 }
 
 // emit takes one change from a connector.
@@ -380,6 +447,11 @@ func (r *run) flush(ctx context.Context) error {
 		}
 	}
 	r.stats.Batches++
+	// Reported here rather than per document, because a batch is the unit that
+	// actually became visible to a query and because a callback on every
+	// document would be a lock per document on the path this whole package is
+	// built to keep cheap.
+	r.report()
 
 	// Reuse the backing arrays. A long sync flushes thousands of times and
 	// there is no reason for each one to allocate a new batch.

--- a/ingest/progress_test.go
+++ b/ingest/progress_test.go
@@ -1,0 +1,94 @@
+package ingest_test
+
+import (
+	"testing"
+
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/ingest"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// How far a run has got, reported while it is still going.
+//
+// The stats a run returns arrive when it is over, which is exactly when nobody
+// needs to be told how far along it is. Everything here is about the numbers
+// somebody watching a screen sees before that.
+
+func TestProgressClimbsWhileTheRunIsStillGoing(t *testing.T) {
+	st := memstore.New()
+	defer func() { _ = st.Close() }()
+
+	var seen []ingest.Progress
+	p, err := ingest.New(st, connector.NewMemoryCheckpoints(),
+		ingest.WithBatchSize(10),
+		ingest.WithProgress(func(pr ingest.Progress) { seen = append(seen, pr) }),
+	)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	run(t, p, &fakeSource{name: "notes", changes: changes(25)})
+
+	// Twenty five documents in batches of ten is two full batches and a flush
+	// of the rest, plus the report that goes out before anything is read.
+	if len(seen) != 4 {
+		t.Fatalf("progress was reported %d times, want 4: %+v", len(seen), seen)
+	}
+	// The first report is the one that says a run has started. Without it the
+	// only news of a sync arrives a whole batch late, which on a slow source is
+	// the whole of the time somebody is waiting.
+	if seen[0].Done != 0 {
+		t.Errorf("the first report already had %d documents in it", seen[0].Done)
+	}
+	for i, want := range []int{0, 10, 20, 25} {
+		if seen[i].Done != want {
+			t.Errorf("report %d said %d documents, want %d", i, seen[i].Done, want)
+		}
+		if seen[i].Source != "notes" || seen[i].Tenant != tenant {
+			t.Errorf("report %d = %+v, want it to name the source and the tenant", i, seen[i])
+		}
+	}
+}
+
+// A run that resumed from a checkpoint says so, because the index already held
+// documents from this source before it started and nothing on screen is missing
+// while it catches up.
+func TestProgressSaysWhetherTheRunResumed(t *testing.T) {
+	st := memstore.New()
+	defer func() { _ = st.Close() }()
+
+	var resumed []bool
+	p, err := ingest.New(st, connector.NewMemoryCheckpoints(),
+		ingest.WithProgress(func(pr ingest.Progress) { resumed = append(resumed, pr.Resumed) }),
+	)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	src := &fakeSource{name: "notes", changes: changes(5), final: connector.Cursor{Value: "0004"}}
+	run(t, p, src)
+	if resumed[0] {
+		t.Error("the first run over an empty checkpoint reported itself as a resume")
+	}
+
+	resumed = nil
+	run(t, p, src)
+	if !resumed[0] {
+		t.Error("a run that started from a saved cursor did not report itself as a resume")
+	}
+}
+
+// A pipeline with nobody watching it does not pay for the reporting, and more
+// to the point does not crash trying to call a function that is not there.
+func TestAPipelineWithNoProgressFunctionRunsAnyway(t *testing.T) {
+	st := memstore.New()
+	defer func() { _ = st.Close() }()
+
+	p, err := ingest.New(st, connector.NewMemoryCheckpoints())
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if got := run(t, p, &fakeSource{name: "notes", changes: changes(3)}).Indexed; got != 3 {
+		t.Errorf("indexed %d, want 3", got)
+	}
+}

--- a/scripts/state-check.mjs
+++ b/scripts/state-check.mjs
@@ -4,14 +4,22 @@
 // decides whether somebody trusts a search product is not. This drives the
 // states: a search that is slow, a search that is very slow, a check that
 // failed behind an answer, a query that matched nothing because of a filter or
-// because of a typo, an index with nothing in it, and a document that is either
-// missing or forbidden.
+// because of a typo, an index with nothing in it, a server that is still
+// reading its corpus, and a document that is either missing or forbidden.
 //
 // Four of those need a request that does not answer, so this one holds the
 // search endpoint open from the browser side rather than asking the server for
 // a delay it has no reason to offer. Holding it is also what makes the timings
 // here real: the hundred and twenty milliseconds before a loading state appears
 // is measured from the moment the request left the page.
+//
+// The state during a first read is answered rather than held: the stats
+// endpoint is fulfilled from here with the report a server halfway through a
+// crawl sends. It is built rather than raced for on purpose. The alternative is
+// starting a server on a corpus large enough that the read is still going when
+// the browser arrives, which makes the gate slower, makes every count it
+// asserts on depend on how far the read had got, and still cannot produce the
+// number the banner rounds.
 //
 // The rest are rendered directly, because they are the states that must be
 // compared rather than watched. A 403 and a 404 on a document have to produce
@@ -79,8 +87,24 @@ async function run(session) {
   // held open for as long as the assertion about it needs.
   let mode = "pass";
   const held = new Set();
+  // What the stats endpoint answers, when this script is answering it. Null
+  // means the real server does, which is every assertion but the last group.
+  let stats = null;
 
-  session.on("Fetch.requestPaused", ({ requestId }) => {
+  session.on("Fetch.requestPaused", ({ requestId, request }) => {
+    if (request && request.url.includes("/api/v1/stats")) {
+      if (!stats) {
+        session("Fetch.continueRequest", { requestId }).catch(() => {});
+        return;
+      }
+      session("Fetch.fulfillRequest", {
+        requestId,
+        responseCode: 200,
+        responseHeaders: [{ name: "content-type", value: "application/json" }],
+        body: Buffer.from(JSON.stringify(stats)).toString("base64"),
+      }).catch(() => {});
+      return;
+    }
     if (mode === "hold") {
       held.add(requestId);
       return;
@@ -105,7 +129,12 @@ async function run(session) {
   };
 
   await session("Page.enable");
-  await session("Fetch.enable", { patterns: [{ urlPattern: "*/api/v1/search*", requestStage: "Request" }] });
+  await session("Fetch.enable", {
+    patterns: [
+      { urlPattern: "*/api/v1/search*", requestStage: "Request" },
+      { urlPattern: "*/api/v1/stats*", requestStage: "Request" },
+    ],
+  });
   await session("Page.addScriptToEvaluateOnNewDocument", { source: WATCH });
 
   // Slow, and then not slow. One navigation covers both the delay before a
@@ -217,6 +246,94 @@ async function run(session) {
     `document.querySelector('.omnibox__input').value === 'search' &&
       location.search.includes('q=search') && document.querySelectorAll('.result').length > 0`,
   );
+
+  // The first ninety seconds. The server binds its port before it has read a
+  // corpus and answers out of an index that is still filling, so every screen
+  // says so until it is done. Nothing here is faked in the page: the report
+  // comes back over the wire, through the same cache and the same refresh as
+  // the real one, and the assertions are about what a person ends up reading.
+  const report = async (indexing) => {
+    stats = { documents: 4182, ...(indexing ? { indexing } : {}) };
+    await evaluate(
+      session,
+      expr(`
+        const { cache } = await import('genba/cache.js');
+        cache.invalidate('');
+        window.dispatchEvent(new PopStateEvent('popstate'));
+        return true;
+      `),
+    );
+  };
+
+  // A source the server has not finished counting reports a total of zero, and
+  // it says nothing at all rather than "0 of about 0".
+  await report({ source: "repo", done: 0, total: 0 });
+  await sleep(600);
+  await check(
+    session,
+    "a first read the server has not finished counting puts nothing on screen",
+    "document.querySelector('.banner').hidden === true",
+  );
+
+  await report({ source: "repo", done: 4182, total: 22235 });
+  await settle(session, `document.querySelector('.banner').dataset.state === 'indexing'`);
+  await check(
+    session,
+    "a server still reading its corpus says so, with what it has done and roughly how much there is",
+    `(() => {
+      const banner = document.querySelector('.banner');
+      return banner.hidden === false && banner.getAttribute('role') === 'status' &&
+        banner.querySelector('.banner__what').textContent === 'Indexing Repo' &&
+        banner.querySelector('.banner__count').textContent === '4,182 of about 22,000' &&
+        banner.textContent.includes('Results are partial until this finishes.');
+    })()`,
+  );
+
+  // The same report twice leaves the same elements. A banner rebuilt on every
+  // refresh is one a screen reader starts again from the top every few seconds,
+  // which is worse for the person who most needs to be told.
+  await evaluate(session, "window.__genba.banner = document.querySelector('.banner__count'), true");
+  await report({ source: "repo", done: 4182, total: 22235 });
+  await sleep(600);
+  await check(
+    session,
+    "a report that has not changed does not rebuild the line somebody is reading",
+    "document.querySelector('.banner__count') === window.__genba.banner",
+  );
+
+  // Two caveats and one line. Results that are partial because a read is
+  // running are still the server's current answer, and results from before the
+  // connection dropped are not, so the connection wins.
+  await evaluate(session, "window.dispatchEvent(new Event('offline')), true");
+  await settle(session, `document.querySelector('.banner').dataset.state === 'offline'`);
+  await check(
+    session,
+    "being offline wins the banner from a read that is still running",
+    `document.querySelector('.banner').textContent.includes('You are offline') &&
+      !document.querySelector('.banner').textContent.includes('Indexing')`,
+  );
+
+  await evaluate(session, "window.dispatchEvent(new Event('online')), true");
+  await settle(session, `document.querySelector('.banner').dataset.state === 'indexing'`);
+  await check(
+    session,
+    "and the read comes back to it when the connection does",
+    "document.querySelector('.banner__what').textContent === 'Indexing Repo'",
+  );
+
+  // And it goes. A caveat still on screen after it stopped being true is worse
+  // than never having had one, because the next time it is true nobody reads it.
+  await report(null);
+  await settle(session, "document.querySelector('.banner').hidden === true");
+  await check(
+    session,
+    "the banner goes when the corpus is read, and leaves nothing behind it",
+    `(() => {
+      const banner = document.querySelector('.banner');
+      return banner.hidden === true && !banner.dataset.state && banner.childNodes.length === 0;
+    })()`,
+  );
+  stats = null;
 
   // The security assertion, and the reason both messages live in one module.
   // Which of the two happened is what the permission system is keeping from

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -78,15 +78,22 @@ for url in "$BASE" "$EMPTY"; do
 	fi
 done
 
-# ready waits for a server to answer its health check, and gives up if the
-# process it is waiting for is no longer there.
+# ready waits for a server to answer its health check and then for it to finish
+# reading its corpus, and gives up if the process it is waiting for is no longer
+# there.
+#
+# The second wait is the one that matters here. The server binds its port before
+# the first read is done and answers out of a part filled index while it runs,
+# which is the right thing for a deployment and the wrong thing for a gate:
+# every count this script asserts on, and every screen axe audits, would be
+# measured against however much of the corpus had been read when the browser got
+# there. That is not a number that means anything twice. So the gate waits for
+# all of it, and the interface state during the read is audited on purpose by
+# scripts/state-check.mjs, which builds it rather than racing for it.
 ready() {
 	i=0
 	until curl -fsS "$1/healthz" >/dev/null 2>&1; do
-		if ! kill -0 "$2" 2>/dev/null; then
-			echo "ui-gate: the server on $1 exited before it was ready" >&2
-			exit 1
-		fi
+		alive "$1" "$2"
 		i=$((i + 1))
 		if [ "$i" -gt 100 ]; then
 			echo "ui-gate: the server on $1 never became healthy" >&2
@@ -94,6 +101,27 @@ ready() {
 		fi
 		sleep 0.2
 	done
+
+	i=0
+	while curl -fsS "$1/readyz" 2>/dev/null | grep -q '"indexing":true'; do
+		alive "$1" "$2"
+		i=$((i + 1))
+		if [ "$i" -gt 600 ]; then
+			echo "ui-gate: the server on $1 was still reading its corpus after two minutes" >&2
+			exit 1
+		fi
+		sleep 0.2
+	done
+}
+
+# alive fails the gate if the process being waited for has gone. Waiting the
+# full timeout for a server that exited a second in reports a timeout, and a
+# timeout is the one failure nobody reads the logs for.
+alive() {
+	if ! kill -0 "$2" 2>/dev/null; then
+		echo "ui-gate: the server on $1 exited before it was ready" >&2
+		exit 1
+	fi
 }
 
 # The repository holds no images, so the grid and the thumbnail endpoint would

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -112,6 +112,9 @@ ready() {
 		fi
 		sleep 0.2
 	done
+	# A server that died mid read stops matching too, and the loop above cannot
+	# tell that apart from one that finished.
+	alive "$1" "$2"
 }
 
 # alive fails the gate if the process being waited for has gone. Waiting the

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -123,9 +123,10 @@ time {
 .app {
   display: grid;
   grid-template-columns: var(--rail-width) minmax(0, 1fr);
-  /* Three rows, and the middle one is the connection banner. It is auto rather
-     than a fixed height so that it takes no space at all when it is hidden,
-     which is almost always. */
+  /* Three rows, and the middle one is the banner that says the connection is
+     gone or a source is still being read. It is auto rather than a fixed height
+     so that it takes no space at all when it is hidden, which is almost
+     always. */
   grid-template-rows: var(--header-height) auto minmax(0, 1fr);
   grid-template-areas:
     "rail header"
@@ -2342,6 +2343,37 @@ h6.prose__h {
   border-radius: var(--radius-full);
   background: var(--warning-600);
   flex: none;
+}
+
+/* Indexing is a working state rather than a wrong one, so the dot is the
+   informational colour and not the warning colour. Being offline is the one
+   worth a warning. */
+.banner[data-state="indexing"] .banner__dot {
+  background: var(--info-600);
+}
+
+.banner__what {
+  color: var(--text-primary);
+  font-weight: var(--weight-semibold);
+}
+
+/* Tabular figures because this number is rewritten every couple of seconds, and
+   proportional ones make the whole line twitch each time a 1 becomes a 4. */
+.banner__count {
+  font-variant-numeric: tabular-nums;
+}
+
+/* The sentence that says what the numbers mean for the page underneath. It is
+   the first thing to go when the row runs out of width, because the two numbers
+   beside it already imply it and a wrapped banner pushes the content down. */
+.banner__why {
+  margin-left: auto;
+}
+
+@media (max-width: 640px) {
+  .banner__why {
+    display: none;
+  }
 }
 
 .progress {

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -11,7 +11,7 @@ import { cache } from "genba/cache.js";
 import { Live } from "genba/live.js";
 import { copies, copy } from "genba/clipboard.js";
 import * as urlState from "genba/state.js";
-import { icon, initials, label, number, sourceColor, when } from "genba/format.js";
+import { icon, initials, label, number, roughly, sourceColor, when } from "genba/format.js";
 import { Omnibox } from "genba/omnibox.js";
 import { CHORD, CHORD_TIMEOUT, SHORTCUTS, arms, binding, keysOf } from "genba/keys.js";
 import { apply as applyPrefs, density, setDensity, setTheme } from "genba/prefs.js";
@@ -157,7 +157,12 @@ class App {
       "aria-atomic": "true",
     });
 
+    // One banner, two things that can put something in it. Being offline and a
+    // source still being read are unrelated and can both be true, and there is
+    // one row above the content for either of them to say so in.
     this.banner = h("div", { class: "banner", role: "status", hidden: true });
+    this.offline = false;
+    this.indexing = null;
 
     this.rail = this.buildRail();
     this.header = this.buildHeader();
@@ -525,6 +530,7 @@ class App {
 
   /** sync renders whatever the URL currently says. */
   sync() {
+    this.askWhatIsLeft();
     // Three routes: a document and the recent list by path, and everything else
     // by query string. A document is the only screen somebody links to from
     // outside the product, which is why it is the only one with an address that
@@ -800,25 +806,86 @@ class App {
    * more useful page than an error.
    */
   connection(online) {
-    this.banner.hidden = online;
+    this.offline = !online;
     clearInterval(this.bannerTimer);
+    this.showBanner();
     if (online) return;
-    this.sayHowOld();
-    // The age is the whole point of the banner, so it keeps counting. A tab
-    // left open through a long outage would otherwise still claim its results
-    // are six seconds old.
-    this.bannerTimer = setInterval(() => this.sayHowOld(), BANNER_TICK);
+    // The age is the whole point of the offline banner, so it keeps counting. A
+    // tab left open through a long outage would otherwise still claim its
+    // results are six seconds old.
+    this.bannerTimer = setInterval(() => this.showBanner(), BANNER_TICK);
   }
 
-  /** sayHowOld writes the offline banner, naming the age of what is on screen. */
-  sayHowOld() {
-    const held = this.currentKey ? cache.read(this.currentKey) : { state: "miss" };
-    const age = held.state === "miss" ? "" : when(new Date(held.at).toISOString());
-    replace(
-      this.banner,
-      h("span", { class: "banner__dot" }),
-      age ? `You are offline. These are the results from ${age}.` : "You are offline. This is the last answer the server gave.",
-    );
+  /**
+   * askWhatIsLeft finds out whether the server is still reading a source.
+   *
+   * It costs nothing that was not already being spent. Every write to the index
+   * is an event on the stream this page is already holding, a sync writes one
+   * per batch, and each of those already brings the page here to check itself
+   * against the server. So the count on the banner climbs on the server's own
+   * schedule and there is no timer behind it.
+   */
+  async askWhatIsLeft() {
+    try {
+      const stats = await cache.swr(cache.key("stats", {}), (opts) => api.stats(opts), () => {});
+      // Both numbers or nothing. A sync the server has not finished counting
+      // reports a total of zero, and a banner reading "0 of about 0" is worse
+      // than no banner: it is a sentence that makes somebody doubt the page
+      // rather than the index.
+      const running = stats && stats.indexing;
+      const now = running && running.total > 0 ? running : null;
+      // Compared rather than assigned, because this runs on every refresh and
+      // the banner is on every screen. Rebuilding an unchanged one would move
+      // it under a screen reader that is in the middle of reading it.
+      if (same(this.indexing, now)) return;
+      this.indexing = now;
+      this.showBanner();
+    } catch {
+      // Nothing. A stats request that failed says nothing about whether a sync
+      // is running, and the honest answer to not knowing is to leave the banner
+      // exactly as it was.
+    }
+  }
+
+  /**
+   * showBanner writes the one banner there is.
+   *
+   * Two things can be true at once and only one line fits, so being offline
+   * wins. Results that are partial because a sync is running are still the
+   * server's current answer, and results from before the connection dropped are
+   * not, which makes the second the larger caveat.
+   */
+  showBanner() {
+    if (this.offline) {
+      const held = this.currentKey ? cache.read(this.currentKey) : { state: "miss" };
+      const age = held.state === "miss" ? "" : when(new Date(held.at).toISOString());
+      this.banner.hidden = false;
+      this.banner.dataset.state = "offline";
+      replace(
+        this.banner,
+        h("span", { class: "banner__dot" }),
+        age ? `You are offline. These are the results from ${age}.` : "You are offline. This is the last answer the server gave.",
+      );
+      return;
+    }
+    if (this.indexing) {
+      const { source, done, total } = this.indexing;
+      this.banner.hidden = false;
+      this.banner.dataset.state = "indexing";
+      replace(
+        this.banner,
+        h("span", { class: "banner__dot" }),
+        h("span", { class: "banner__what" }, `Indexing ${label(source)}`),
+        h("span", { class: "banner__count" }, `${number(done)} of about ${roughly(total)}`),
+        h("span", { class: "banner__why" }, "Results are partial until this finishes."),
+      );
+      return;
+    }
+    // Emptied as well as hidden, so that the row it sits in reserves nothing
+    // and the grid is the height it would be if this element were not here.
+    this.banner.hidden = true;
+    delete this.banner.dataset.state;
+    replace(this.banner);
   }
 
   /**
@@ -1200,6 +1267,17 @@ function countIn(kinds, vertical) {
   return (kinds || [])
     .filter((k) => vertical.kinds.includes(k.value))
     .reduce((n, k) => n + k.count, 0);
+}
+
+/**
+ * same compares two indexing reports, either of which may be nothing.
+ *
+ * It is three fields written out rather than a stringify, because the second
+ * one would compare key order as well and the server is free to change that.
+ */
+function same(a, b) {
+  if (!a || !b) return !a && !b;
+  return a.source === b.source && a.done === b.done && a.total === b.total;
 }
 
 // Theme before first paint, so a dark theme does not arrive as a white flash.

--- a/web/dist/assets/format.js
+++ b/web/dist/assets/format.js
@@ -224,6 +224,22 @@ export function number(n) {
   return NUMBER.format(n || 0);
 }
 
+/**
+ * roughly renders an estimate as an estimate.
+ *
+ * A count of a tree that is still being walked is not exact and printing it to
+ * the unit says it is. Twenty two thousand two hundred and thirty five is a
+ * claim about a number nobody counted; twenty two thousand is the same
+ * information without the claim, and it is what somebody reads off the line
+ * anyway.
+ */
+export function roughly(n) {
+  const size = Number(n) || 0;
+  if (size < 100) return number(size);
+  const step = size < 1000 ? 10 : size < 10000 ? 100 : 1000;
+  return number(Math.round(size / step) * step);
+}
+
 /** duration renders the server's own timing, rounded to something readable. */
 export function duration(ms) {
   if (ms === undefined || ms === null) return "";


### PR DESCRIPTION
Closes #136.

`08_states.md` lists ten states worth designing and #110 built nine of them.
The tenth is the one on screen for the first ninety seconds of every install, and it could not be built, because the thing it describes was not happening.

## The server did not answer before the corpus was read

The issue opens with "the server binds its port and starts answering before the corpus has been read".
It did not.
`ingestCorpus` ran the whole first sync in front of `ListenAndServe`, and has done since #48, so a server pointed at a corpus refused connections until the walk was over.
On the corpus in `01_reality.md` that is a minute and a half of connection refused, which a load balancer reads as a failed deploy and a person reads as a hang.

Building a banner for a state the binary could not be in would have been building a banner nobody ever sees, so the first half of this is making that sentence true.

Every feed still starts where it started, in front of the listener.
Everything that can be wrong with a flag is checked there, so a bad corpus directory or a bucket with no credentials is still an error the process exits on rather than a warning it logs ninety seconds later.
What moved behind the listener is the reading.

## What is on the wire

Two answers, split along the line #133 drew.

```
GET /api/v1/stats
{"documents": 4182, "indexing": {"source": "notes", "done": 4182, "total": 22235}}

GET /readyz
{"status": "ready", "indexing": true}
```

How large somebody's corpus is and what their sources are called go to a caller who authenticated.
Whether to wait goes to whoever can reach the port, because the thing that needs to know is a readiness probe and it carries no credential.
There is a test that the source name and the total do not appear in the unauthenticated answer.

`indexing` is absent rather than zeroed when nothing is being read, so the interface renders on the key being there and never compares two numbers to work out whether a sync is running.

The count comes from `connector.Enumerator`, which #131 added for the reconciler and which walks a source without reading it.
The pipeline reports progress once per flush rather than once per document, so a long sync does not pay a lock per file.

## What is on screen

```
Indexing Library    7,000 of about 9,600    Results are partial until this finishes.
```

That is a real one, from a server reading `/usr/share` on server2.

It is the element the offline banner already uses, so it appears above whatever is on screen without moving the layout, and it reserves no space when it is false: hidden and emptied, not hidden and full.
Nothing is disabled while it is up.
A partial index still answers most questions and locking somebody out of their own data while a machine catches up is the wrong trade.

Two things can be true at once and one line fits, so being offline wins.
Results that are partial because a read is running are still the server's current answer, and results from before the connection dropped are not, which makes the second the larger caveat.

The count climbs on the server's own schedule.
Every batch a sync writes is already an event on the stream the page is holding, and every one of those already brings the page back to check itself against the server, so there is no new timer behind any of this.
An unchanged report does not rebuild the line, which matters for whoever is having it read to them.

The total is rounded.
A tree people are working in grows while it is read, and a banner reading 22,100 of about 22,000 makes the one exact number on it the one nobody believes.

## The rule that keeps it honest

A source is reported only while it is being read for the first time, and whether this is a first time is decided once, at process start, by asking the store whether it holds anything.

Checkpoints are held in memory, so a restart against a SQLite file that already has the whole corpus in it re-reads the tree from a zero cursor.
Nothing is missing from the index while that runs.
Gating on the cursor being zero would have put the banner up on every restart of every server that persists its index, and a caveat that is wrong twice is one nobody reads on the day it is true.

A read the server has not finished counting reports a total of zero.
The probe is told to keep waiting and the interface shows nothing, because "0 of about 0" is a sentence that makes somebody doubt the page rather than the index.

## Tests

`api/indexing_test.go` covers the two responses and the leak.
`ingest/progress_test.go` covers the reports a run makes while it is still going.
`cmd/genbad/indexing_test.go` covers the rules above, including the restart over a full index and the source that overshot its own count.
`cmd/genbad/first_read_test.go` starts the real binary over two thousand files and asserts that it answers, and says so, before it has read them.

The states check drives the banner in a browser: a read that has not been counted, a read that has, the same report twice, offline winning it, the connection coming back, and the banner leaving nothing behind when the corpus is read.
It answers the stats endpoint itself for those six rather than racing a real crawl, because racing one makes every other count in the gate depend on how far the read had got.

`ready()` in the gate waits for the read now rather than for the port, for the same reason.

## Run

`go test ./...` on server3, which passes apart from `TestALostRecordMakesTheNextSyncWalk` in `fssource`, a ten second deadline on a box carrying a load average of fifty.
Every file in `connector/` on this branch is the same as on `main`, so whatever that is, it is not this.

`scripts/ui-gate.sh` on server2: 108 checks, axe over ten screens with no violations, Lighthouse accessibility 99 and best practices 100.

Two numbers from that run are worth writing down rather than burying.
The latency report is at a p50 of 3.2 seconds against a budget of 10ms, on a corpus of 325 documents, and the Lighthouse performance score is 49.
Neither is this branch, both are #55, and they are the largest numbers in the product.
A banner that says the answers are partial is worth much less on a screen that takes three seconds to produce one at all.
