### PR TITLE
Draw the filter rail without ranking five hundred documents

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -585,14 +585,20 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request, p *acl.Princip
 		Sources: []facet{},
 		Kinds:   []facet{},
 	}
-	res, err := s.searcher.Search(r.Context(), p, index.Query{Limit: 1})
+	// The counts and nothing else. This used to run a search with a limit of one,
+	// which is not a cheap search: the candidate pool has a floor, so it asked
+	// the driver for five hundred documents, scored all five hundred, sorted
+	// them, took a page of one and fetched it, and then used none of that. It was
+	// the most expensive endpoint in the product and it is the one that has to
+	// answer before a single pixel can be drawn.
+	facets, err := s.searcher.Filters(r.Context(), p)
 	if err != nil {
 		s.log.Error("bootstrap failed", "error", err, "tenant", p.Tenant)
 		writeError(w, http.StatusInternalServerError, "internal", "the session could not be loaded")
 		return
 	}
-	out.Sources = facetValues(res.Facets["source"])
-	out.Kinds = facetValues(res.Facets["kind"])
+	out.Sources = facetValues(facets["source"])
+	out.Kinds = facetValues(facets["kind"])
 	writeConditional(w, r, http.StatusOK, out, nil)
 }
 

--- a/benchcorpus/BASELINE.md
+++ b/benchcorpus/BASELINE.md
@@ -105,10 +105,23 @@ The candidate cut walks it to find the best five hundred, and the counts stateme
 Timed separately on this corpus, with the C build of SQLite so the driver is out of the picture, the candidate cut is 6ms and the counts statement is 7ms for a match set of three thousand.
 Through the Go driver each is roughly one and a half times that, and the rest of the difference between 13ms and 50ms is the classes with larger match sets that the benchmark averages over.
 
-`BenchmarkAPIMe` is the worst number here and it is the first request the interface makes.
-It runs a search with no terms and no filters, so the match set is every document the reader may see, which is fifteen thousand of the twenty thousand.
-It then throws away everything except the source and kind facet lists, which are the same on every page load and change only when somebody indexes a document.
-That is a cache, and it is the next piece of work.
+`BenchmarkAPIMe` was the worst number here and it is the first request the interface makes.
+The 86.8ms in the table above is what it cost when it ran a search with a limit of one to get two facet lists out of it.
+That is not a small search: the candidate pool has a floor of five hundred, so it asked the driver for five hundred documents, scored all five hundred, sorted them, took a page of one, fetched that one and used none of it.
+
+It now asks for the counts and no candidates, which is #141.
+Measured on the twenty thousand document corpus, eight runs of each on the same loaded machine in the same half hour, taking the minimum because the machine is shared and the minimum is the one least contended for:
+
+| | Time | Bytes | Allocations |
+| --- | --- | --- | --- |
+| through a search | 502ms | 491KB | 10,015 |
+| counts and no candidates | 347ms | 60KB | 1,038 |
+
+The times are that machine and not this table's laptop, so read the ratio and not the number.
+At the driver, again minimum of three, the same selection with the pool costs 846ms and without it 316ms.
+
+What is left on this path is a count over every visible document that nobody reads, and four facet groupings where two are used.
+Both are smaller than what was removed and neither is free.
 
 ## What is not met yet
 

