### PR TITLE
Stop reading four columns nothing looks at

### DIFF
--- a/index/cache_test.go
+++ b/index/cache_test.go
@@ -68,10 +68,6 @@ func (s *counting) Rank(ctx context.Context, p *acl.Principal, r store.Request, 
 		a := d.Analyze()
 		c := store.Candidate{
 			ID:          d.ID,
-			Source:      d.Source,
-			Kind:        d.Kind,
-			Container:   d.Container,
-			Author:      d.Author.Display(),
 			ModifiedAt:  d.ModifiedAt,
 			TitleTokens: a.TitleTokens,
 			BodyTokens:  a.BodyTokens,

--- a/index/score.go
+++ b/index/score.go
@@ -286,10 +286,6 @@ func candidateOf(d doc.Document, terms []string) store.Candidate {
 	a := d.Analyze()
 	c := store.Candidate{
 		ID:          d.ID,
-		Source:      d.Source,
-		Kind:        d.Kind,
-		Container:   d.Container,
-		Author:      d.Author.Display(),
 		ModifiedAt:  d.ModifiedAt,
 		TitleTokens: a.TitleTokens,
 		BodyTokens:  a.BodyTokens,

--- a/store/pgstore/rank.go
+++ b/store/pgstore/rank.go
@@ -135,8 +135,7 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 func (s *Store) candidates(ctx context.Context, c *clause, order string, orderArgs []any, limit int) ([]store.Candidate, error) {
 	args := append(append(append([]any{}, c.args...), orderArgs...), limit)
 	rows, err := s.query(ctx, `
-		SELECT d.id, d.source, d.kind, d.container, d.author_name, d.modified_at,
-		       d.title_tokens, d.body_tokens
+		SELECT d.id, d.modified_at, d.title_tokens, d.body_tokens
 		FROM document d
 		WHERE `+c.where()+`
 		ORDER BY `+order+`
@@ -150,15 +149,12 @@ func (s *Store) candidates(ctx context.Context, c *clause, order string, orderAr
 	for rows.Next() {
 		var (
 			cand     store.Candidate
-			kind     string
 			modified *int64
 		)
-		if err := rows.Scan(&cand.ID, &cand.Source, &kind, &cand.Container, &cand.Author,
-			&modified, &cand.TitleTokens, &cand.BodyTokens); err != nil {
+		if err := rows.Scan(&cand.ID, &modified, &cand.TitleTokens, &cand.BodyTokens); err != nil {
 			return nil, err
 		}
 		s.counters.rows.Add(1)
-		cand.Kind = doc.Kind(kind)
 		if modified != nil {
 			cand.ModifiedAt = unixNano(*modified)
 		}

--- a/store/rank.go
+++ b/store/rank.go
@@ -121,17 +121,20 @@ type Ranked struct {
 	Approximate bool
 }
 
-// Candidate is what a ranker needs to score a document without reading it.
+// Candidate is what a ranker needs to score a document without reading it, and
+// nothing else.
 //
-// The four strings are the display forms a facet is counted over and a result
-// row is drawn from. They are here rather than decoded out of the document
-// because decoding the document is the cost being removed.
+// It used to carry the source, the kind, the container and the author as well,
+// on the reasoning that a facet is counted over them and a result row is drawn
+// from them. Neither turned out to be true. The facets are counted by the driver
+// in its counting statement, over its own columns, and the fallback counts them
+// in Go from the document. A result row is drawn from the document the page
+// fetch returns, because a row needs a snippet and a snippet needs a body. So
+// the four were selected, scanned and allocated for five hundred rows on every
+// search, read by nothing and asserted by nothing, which meant a driver could
+// have returned the wrong author for every candidate and passed conformance.
 type Candidate struct {
-	ID        string
-	Source    string
-	Kind      doc.Kind
-	Container string
-	Author    string
+	ID string
 
 	ModifiedAt time.Time
 

--- a/store/sqlitestore/rank.go
+++ b/store/sqlitestore/rank.go
@@ -140,8 +140,7 @@ func (s *Store) Rank(ctx context.Context, p *acl.Principal, r store.Request, sel
 func (s *Store) candidates(ctx context.Context, from string, c *clause, order string, limit int) ([]store.Candidate, []int64, error) {
 	args := append(append([]any{}, c.args...), limit)
 	rows, err := s.query(ctx, `
-		SELECT d.id, d.source, d.kind, d.container, d.author_name, d.modified_at,
-		       d.title_tokens, d.body_tokens, d.rowid
+		SELECT d.id, d.modified_at, d.title_tokens, d.body_tokens, d.rowid
 		FROM `+from+`
 		WHERE `+c.where()+`
 		ORDER BY `+order+`
@@ -158,16 +157,13 @@ func (s *Store) candidates(ctx context.Context, from string, c *clause, order st
 	for rows.Next() {
 		var (
 			cand     store.Candidate
-			kind     string
 			modified sql.NullInt64
 			rowid    int64
 		)
-		if err := rows.Scan(&cand.ID, &cand.Source, &kind, &cand.Container, &cand.Author,
-			&modified, &cand.TitleTokens, &cand.BodyTokens, &rowid); err != nil {
+		if err := rows.Scan(&cand.ID, &modified, &cand.TitleTokens, &cand.BodyTokens, &rowid); err != nil {
 			return nil, nil, fmt.Errorf("sqlitestore: rank: %w", err)
 		}
 		s.counters.rows.Add(1)
-		cand.Kind = doc.Kind(kind)
 		if modified.Valid {
 			cand.ModifiedAt = unixNano(modified.Int64)
 		}


### PR DESCRIPTION
Closes #144.

`store.Candidate` carried four display strings.
The comment above them said they were the display forms a facet is counted over and a result row is drawn from.

Neither is true any more.
The facets are counted by the driver in its counting statement, over its own columns, and the scan fallback counts them in Go from the document.
A result row is drawn from the document the page fetch returns, because a row needs a snippet and a snippet needs a body.

So they were written in three places and read in none.
Both drivers selected and scanned them for five hundred rows on every search, `index.candidateOf` copied them off the document, and the only fields anything reads off a candidate are `ID`, `ModifiedAt`, `TitleTokens`, `BodyTokens` and `Terms`.
Nothing in `storetest` asserted them either, so a driver returning the wrong author for every candidate passed conformance.

## What it was costing

The candidate statement selected nine columns and now selects five.
Five runs of twenty on the twenty thousand document corpus, on a shared machine:

| | Bytes before | Bytes after | Allocations before | Allocations after |
| --- | --- | --- | --- | --- |
| `BenchmarkRank` | 575KB | 397KB | 12,842 | 8,332 |
| `BenchmarkAPISearch` | 1.23MB | 1.01MB | 15,883 | 11,374 |

Four and a half thousand allocations a search, which is twenty eight percent of what the endpoint does.
Nine allocations a row rather than the four I expected, because the driver allocates per column as well as per string.

It is not a latency fix and it does not claim to be.
Decomposed at the driver for a common term, minimum of five runs of thirty, the candidate statement is 232ms of a 522ms retrieval and most of that is the ranking function SQLite evaluates over every match rather than the five hundred rows it returns.
The frequency statement is 95ms and the counting statement is 165ms.
That decomposition is on #144 and it is what the next piece of #55 should start from.

## What says this is safe

Nothing read the fields, so nothing should change, and the tests that would notice are the ones that compare the two paths against each other.
`TestDriversAgree` holds the scan path and the rank path to identical results, totals, facets and snippets for twenty two queries.
`RunRanker` checks the totals, the facet counts and the drill down arithmetic against the same numbers computed from `Scan`.
Both pass unchanged, and CI runs `RunRanker` against Postgres as well.
