### PR TITLE
Measure the driver a deployment runs on

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -850,6 +850,21 @@ type statsResponse struct {
 	Driver    string `json:"driver,omitempty"`
 	IndexedAt string `json:"indexed_at,omitempty"`
 
+	// Ranking reports whether the driver cuts to a candidate pool for itself, or
+	// is walked document by document with the ranking done above it.
+	//
+	// It is the difference between a search whose cost follows the page and one
+	// whose cost follows the corpus, and on the same few hundred documents it
+	// measured as seventeen milliseconds against two seconds. That is far too
+	// large a gap to leave somebody to infer from a latency graph, and it is not
+	// a gap anybody guesses at: both drivers answer the same queries with the
+	// same results, so the only thing that gives it away is the clock.
+	//
+	// It is always present rather than omitted when false, because false is the
+	// case worth knowing about and a key that disappears is one nobody checks
+	// for.
+	Ranking bool `json:"ranking"`
+
 	// Indexing is the source being read for the first time, and is absent when
 	// nothing is, which is the ordinary case.
 	//
@@ -889,6 +904,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request, _ *acl.Prin
 		Cache:       s.cacheStats(),
 		Driver:      s.driver,
 		IndexedAt:   s.indexedAt(),
+		Ranking:     s.searcher.Ranking(),
 		Indexing:    indexing,
 	})
 }

--- a/api/settings_test.go
+++ b/api/settings_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/index"
 	"github.com/tamnd/genba/store/memstore"
+	"github.com/tamnd/genba/store/sqlitestore"
 )
 
 // The facts the settings screen prints about the deployment. They are asserted
