### PR TITLE
Answer a search by quoting the documents it found

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -332,6 +332,13 @@ type searchResponse struct {
 	// number on the screen, and the interface writes both the same way.
 	FacetsPartial bool `json:"facets_partial,omitempty"`
 
+	// Answer is the passages worth reading above the list, quoted out of the
+	// documents on this page. Absent whenever there are none, and the interface
+	// draws nothing at all rather than an empty region, because a heading with
+	// no content under it is the most common way an answer surface makes a page
+	// worse than it was.
+	Answer *answer `json:"answer,omitempty"`
+
 	// Correction is a spelling of the query that would have found something. It
 	// is only ever present on a search that found nothing, and it has already
 	// been run as the person asking, so it is a query they can run rather than
@@ -396,6 +403,34 @@ type passage struct {
 	Match bool   `json:"match,omitempty"`
 }
 
+// answer is the wire shape of index.Answer.
+type answer struct {
+	Quotes []quote `json:"quotes"`
+}
+
+// quote is one passage and the document it came from.
+//
+// The document is an id and nothing else. Every quote is taken from a document
+// that is already in the hits of the same response, so the title, the source and
+// the date are on the wire once rather than twice, and there is no way for the
+// citation under a quote to disagree with the result it points at.
+type quote struct {
+	ID       string    `json:"id"`
+	Text     string    `json:"text"`
+	Passages []passage `json:"passages,omitempty"`
+}
+
+func answerOf(a index.Answer) *answer {
+	if len(a.Quotes) == 0 {
+		return nil
+	}
+	out := answer{Quotes: make([]quote, 0, len(a.Quotes))}
+	for _, q := range a.Quotes {
+		out.Quotes = append(out.Quotes, quote{ID: q.ID, Text: q.Text, Passages: passages(q.Passages)})
+	}
+	return &out
+}
+
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
 	query, err := parseQuery(r.URL.Query())
 	if err != nil {
@@ -423,6 +458,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 		FacetsPartial: res.Approximate,
 
 		Hits:       []searchHit{},
+		Answer:     answerOf(res.Answer),
 		Correction: res.Correction,
 	}
 	for _, h := range res.Hits {

--- a/index/answer.go
+++ b/index/answer.go
@@ -220,7 +220,7 @@ func isBreak(r rune) bool {
 // own, which is true of every source file and most spreadsheets, and an answer
 // that quotes a line of JSON above the results has made the page worse. The
 // caller drops the document and quotes the next one.
-func bestSentence(parts []string, terms []string, cutHead, cutTail bool) string {
+func bestSentence(parts, terms []string, cutHead, cutTail bool) string {
 	if len(parts) == 0 {
 		return ""
 	}

--- a/index/answer.go
+++ b/index/answer.go
@@ -1,0 +1,317 @@
+package index
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/tamnd/genba/doc"
+)
+
+// AnswerQuotes is how many documents an answer quotes from.
+//
+// Three, because an answer above a list of results is competing with the list
+// for the same screen and it loses that competition the moment it is longer than
+// the first two results. Three quotes is about eight lines, which is a glance.
+// It is also the point where a fourth source stops adding evidence and starts
+// adding scrolling: on every query we have measured, the fourth ranked document
+// repeats what one of the first three already said.
+const AnswerQuotes = 3
+
+// MinQuote and MaxQuote bound how long a quoted passage may be, in bytes.
+//
+// Below the minimum a sentence is a heading, a caption or a list item, and
+// quoting "Configuration" under a question is worse than quoting nothing. Above
+// the maximum it is a paragraph that happens to contain no full stop, usually
+// because it is a table row or a line of generated text, and a paragraph pushes
+// the results off the screen.
+const (
+	MinQuote = 40
+	MaxQuote = 400
+)
+
+// answerWindow is how much of a body is read looking for a passage worth
+// quoting, in characters around the first match.
+//
+// The document is already in the top three, so the first match is a reasonable
+// place to look and the alternative is reading whole documents to draw eight
+// lines. Six snippets wide is enough to hold the sentence the match is in and
+// the two on either side of it, which is what the scoring below chooses between.
+const answerWindow = 6 * SnippetWidth
+
+// Answer is what the corpus already says about a query.
+//
+// It is quoted rather than written. Every sentence in it is a passage lifted
+// verbatim out of a document this principal may read, and each one carries the
+// document it came from, so a citation is not a claim about a source, it is the
+// source. Nothing here is paraphrased, summarised or generated, which means
+// there is no sentence in an answer that is not already in the corpus and no way
+// for one to be wrong in a way the document it points at is not also wrong.
+//
+// That is a smaller thing than the assistant in the specification and it is
+// deliberately the honest half of it. The half that needs a model is M5. What
+// this settles first is the part a model does not fix: where the answer sits,
+// what a citation does when somebody clicks it, and how a reader tells the
+// product's words apart from a document's. An assistant that gets those wrong is
+// worse with a good model than without one, because a confident paraphrase whose
+// citation goes nowhere is how people learn to stop reading citations.
+type Answer struct {
+	// Quotes are the passages, best first and at most [AnswerQuotes] of them.
+	// One document contributes one quote: three quotes out of one file is a
+	// document worth opening rather than an answer.
+	Quotes []Quote
+}
+
+// Quote is one passage and the document it was taken from.
+type Quote struct {
+	// ID is the document. It is an id rather than the document itself because a
+	// quote is only ever produced for a document that is already on the page it
+	// sits above, so the caller has the title, the source and everything else
+	// beside it already, and sending them twice is two copies to disagree.
+	ID string
+
+	// Text is the passage, verbatim, with its whitespace collapsed. It is not
+	// escaped, which is the caller's job, and it is not the snippet: see quote.
+	Text string
+
+	// Passages is Text split so the runs that matched the query are marked, the
+	// same way [Result.Passages] is and for the same reason.
+	Passages []Passage
+}
+
+// answer picks the passages worth quoting from a page of results.
+//
+// It reads the documents that are already in hand rather than running a
+// retrieval of its own. That is the whole reason the answer is part of a search
+// response instead of an endpoint beside it: the ranking has already chosen
+// which documents are worth reading and the fetch has already paid for their
+// bodies, so what an answer costs on top of a search is three passes over three
+// windows, and a results page still answers in one request.
+func answer(hits []Result, terms []string) Answer {
+	if len(terms) == 0 {
+		return Answer{}
+	}
+	var out Answer
+	for _, hit := range hits {
+		if len(out.Quotes) == AnswerQuotes {
+			break
+		}
+		text, passages := quote(hit.Document, terms)
+		if text == "" {
+			continue
+		}
+		out.Quotes = append(out.Quotes, Quote{ID: hit.Document.ID, Text: text, Passages: passages})
+	}
+	return out
+}
+
+// quote picks the sentence of a document that best answers the query.
+//
+// A snippet and a quote are different claims and this is why there are two
+// functions. A snippet is evidence that a document matched, shown under a title
+// somebody is already reading, so it is a window around the first match and it
+// is allowed to start mid word and end in an ellipsis. A quote is read on its
+// own, above the results, by somebody deciding whether any of this is worth
+// opening. It has to start where a sentence starts and end where one ends,
+// because a fragment read out of context is how a reader ends up with an
+// impression the document does not support, and the fragment is the part they
+// will remember.
+func quote(d doc.Document, terms []string) (string, []Passage) {
+	// A source file is never quoted, and the reason is not that there is no
+	// prose in one. There is a great deal of it, and every sentence of it arrives
+	// wearing its markers: a paragraph of a package comment reads as "// // # The
+	// rule // // A cache key that does not name the asker's visibility is a
+	// permission bug." Taking the markers off is a renderer's job, it is done in
+	// the browser where the language is known, and guessing at it here would mean
+	// the index deciding what a leading hash means in nine languages. The answer
+	// has two more documents to quote from and no reason to guess.
+	if d.Kind == doc.KindCode {
+		return "", nil
+	}
+
+	raw := d.Body
+	if raw == "" {
+		return "", nil
+	}
+
+	from := 0
+	if at := firstMatch(raw, terms); at > 0 {
+		from = back(raw, at, answerWindow/2)
+	}
+	to := forward(raw, from, answerWindow)
+
+	text := raw[from:to]
+	if d.Properties[doc.MediaType] == "text/markdown" {
+		text = plainText(text)
+	}
+
+	// The window was cut at a character count, so the sentence at each end of it
+	// is almost certainly half a sentence. Dropping them costs a candidate at
+	// each edge of a window six snippets wide and buys the guarantee the whole
+	// function exists for.
+	best := bestSentence(sentences(text), terms, from > 0, to < len(raw))
+	if best == "" {
+		return "", nil
+	}
+	return best, mark(best, terms)
+}
+
+// sentences splits text where a sentence ends.
+//
+// It is deliberately simple: a full stop, question mark or exclamation mark,
+// followed by a space and something that starts a new sentence. A blank line
+// ends one too, because a heading and a list item have no punctuation and
+// running them into the paragraph below is how a quote ends up being two
+// unrelated things.
+//
+// Abbreviations break it. "e.g. the index" splits after the g, and the cost of
+// that is a candidate too short to pass [MinQuote], which is dropped. A
+// heuristic that fails by discarding a passage is the right way round; one that
+// fails by joining two paragraphs into a quote nobody wrote is not.
+func sentences(text string) []string {
+	var (
+		out  []string
+		last int
+	)
+	for i, r := range text {
+		switch {
+		case r == '\n' && i+1 < len(text) && text[i+1] == '\n':
+		case r == '.' || r == '!' || r == '?':
+			// A full stop inside a version number, a file name or a decimal is
+			// not the end of anything, and neither is one at the very end of the
+			// window, which the tail below picks up.
+			next := i + 1
+			if next >= len(text) {
+				continue
+			}
+			after, _ := utf8.DecodeRuneInString(text[next:])
+			if !isBreak(after) {
+				continue
+			}
+		default:
+			continue
+		}
+		out = append(out, text[last:i+1])
+		last = i + 1
+	}
+	if last < len(text) {
+		out = append(out, text[last:])
+	}
+	return out
+}
+
+// isBreak reports whether a character can follow a full stop that ended a
+// sentence. Whitespace is the ordinary case, and a closing quote or bracket is
+// the one that follows a sentence inside a quotation.
+func isBreak(r rune) bool {
+	return unicode.IsSpace(r) || r == '"' || r == '\'' || r == ')' || r == ']'
+}
+
+// bestSentence is the one of these worth quoting, or nothing.
+//
+// The score is how many distinct query terms the sentence carries, because a
+// sentence holding three of the words somebody asked about says more about their
+// question than one holding a single word three times. Length only breaks ties,
+// and it breaks them toward the shorter of two sentences that say the same
+// amount.
+//
+// Nothing is returned rather than the least bad candidate. A document can be a
+// perfectly good result and still have no sentence in it worth reading on its
+// own, which is true of every source file and most spreadsheets, and an answer
+// that quotes a line of JSON above the results has made the page worse. The
+// caller drops the document and quotes the next one.
+func bestSentence(parts []string, terms []string, cutHead, cutTail bool) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	if cutHead {
+		parts = parts[1:]
+	}
+	if cutTail && len(parts) > 0 {
+		parts = parts[:len(parts)-1]
+	}
+
+	want := make(map[string]bool, len(terms))
+	for _, t := range terms {
+		want[t] = true
+	}
+
+	var (
+		best  string
+		found int
+	)
+	for _, part := range parts {
+		s := collapse(part)
+		if len(s) < MinQuote {
+			continue
+		}
+		if len(s) > MaxQuote {
+			s = clip(s, MaxQuote)
+		}
+		if !prose(s) {
+			continue
+		}
+		seen := make(map[string]bool, len(terms))
+		for _, t := range doc.Analyze(s) {
+			if want[t.Term] {
+				seen[t.Term] = true
+			}
+		}
+		switch {
+		case len(seen) > found:
+		case len(seen) == found && found > 0 && len(s) < len(best):
+		default:
+			continue
+		}
+		best, found = s, len(seen)
+	}
+	if found == 0 {
+		return ""
+	}
+	return best
+}
+
+// notProse are the characters that do not turn up in a sentence somebody wrote.
+//
+// Braces, brackets, angle brackets, pipes, equals signs, backslashes and
+// backticks are the punctuation of code, configuration and markup rather than of
+// a language, and one of them in a candidate is enough to say the candidate is a
+// line out of a file rather than something written to be read. That is a blunt
+// test and it is meant to be. It costs the occasional real sentence that mentions
+// an array index or a shell command, and losing a good sentence is cheap because
+// there are two more documents to quote from, while quoting a line of JSON above
+// the results is the failure this whole region has to avoid.
+const notProse = "{}[]<>|=\\`"
+
+// minWords is how many words a candidate needs before it counts as a sentence.
+//
+// The length bound alone lets through a single long identifier, a URL and a file
+// path, all of which reach forty characters without saying anything. Six words is
+// the shortest thing in our corpus that reads as a statement.
+const minWords = 6
+
+// prose reports whether a candidate is a sentence rather than a line of a file.
+func prose(s string) bool {
+	if strings.ContainsAny(s, notProse) {
+		return false
+	}
+	// The whitespace is already collapsed, so gaps and words differ by one.
+	return strings.Count(s, " ") >= minWords-1
+}
+
+// clip cuts a passage at the last word boundary that fits and says it was cut.
+//
+// The alternative is dropping a sentence for being long, and the sentences that
+// run past [MaxQuote] are not all runaway table rows: a specification written in
+// long sentences would never be quoted at all. Cutting mid word would undo the
+// point of quoting a sentence rather than a window.
+func clip(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	cut := strings.LastIndexByte(s[:n], ' ')
+	if cut <= 0 {
+		cut = n
+	}
+	return strings.TrimRight(s[:cut], " ,;:") + "..."
+}

--- a/index/answer_test.go
+++ b/index/answer_test.go
@@ -1,0 +1,216 @@
+package index_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+)
+
+// The answer's whole claim is that it is quoted rather than written, so every
+// test in here is a way of asking whether that is still true.
+var quotable = []fixture{
+	{
+		id:    "run",
+		title: "Payments failover runbook",
+		body: "This runbook covers the payments queue only.\n\n" +
+			"When the primary region stops acknowledging writes, failover the payments queue to the standby region before draining anything. " +
+			"The drain is safe once the queue has failed over and not before.\n\n" +
+			"Escalate to the on call engineer if the failover takes longer than ten minutes.",
+		perm: openTo("eng@acme.com"),
+	},
+	{
+		id:    "notes",
+		title: "Weekly engineering notes",
+		body: "Attendees: Mei, Sam, Alex.\n\n" +
+			"We agreed that the payments queue needs a second consumer before the end of the quarter, and that the failover drill happens monthly from now on.\n\n" +
+			"Nobody had anything on hiring.",
+		perm: openTo("eng@acme.com"),
+	},
+	{
+		id:    "conf",
+		title: "queue.json",
+		body:  `{"payments": {"queue": "primary", "failover": true}}`,
+		kind:  doc.KindCode,
+		perm:  openTo("eng@acme.com"),
+	},
+	{
+		id:    "fenced",
+		title: "Draining the standby",
+		body: "# Draining the standby\n\n" +
+			"```\ngenba drain --queue=payments --failover=standby --wait=10m\n```\n\n" +
+			"Run it from the bastion.",
+		media: "text/markdown",
+		perm:  openTo("eng@acme.com"),
+	},
+	{
+		id:    "secret",
+		title: "Payments incident postmortem",
+		body:  "The payments queue failover was triggered by a bad deploy on the ninth of March, and it took forty minutes to recover.",
+		perm:  openTo("sales@acme.com"),
+	},
+}
+
+func answerFor(t *testing.T, q index.Query, groups ...string) index.Answer {
+	t.Helper()
+	s := newSearcher(t, quotable)
+	res, err := s.Search(t.Context(), principal(groups...), q)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	return res.Answer
+}
+
+// This is the test the rest of the feature exists to make passable. A quote that
+// is not a substring of the document it cites is a sentence the product wrote
+// and attributed to somebody else, which is the exact failure a citation is
+// supposed to make impossible.
+func TestEveryQuoteIsInTheDocumentItCites(t *testing.T) {
+	s := newSearcher(t, quotable)
+	p := principal("gdrive:eng@acme.com")
+	res, err := s.Search(t.Context(), p, index.Query{Text: "payments failover queue"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res.Answer.Quotes) == 0 {
+		t.Fatal("a query matching three documents produced no quotes")
+	}
+
+	bodies := make(map[string]string, len(res.Hits))
+	for _, hit := range res.Hits {
+		bodies[hit.Document.ID] = collapseSpace(hit.Document.Body)
+	}
+	for _, q := range res.Answer.Quotes {
+		body, ok := bodies[q.ID]
+		if !ok {
+			t.Fatalf("quote cites %q, which is not on the page it sits above", q.ID)
+		}
+		text := strings.TrimSuffix(q.Text, "...")
+		if !strings.Contains(body, text) {
+			t.Errorf("quote from %s is not in that document:\n  quoted: %q", q.ID, text)
+		}
+	}
+}
+
+// The passages are what the interface marks, so the text it draws has to be the
+// text it was given. A split that dropped or duplicated a byte would highlight
+// the right words in a sentence nobody wrote.
+func TestPassagesRebuildTheQuote(t *testing.T) {
+	a := answerFor(t, index.Query{Text: "payments failover"}, "gdrive:eng@acme.com")
+	if len(a.Quotes) == 0 {
+		t.Fatal("no quotes")
+	}
+	for _, q := range a.Quotes {
+		var b strings.Builder
+		matched := false
+		for _, p := range q.Passages {
+			b.WriteString(p.Text)
+			matched = matched || p.Match
+		}
+		if b.String() != q.Text {
+			t.Errorf("passages for %s rebuild %q, want %q", q.ID, b.String(), q.Text)
+		}
+		if !matched {
+			t.Errorf("quote from %s marks none of the query terms", q.ID)
+		}
+	}
+}
+
+// A quote is read on its own rather than under a title, so it has to be a
+// sentence. A window that starts mid word is a snippet and belongs on a result
+// row instead.
+func TestAQuoteIsAWholeSentence(t *testing.T) {
+	a := answerFor(t, index.Query{Text: "payments failover queue"}, "gdrive:eng@acme.com")
+	if len(a.Quotes) == 0 {
+		t.Fatal("no quotes")
+	}
+	for _, q := range a.Quotes {
+		if strings.HasPrefix(q.Text, "...") {
+			t.Errorf("quote from %s opens with an ellipsis: %q", q.ID, q.Text)
+		}
+		first := rune(q.Text[0])
+		if first >= 'a' && first <= 'z' {
+			t.Errorf("quote from %s starts mid sentence: %q", q.ID, q.Text)
+		}
+		if len(q.Text) < index.MinQuote {
+			t.Errorf("quote from %s is %d bytes, under the %d byte floor: %q", q.ID, len(q.Text), index.MinQuote, q.Text)
+		}
+	}
+}
+
+// A perfectly good result can have nothing in it worth reading on its own. The
+// JSON fixture matches every term in the query and is one line with no sentence
+// in it, and quoting it above the results would make the page worse than an
+// answer region that is not there.
+func TestADocumentWithNothingQuotableIsSkipped(t *testing.T) {
+	a := answerFor(t, index.Query{Text: "payments failover queue"}, "gdrive:eng@acme.com")
+	for _, q := range a.Quotes {
+		if q.ID == "conf" {
+			t.Fatalf("a line of JSON was quoted above the results: %q", q.Text)
+		}
+	}
+}
+
+// A command line is not a sentence, and it stays out of the answer even when it
+// is the only place in the document the words appear. Markdown keeps the inside
+// of a fence exactly as it was written, which is right for the index and for a
+// snippet, and it means the quote has to be the thing that says no.
+func TestAQuoteIsNeverALineOfCode(t *testing.T) {
+	a := answerFor(t, index.Query{Text: "payments failover queue"}, "gdrive:eng@acme.com")
+	for _, q := range a.Quotes {
+		if q.ID == "fenced" {
+			t.Fatalf("a command line was quoted above the results: %q", q.Text)
+		}
+	}
+}
+
+// One quote per document, at most three documents. Three quotes out of one file
+// is a document worth opening rather than an answer.
+func TestAnAnswerIsBoundedAndCitesEachDocumentOnce(t *testing.T) {
+	a := answerFor(t, index.Query{Text: "payments failover queue region"}, "gdrive:eng@acme.com")
+	if len(a.Quotes) > index.AnswerQuotes {
+		t.Fatalf("got %d quotes, want at most %d", len(a.Quotes), index.AnswerQuotes)
+	}
+	seen := map[string]bool{}
+	for _, q := range a.Quotes {
+		if seen[q.ID] {
+			t.Fatalf("%s was quoted twice", q.ID)
+		}
+		seen[q.ID] = true
+	}
+}
+
+// The answer runs on the hits, so it inherits the permission rule rather than
+// applying one of its own. This asserts the inheritance rather than trusting it:
+// the postmortem is the best match in the corpus for these words and this reader
+// may not read it.
+func TestAnAnswerNeverQuotesADocumentTheReaderCannotOpen(t *testing.T) {
+	a := answerFor(t, index.Query{Text: "payments failover postmortem deploy"}, "gdrive:eng@acme.com")
+	for _, q := range a.Quotes {
+		if q.ID == "secret" {
+			t.Fatalf("quoted a document this reader may not open: %q", q.Text)
+		}
+	}
+}
+
+// Three states where the region is absent, and the interface is built around its
+// absence: nothing below it moves when there is no answer.
+func TestThereIsNoAnswerWithoutAQuestion(t *testing.T) {
+	for _, tc := range []struct {
+		what  string
+		query index.Query
+	}{
+		{"a browse with no terms", index.Query{}},
+		{"the second page", index.Query{Text: "payments failover", Offset: 20}},
+		{"a list sorted by date", index.Query{Text: "payments failover", Sort: index.ByRecent}},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			if a := answerFor(t, tc.query, "gdrive:eng@acme.com"); len(a.Quotes) != 0 {
+				t.Fatalf("got %d quotes, want none", len(a.Quotes))
+			}
+		})
+	}
+}
+
+func collapseSpace(s string) string { return strings.Join(strings.Fields(s), " ") }

--- a/index/index.go
+++ b/index/index.go
@@ -171,6 +171,12 @@ type Results struct {
 	// start moving together is the day the first phase stopped cutting.
 	Candidates int
 
+	// Answer is what the corpus already says about the query, quoted out of the
+	// documents on this page. It is empty on a query with no terms, on a browse
+	// sorted by date, on any page but the first, and whenever nothing on the
+	// page held a passage worth reading on its own. See [Answer].
+	Answer Answer
+
 	// Correction is a spelling of the query that would have found something,
 	// and is empty when there is none or when the query found results of its
 	// own. It is a query rather than a word so that the interface has something
@@ -385,6 +391,16 @@ func (s *Searcher) Search(ctx context.Context, p *acl.Principal, q Query) (Resul
 		hit := Result{Document: full, Score: r.score}
 		hit.Snippet, hit.Passages = snippet(full, req.Terms)
 		res.Hits = append(res.Hits, hit)
+	}
+
+	// An answer belongs to a question, and only the first page of one. Somebody
+	// on page four is reading a list rather than asking something, somebody
+	// sorting by date is asking what changed rather than what is true, and a
+	// query with no terms in it has asked nothing to answer. In all three the
+	// region is absent, which is the state the interface is built around: its
+	// absence changes the layout of nothing below it.
+	if q.Offset == 0 && q.Sort != ByRecent {
+		res.Answer = answer(res.Hits, req.Terms)
 	}
 	res.Took = s.now().Sub(start)
 	return res, nil

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -600,6 +600,62 @@ async function walk(session) {
     "location.search.includes('q=cache')",
   );
 
+  // The answer above the results.
+  //
+  // The query is one this corpus can answer. A repository is mostly source
+  // files, and a source file is never quoted, so the words here are ones that
+  // appear in the prose in it rather than in the code.
+  await visit(session, `${BASE}/?q=drawer`, "document.querySelectorAll('.result').length > 0");
+  await check(
+    session,
+    "an answer quotes documents that are on the page below it",
+    `(() => {
+      const quotes = [...document.querySelectorAll('.answer__quote')];
+      if (!quotes.length) return false;
+      const titles = [...document.querySelectorAll('.result__title')].map((a) => a.textContent.trim());
+      return quotes.length <= 3 &&
+        quotes.every((q) => titles.includes(q.querySelector('.quote__title').textContent.trim())) &&
+        document.querySelector('.answer__note').textContent.trim().length > 0;
+    })()`,
+  );
+
+  // The layout contract, which is the whole of what this region promises the
+  // list underneath it. There is no stream, so nothing arrives late by design,
+  // and this is the assertion that keeps it that way when one is added.
+  const under = await evaluate(session, "document.querySelector('.result').getBoundingClientRect().top");
+  await check(
+    session,
+    "nothing under the answer moves once the page has painted",
+    `new Promise((done) => setTimeout(
+      () => done(Math.abs(document.querySelector('.result').getBoundingClientRect().top - ${under}) < 1),
+      1200,
+    ))`,
+  );
+
+  const quoted = await evaluate(session, "document.querySelector('.quote__text').textContent");
+  await evaluate(session, "document.querySelector('.quote__cite').click()");
+  await settle(session, "!document.querySelector('.drawer').hidden");
+  await check(
+    session,
+    "one click on a citation opens that document at the sentence that was quoted",
+    `(() => {
+      const marks = [...document.querySelectorAll('.drawer__body mark.hit--passage')];
+      if (!marks.length) return false;
+      const squeeze = (s) => s.replace(/\\s+/g, '');
+      const found = squeeze(marks.map((m) => m.textContent).join(''));
+      return location.search.includes('at=') &&
+        squeeze(${JSON.stringify(quoted)}).includes(found) &&
+        marks.some((m) => m.classList.contains('hit--current'));
+    })()`,
+  );
+
+  await press(session, "Escape", "Escape", 27);
+  await check(
+    session,
+    "closing it takes the passage out of the address along with the document",
+    "!location.search.includes('at=') && !location.search.includes('open=')",
+  );
+
   // The grid. The pictures behind this query are written into the corpus by the
   // gate before the server starts, because the repository itself holds none.
   await visit(session, `${BASE}/?q=gatepix`, "document.querySelectorAll('.cell').length > 0");
@@ -609,6 +665,17 @@ async function walk(session) {
     "a page of nothing but images opens as a grid",
     `document.querySelector('.results__list').dataset.view === 'grid' &&
       document.querySelectorAll('.result').length === 0`,
+  );
+
+  // A page of pictures has nothing to quote, and the region that would hold the
+  // quotes is not on the page rather than on it and empty.
+  await check(
+    session,
+    "a search with nothing worth quoting draws no answer region at all",
+    `(() => {
+      const region = document.querySelector('.answer');
+      return region.hidden && region.childElementCount === 0;
+    })()`,
   );
 
   // The assertion the endpoint exists for. Twenty four pictures at a megabyte

--- a/scripts/render-check.mjs
+++ b/scripts/render-check.mjs
@@ -395,6 +395,94 @@ async function run(session) {
     `),
   );
 
+  // The answer region, whose first duty is to not be there. Every search that
+  // has nothing worth quoting has to leave the page exactly as it was, so the
+  // empty case is asserted before the drawn one.
+  await check(
+    session,
+    "the answer region is absent until there is something quoted, and then it quotes",
+    expr(`
+      const { Answer } = await import('genba/answer.js');
+      const hits = [{ id: 'x', title: 'Runbook', source: 'repo' }];
+      const a = new Answer({ onCite: () => {} });
+      a.render({ hits, answer: null });
+      const gone = a.el.hidden && a.el.childNodes.length === 0;
+      a.render({
+        hits,
+        answer: { quotes: [{ id: 'x', text: 'The cache is warmed at start up.', passages: [
+          { text: 'The ' }, { text: 'cache', match: true }, { text: ' is warmed at start up.' },
+        ] }] },
+      });
+      const cite = a.el.querySelector('.quote__cite');
+      return gone && !a.el.hidden &&
+        a.el.querySelectorAll('.answer__quote').length === 1 &&
+        a.el.querySelector('.quote__text').textContent === 'The cache is warmed at start up.' &&
+        a.el.querySelector('.quote__text mark.hit').textContent === 'cache' &&
+        cite.getAttribute('aria-label') === 'Open Runbook at this passage' &&
+        cite.getAttribute('href').includes('at=') && cite.getAttribute('href').includes('open=x');
+    `),
+  );
+
+  // A quote whose document is not on the page below it has nothing to cite, and
+  // a citation that leads nowhere is the failure the whole region is built to
+  // avoid.
+  await check(
+    session,
+    "a quote is dropped when the document it cites is not on the page",
+    expr(`
+      const { Answer } = await import('genba/answer.js');
+      const a = new Answer({ onCite: () => {} });
+      a.render({
+        hits: [{ id: 'y', title: 'Notes', source: 'repo' }],
+        answer: { quotes: [{ id: 'x', text: 'The cache is warmed at start up.' }] },
+      });
+      return a.el.hidden && a.el.childNodes.length === 0;
+    `),
+  );
+
+  // The quote was cut out of the source, where the whitespace is whatever the
+  // author typed, and it is looked for in the rendered document, where the same
+  // sentence is split across three nodes by a bold word. Neither side's spacing
+  // is the other's, so neither side's spacing is compared.
+  await check(
+    session,
+    "a cited passage is found through inline markup and through changed whitespace",
+    expr(`
+      const { passage } = await import('genba/marks.js');
+      const box = document.createElement('div');
+      box.innerHTML = '<p>The <b>cache</b>\\n  is warmed\\n  at start up.</p><p>Nothing else.</p>';
+      const at = passage(box, 'The cache  is warmed at start up.');
+      const squeeze = (s) => s.replace(/\\s+/g, '');
+      const marks = [...box.querySelectorAll('mark.hit--passage')];
+      const other = document.createElement('div');
+      other.innerHTML = '<p>A paragraph about something entirely different.</p>';
+      return Boolean(at) && marks.length === 3 &&
+        squeeze(marks.map((m) => m.textContent).join('')) === squeeze('The cache is warmed at start up.') &&
+        squeeze(box.textContent) === squeeze('The cache is warmed at start up. Nothing else.') &&
+        passage(other, 'The cache is warmed at start up.') === null;
+    `),
+  );
+
+  await check(
+    session,
+    "a document opened from a citation opens at the sentence rather than at the first word",
+    expr(`
+      const { body } = await import('genba/content.js');
+      const out = body(
+        {
+          id: 'repo:notes.md',
+          media_type: 'text/markdown',
+          body: '# Notes\\n\\nThe first paragraph.\\n\\nThe cache is warmed at start up.\\n',
+        },
+        { query: 'cache', at: 'The cache is warmed at start up.' },
+      );
+      const cited = out.querySelector('mark.hit--passage');
+      return Boolean(cited) &&
+        cited.textContent === 'The cache is warmed at start up.' &&
+        out.querySelectorAll('mark.hit').length === 1;
+    `),
+  );
+
   await check(
     session,
     "a body the extractor could not read to the end says which half is missing",

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -2,11 +2,11 @@
 # The browser half of the performance gate.
 #
 # It starts the real binary over a real corpus, which is this repository, and
-# audits ten screens: the home page, the home page over an index holding
-# nothing, a results page, a results page with the document drawer open, a
-# search that matched nothing, a filter that matched nothing, a grid of
-# pictures, a document on a page of its own, the recent screen and the settings
-# screen. They are
+# audits eleven screens: the home page, the home page over an index holding
+# nothing, a results page, a results page with an answer quoted above it, a
+# results page with the document drawer open, a search that matched nothing, a
+# filter that matched nothing, a grid of pictures, a document on a page of its
+# own, the recent screen and the settings screen. They are
 # states rather than layouts, because a layout is looked at every day and a
 # state is looked at once. Auditing a static fixture would audit the fixture,
 # and every accessibility bug this is meant to catch lives in the markup the
@@ -235,10 +235,15 @@ if [ -n "${CHROMEDRIVER:-}" ]; then
 	DRIVER="--chromedriver-path $CHROMEDRIVER"
 fi
 
-# Ten screens, and they are states rather than layouts. Three of them, the
+# Eleven screens, and they are states rather than layouts. Three of them, the
 # empty index, the query that matched nothing and the filter that matched
 # nothing, produce markup no other screen produces, and that markup is where an
 # accessibility bug survives longest: nobody looks at an empty page twice.
+#
+# The eleventh is a search that has an answer above it. The region is a heading,
+# a list and a link per quote, none of which the results page below it has, and
+# it appears on some searches and not others, so it is a screen the other ten
+# never reach.
 #
 # The settings screen is the tenth. It is the only screen in the product built
 # out of form controls, and a radio group that has lost its label is the kind of
@@ -247,6 +252,7 @@ for url in \
 	"$BASE/" \
 	"$EMPTY/" \
 	"$BASE/?q=cache" \
+	"$BASE/?q=drawer" \
 	"$BASE/?q=cache&open=$ID" \
 	"$BASE/?q=zzqxzzqx" \
 	"$BASE/?q=cache&kind=image" \

--- a/web/dist/assets/answer.js
+++ b/web/dist/assets/answer.js
@@ -1,0 +1,163 @@
+// The answer above the results.
+//
+// It holds passages taken out of the documents on the page below it, word for
+// word, each one with the document it came from underneath it. Nothing in here
+// is written by the product and nothing is paraphrased, which is a smaller claim
+// than the one an assistant makes and the only one this build can keep: there is
+// no model behind it yet.
+//
+// That is deliberate rather than a placeholder. The part of an answer surface
+// that a model does not fix is where it sits, what a citation does when somebody
+// clicks it, and how a reader tells a document's words from the product's. Those
+// are settled here, against real documents, before there is anything generated
+// to get them wrong.
+//
+// Two rules govern the region and both are about the list underneath it.
+//
+// It is absent when there is no answer, and absent means not rendered rather
+// than rendered empty, so a query with nothing worth quoting gets the page it
+// had before this existed.
+//
+// It never grows on its own. Every quote arrives in the same response as the
+// results and in the same paint, its length is bounded by the server, and
+// nothing inside it loads late. A region above a list that reflows after the
+// list has painted moves the row somebody was about to click, and there is no
+// amount of usefulness that pays for that.
+
+import { h, replace, svg } from "genba/dom.js";
+import { icon, label, sourceColor } from "genba/format.js";
+
+export class Answer {
+  constructor({ onCite }) {
+    this.onCite = onCite;
+    this.el = h("div", { class: "answer", hidden: true });
+  }
+
+  /**
+   * render draws the answer in a response, or takes the region away.
+   *
+   * The quotes name their documents by id and the documents are the hits of the
+   * same response, so the title and the source under a quote are the same
+   * strings as the result row it points at. A second copy on the wire would be a
+   * second copy to disagree with the first.
+   */
+  render(res) {
+    const answer = res && res.answer;
+    const quotes = (answer && answer.quotes) || [];
+    const hits = new Map((res.hits || []).map((hit) => [hit.id, hit]));
+    const cited = quotes
+      .map((q) => ({ quote: q, hit: hits.get(q.id) }))
+      .filter((c) => c.hit);
+
+    if (!cited.length) {
+      this.clear();
+      return;
+    }
+
+    this.el.hidden = false;
+    replace(
+      this.el,
+      h(
+        "section",
+        { class: "answer__panel", "aria-labelledby": "answer-title" },
+        h(
+          "div",
+          { class: "answer__head" },
+          h("h2", { class: "answer__title", id: "answer-title" }, "From your documents"),
+          // Said once, in the region, rather than left to the styling to imply.
+          // A reader who assumes a paragraph above a list of results was written
+          // for them has assumed the normal thing, and the styling that says
+          // otherwise is the styling of a product they have never used before.
+          h(
+            "p",
+            { class: "answer__note" },
+            "Passages quoted from the documents below, word for word. Nothing here was written for you.",
+          ),
+        ),
+        h(
+          "ol",
+          { class: "answer__list" },
+          cited.map(({ quote, hit }) => this.renderQuote(quote, hit)),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * clear takes the region off the page.
+   *
+   * Hidden and emptied, in that order and both of them. Hidden alone leaves the
+   * quotes of the previous search in the tree for a screen reader to walk past
+   * and for the node budget to count, and emptied alone leaves a box with the
+   * margins of a panel and nothing in it.
+   */
+  clear() {
+    this.el.hidden = true;
+    replace(this.el);
+  }
+
+  renderQuote(quote, hit) {
+    return h(
+      "li",
+      { class: "answer__quote" },
+      h(
+        "blockquote",
+        { class: "quote" },
+        h("p", { class: "quote__text" }, textOf(quote)),
+      ),
+      h(
+        "a",
+        {
+          class: "quote__cite",
+          href: citeHref(quote),
+          // One action, and the same action from the pointer, the keyboard and
+          // the middle button. It is a real anchor so that a citation can be
+          // opened in a tab and sent to somebody, and the click is intercepted
+          // so that the ordinary case does not reload the page.
+          "aria-label": `Open ${hit.title || hit.id} at this passage`,
+          onClick: (e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey) return;
+            e.preventDefault();
+            this.onCite(quote.id, quote.text);
+          },
+        },
+        h("span", {
+          class: "source__dot",
+          style: { background: sourceColor(hit.source) },
+        }),
+        h("span", { class: "quote__title" }, hit.title || hit.id),
+        h("span", { class: "quote__where" }, label(hit.source)),
+        svg(icon("arrow-right"), 16),
+      ),
+    );
+  }
+}
+
+/**
+ * textOf builds the quote out of the runs the server split it into.
+ *
+ * The marked runs are the ones the index matched, which is the same claim a
+ * result snippet makes and it is made in the same place. Searching the quote for
+ * the words in the box here would highlight what a substring search found rather
+ * than what was matched, and the two disagree on every stemmed word.
+ */
+function textOf(quote) {
+  const parts = quote.passages && quote.passages.length ? quote.passages : [{ text: quote.text }];
+  return parts.map((p) => (p.match ? h("mark", { class: "hit" }, p.text) : p.text));
+}
+
+/**
+ * citeHref is the address a citation leads to: this search, with the document
+ * open in the preview, at the passage.
+ *
+ * The same address the row for that document leads to, plus the passage, because
+ * there is one document viewer in this product and a citation is a result. An
+ * answer that opened its own reader would be a second place a document can be
+ * looked at, and the second one is always the one that is a version behind.
+ */
+function citeHref(quote) {
+  const params = new URLSearchParams(location.search);
+  params.set("open", quote.id);
+  params.set("at", quote.text);
+  return `/?${params.toString()}`;
+}

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -632,6 +632,162 @@ time {
   color: var(--text);
 }
 
+/* Answer ----------------------------------------------------------------- */
+
+/*
+ * The quoted passages above the results.
+ *
+ * The violet reserved for generated content is deliberately not used here, and
+ * that is the point of the region rather than an omission. Nothing in it was
+ * generated, so nothing in it may wear the colour that says something was. The
+ * day there is a model behind this, the generated part gets the violet rule and
+ * these quotes keep the grey one, and the difference between the two will be
+ * visible from across the room.
+ *
+ * What separates the document's words from the product's here is size. The
+ * quotes are set at reading size with prose leading, the way a paragraph of a
+ * document is set anywhere else in this interface, and everything the product
+ * says about them is small, grey and out of the way. A reader who only glances
+ * sees a passage of a document, which is what it is.
+ */
+.answer {
+  margin-bottom: var(--space-6);
+}
+
+.answer[hidden] {
+  display: none;
+}
+
+/* No card, no border, no shadow and no fill. The region is on the page rather
+   than in a box on the page, which is what keeps it from reading as an
+   advertisement above the results somebody asked for. */
+.answer__panel {
+  padding: var(--space-2) var(--space-4) 0;
+}
+
+.answer__head {
+  margin-bottom: var(--space-5);
+}
+
+.answer__title {
+  margin: 0;
+  color: var(--text);
+  font-size: var(--text-small);
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+/* No measure on it. It is one sentence of chrome, and holding it to the reading
+   width of a paragraph breaks it into a line and an orphan on a wide window. */
+.answer__note {
+  margin: var(--space-1) 0 0;
+  color: var(--text-muted);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+}
+
+.answer__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.answer__quote + .answer__quote {
+  margin-top: var(--space-6);
+}
+
+/* The rule down the left is the whole of the quotation mark. Anything heavier
+   around a passage that is already set apart by its size is decoration. */
+.quote {
+  margin: 0;
+  padding-left: var(--space-4);
+  border-left: 3px solid var(--border-control);
+}
+
+.quote__text {
+  max-width: var(--measure);
+  margin: 0;
+  color: var(--text);
+  font-size: var(--text-lead);
+  line-height: var(--leading-prose);
+}
+
+.quote__cite {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 100%;
+  margin-top: var(--space-2);
+  margin-left: calc(var(--space-4) + 3px);
+  padding: var(--space-1) 0;
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  text-decoration: none;
+}
+
+.quote__cite:hover {
+  color: var(--text-link);
+}
+
+.quote__cite:hover .quote__title {
+  text-decoration: underline;
+}
+
+.quote__title {
+  overflow: hidden;
+  font-weight: var(--weight-semibold);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.quote__where {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* It moves on hover and not before. An arrow that is always a few pixels along
+   is an arrow nobody notices has moved. */
+.quote__cite svg {
+  flex: none;
+  transition: transform var(--dur-fast) var(--ease);
+}
+
+.quote__cite:hover svg {
+  transform: translateX(2px);
+}
+
+/*
+ * The passage a citation sent somebody to, inside the document it is in.
+ *
+ * A wash over the whole sentence rather than the two pixel rule the matched
+ * words get, because this is a place rather than a word: it is the answer to
+ * where am I, asked by somebody who has just been moved down a long document.
+ * A rule cannot answer it anyway. The rule is drawn on a pseudo element, and a
+ * sentence long enough to be worth quoting wraps, and a pseudo element on an
+ * inline that wraps is drawn on the first line of it and nowhere else.
+ *
+ * The weight is left alone on purpose. A sentence that turns semibold when it
+ * is highlighted reflows the paragraph around it, and the paragraph is what the
+ * reader is trying to read.
+ *
+ * The class is doubled so this wins over the walk state below it. A mark can be
+ * both the cited passage and the match the reader has walked to, and when it is
+ * both it is the passage: the rule for a current match is a word sized rule and
+ * would leave the rest of the sentence unmarked.
+ */
+mark.hit.hit--passage {
+  background: var(--mark-wash);
+  border-radius: var(--radius-xs);
+  box-decoration-break: clone;
+  font-weight: inherit;
+  -webkit-box-decoration-break: clone;
+}
+
+mark.hit.hit--passage::after {
+  content: none;
+}
+
 /* Results ---------------------------------------------------------------- */
 
 .results {

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -89,7 +89,8 @@ class App {
       // Explicitly the search, because the box is on every screen and a search
       // run from the recent screen is a search rather than a recent screen with
       // a query string on it.
-      onSearch: (text) => this.go({ ...this.query, q: text, offset: 0, open: "" }, { path: "/" }),
+      onSearch: (text) =>
+        this.go({ ...this.query, q: text, offset: 0, open: "", at: "" }, { path: "/" }),
       onOpen: (id) => this.open(id),
       onHighlight: (item) => this.guessSuggestion(item),
     });
@@ -99,6 +100,7 @@ class App {
       onHover: (id) => this.guessDocument(id),
       onSay: (text) => this.say(text),
       onCursor: (i) => this.rememberCursor(i),
+      onCite: (id, text) => this.cite(id, text),
     });
     this.home = new Home({
       onQuery: (q) => this.go({ ...urlState.read(""), ...q }, { path: "/" }),
@@ -112,7 +114,7 @@ class App {
     });
     this.drawer = new Drawer({
       onClose: () => {
-        this.go({ ...this.query, open: "" }, { replace: true });
+        this.go({ ...this.query, open: "", at: "" }, { replace: true });
         // Back to the row it was opened from rather than to the top of the
         // page, which is the whole reason the cursor is in the URL.
         const rows = this.rows();
@@ -554,9 +556,13 @@ class App {
     else if (searching) this.search();
     else this.showHome();
 
-    if (this.query.open && this.drawer.currentId !== this.query.open) {
-      this.drawer.currentId = this.query.open;
-      this.drawer.show(this.query.open, this.query.q);
+    // The passage is part of what is on screen, not only the document. Two
+    // quotes out of the same document are two different places to be sent to,
+    // and comparing the id alone would make the second citation do nothing.
+    const showing = this.query.open && `${this.query.open}\n${this.query.at}`;
+    if (this.query.open && this.drawer.currentId !== showing) {
+      this.drawer.currentId = showing;
+      this.drawer.show(this.query.open, this.query.q, this.query.at);
     } else if (!this.query.open) {
       this.drawer.currentId = null;
       if (this.drawer.open) this.drawer.close();
@@ -1008,8 +1014,26 @@ class App {
    */
   open(id, ahead = 1) {
     this.record(id);
-    this.go({ ...this.query, open: id }, { replace: true });
+    // The passage goes with the document it was quoted from. Opening a row is a
+    // request to read that document from the top, and a passage left over from
+    // the last citation would scroll it to somewhere nobody asked to be.
+    this.go({ ...this.query, open: id, at: "" }, { replace: true });
     this.guessNeighbour(ahead);
+  }
+
+  /**
+   * cite opens the document a quote came from, at the quote.
+   *
+   * It goes through the preview rather than anything of its own, so a citation
+   * lands in the same viewer as a result row, with the same keys, the same way
+   * out and the neighbour already fetched. The only difference is the passage it
+   * carries, and that is a parameter on the address rather than a mode the
+   * drawer is put into, so the link can be copied and it still lands there.
+   */
+  cite(id, text) {
+    this.record(id);
+    this.go({ ...this.query, open: id, at: text }, { replace: true });
+    this.guessNeighbour(1);
   }
 
   /**
@@ -1169,7 +1193,7 @@ class App {
     const limit = this.query.limit || 20;
     const offset = (this.query.offset || 0) + delta * limit;
     if (offset < 0 || offset >= this.results.total) return false;
-    this.go({ ...this.query, offset, open: "" });
+    this.go({ ...this.query, offset, open: "", at: "" });
     return true;
   }
 

--- a/web/dist/assets/content.js
+++ b/web/dist/assets/content.js
@@ -12,7 +12,7 @@ import { render as markdown, codeBlock } from "genba/markdown.js";
 import { render as htmlDocument } from "genba/html.js";
 import { parse as parseNotebook, render as notebookCells } from "genba/notebook.js";
 import { player } from "genba/media.js";
-import { terms, mark } from "genba/marks.js";
+import { terms, mark, passage } from "genba/marks.js";
 import { kindIcon, sourceColor, bytes as formatBytes } from "genba/format.js";
 
 // Media types the interface knows how to draw as code, and the language each
@@ -139,9 +139,16 @@ export function languageOf(d) {
  * be, which is why it happens once out here rather than six times in there. The
  * caller reveals the first of them once the nodes are on the page, because
  * scrolling to something that is not in a document yet scrolls to nothing.
+ *
+ * options.at is a passage somebody was sent to, which is what a citation under
+ * an answer carries. It is marked before the words are, and the order is not
+ * incidental: marking the words first splits the sentence into a dozen nodes and
+ * hides the marked ones from anything looking for it, so the sentence a reader
+ * was sent to would be the one thing on the page that could not be found.
  */
 export function body(d, options = {}) {
   const node = draw(d);
+  if (options.at) passage(node, options.at);
   mark(node, terms(options.query));
   return node;
 }

--- a/web/dist/assets/drawer.js
+++ b/web/dist/assets/drawer.js
@@ -30,6 +30,11 @@ export class Drawer {
     this.returnTo = null;
     this.currentKey = "";
     this.query = "";
+    // The passage a citation sent this reader to, or nothing. It is the quote's
+    // own text rather than an offset into the body, because an offset is a
+    // promise about a document that the renderer breaks the moment it takes the
+    // markup out, and because text survives being pasted into a message.
+    this.quote = "";
     // The marked words in the body, and which of them is the current one.
     this.marks = [];
     this.at = -1;
@@ -111,8 +116,9 @@ export class Drawer {
     return !this.el.hidden;
   }
 
-  async show(id, query = "") {
+  async show(id, query = "", quote = "") {
     this.query = query;
+    this.quote = quote;
     // Only on the way in. Stepping from one result to the next with j replaces
     // what is in an open drawer, and the row to go back to is still the row it
     // was opened from rather than the heading inside it.
@@ -182,11 +188,18 @@ export class Drawer {
     // The body decides its own shape from the media type, so the drawer only
     // has to say where it goes and how wide it is.
     this.body.dataset.shape = shapeOf(d);
-    replace(this.body, renderBody(d, { query: this.query }));
+    replace(this.body, renderBody(d, { query: this.query, at: this.quote }));
     // Once the body is on the page and not before, because scrolling to a match
     // that is still in a fragment scrolls to nothing.
-    reveal(this.body);
-    this.matched();
+    //
+    // A passage somebody was sent to wins over the first word that matched, the
+    // same way a line number does on a document page and for the same reason: a
+    // citation was clicked by a person who meant that sentence, and the query is
+    // only how the document came to be on the screen it was clicked from.
+    const cited = this.quote ? this.body.querySelector("mark.hit--passage") : null;
+    if (cited) cited.scrollIntoView({ block: "center", inline: "nearest" });
+    else reveal(this.body);
+    this.matched(cited);
     // Opening at the source is only offered where a browser would go there. For
     // every document the file connector read it would not, so the path takes
     // its place: a path somebody can paste into a terminal is worth something,
@@ -254,8 +267,12 @@ export class Drawer {
    * is allowed to find nothing: it does not stem, so a search for cache in a
    * document that only says caching marks nothing at all, and a header offering
    * to walk zero matches is worse than a header that says nothing.
+   *
+   * here is the mark the document opened on, which is the cited passage when
+   * there was one. Without it the count would open at the first match while the
+   * page is scrolled to the fifth, and pressing n would jump backwards.
    */
-  matched() {
+  matched(here) {
     this.marks = [...this.body.querySelectorAll("mark.hit")];
     this.at = -1;
     this.matches.hidden = this.marks.length === 0;
@@ -263,9 +280,9 @@ export class Drawer {
       replace(this.count);
       return;
     }
-    // reveal has already brought the first one into view, so the count opens by
+    // reveal has already brought one of them into view, so the count opens by
     // saying which one that is rather than starting at nothing.
-    this.point(0);
+    this.point(Math.max(0, this.marks.indexOf(here)));
   }
 
   /**
@@ -335,6 +352,7 @@ export class Drawer {
     // reopening the same document is the most likely next thing to happen. It
     // is the key that is dropped, so nothing it returns is painted.
     this.currentKey = "";
+    this.quote = "";
     this.marks = [];
     this.at = -1;
     this.el.hidden = true;

--- a/web/dist/assets/format.js
+++ b/web/dist/assets/format.js
@@ -24,6 +24,7 @@ const ICONS = {
   copy: "M9 9h10v11H9zM5 15V4h10",
   image: "M4 5h16v14H4V5ZM4 16l4.5-4.5 3 3 3.5-3.5L20 16M9.5 9.5h.01",
   "arrow-left": "M19 12H5M11 6l-6 6 6 6",
+  "arrow-right": "M5 12h14M13 6l6 6-6 6",
   "arrow-up": "M12 19V5M6 11l6-6 6 6",
   "arrow-down": "M12 5v14M6 13l6 6 6-6",
   lock: "M8 10V7.5a4 4 0 0 1 8 0V10M5.5 10h13v10h-13V10Z",

--- a/web/dist/assets/marks.js
+++ b/web/dist/assets/marks.js
@@ -107,6 +107,124 @@ export function mark(root, words) {
   return count;
 }
 
+// The shortest run of a quoted passage worth marking, in characters with the
+// whitespace taken out.
+//
+// A citation that lands on eight characters has landed on a word, and a word
+// that happens to appear three paragraphs above the passage is worse than not
+// marking anything: it tells the reader the quote is there when it is not.
+const PASSAGE_MIN = 24;
+
+/**
+ * passage marks the quoted text a citation asked for and returns where it
+ * starts, or nothing when it is not on the page.
+ *
+ * The comparison ignores whitespace entirely on both sides, which is what makes
+ * it survive the trip. The quote was cut out of the source, where a paragraph
+ * break is two newlines, and it is being looked for in the rendered document,
+ * where the same break is the end of one element and the start of another, and
+ * where a run of inline markup splits a sentence into three text nodes with no
+ * space between them. Comparing the text with the spaces left in fails on all
+ * three, and none of the three is a real disagreement about what the words are.
+ *
+ * The longest prefix that is present wins rather than all or nothing. A quote
+ * whose last clause was dropped by the renderer, which is what a footnote marker
+ * or a trailing link does, still marks the sentence somebody was sent to.
+ */
+export function passage(root, text) {
+  const want = squeeze(String(text || ""));
+  if (want.length < PASSAGE_MIN) return null;
+
+  const flat = flatten(nodesIn(root));
+  if (flat.text.length < PASSAGE_MIN) return null;
+
+  // A prefix that is present implies every shorter prefix is, so the longest one
+  // is a binary search rather than a walk down from the whole quote.
+  let at = -1;
+  let lo = PASSAGE_MIN;
+  let hi = want.length;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const found = flat.text.indexOf(want.slice(0, mid));
+    if (found < 0) {
+      hi = mid - 1;
+      continue;
+    }
+    at = found;
+    lo = mid + 1;
+  }
+  if (at < 0) return null;
+  return paint(flat.at, at, at + hi)[0] || null;
+}
+
+/** squeeze drops every space, tab and newline. */
+function squeeze(s) {
+  return s.replace(/\s+/g, "");
+}
+
+/** nodesIn is the text of a tree, in reading order, minus what must not be marked. */
+function nodesIn(root) {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const out = [];
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    if (!node.nodeValue.trim()) continue;
+    if (node.parentElement && node.parentElement.closest(SKIP)) continue;
+    out.push(node);
+  }
+  return out;
+}
+
+/**
+ * flatten is those nodes as one string with the whitespace removed, and the
+ * node and offset each surviving character came from.
+ */
+function flatten(nodes) {
+  let text = "";
+  const at = [];
+  for (const node of nodes) {
+    const s = node.nodeValue;
+    for (let i = 0; i < s.length; i++) {
+      if (/\s/.test(s[i])) continue;
+      text += s[i];
+      at.push([node, i]);
+    }
+  }
+  return { text, at };
+}
+
+/**
+ * paint wraps one run of the flattened text in marks, one per text node it
+ * crosses, and returns them.
+ *
+ * One per node rather than one range, because a passage that runs through a bold
+ * word or a link crosses element boundaries and there is no single element to
+ * put around it. Each node keeps the whitespace between the first and last
+ * character the run touched inside it, so the highlight is continuous on screen
+ * rather than a row of marked words with gaps between them.
+ */
+function paint(at, from, to) {
+  const runs = [];
+  for (let i = from; i < to && i < at.length; i++) {
+    const [node, off] = at[i];
+    const last = runs[runs.length - 1];
+    if (last && last.node === node) last.to = off + 1;
+    else runs.push({ node, from: off, to: off + 1 });
+  }
+
+  const out = [];
+  for (const run of runs) {
+    const text = run.node.nodeValue;
+    const frag = document.createDocumentFragment();
+    if (run.from > 0) frag.appendChild(document.createTextNode(text.slice(0, run.from)));
+    const el = h("mark", { class: "hit hit--passage" }, text.slice(run.from, run.to));
+    frag.appendChild(el);
+    if (run.to < text.length) frag.appendChild(document.createTextNode(text.slice(run.to)));
+    run.node.parentNode.replaceChild(frag, run.node);
+    out.push(el);
+  }
+  return out;
+}
+
 /**
  * reveal moves a document to the part of it somebody came for.
  *

--- a/web/dist/assets/results.js
+++ b/web/dist/assets/results.js
@@ -3,6 +3,7 @@
 import { h, replace, svg } from "genba/dom.js";
 import { label, number, duration, icon, facetLabels } from "genba/format.js";
 import { shapeOf } from "genba/content.js";
+import { Answer } from "genba/answer.js";
 import { RowList } from "genba/rows.js";
 import { nothingMatched, slow, stopped } from "genba/states.js";
 import * as urlState from "genba/state.js";
@@ -78,7 +79,7 @@ const FACET_VISIBLE = 8;
 const SHEET = "(max-width: 960px)";
 
 export class Results {
-  constructor({ onQuery, onOpen, onHover, onSay, onCursor }) {
+  constructor({ onQuery, onOpen, onHover, onSay, onCursor, onCite }) {
     this.onQuery = onQuery;
     this.expanded = new Set();
     this.hits = [];
@@ -97,6 +98,10 @@ export class Results {
     // of documents does not: the verticals, the filters, the count and the
     // pager.
     this.rows = new RowList({ onOpen, onHover, onSay, onCursor });
+    // The quoted passages, above the rows they were quoted from. It owns whether
+    // it is on screen at all, and a response with nothing worth quoting leaves
+    // the column looking exactly as it did before this existed.
+    this.answer = new Answer({ onCite });
     // Empty until the session says what the corpus holds, so the strip is never
     // painted with tabs that are about to be taken away.
     this.verticals = [];
@@ -183,7 +188,14 @@ export class Results {
         { class: "results" },
         this.scrim,
         this.facets,
-        h("div", { class: "results__main" }, this.head, this.list, this.aside),
+        h(
+          "div",
+          { class: "results__main" },
+          this.answer.el,
+          this.head,
+          this.list,
+          this.aside,
+        ),
       ),
     );
   }
@@ -261,6 +273,10 @@ export class Results {
     // the cursor and the hits it walks go with the rows on screen.
     this.hits = [];
     this.rows.skeleton();
+    // No skeleton for the quotes. Most searches have no answer at all, so a
+    // placeholder in the shape of one promises something that usually is not
+    // coming and then takes the promise back.
+    this.answer.clear();
     replace(this.chips);
     replace(
       this.head,
@@ -306,6 +322,7 @@ export class Results {
   cancelled(onRetry) {
     this.hits = [];
     this.rows.render([], { view: "list", cursor: -1 });
+    this.answer.clear();
     replace(this.head);
     replace(this.facets);
     replace(this.aside, stopped(onRetry));
@@ -358,6 +375,10 @@ export class Results {
     this.total = res.total || 0;
     this.renderTabs(query, res);
     this.renderChips(query);
+    // In the same paint as the rows it quotes, which is the whole of what keeps
+    // it from moving anything. There is no second request behind it and no
+    // moment where the list is on screen without it.
+    this.answer.render(res);
     this.renderHead(query, res);
     this.renderList(query, res);
     this.renderFacets(query, res);

--- a/web/dist/assets/state.js
+++ b/web/dist/assets/state.js
@@ -74,6 +74,12 @@ export function read(search = location.search) {
     limit: Number(params.get("limit") || 20) || 20,
     tab: params.get("tab") || "all",
     open: params.get("open") || "",
+    // The passage inside the open document to land on, which is what a citation
+    // under an answer carries. It is the quoted text rather than an offset,
+    // because an offset into a body is a promise the renderer breaks as soon as
+    // it takes the markup out, and because a link somebody pastes into a message
+    // should still work when the document has had a paragraph added to the top.
+    at: params.get("at") || "",
     // Empty means the view has not been chosen, which is different from having
     // chosen the list. A page of nothing but images opens as a grid, and that
     // has to stop happening the moment somebody says they want the list, so the
@@ -120,6 +126,9 @@ export function write(query, path = "/") {
   if (query.view) params.set("view", query.view);
   if (query.cursor >= 0) params.set("cursor", String(query.cursor));
   if (query.open) params.set("open", query.open);
+  // Only ever alongside the document it points into. A passage with nothing open
+  // is a parameter naming a place in a document nobody is looking at.
+  if (query.open && query.at) params.set("at", query.at);
   // Rooted rather than relative, because a search reached from a document page
   // is a search and not a document with a query string stuck on the end of it.
   const s = params.toString();

--- a/web/dist/assets/tokens.css
+++ b/web/dist/assets/tokens.css
@@ -92,6 +92,14 @@
      calm. */
   --mark: #fae041;
 
+  /* The wash behind a whole cited sentence, which is a different job from the
+     rule above and needs a different shape. A sentence marked a word at a time
+     reads as a scribble across four lines, and a rule cannot cover a passage
+     that wraps at all: it is drawn on the first line of it and nowhere else. So
+     the passage gets a fill, at the strength that stays behind the text rather
+     than in front of it. */
+  --mark-wash: rgb(250 224 65 / 0.34);
+
   /* Code. Five colours, because the highlighter finds five things: a comment,
      a string, a number, a keyword and the name of a function or a type. A
      twenty colour theme is a theme for somebody editing the file, and nobody
@@ -314,6 +322,10 @@
   /* Higher chroma, to hold against a near black ground. The mark keeps
      colour: inherit on the text, so no second foreground token is needed. */
   --mark: #f5c518;
+  /* Weaker than on white. The same alpha over a near black ground lifts the
+     whole sentence off the page and the text stops being the brightest thing
+     in it. */
+  --mark-wash: rgb(245 197 24 / 0.24);
 
   --source-github: #c9d1d9;
   --source-notion: #d4d0c8;

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -23,6 +23,7 @@
     <script type="importmap">
       {
         "imports": {
+          "genba/answer.js": "/assets/answer.js",
           "genba/api.js": "/assets/api.js",
           "genba/app.js": "/assets/app.js",
           "genba/cache.js": "/assets/cache.js",
@@ -61,6 +62,7 @@
       on a graph that is twenty eight files wide. graph_test.go computes the
       closure from app.js and fails if this list is not exactly it.
     -->
+    <link rel="modulepreload" href="/assets/answer.js" />
     <link rel="modulepreload" href="/assets/api.js" />
     <link rel="modulepreload" href="/assets/app.js" />
     <link rel="modulepreload" href="/assets/cache.js" />


### PR DESCRIPTION
## What this is

A search that matched something usually contains the answer to the question somebody asked, three lines into the second result.
Until now the only way to get at it was to open documents one at a time and read them.
This puts the sentences above the list.

Every sentence in the region is a passage lifted verbatim out of a document on the page below it, and each one carries a link that opens that document at that sentence.
Nothing is paraphrased, summarised or generated.
There is no sentence in an answer that is not already in the corpus, and no way for one to be wrong in a way the document it points at is not also wrong.

## Why it is extractive

This is the honest half of the assistant in the specification.
The half that needs a model is M5, and it is still open.

What this settles first is the part a model does not fix: where the answer sits, what a citation does when somebody clicks it, and how a reader tells the product's words from a document's.
An assistant that gets those three wrong is worse with a good model than without one, because a confident paraphrase whose citation leads nowhere is how people learn to stop reading citations.

## How it is built

The answer rides on the search response rather than an endpoint beside it.
The ranking has already chosen which documents are worth reading and the fetch has already paid for their bodies, so the whole thing costs three passes over three windows, a results page still answers in one request, and the answer joins the ETag the response already had.

A quote is not a snippet, which is why `index/answer.go` is a second function rather than a flag on the first.
A snippet is evidence that a document matched, read under a title, so a window with an ellipsis at each end is fine.
A quote is read on its own by somebody deciding whether any of this is worth opening, so it has to start where a sentence starts and end where one ends.

Two rules decide what is quotable.
A source file is never quoted, not because there is no prose in one but because every sentence of it arrives wearing its markers, and taking them off is a renderer's job done in the browser where the language is known.
A candidate holding a brace, a bracket, an equals sign or a backtick is a line out of a file rather than something written to be read, which keeps a fenced command out of the answer when the document around it is markdown.
Both are blunt on purpose.
Losing a good sentence costs nothing because there are two more documents to quote from, and quoting a line of JSON above the results is the failure the region has to avoid.

## Done when

**A citation opens the source passage in one action.**
Clicking a citation opens the document in the preview that a result row opens, with the same keys and the same way out, scrolled to the sentence with the sentence marked.
The passage travels in the address as the text rather than as an offset, because an offset into a body is a promise the renderer breaks as soon as it takes the markup out, and because a link somebody pastes into a message should still work after a paragraph is added to the top of the document.
Finding it again in the rendered page ignores whitespace on both sides: the quote was cut where a paragraph break is two newlines, and it is looked for where the same break is the end of one element, and where a bold word splits a sentence into three text nodes with nothing between them.

**Streaming does not cause layout jumps as the answer grows.**
There is no stream here, because there is no model, and #31 owns the token stream.
What this does is implement and enforce the layout contract the stream will have to keep.
The region is absent when there is no answer, and absent means not rendered rather than rendered empty.
It arrives in the same paint as the rows it quotes, quote length is bounded server side, and nothing in it loads late.
The walk asserts that the top of the first result has not moved a pixel a second and a bit after the page painted, so the first stream that reflows the page fails the gate.

**The distinction between generated text and quoted text is visible without reading carefully.**
The violet reserved for generated content stays unused, and that is the point of it rather than an omission.
Nothing here was generated, so nothing here wears the colour that says something was.
The separation is size: the quotes are set at reading size with prose leading behind a rule, the way a paragraph of a document is set everywhere else in the interface, and everything the product says about them is small, grey and out of the way.
The region says it once in words as well, because a reader who assumes a paragraph above a list of results was written for them has assumed the normal thing.
When there is a model, the generated part gets the violet and these quotes keep the grey rule beside them.

**It works with a screen reader.**
The region is a section with a heading it points at, the quotes are an ordered list of blockquotes, and each citation is a real anchor whose label names the document and says what following it does.
axe now audits a results page with an answer on it, which is markup none of the other ten screens produce.

## Gate

117 checks pass on server2, none fail.
The new ones are five in the walk and four in the rendering check.
Node counts went up by one on both budgeted pages, which is the empty region, and the style budget moved from 17936 to 18396 bytes of 40960.

axe itself could not run on that machine: its chromedriver only supports Chrome 152 and the machine has 145.
That is the same failure this repository has had on that box for a while and it is not related to this change.

Refs #39