--- a/index/driver_test.go
+++ b/index/driver_test.go
@@ -27,7 +27,10 @@ import (
 // written at index time that disagrees with what the tokenizer produces now
 // moves every score that document is compared against.
 
-func TestDriversAgree(t *testing.T) {
+// searchers is the same corpus behind both paths, with the capability checks
+// that say each searcher is still on the path it is here to cover.
+func searchers(t *testing.T) (scanning, retrieving *index.Searcher) {
+	t.Helper()
 	mem := memstore.New()
 	t.Cleanup(func() { _ = mem.Close() })
 
@@ -54,14 +57,19 @@ func TestDriversAgree(t *testing.T) {
 		}
 	}
 
-	scanning := index.New(mem, index.WithClock(clock))
-	retrieving := index.New(sq, index.WithClock(clock))
+	scanning = index.New(mem, index.WithClock(clock))
+	retrieving = index.New(sq, index.WithClock(clock))
 	if scanning.Ranking() {
 		t.Fatal("the memstore searcher reports that it ranks in the driver")
 	}
 	if !retrieving.Ranking() {
 		t.Fatal("the sqlite searcher reports that it scans")
 	}
+	return scanning, retrieving
+}
+
+func TestDriversAgree(t *testing.T) {
+	scanning, retrieving := searchers(t)
 
 	p := &acl.Principal{
 		Tenant:  "acme",
@@ -140,6 +148,40 @@ func TestDriversAgree(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The filter rail is the same rail whichever driver drew it, and it is the same
+// rail a search would have drawn.
+//
+// It used to be drawn from a search with a limit of one, which is where the
+// counts came from and is why they were right. Now it is drawn from a selection
+// that asks for the counts and no candidates, so the thing worth asserting is
+// that nothing moved: the values, the counts and the order are what the search
+// reports, on the driver that counts in SQL and on the one that counts in Go.
+func TestFiltersMatchWhatASearchWouldHaveCounted(t *testing.T) {
+	scanning, retrieving := searchers(t)
+
+	for _, who := range []*acl.Principal{
+		{Tenant: "acme", Subject: "u_mei", Groups: acl.GroupSet{Version: 1, Members: []string{"gdrive:eng@acme.com"}}},
+		{Tenant: "acme", Subject: "u_nobody", Groups: acl.GroupSet{Version: 1}},
+	} {
+		for name, s := range map[string]*index.Searcher{"memstore": scanning, "sqlite": retrieving} {
+			res, err := s.Search(t.Context(), who, index.Query{Limit: 1})
+			if err != nil {
+				t.Fatalf("%s Search: %v", name, err)
+			}
+			got, err := s.Filters(t.Context(), who)
+			if err != nil {
+				t.Fatalf("%s Filters: %v", name, err)
+			}
+			for _, field := range []string{"source", "kind", "container", "author"} {
+				if !slices.Equal(got[field], res.Facets[field]) {
+					t.Errorf("%s %s filters for %s = %v, a search counted %v",
+						name, field, who.Subject, got[field], res.Facets[field])
+				}
+			}
+		}
 	}
 }
 

--- a/index/index.go
+++ b/index/index.go
@@ -465,6 +465,38 @@ func (s *Searcher) Recent(ctx context.Context, p *acl.Principal, limit int) ([]d
 	return out, nil
 }
 
+// Filters is what a filter rail is drawn from: every facet value the principal
+// can see, and how many documents carry each.
+//
+// It is a separate method rather than a search with a tiny limit because the
+// candidate pool has a floor. Asking for one result asks the driver for five
+// hundred, which are then scored, sorted, paged and thrown away unread, and that
+// is what the first request of every session did. It made the endpoint that has
+// to answer before anything can be drawn the most expensive one in the product,
+// more expensive than a real search, for two lists that are the same on every
+// page load.
+//
+// It is also not a special case inside Search, because a search that returns no
+// results is a different thing from a request for the counts, and folding the
+// two together is how a limit of zero comes to mean whichever of them the reader
+// guesses.
+//
+// The counts are bounded by [FacetPool], which is the same bound a search puts
+// on its sidebar and the same one this endpoint was already getting when it went
+// through Search. Counting them exactly is a read of four columns of every
+// document the principal can see, and it was measured: on twenty thousand
+// documents the exact count costs more than the five hundred candidates removing
+// it saved, so a change made to take work off this path would have put more
+// back. What the bound costs is that the rail's numbers are lower bounds on a
+// corpus larger than the pool, which is #142.
+func (s *Searcher) Filters(ctx context.Context, p *acl.Principal) (map[string][]Facet, error) {
+	found, err := s.collect(ctx, p, store.Request{}, store.Selection{Counts: true, Facets: FacetPool})
+	if err != nil {
+		return nil, err
+	}
+	return found.facets, nil
+}
+
 // fetch reads the documents behind one page.
 //
 // A driver that can do it in one statement is asked to. One that cannot is

--- a/index/score.go
+++ b/index/score.go
@@ -150,10 +150,11 @@ func (s *Searcher) collect(ctx context.Context, p *acl.Principal, r store.Reques
 	// See [store.Request.Without].
 	base := r.WithoutFacets()
 	var (
-		out    pool
-		seen   []store.Candidate
-		counts = newDrill(r)
-		walked int
+		out     pool
+		seen    []store.Candidate
+		matched int
+		counts  = newDrill(r)
+		walked  int
 	)
 	take := func(d doc.Document) bool {
 		// The cap is on the walk rather than on the match set, because the walk
@@ -164,7 +165,15 @@ func (s *Searcher) collect(ctx context.Context, p *acl.Principal, r store.Reques
 			return false
 		}
 		walked++
-		if counts.add(d) {
+		if !counts.add(d) {
+			return true
+		}
+		matched++
+		// A selection that asked for no candidates is asking what the counts are,
+		// and the counting is done by the line above. What is skipped here is
+		// re-analysing the document, which is this path's whole cost and is the
+		// same work the drivers skip when they do not run the candidate statement.
+		if sel.Limit > 0 {
 			seen = append(seen, candidateOf(d, r.Terms))
 		}
 		return true
@@ -193,7 +202,7 @@ func (s *Searcher) collect(ctx context.Context, p *acl.Principal, r store.Reques
 	// score that has not been computed yet, so the pool is trimmed after
 	// scoring instead: see [Searcher.Search].
 	out.cands = seen
-	out.total = len(seen)
+	out.total = matched
 	out.facets = counts.facets()
 	// Exact, unless [MaxMatches] stopped the walk, in which case the counts are
 	// over what was walked and are a lower bound like a driver's bounded ones.

--- a/store/pgstore/rank.go
+++ b/store/pgstore/rank.go
@@ -37,8 +37,8 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 	if p == nil {
 		return store.Ranked{}, genba.ErrNoPrincipal
 	}
-	if sel.Limit <= 0 {
-		return store.Ranked{}, errors.New("pgstore: rank: no candidate limit")
+	if sel.Limit <= 0 && !sel.Counts {
+		return store.Ranked{}, errors.New("pgstore: rank: asked for neither candidates nor counts")
 	}
 
 	// The predicate for a request, built the same way whatever is being asked
@@ -80,9 +80,15 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 
 	out := store.Ranked{}
 	err := s.retry(ctx, func(ctx context.Context) error {
-		cands, err := s.candidates(ctx, c, order, orderArgs, sel.Limit)
-		if err != nil {
-			return err
+		// A selection that asked for no pool skips both of the statements that
+		// read the match set row by row. What is left is the counting, which is
+		// what it asked for.
+		var cands []store.Candidate
+		if sel.Limit > 0 {
+			var err error
+			if cands, err = s.candidates(ctx, c, order, orderArgs, sel.Limit); err != nil {
+				return err
+			}
 		}
 		if len(cands) > 0 && len(r.Terms) > 0 {
 			if err := s.frequencies(ctx, cands, r.Terms); err != nil {
@@ -113,7 +119,7 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 			// count has no total to be compared against, so stopped carries the
 			// same claim for those.
 			Approximate: counted < total || stopped,
-			Truncated:   total > len(cands),
+			Truncated:   sel.Limit > 0 && total > len(cands),
 		}
 		return nil
 	})

--- a/store/rank.go
+++ b/store/rank.go
@@ -29,6 +29,14 @@ type Selection struct {
 	// Limit is the size of the candidate pool. A driver returns at most this
 	// many candidates, and when it is also asked for the counts it counts the
 	// whole match set.
+	//
+	// Zero asks for no candidates at all, which is only legal alongside Counts.
+	// That is the filter rail on its own: how many documents there are of each
+	// source and each kind, with no page under it and nothing to rank. It has to
+	// be sayable because the pool has a floor, so a caller that wants the counts
+	// and no results cannot ask for them by requesting a small page. It ends up
+	// requesting five hundred documents, scoring all of them and reading none,
+	// which is what the first request of every session used to do.
 	Limit int
 
 	// Recent asks for the most recently modified rather than the best matching.
@@ -83,7 +91,9 @@ type Ranked struct {
 	// Truncated reports that the match set was larger than the pool, so the
 	// ranking is over candidates rather than over everything. A caller is
 	// entitled to know which of the two it got. Without the counts there is
-	// nothing to compare the pool against, so it is false.
+	// nothing to compare the pool against, so it is false, and so is it for a
+	// selection that asked for no pool: there is no ranking for it to be a claim
+	// about, and a total next to an empty page would otherwise always report one.
 	Truncated bool
 
 	// Facets are counted over the match set rather than over the page, which is

--- a/store/sqlitestore/rank.go
+++ b/store/sqlitestore/rank.go
@@ -35,8 +35,8 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 	if p == nil {
 		return store.Ranked{}, genba.ErrNoPrincipal
 	}
-	if sel.Limit <= 0 {
-		return store.Ranked{}, errors.New("sqlitestore: rank: no candidate limit")
+	if sel.Limit <= 0 && !sel.Counts {
+		return store.Ranked{}, errors.New("sqlitestore: rank: asked for neither candidates nor counts")
 	}
 
 	// The predicate for a request, built the same way whatever is being asked
@@ -91,11 +91,21 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 		}
 	}
 
-	cands, rowids, err := s.candidates(ctx, from, c, order, sel.Limit)
-	if err != nil {
-		return store.Ranked{}, err
+	// A selection that asked for no pool skips both of the statements that read
+	// the match set row by row. What is left is the counting, which is what it
+	// asked for.
+	var (
+		cands  []store.Candidate
+		rowids []int64
+		err    error
+	)
+	if sel.Limit > 0 {
+		cands, rowids, err = s.candidates(ctx, from, c, order, sel.Limit)
+		if err != nil {
+			return store.Ranked{}, err
+		}
+		s.counters.candidates.Add(int64(len(cands)))
 	}
-	s.counters.candidates.Add(int64(len(cands)))
 
 	out := store.Ranked{Candidates: cands}
 	if len(cands) > 0 && len(r.Terms) > 0 {
@@ -121,7 +131,7 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 	// thing that knows whether it did. A lifted count has no total to be compared
 	// against, so stopped carries the same claim for those.
 	out.Approximate = counted < out.Total || stopped
-	out.Truncated = out.Total > len(cands)
+	out.Truncated = sel.Limit > 0 && out.Total > len(cands)
 	return out, nil
 }
 

--- a/store/storetest/rank.go
+++ b/store/storetest/rank.go
@@ -47,6 +47,7 @@ var rankCases = []rankCase{
 	{"a facet count lifts its own filter and applies the others", testRankDrillDown},
 	{"a facet bound counts a sample and says the counts are a lower bound", testRankFacetBound},
 	{"a selection with no counts ranks the same documents", testRankWithoutCounts},
+	{"a selection with no candidates counts the same documents", testRankCountsWithoutCandidates},
 	{"the principal is applied inside rank", testRankPermission},
 	{"a nil principal ranks nothing", testRankNilPrincipal},
 	{"a candidate carries the token counts the analyzer produces", testRankTokens},
@@ -393,6 +394,42 @@ func testRankWithoutCounts(t *testing.T, s store.Store) {
 			if len(values) != 0 {
 				t.Fatalf("the %s facet was counted for a selection that asked for no counts: %v", field, values)
 			}
+		}
+	}
+}
+
+// A selection that asks for no candidates gets the counts and nothing else, and
+// they are the same counts a selection with a pool would have produced.
+//
+// This is what the filter rail is drawn from, and it is the first request of
+// every session. It used to be a search with a limit of one, which asked for
+// five hundred candidates because the pool has a floor and then read none of
+// them, so it was the most expensive endpoint in the product. What matters here
+// is that the cheap answer is the same answer: a driver that counted a different
+// set when it stopped fetching rows would draw a rail nobody can reconcile with
+// the results they get from ticking it.
+func testRankCountsWithoutCandidates(t *testing.T, s store.Store) {
+	rk := ranker(t, s)
+	mustPut(t, s, corpus()...)
+
+	for _, r := range []store.Request{{}, {Terms: []string{"payments"}}, {Sources: []string{"gdrive"}}} {
+		full := mustRank(t, rk, reader(), r, pool())
+		bare := mustRank(t, rk, reader(), r, store.Selection{Counts: true})
+
+		if len(bare.Candidates) != 0 {
+			t.Fatalf("a selection that asked for no candidates got %d of them for %+v", len(bare.Candidates), r)
+		}
+		if bare.Total != full.Total {
+			t.Fatalf("Total = %d without a pool and %d with one, for %+v", bare.Total, full.Total, r)
+		}
+		// There is no ranking to be a claim about, and the pool it would be
+		// compared against is empty, so a driver reporting one would be telling
+		// every caller of this that its results are partial.
+		if bare.Truncated {
+			t.Fatalf("Truncated is set for a selection that asked for no candidates, for %+v", r)
+		}
+		if got, want := gotFacets(t, bare), gotFacets(t, full); !maps.EqualFunc(got, want, maps.Equal) {
+			t.Fatalf("facets without a pool are %v for %+v, and with one they are %v", got, r, want)
 		}
 	}
 }


### PR DESCRIPTION
Closes #141.

`GET /api/v1/me` is the first request the interface makes and nothing can be drawn until it answers.
It returns who the caller is and the source and kind lists the filter rail is built from, and it got those lists by running a search with a limit of one.

That is not a small search.
The candidate pool has a floor of five hundred, so a limit of one asks the driver for five hundred candidate rows, scores all five hundred, sorts them, takes a page of one, fetches that document and then uses none of it.
It made the endpoint that has to answer before a single pixel appears the most expensive one in the product, more expensive than a real search.

## What changed

A selection can now ask for the counts and no candidates.
`Limit` of zero was an error and is legal alongside `Counts`, so the rule is that a selection has to ask for one of the two rather than that it has to ask for candidates.

Both drivers skip the candidate statement and the frequency statement that follows it.
The scan fallback skips re-analysing each matching document, which is the same work in the same place, and still counts.

`Searcher.Filters` is the caller.
It is a method rather than a special case inside `Search` because a search that returns no results is a different thing from a request for the counts, and folding the two together is how a limit of zero ends up meaning whichever of them the reader guesses.

## Measurements

Twenty thousand document corpus, eight runs of each on the same machine in the same half hour.
The minimum is taken because the machine is shared and the minimum is the run least contended for.
The times are that machine and not the laptop the checked in baseline is from, so read the ratio and not the number.

| | Time | Bytes | Allocations |
| --- | --- | --- | --- |
| through a search | 502ms | 491KB | 10,015 |
| counts and no candidates | 347ms | 60KB | 1,038 |

At the driver, minimum of three, the same selection with the pool costs 846ms and without it 316ms.

## The bound stayed where it was

The first version of this asked for exact facet counts, since a rail is meant to say how much of something there is.
It made the endpoint slower.
Counting them exactly is a read of four columns of every visible document, and it measured at 1,316ms against 316ms for the bounded count, so a change made to take work off this path would have put more back.

So the bound is `FacetPool`, which is what this endpoint was already getting when it went through `Search`.
The counts on the wire are unchanged.
What that costs is that the rail's numbers are lower bounds on a corpus larger than the pool, which is not new and is now written down as #142 with three options and a recommendation.

## Tests

`RunRanker` gains the case that matters: a selection with no candidates returns the same total and the same facet counts as one with a pool, and no candidates.
A driver that counted a different set when it stopped fetching rows would draw a rail nobody can reconcile with the results ticking it produces.

`TestFiltersMatchWhatASearchWouldHaveCounted` runs both paths through both drivers and requires the four facet lists to be value for value what a search reports, for a principal who can read things and for one who cannot.

## Checked on a real server

The UI gate on server2 is 108 ok and 0 FAIL.
The axe step fails there for an unrelated reason: the chromedriver bundled with axe wants Chrome 152 and the box has 145.

Against a live server on the repo corpus, `/me` answers in 1 to 9ms with `sources` `[{repo, 327}]` and `kinds` `[{code, 285}, {page, 30}, {file, 12}]`, which sums to the 327 documents `/stats` reports.

The pgstore change is not covered locally, since those tests skip without `GENBA_TEST_POSTGRES`. CI runs them.