@@ -34,6 +35,37 @@ func newNamedServer(t *testing.T, driver string, now func() time.Time) (http.Han
 type statsBody struct {
 	Driver    string `json:"driver"`
 	IndexedAt string `json:"indexed_at"`
+	Ranking   bool   `json:"ranking"`
+}
+
+// Which of the two query paths this deployment is on.
+//
+// The two answer the same queries with the same results and differ only in the
+// clock, by a factor of a hundred on a few hundred documents, so nothing except
+// this says which one somebody got. The performance gate was pointed at the
+// scanning driver for months and printed a real number for a deployment nobody
+// has, which is the failure this exists to make impossible.
+func TestStatsSayWhetherTheDriverRanksForItself(t *testing.T) {
+	h, _ := newNamedServer(t, "memory", nil)
+	w := request(t, h, http.MethodGet, "/api/v1/stats", engineer())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if decode[statsBody](t, w).Ranking {
+		t.Error("the reference driver reports that it ranks in the driver")
+	}
+
+	sq, err := sqlitestore.Open(t.Context(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sq.Close() })
+
+	s := api.New(sq, index.New(sq), api.HeaderAuth{Tenant: "acme"}, api.WithDriver("sqlite"))
+	w = request(t, s.Handler(), http.MethodGet, "/api/v1/stats", engineer())
+	if !decode[statsBody](t, w).Ranking {
+		t.Error("the sqlite driver reports that it is scanned")
+	}
 }
 
 func TestStatsNameTheStoreThisProcessWasStartedWith(t *testing.T) {

--- a/scripts/latency-report.mjs
+++ b/scripts/latency-report.mjs
@@ -5,6 +5,16 @@
 // and measures the cache, and the number worth watching is what somebody gets
 // when they type something nobody has typed before.
 //
+// It asks the server what it is running on before it times anything, and stops
+// if the answer is a driver with no index of its own. A driver like that is
+// walked document by document with the ranking done above it, and on the same
+// few hundred documents that measured at a p50 of 1.8 seconds against 17
+// milliseconds for SQLite. Timing it produces a real number for a deployment
+// nobody has, printed next to a budget it was never going to meet, and it is
+// read as the product being slow. That happened, and it went unnoticed for as
+// long as it did because the number arrived every run and looked like a
+// measurement.
+//
 // It prints and it does not fail, until #55 lands and the query stops being
 // linear in the size of the match set. It prints anyway, because a number
 // nobody prints is a number nobody watches, and that is exactly how a fifth of
@@ -77,6 +87,30 @@ const headers = {
   "X-Genba-Subject": "dev@example.com",
   "X-Genba-Groups": "everyone",
 };
+
+// What is being measured, asked before anything is timed. A failure to answer
+// is not fatal, because an embedder that named no driver is entitled to report
+// nothing and this report is not the place to insist on it.
+let driver = "";
+let ranking = true;
+try {
+  const res = await fetch(`${BASE}/api/v1/stats`, { headers });
+  if (res.ok) {
+    const body = await res.json();
+    driver = body.driver || "";
+    ranking = body.ranking !== false;
+  }
+} catch {
+  // Left as it was. The queries below fail on their own if the server is gone.
+}
+console.log(`latency-report: driver ${driver || "unnamed"}, ranking ${ranking ? "yes" : "no"}`);
+if (!ranking) {
+  console.error(
+    `latency-report: ${driver || "this driver"} has no index of its own, so it is walked per query and there is no latency here worth reporting`,
+  );
+  console.error(`latency-report: point the gate at sqlite or postgres`);
+  process.exit(1);
+}
 
 const timings = [];
 let empty = 0;

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -42,6 +42,9 @@ TENANT=demo
 LIGHTHOUSE_MIN=${LIGHTHOUSE_MIN:-95}
 SERVER=
 BLANK=
+# Where the two databases go. The gate runs on the driver a deployment runs on,
+# not on the reference one: see the comment above the servers below.
+STATE=$(mktemp -d -t genba-ui-gate.XXXXXX)
 # Where the pictures go. It is inside the corpus because the corpus is this
 # directory, it is gitignored, and it is not a dotted name because the file
 # connector skips anything that starts with a dot and would index none of it.
@@ -52,7 +55,7 @@ cleanup() {
 		kill "$pid" 2>/dev/null || true
 		wait "$pid" 2>/dev/null || true
 	done
-	rm -rf "$IMAGES"
+	rm -rf "$IMAGES" "$STATE"
 }
 trap cleanup EXIT INT TERM
 
@@ -135,13 +138,24 @@ node scripts/gate-images.mjs "$IMAGES" 24
 # The corpus is this repository. It is a few hundred documents of real prose and
 # code, which is enough for a results page with snippets, facets and a drawer,
 # and it needs nothing downloaded.
-"$BIN" -addr "127.0.0.1:$PORT" -store memory -tenant "$TENANT" -corpus . -corpus-name repo -log-level error &
+#
+# On SQLite, which is the point. The memory driver is the reference one: it has
+# no index of its own, so it is walked document by document and the ranking
+# happens above it, re-running the analyzer over every matching body. On this
+# same corpus, on the same machine, in the same minute, that measured at a p50
+# of 1.8 seconds against 17 milliseconds for SQLite. Every latency number this
+# gate has ever printed was a number for a driver nobody deploys, which is worse
+# than printing none: it read as the product being two hundred times over its
+# budget, and the budget was never being watched on the path anybody is on.
+"$BIN" -addr "127.0.0.1:$PORT" -store sqlite -dsn "$STATE/corpus.db" \
+	-tenant "$TENANT" -corpus . -corpus-name repo -log-level error &
 SERVER=$!
 
 # The same binary with nothing to index. It is one more process rather than a
 # fixture because the empty state is what the interface does with an answer of
 # no documents, and an answer of no documents has to come from the server.
-"$BIN" -addr "127.0.0.1:$EMPTY_PORT" -store memory -tenant "$TENANT" -log-level error &
+"$BIN" -addr "127.0.0.1:$EMPTY_PORT" -store sqlite -dsn "$STATE/empty.db" \
+	-tenant "$TENANT" -log-level error &
 BLANK=$!
 
 ready "$BASE" "$SERVER"

--- a/web/dist/assets/settings.js
+++ b/web/dist/assets/settings.js
@@ -231,6 +231,11 @@ export class Settings {
         ["Commit", health.commit],
         ["Built", health.built === "unknown" ? "" : exact(health.built) || health.built],
         ["Store", stats.driver ? label(stats.driver) : ""],
+        // Which of the two query paths this deployment is on. It is here rather
+        // than left to be inferred from the clock because the two answer the
+        // same queries with the same results, and on a few hundred documents
+        // they are a hundred times apart.
+        ["Queries", this.stats ? (stats.ranking ? "ranked in the store" : "scanned one at a time") : ""],
         ["Documents", this.stats ? number(stats.documents) : ""],
         ["Held back", this.stats ? number(stats.quarantined) : ""],
         ["Last indexed", stats.indexed_at ? when(stats.indexed_at) : "not since this process started"],


### PR DESCRIPTION
Closes #138.

The interface gate started its server with `-store memory` and then ran the latency report against it.

The memory driver is the reference one.
It implements neither `store.Ranker` nor `store.Fetcher`, so `index.collect` falls through to its scan branch, walks every document the asker may read and calls `d.Analyze()` on each one, which re-runs the analyzer over full bodies at query time.
That is the right thing for a reference implementation to be, and it is the wrong thing to point a latency budget at.

## What that cost

Measured on server3, one server per driver, same 327 document corpus, same fifty queries, same minute:

| Driver | p50 | p95 | p99 |
| --- | --- | --- | --- |
| memory | 1839.3ms | 4131.7ms | 4445.7ms |
| sqlite | 16.6ms | 79.5ms | 91.5ms |

Three rounds each and the shape held.
So every latency number this gate has printed is out by two orders of magnitude, in the direction that makes the product look broken.
It was quoted that way twice this week, on #55 and on #114, both times as evidence for a diagnosis it cannot support, and both comments are corrected on those issues.

It survived because the number arrived on every run and looked like a measurement.
A missing number gets noticed and a wrong one gets cited.

The Go latency gate, `make bench-gate`, was never affected. It builds its corpus through `benchcorpus.Fixture`, which is SQLite.

## What changed

Both gate servers run on SQLite now, into a temporary directory the existing trap removes.
The empty one moves too, so nothing in the gate runs a driver nobody deploys.

The report asks the server what it is on before it times anything and stops with an error if the driver is scanned, naming what to point it at instead.
A gate that cannot be pointed at the wrong thing is worth more than a comment saying not to.

Nothing said which of the two paths a deployment was on.
Both drivers answer the same queries with the same results, which is what `store/storetest` holds them to, so the only thing that tells them apart is the clock.
`index.Searcher.Ranking()` exists for exactly this, its own comment says so, and it was called nowhere outside a test.
It is on the stats response now, next to the driver name, on the same authenticated endpoint and for the same reason: what a deployment runs on is not for whoever can reach the port.
It is present when false rather than omitted, because false is the case worth knowing about and a key that disappears is one nobody checks for.

The settings screen prints it as a row, since that is the screen somebody comes to for the truth about their deployment.

```
Store              Sqlite
Queries            ranked in the store
Documents          327
```

and on the reference driver:

```
Store              Memory
Queries            scanned one at a time
```

Both of those are real, read out of the rendered page on server2.

## What the gate says now

The cleanest before and after is CI itself, since it is the same runner and the same fifty queries an hour apart.

```
main, before          p50 303.2ms   p95 555.6ms   p99 578.3ms   budget 10.0ms
this branch           p50   6.5ms   p95  13.4ms   p99  20.6ms   budget 10.0ms
```

with the branch also printing `latency-report: driver sqlite, ranking yes` in front of it.

A factor of forty six at p50, and the p50 is now inside the budget rather than thirty times over it.
The p95 is thirty four percent over, which is a real gap and is #55, and it is a gap somebody can now reason about.

Lighthouse did not move. It was 99 on performance and 100 on accessibility and best practices on the runner before this change and after it, which is worth saying because I quoted a performance score of 49 on #55 as though it were a product number and it was a loaded server.

On server2, under a load average of thirty with Chrome and axe on the same six cores, the same run reports p50 56.7ms and a Lighthouse performance of 61, against 3185.0ms and 49 before. Read those as the shape rather than the numbers.

Refusing a scanned driver, against a real memory server on server2:

```
latency-report: driver memory, ranking no
latency-report: memory has no index of its own, so it is walked per query and there is no latency here worth reporting
latency-report: point the gate at sqlite or postgres
exit 1
```

## Tests

`api/settings_test.go` covers both answers of `ranking` against the two real drivers, a memstore and a SQLite one, rather than against a double, since what is being asserted is which capabilities a driver actually has.

## Run

`go test ./...` on server3, which passes apart from `TestALostRecordMakesTheNextSyncWalk` in `fssource`, a ten second deadline on a box carrying a load average of thirty. It is the same failure as on #137 and `connector/` is untouched here.

`scripts/ui-gate.sh` on server2: 108 checks, no failures, axe over ten screens with no violations.

`golangci-lint run ./api/...` reports no issues.
