### PR TITLE
Show an operator what the connectors did and what is held back

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,15 @@ Everything the interface does is an HTTP call, and there is nothing it can reach
 | `GET /api/v1/documents/{id}` | one document, or the same error as one that does not exist |
 | `GET /api/v1/me` | the caller, and the sources and kinds that caller can actually see |
 | `GET /api/v1/stats` | how much is indexed and how much is quarantined |
+| `GET /api/v1/admin/operations` | what the connectors are doing, and what is being held back and why |
 | `GET /healthz`, `GET /readyz` | liveness, and whether the store answers |
 
 `search` takes `q` for the text and the operators, and `source`, `kind`, `container`, `author` and `owner` as repeated or comma separated parameters, plus `since`, `until`, `sort`, `limit` and `offset`.
 The snippet comes back as marked passages rather than as offsets, so a client highlights what the analyzer matched without reimplementing the analyzer.
+
+`admin/operations` needs the `admin` role, which comes from `X-Genba-Roles` or from `GENBA_ADMINS`, and the default is that nobody has it.
+The role grants nothing over documents and it must not start to.
+Both the reads and the refusals are logged with the subject.
 
 By default every file in the corpus is readable by everybody in the tenant, which is the right rule for a public checkout and the wrong one for almost anything else.
 If the tree has OWNERS files in it, `-corpus-acl owners` reads them instead, and a query then returns different results depending on who is asking.
@@ -156,6 +161,7 @@ The environment variable is the flag in upper case with a `GENBA_` prefix, and a
 | `GENBA_STORE` | `memory` | storage driver: `memory`, `sqlite`, `postgres` or `kura` |
 | `GENBA_DSN` | empty | path or connection string for the driver |
 | `GENBA_TENANT` | empty | tenant served by a single tenant deployment |
+| `GENBA_ADMINS` | empty | subjects that hold the administrator role, comma separated |
 | `GENBA_LOG_LEVEL` | `info` | `debug`, `info`, `warn` or `error` |
 | `GENBA_READ_TIMEOUT` | `30s` | request read timeout |
 | `GENBA_WRITE_TIMEOUT` | `60s` | request write timeout |

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -89,6 +89,17 @@ func (p *Principal) IdentityIn(source string) (string, bool) {
 	return "", false
 }
 
+// RoleAdmin is the role that may see how the deployment is running.
+//
+// It grants nothing over documents and it must not start to. Everything it
+// opens up is about the machinery: which connectors are syncing, which runs
+// failed, what is being held back and why. A person holding it sees the same
+// search results as they did without it, because an operator being able to read
+// the corpus is a decision about that person and not about that job, and the
+// day the two are the same role is the day nobody can be given the second
+// without the first.
+const RoleAdmin = "admin"
+
 // HasRole reports whether the principal holds the named role.
 func (p *Principal) HasRole(role string) bool {
 	return p != nil && slices.Contains(p.Roles, role)
@@ -210,6 +221,25 @@ type Permissions struct {
 	// Version increases every time the source reports a change. It is what a
 	// revocation bumps, and what derived bitmaps are keyed on.
 	Version uint64
+
+	// Reason says why the mode is unknown, in the words of whatever failed to
+	// resolve it. It is empty for every descriptor that resolved, and nothing
+	// reads it to decide anything.
+	//
+	// It is here because a quarantined document is otherwise a number. An
+	// operator looking at a count of eleven hundred held back documents has no
+	// way to tell one connector's broken role mapping from a tenant boundary
+	// working exactly as intended, and the two want opposite actions. The
+	// mapping already knows which it was at the moment it gave up, so the
+	// sentence it would have logged and thrown away travels with the document
+	// instead, and the screen that lists the quarantine can say why for each
+	// entry rather than in aggregate.
+	//
+	// It is the one field here with a JSON tag, because every document in the
+	// store is written as JSON with these names and almost none of them have a
+	// reason. An always present empty string on every row of a corpus is a cost
+	// paid by the many for the few.
+	Reason string `json:",omitempty"`
 }
 
 // Allows reports whether the principal may read the document.

--- a/api/admin.go
+++ b/api/admin.go
@@ -1,0 +1,248 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+// HeldLimit is how many quarantined documents one administration response
+// carries.
+//
+// A hundred, and the response says how many there are in total, so the screen
+// can say a hundred of fourteen hundred rather than implying it has them all.
+// The number is a compromise between two failures. Too few and a corpus with
+// three connectors' worth of held documents shows one connector's, because the
+// list is ordered by date and not spread across sources. Too many and a screen
+// that has to answer in ten milliseconds is reading a megabyte of JSON to draw
+// a list nobody scrolls to the bottom of.
+const HeldLimit = 100
+
+// Operations is what this deployment is doing, as whatever runs the connectors
+// sees it.
+//
+// It is supplied by the caller through [WithOperations] rather than worked out
+// here, for the same reason [Indexing] is: the thing that knows is the thing
+// running the syncs, and this package deliberately does not. An embedder that
+// indexes on its own schedule fills this in and gets the same screen.
+type Operations struct {
+	Connectors []Connector `json:"connectors"`
+}
+
+// Connector is one source this process syncs, and how it is getting on.
+type Connector struct {
+	// Source is the name the documents carry, which is what ties a row on this
+	// screen to a filter in a search.
+	Source string `json:"source"`
+
+	// Kind is what sort of source it is, such as a directory or a bucket, and
+	// Target is which one, so that two directories are two rows a person can
+	// tell apart rather than two rows called directory.
+	Kind   string `json:"kind"`
+	Target string `json:"target"`
+
+	// Tenant is whose corpus it feeds.
+	Tenant string `json:"tenant"`
+
+	// Refresh is how often it syncs again, as a duration, and is empty for a
+	// source that syncs once at startup and never again.
+	Refresh string `json:"refresh,omitempty"`
+
+	// Syncing says a run is going right now. It is separate from the last run's
+	// outcome because the two answer different questions, and a screen that
+	// worked it out by comparing timestamps would flicker.
+	Syncing bool `json:"syncing"`
+
+	// Runs are the syncs this process has done, most recent first and bounded.
+	// A source that has not finished one yet has none, which is not an error
+	// and is what a screen should say rather than drawing a zero.
+	Runs []Run `json:"runs"`
+
+	// Permissions is what the access control mapping made of this source, and
+	// is absent for a connector whose policy does not count. It is the aggregate
+	// half of the quarantine: this says how many were held for each reason
+	// across the whole corpus, and the list below says which documents.
+	Permissions *Mapping `json:"permissions,omitempty"`
+}
+
+// Run is one sync of one source.
+type Run struct {
+	// Started is when it began, in RFC 3339, and Duration is how long it took
+	// in milliseconds. A run still going has a duration of zero.
+	Started  string `json:"started"`
+	Duration int64  `json:"duration_ms"`
+
+	// Error is what went wrong, and is empty for a run that finished.
+	//
+	// It is the message rather than a code, because there is nothing useful to
+	// switch on: the failures here are a directory that disappeared, a bucket
+	// refusing a signature and a token that expired, and what an operator needs
+	// is the sentence. This is the whole of what box two of the issue asks for,
+	// so it is not truncated.
+	Error string `json:"error,omitempty"`
+
+	// The counts, which are ingest.Stats as it crossed the wire. Indexed and
+	// Quarantined are documents this run stored, Deleted is what it removed
+	// because the source no longer had it, Repermissioned is what it rewrote
+	// the access control list of without refetching, and Skipped is what it
+	// rejected before the store.
+	Indexed        int   `json:"indexed"`
+	Quarantined    int   `json:"quarantined"`
+	Deleted        int   `json:"deleted"`
+	Repermissioned int   `json:"repermissioned"`
+	Skipped        int   `json:"skipped"`
+	Bytes          int64 `json:"bytes"`
+}
+
+// Mapping is what one source's permission mapping has seen, by reason.
+//
+// The three quarantine reasons are separate because they want three different
+// actions. A foreign domain is a decision somebody has to make about the
+// tenant, an unmappable deny is usually a source feature nobody has written the
+// mapping for yet, and a malformed grant is a bug in a connector. One number
+// for all three is a number nobody can act on.
+type Mapping struct {
+	Mapped         int64 `json:"mapped"`
+	ForeignDomain  int64 `json:"foreign_domain"`
+	UnmappableDeny int64 `json:"unmappable_deny"`
+	Malformed      int64 `json:"malformed"`
+
+	// Ignored is statements whose role does not confer read. It is not a
+	// failure and it is worth watching: a sudden climb usually means a source
+	// renamed a role and the mapping has not caught up, which shows up to
+	// somebody as documents they used to be able to find.
+	Ignored int64 `json:"ignored"`
+}
+
+// WithOperations supplies what the connectors are doing.
+//
+// Without it the administration screen still works and says this process runs
+// no connectors, which is the truth for an embedder that indexes elsewhere and
+// is a better answer than an empty list that looks like a broken sync.
+func WithOperations(fn func() Operations) Option {
+	return func(s *Server) { s.operations = fn }
+}
+
+// adminResponse is the whole administration screen in one request.
+//
+// One request rather than three, because every number on the screen is a
+// snapshot of the same moment and three requests would let the list of held
+// documents disagree with the count above it. It is also the cheapest shape:
+// the connector state is in memory, the counts are one aggregate, and the list
+// is one bounded query.
+type adminResponse struct {
+	Connectors []Connector `json:"connectors"`
+
+	// Documents and Quarantined are the corpus, the same two numbers the stats
+	// endpoint reports. They are repeated here rather than left to a second
+	// request so that the total above the list and the list itself were read
+	// together.
+	Documents   int `json:"documents"`
+	Quarantined int `json:"quarantined"`
+
+	// Held is a bounded sample of the quarantine, newest first where the driver
+	// can order it. Listable says whether the driver can produce one at all: a
+	// screen showing an empty list under a count of fourteen hundred has to be
+	// able to say the driver cannot list them rather than that there are none.
+	Held     []held `json:"held"`
+	Listable bool   `json:"listable"`
+}
+
+// held is one quarantined document on the wire.
+type held struct {
+	ID     string `json:"id"`
+	Title  string `json:"title,omitempty"`
+	Source string `json:"source,omitempty"`
+	Reason string `json:"reason,omitempty"`
+
+	// ModifiedAt is when the source last changed it, in RFC 3339, and is absent
+	// where the source never said.
+	ModifiedAt string `json:"modified_at,omitempty"`
+}
+
+// admin wraps a handler that only an administrator may reach.
+//
+// The refusal is logged and the success is logged, both with the subject, which
+// is the beginning of the audit trail these screens need. A read of what the
+// deployment is doing is not a read of anybody's documents, and it is still
+// something a deployment should be able to show somebody afterwards.
+func (s *Server) admin(h func(http.ResponseWriter, *http.Request, *acl.Principal)) http.Handler {
+	return s.authenticated(func(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+		if !p.HasRole(acl.RoleAdmin) {
+			s.log.Warn("administration refused",
+				"subject", p.Subject, "tenant", p.Tenant, "path", r.URL.Path)
+			// Forbidden rather than not found. Hiding the existence of an
+			// administration endpoint protects nothing, because it is in the
+			// interface and in this file, and a person who has been given the
+			// wrong account needs to be told which of the two things is wrong.
+			writeError(w, http.StatusForbidden, "forbidden", "this needs an administrator")
+			return
+		}
+		s.log.Info("administration read",
+			"subject", p.Subject, "tenant", p.Tenant, "path", r.URL.Path)
+		h(w, r, p)
+	})
+}
+
+// handleAdmin reports what the deployment is doing.
+//
+// Like the stats endpoint this carries no entity tag, and for the same reason:
+// half of what it reports is counters that move while nobody is looking, so a
+// tag over the body could never match and a tag that excluded them would pin
+// the client to the first answer it ever saw.
+func (s *Server) handleAdmin(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	st, err := s.store.Stats(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", "the corpus statistics are not available")
+		return
+	}
+
+	res := adminResponse{
+		Connectors:  []Connector{},
+		Documents:   st.Documents,
+		Quarantined: st.Quarantined,
+		Held:        []held{},
+	}
+	if s.operations != nil {
+		res.Connectors = s.operations().Connectors
+	}
+
+	// The listing is a capability rather than part of the interface, so a driver
+	// that cannot walk what it is not indexing says so and the screen says so
+	// too. See [store.Quarantine].
+	if q, ok := s.store.(store.Quarantine); ok {
+		res.Listable = true
+		// Only asked for when there is something to list. On the ordinary corpus
+		// the count is zero and this is a query nobody has to make.
+		if st.Quarantined > 0 {
+			list, err := q.Quarantined(r.Context(), p.Tenant, HeldLimit)
+			if err != nil {
+				// Not fatal. The connectors and the counts are still the truth,
+				// and a screen missing its list is a great deal more use than a
+				// screen missing everything.
+				s.log.Error("listing the quarantine", "tenant", p.Tenant, "error", err)
+				res.Listable = false
+			}
+			res.Held = heldOf(list)
+		}
+	}
+
+	h := w.Header()
+	h.Set("Cache-Control", cacheControl)
+	h.Set(varyHeader, varyValue)
+	writeJSON(w, http.StatusOK, res)
+}
+
+// heldOf puts the store's quarantine list on the wire.
+func heldOf(in []store.Held) []held {
+	out := make([]held, len(in))
+	for i, h := range in {
+		out[i] = held{ID: h.ID, Title: h.Title, Source: h.Source, Reason: h.Reason}
+		if !h.At.IsZero() {
+			out[i].ModifiedAt = h.At.UTC().Format(time.RFC3339)
+		}
+	}
+	return out
+}

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -1,0 +1,308 @@
+package api_test
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// What an operator can see about the deployment, and what everybody else
+// cannot.
+//
+// The two halves of this file are the two halves of the endpoint. The first is
+// the gate, which is a role and not a tenant, and which has to refuse in a way
+// that says why. The second is the answer, which is the connectors, the counts
+// and the list of what is being held back, all read at the same moment so that
+// the number above the list and the list agree.
+
+type adminBody struct {
+	Connectors []struct {
+		Source  string `json:"source"`
+		Kind    string `json:"kind"`
+		Target  string `json:"target"`
+		Syncing bool   `json:"syncing"`
+		Refresh string `json:"refresh"`
+		Runs    []struct {
+			Started     string `json:"started"`
+			Duration    int64  `json:"duration_ms"`
+			Error       string `json:"error"`
+			Indexed     int    `json:"indexed"`
+			Quarantined int    `json:"quarantined"`
+		} `json:"runs"`
+		Permissions *struct {
+			Mapped        int64 `json:"mapped"`
+			ForeignDomain int64 `json:"foreign_domain"`
+		} `json:"permissions"`
+	} `json:"connectors"`
+	Documents   int  `json:"documents"`
+	Quarantined int  `json:"quarantined"`
+	Listable    bool `json:"listable"`
+	Held        []struct {
+		ID         string `json:"id"`
+		Title      string `json:"title"`
+		Source     string `json:"source"`
+		Reason     string `json:"reason"`
+		ModifiedAt string `json:"modified_at"`
+	} `json:"held"`
+}
+
+// operator is a subject the deployment has named as an administrator.
+func operator() map[string]string {
+	return map[string]string{
+		api.HeaderSubject: "u_ops",
+		api.HeaderRoles:   acl.RoleAdmin,
+	}
+}
+
+// newAdminServer is a server holding one readable document and two that were
+// held back, with a log to read the audit trail out of.
+func newAdminServer(t *testing.T, ops func() api.Operations) (http.Handler, *bytes.Buffer) {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	held := func(id, reason string) doc.Document {
+		return doc.Document{
+			ID: id, Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title:      "Payroll " + id,
+			ModifiedAt: time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC),
+			Permissions: acl.Permissions{
+				Mode: acl.ModeUnknown, Source: "gdrive", Reason: reason,
+			},
+		}
+	}
+	docs := []doc.Document{
+		{
+			ID: "d1", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Payments failover runbook",
+			Permissions: acl.Permissions{
+				Mode: acl.ModePublicToTenant, Source: "gdrive", Version: 1,
+			},
+		},
+		held("d2", "foreign domain: a grant to @contractor.example"),
+		held("d3", "malformed grant: the entry named no principal"),
+	}
+	if err := st.Put(t.Context(), docs...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	var logged bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	opts := []api.Option{api.WithLogger(log)}
+	if ops != nil {
+		opts = append(opts, api.WithOperations(ops))
+	}
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}, opts...)
+	return s.Handler(), &logged
+}
+
+// The gate is the role and nothing else. A person with a perfectly good account
+// on the right tenant is still not an operator, and the deployment has to be
+// able to show afterwards that they were turned away.
+func TestAdministrationRefusesSomebodyWithoutTheRole(t *testing.T) {
+	h, logged := newAdminServer(t, nil)
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/operations", engineer())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	// Forbidden rather than not found, so that somebody handed the wrong account
+	// is told which of the two things is wrong.
+	if body := w.Body.String(); !strings.Contains(body, "administrator") {
+		t.Errorf("the refusal did not say what was missing: %s", body)
+	}
+	if got := logged.String(); !strings.Contains(got, "administration refused") || !strings.Contains(got, "u_mei") {
+		t.Errorf("the refusal was not audited: %s", got)
+	}
+}
+
+func TestAdministrationRefusesAnAnonymousCaller(t *testing.T) {
+	h, _ := newAdminServer(t, nil)
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/operations", nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}
+
+// A read of how the deployment is running is not a read of anybody's documents,
+// and it is still something the deployment should be able to account for.
+func TestAdministrationAuditsTheRead(t *testing.T) {
+	h, logged := newAdminServer(t, nil)
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/operations", operator())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	got := logged.String()
+	if !strings.Contains(got, "administration read") || !strings.Contains(got, "u_ops") {
+		t.Errorf("the read was not audited: %s", got)
+	}
+}
+
+// The counts and the list are read together, so the total above the list and
+// the list itself cannot disagree.
+func TestAdministrationListsTheQuarantineWithReasons(t *testing.T) {
+	h, _ := newAdminServer(t, nil)
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/operations", operator())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := decode[adminBody](t, w)
+	// One servable and two held, which is the split the screen draws. Documents
+	// is what a query can reach rather than what the store holds, so the two
+	// numbers add up to the corpus rather than one containing the other.
+	if body.Documents != 1 {
+		t.Errorf("documents = %d, want 1", body.Documents)
+	}
+	if body.Quarantined != 2 {
+		t.Errorf("quarantined = %d, want 2", body.Quarantined)
+	}
+	if !body.Listable {
+		t.Fatal("the driver lists its quarantine and the response said it does not")
+	}
+	if len(body.Held) != 2 {
+		t.Fatalf("held = %d entries, want 2", len(body.Held))
+	}
+	// The reason is the only thing on this screen anybody acts on. A list of two
+	// held documents with no reasons is the count again, drawn as a table.
+	reasons := map[string]string{}
+	for _, h := range body.Held {
+		reasons[h.ID] = h.Reason
+		if h.Title == "" {
+			t.Errorf("%s was listed with no title, which is an id nobody can recognise", h.ID)
+		}
+		if h.Source != "gdrive" {
+			t.Errorf("%s source = %q, want gdrive", h.ID, h.Source)
+		}
+		if h.ModifiedAt != "2026-03-01T09:00:00Z" {
+			t.Errorf("%s modified_at = %q", h.ID, h.ModifiedAt)
+		}
+	}
+	if want := "foreign domain: a grant to @contractor.example"; reasons["d2"] != want {
+		t.Errorf("d2 reason = %q, want %q", reasons["d2"], want)
+	}
+	if want := "malformed grant: the entry named no principal"; reasons["d3"] != want {
+		t.Errorf("d3 reason = %q, want %q", reasons["d3"], want)
+	}
+	// The readable document is not in the quarantine, which is the way this
+	// endpoint would leak: it is the one place that reads documents without
+	// asking whether the caller may see them, because what failed is exactly
+	// that question.
+	if strings.Contains(w.Body.String(), "Payments failover runbook") {
+		t.Error("a document that resolved was listed as held back")
+	}
+}
+
+// A process that runs no connectors says so, rather than drawing an empty list
+// that looks like every sync has stopped.
+func TestAdministrationReportsNoConnectorsWithoutOperations(t *testing.T) {
+	h, _ := newAdminServer(t, nil)
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/operations", operator())
+	if body := decode[adminBody](t, w); len(body.Connectors) != 0 {
+		t.Fatalf("connectors = %d, want none", len(body.Connectors))
+	}
+	if strings.Contains(w.Body.String(), `"connectors":null`) {
+		t.Error("connectors was null, which a client has to special case")
+	}
+}
+
+// The failure of a sync is the whole of what box two of the issue asks for, so
+// the message travels whole rather than as a code nobody can switch on.
+func TestAdministrationReportsSyncFailures(t *testing.T) {
+	h, _ := newAdminServer(t, func() api.Operations {
+		return api.Operations{Connectors: []api.Connector{{
+			Source:  "files",
+			Kind:    "corpus",
+			Target:  "/srv/notes",
+			Tenant:  "acme",
+			Refresh: "30s",
+			Syncing: true,
+			Runs: []api.Run{
+				{Started: "2026-03-01T09:00:30Z", Duration: 12, Error: "open /srv/notes: no such file or directory"},
+				{Started: "2026-03-01T09:00:00Z", Duration: 940, Indexed: 1204, Quarantined: 2},
+			},
+			Permissions: &api.Mapping{Mapped: 1204, ForeignDomain: 2},
+		}}}
+	})
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/operations", operator())
+	body := decode[adminBody](t, w)
+	if len(body.Connectors) != 1 {
+		t.Fatalf("connectors = %d, want 1", len(body.Connectors))
+	}
+	c := body.Connectors[0]
+	if c.Source != "files" || c.Kind != "corpus" || c.Target != "/srv/notes" || c.Refresh != "30s" {
+		t.Errorf("connector = %+v, want the source, kind, target and refresh", c)
+	}
+	if !c.Syncing {
+		t.Error("the connector is syncing and the response said it is not")
+	}
+	if len(c.Runs) != 2 {
+		t.Fatalf("runs = %d, want 2", len(c.Runs))
+	}
+	// Newest first, because the question is what is happening now and a screen
+	// should not have to sort to answer it.
+	if c.Runs[0].Error == "" {
+		t.Error("the failed run carried no message, which leaves nothing to act on")
+	}
+	if !strings.Contains(c.Runs[0].Error, "no such file or directory") {
+		t.Errorf("run error = %q, want the whole message", c.Runs[0].Error)
+	}
+	if c.Runs[1].Indexed != 1204 || c.Runs[1].Quarantined != 2 {
+		t.Errorf("run counts = %+v, want 1204 indexed and 2 held", c.Runs[1])
+	}
+	if c.Permissions == nil || c.Permissions.ForeignDomain != 2 {
+		t.Errorf("permissions = %+v, want the mapping counts by reason", c.Permissions)
+	}
+}
+
+// The role can come from the proxy or from the deployment's own list, and the
+// two do not have to agree. The list adds and never takes away, so an operator
+// who named themselves at startup is one whatever the proxy sends.
+func TestAdministrationTakesTheRoleFromTheConfiguredList(t *testing.T) {
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme", Admins: []string{"u_ops"}})
+	h := s.Handler()
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/operations",
+		map[string]string{api.HeaderSubject: "u_ops"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, the deployment named this subject", w.Code)
+	}
+
+	// And nobody else, which is the half that matters. A list that let one name
+	// in and everybody else as well would be worse than no list.
+	w = request(t, h, http.MethodGet, "/api/v1/admin/operations",
+		map[string]string{api.HeaderSubject: "u_mei"})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}
+
+// Empty means nobody. A deployment that has not said who operates it has not
+// decided, and the answer that cannot be taken back is the wrong guess.
+func TestAdministrationAdmitsNobodyByDefault(t *testing.T) {
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	h := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}).Handler()
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/operations",
+		map[string]string{api.HeaderSubject: "u_ops"})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}

--- a/api/api.go
+++ b/api/api.go
@@ -87,6 +87,11 @@ type Server struct {
 	// that runs no connectors, and a nil one is the same answer as no.
 	indexing func() (Indexing, bool)
 
+	// operations is asked, on every administration request, what the connectors
+	// are doing. It is nil for an embedder that runs none, and a nil one is the
+	// same answer as no connectors.
+	operations func() Operations
+
 	// heartbeat is how often an idle event stream sends a comment.
 	heartbeat time.Duration
 
@@ -219,6 +224,7 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("POST /api/v1/recent", s.authenticated(s.handleRecordOpen))
 	mux.Handle("GET /api/v1/stats", s.authenticated(s.handleStats))
 	mux.Handle("GET /api/v1/events", s.authenticated(s.handleEvents))
+	mux.Handle("GET /api/v1/admin/operations", s.admin(s.handleAdmin))
 	if s.assets != nil {
 		mux.Handle("GET /", s.assets)
 	}

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -23,11 +24,11 @@ import (
 // and a number there are comparable and the difference between them is the cost
 // of the HTTP layer.
 
-func handler(b *testing.B) (h http.Handler, ids map[string]string) {
+func handler(b *testing.B, opts ...api.Option) (h http.Handler, ids map[string]string) {
 	b.Helper()
 	st, spec := benchcorpus.Fixture(b)
 	s := api.New(st, index.New(st, index.WithClock(func() time.Time { return benchcorpus.Epoch })),
-		api.HeaderAuth{Tenant: benchcorpus.Tenant})
+		api.HeaderAuth{Tenant: benchcorpus.Tenant}, opts...)
 	return s.Handler(), headers(spec.Principal())
 }
 
@@ -182,6 +183,26 @@ func BenchmarkAPIStats(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		get(b, h, "/api/v1/stats", hdr)
+	}
+}
+
+// BenchmarkAPIAdmin is the administration screen, which repaints itself every
+// five seconds for as long as somebody leaves it open. That is the reason it is
+// measured: an endpoint nobody calls twice can afford to be slow and one that
+// answers on a timer cannot. It reads memory for the connectors and then asks
+// the store for its counts and for a bounded page of what is being held back,
+// so the number here is the cost of those two queries over the whole corpus.
+// Every read of it is audited, and the audit goes to the process log, so the
+// logger is thrown away here. Measuring an endpoint with its log line going to
+// a terminal measures the terminal.
+func BenchmarkAPIAdmin(b *testing.B) {
+	h, hdr := handler(b, api.WithLogger(slog.New(slog.DiscardHandler)))
+	hdr[api.HeaderRoles] = acl.RoleAdmin
+	get(b, h, "/api/v1/admin/operations", hdr)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		get(b, h, "/api/v1/admin/operations", hdr)
 	}
 }
 

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -127,6 +127,36 @@ func TestStatsCarryNoTagBecauseReadingThemMovesThem(t *testing.T) {
 	}
 }
 
+// TestAdministrationCarriesNoTagForTheSameReasonStatsDoNot covers the second
+// and last endpoint excused the tag. Half of what it reports is what the
+// connectors are doing right now, and a sync that starts between two requests
+// changes the body without changing anything a tag could be computed over
+// cheaply. Tagging it would either produce a tag that never matches, which is a
+// revalidation that can never succeed, or a tag computed over the parts that
+// hold still, which would pin an operator to the first answer they ever saw on
+// the one screen they open to find out whether anything is wrong.
+//
+// The headers that keep the answer out of a shared cache still apply, because
+// this body names documents that are being held back and who is allowed to see
+// them is exactly what a proxy in the middle does not know.
+func TestAdministrationCarriesNoTagForTheSameReasonStatsDoNot(t *testing.T) {
+	_, h := cachingServer(t)
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/operations", operator())
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200: %s", w.Code, w.Body)
+	}
+	if got := w.Header().Get("ETag"); got != "" {
+		t.Errorf("administration carries ETag %q, which no later request can match", got)
+	}
+	if got := w.Header().Get("Cache-Control"); got != "private, max-age=0, must-revalidate" {
+		t.Errorf("Cache-Control is %q, want a private response that must be revalidated", got)
+	}
+	if got := w.Header().Get("Vary"); !strings.Contains(got, "Authorization") || !strings.Contains(got, "Cookie") {
+		t.Errorf("Vary is %q, want the credential headers: without them a cache may serve this to somebody without the role", got)
+	}
+}
+
 func TestARepeatedRequestIsAnsweredWithoutABody(t *testing.T) {
 	_, h := cachingServer(t)
 

--- a/api/headerauth.go
+++ b/api/headerauth.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -23,6 +24,21 @@ type HeaderAuth struct {
 	// Tenant is used when the request does not carry one. A single tenant
 	// deployment sets it here and never sends the header.
 	Tenant string
+
+	// Admins are the subjects that hold [acl.RoleAdmin] whatever the request
+	// says, named by whoever started the process.
+	//
+	// It is here rather than only in the roles header because of what the two
+	// are for. The header is how a proxy that has already authenticated
+	// somebody passes their roles down, and it is only as trustworthy as the
+	// proxy stripping it. This is how a deployment with no proxy in front of it
+	// still has an administrator, which is every first install and every
+	// laptop, and it is a list somebody typed rather than a default: empty
+	// means nobody is an administrator and the screens that need one are
+	// refused. That is the right way round. A deployment that has not decided
+	// who operates it has not decided, and guessing everybody is the answer
+	// that cannot be taken back.
+	Admins []string
 }
 
 // Header names read by [HeaderAuth].
@@ -32,6 +48,7 @@ const (
 	HeaderGroups       = "X-Genba-Groups"
 	HeaderGroupVersion = "X-Genba-Group-Version"
 	HeaderIdentities   = "X-Genba-Identities"
+	HeaderRoles        = "X-Genba-Roles"
 )
 
 // Authenticate builds a principal from the headers.
@@ -58,6 +75,14 @@ func (h HeaderAuth) Authenticate(r *http.Request) (*acl.Principal, error) {
 		Subject: subject,
 		Kind:    acl.KindUser,
 		Groups:  acl.GroupSet{Version: version, Members: splitCSV(r.Header.Get(HeaderGroups))},
+		Roles:   splitCSV(r.Header.Get(HeaderRoles)),
+	}
+	// The configured list wins over the header in the only direction that
+	// matters: it can add the role and it never takes it away, so a proxy that
+	// hands down roles and an operator who named themselves at startup do not
+	// have to agree.
+	if slices.Contains(h.Admins, subject) && !p.HasRole(acl.RoleAdmin) {
+		p.Roles = append(p.Roles, acl.RoleAdmin)
 	}
 	for _, raw := range splitCSV(r.Header.Get(HeaderIdentities)) {
 		source, value, ok := strings.Cut(raw, ":")

--- a/cmd/genbad/bucket.go
+++ b/cmd/genbad/bucket.go
@@ -196,7 +196,7 @@ func bucketPolicyFor(c *objectsource.Client, o bucketOptions) (objectsource.Poli
 // It runs on the same schedule the directory does, for the same reason: every
 // sync including the first runs behind the listener, and later ones are
 // incremental against the cursor the last one saved.
-func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant string, track *indexing, log *slog.Logger) (func(), error) {
+func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant string, track *indexing, ops *operations, log *slog.Logger) (func(), error) {
 	if cfg.Bucket == "" {
 		return func() {}, nil
 	}
@@ -251,6 +251,7 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 	return runFeed(ctx, st, feed{
 		Kind:      "bucket",
 		Source:    src,
+		Target:    cfg.Bucket,
 		Tenant:    tenant,
 		Refresh:   cfg.Refresh,
 		Reconcile: cfg.Reconcile,
@@ -258,6 +259,7 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 		Report:    func() []any { return requesting(client, limiter) },
 		Policy:    policy,
 		Track:     track,
+		Ops:       ops,
 		Release:   func() { _ = src.Close() },
 	}, log)
 }

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -146,7 +146,7 @@ func policyFor(o corpusOptions) (fssource.Policy, error) {
 // from the moment it says it is up and says on screen that the answers are
 // partial while the first read finishes. Later syncs are incremental: the
 // connector reports only what changed since the cursor the last one saved.
-func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant string, track *indexing, log *slog.Logger) (func(), error) {
+func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant string, track *indexing, ops *operations, log *slog.Logger) (func(), error) {
 	if cfg.Dir == "" {
 		return func() {}, nil
 	}
@@ -182,6 +182,7 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 	return runFeed(ctx, st, feed{
 		Kind:      "corpus",
 		Source:    src,
+		Target:    cfg.Dir,
 		Tenant:    tenant,
 		Refresh:   cfg.Refresh,
 		Reconcile: cfg.Reconcile,
@@ -189,6 +190,7 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 		Report:    func() []any { return watching(watcher) },
 		Policy:    policy,
 		Track:     track,
+		Ops:       ops,
 		Release: func() {
 			if watcher != nil {
 				_ = watcher.Close()

--- a/cmd/genbad/feed.go
+++ b/cmd/genbad/feed.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/api"
 	"github.com/tamnd/genba/connector"
 	"github.com/tamnd/genba/connector/aclmap"
 	"github.com/tamnd/genba/ingest"
@@ -29,6 +30,11 @@ type feed struct {
 
 	// Source is the connector to sync.
 	Source connector.Connector
+
+	// Target is which directory or bucket this feed reads, for the
+	// administration screen. Two directories are two rows a person can tell
+	// apart only if each says which one it is.
+	Target string
 
 	// Tenant is who the documents belong to.
 	Tenant string
@@ -59,6 +65,13 @@ type feed struct {
 	// A nil one is a feed nobody is watching.
 	Track *indexing
 
+	// Ops is where each sync is recorded for the administration screen. It is
+	// the same arrangement as Track and it is separate from it because the two
+	// answer different questions: Track is how far the first crawl has got, and
+	// this is what every run since then did and which of them failed. A nil one
+	// records nothing.
+	Ops *operations
+
 	// Release is called once the last sync has returned, and is where a watcher
 	// and a source get closed.
 	Release func()
@@ -88,12 +101,39 @@ func runFeed(ctx context.Context, st store.Store, f feed, log *slog.Logger) (fun
 		return nil, err
 	}
 
+	// Said here rather than in the goroutine, so that the answer to whether this
+	// process is still reading its sources is already correct by the time the
+	// listener opens. A readiness check that arrives in the microsecond between
+	// the two would otherwise be told the crawl is over because it has not
+	// started.
+	source := f.Source.Source()
+	tracked := f.Track != nil && f.Track.expect(source)
+	if f.Ops != nil {
+		// Registered before the first sync, so a screen opened during the first
+		// crawl of a large corpus shows the connector with no runs yet rather
+		// than showing nothing at all.
+		f.Ops.register(api.Connector{
+			Source:  source,
+			Kind:    f.Kind,
+			Target:  f.Target,
+			Tenant:  f.Tenant,
+			Refresh: refreshOf(f.Refresh),
+		}, f.Policy)
+	}
+
 	var swept time.Time
 	sync := func(ctx context.Context) {
 		var before, after runtime.MemStats
 		runtime.ReadMemStats(&before)
 
+		started := time.Now()
+		if f.Ops != nil {
+			f.Ops.starting(source, started)
+		}
 		stats, err := pipeline.Run(ctx, genba.TenantID(f.Tenant), f.Source)
+		if f.Ops != nil {
+			f.Ops.finished(source, time.Since(started), stats, err)
+		}
 		if err != nil {
 			log.Error(f.Kind+" sync failed", append(slices.Clone(f.Fields),
 				"error", err,
@@ -138,14 +178,6 @@ func runFeed(ctx context.Context, st store.Store, f feed, log *slog.Logger) (fun
 	if release == nil {
 		release = func() {}
 	}
-
-	// Said here rather than in the goroutine, so that the answer to whether this
-	// process is still reading its sources is already correct by the time the
-	// listener opens. A readiness check that arrives in the microsecond between
-	// the two would otherwise be told the crawl is over because it has not
-	// started.
-	source := f.Source.Source()
-	tracked := f.Track != nil && f.Track.expect(source)
 
 	done := make(chan struct{})
 	go func() {

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -69,6 +70,11 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	fs.StringVar(&cfg.DSN, "dsn", cfg.DSN, "storage data source")
 	fs.StringVar(&cfg.Tenant, "tenant", cfg.Tenant, "tenant served by a single tenant deployment")
 	fs.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "debug, info, warn or error")
+	// A string rather than a repeated flag, because it is a list of a handful of
+	// names that is written once in a unit file. Empty means nobody is an
+	// administrator, which is the right default for a deployment that has not
+	// said who operates it.
+	admins := fs.String("admins", strings.Join(cfg.Admins, ","), "subjects that hold the administrator role, comma separated")
 
 	var corpus corpusOptions
 	fs.StringVar(&corpus.Dir, "corpus", "", "directory to index at startup")
@@ -113,6 +119,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		fmt.Fprintf(stdout, "genbad %s (%s, built %s)\n", genba.Version, genba.Commit, genba.Date)
 		return nil
 	}
+	cfg.Admins = subjects(*admins)
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
@@ -142,10 +149,15 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	// empty index and there is exactly one moment at which that can be asked.
 	track := newIndexing(ctx, st)
 
+	// The same arrangement for what the connectors are doing, which the
+	// administration screen reads and nothing else does.
+	ops := newOperations()
+
 	opts := []api.Option{
 		api.WithLogger(log),
 		api.WithDriver(string(cfg.Store)),
 		api.WithIndexing(track.State),
+		api.WithOperations(ops.State),
 	}
 	if h := web.Handler(); h != nil {
 		opts = append(opts, api.WithAssets(h))
@@ -160,7 +172,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	// listens for the store's writes and the first sync is a write like any
 	// other. Building it afterwards left it reporting that nothing had been
 	// indexed since it came up while sitting on a corpus it had just loaded.
-	srv := api.New(st, searcher, api.HeaderAuth{Tenant: cfg.Tenant}, opts...)
+	srv := api.New(st, searcher, api.HeaderAuth{Tenant: cfg.Tenant, Admins: cfg.Admins}, opts...)
 
 	// Each source starts syncing here and keeps going behind the listener. What
 	// is built here and not in the background is everything that can be wrong
@@ -169,13 +181,13 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	// later. A server pointed at both indexes both, and the two are separate
 	// feeds with separate cursors rather than one merged crawl, because a bucket
 	// that is refusing requests should not stop a directory being reindexed.
-	waitForCorpus, err := ingestCorpus(ctx, st, corpus, cfg.Tenant, track, log)
+	waitForCorpus, err := ingestCorpus(ctx, st, corpus, cfg.Tenant, track, ops, log)
 	if err != nil {
 		return err
 	}
 	defer waitForCorpus()
 
-	waitForBucket, err := ingestBucket(ctx, st, bucket, cfg.Tenant, track, log)
+	waitForBucket, err := ingestBucket(ctx, st, bucket, cfg.Tenant, track, ops, log)
 	if err != nil {
 		return err
 	}
@@ -299,4 +311,20 @@ func searchOptions(cfg config.Config) []index.Option {
 	return []index.Option{
 		index.WithCache(index.NewCache(index.WithResultExpiry(cfg.CacheResultExpiry))),
 	}
+}
+
+// subjects splits a comma separated list of names, dropping the empties.
+//
+// The empties matter. A flag left at its default is an empty string, and a
+// naive split of that is a list holding one name that is nothing at all, which
+// would make an unauthenticated request an administrator on any deployment
+// where the subject is also empty.
+func subjects(v string) []string {
+	var out []string
+	for _, s := range strings.Split(v, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/cmd/genbad/operations.go
+++ b/cmd/genbad/operations.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/ingest"
+)
+
+// runHistory is how many syncs per source are kept.
+//
+// Ten, which is enough to see a pattern and small enough to hold forever. The
+// thing an operator is looking for on this screen is not one failure, it is
+// whether the failures started at four this morning or have been there since
+// the process came up, and a single last run cannot answer that. Keeping them
+// all could: a source on a ten second refresh produces eight and a half
+// thousand entries a day, in memory, to answer a question the last ten already
+// answered.
+const runHistory = 10
+
+// operations is what the administration screen reads.
+//
+// It is the same shape of thing as [indexing] and it is here for the same
+// reason: the process running the connectors is the only thing that knows how
+// they are getting on, and the API package deliberately does not. This is where
+// that knowledge is written down, and [operations.State] is the function handed
+// to [api.WithOperations].
+//
+// Everything in it is in memory and nothing survives a restart. That is honest
+// rather than lazy. A sync history read out of a database would be a history of
+// every process that ever ran against it, and the question this screen answers
+// is what is happening now, which is a question about this process.
+type operations struct {
+	mu sync.Mutex
+
+	// sources is each connector's state, and order is the order they were
+	// registered in, so that a process reading a directory and a bucket draws
+	// them in the same order every time rather than in map order.
+	sources map[string]*sourceOps
+	order   []string
+}
+
+// sourceOps is one connector.
+type sourceOps struct {
+	// info is everything about the source that does not change while it runs.
+	info api.Connector
+
+	// runs are the syncs, newest first.
+	runs []api.Run
+
+	// syncing says one is going right now.
+	syncing bool
+
+	// policy is the permission policy, asked for its counters at report time
+	// rather than copied, because they climb during a run and a copy taken when
+	// the connector was registered would be zeroes forever. It is an any
+	// because the two connectors have unrelated policy interfaces and what is
+	// wanted here is the one method some of their implementations share.
+	policy any
+}
+
+// newOperations returns an empty recorder.
+func newOperations() *operations {
+	return &operations{sources: make(map[string]*sourceOps, 2)}
+}
+
+// register records a connector before it starts syncing.
+//
+// Called before the first run rather than after it, so that a screen opened
+// during the first crawl of a large corpus shows the connector with no runs
+// yet, rather than showing nothing and looking like a process with no
+// connectors at all.
+func (o *operations) register(info api.Connector, policy any) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if _, seen := o.sources[info.Source]; seen {
+		return
+	}
+	o.sources[info.Source] = &sourceOps{info: info, policy: policy}
+	o.order = append(o.order, info.Source)
+}
+
+// starting records that a sync has begun.
+func (o *operations) starting(source string, at time.Time) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	s, ok := o.sources[source]
+	if !ok {
+		return
+	}
+	s.syncing = true
+	s.runs = append([]api.Run{{Started: at.UTC().Format(time.RFC3339)}}, s.runs...)
+	if len(s.runs) > runHistory {
+		s.runs = s.runs[:runHistory]
+	}
+}
+
+// finished records what a sync did, and what went wrong if anything did.
+//
+// The stats are recorded whether or not there is an error, because a run that
+// failed halfway still indexed what it got to and an operator reading a failure
+// wants to know whether it managed anything at all.
+func (o *operations) finished(source string, took time.Duration, stats ingest.Stats, err error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	s, ok := o.sources[source]
+	if !ok || len(s.runs) == 0 {
+		return
+	}
+	s.syncing = false
+	run := &s.runs[0]
+	run.Duration = took.Milliseconds()
+	run.Indexed = stats.Indexed
+	run.Quarantined = stats.Quarantined
+	run.Deleted = stats.Deleted
+	run.Repermissioned = stats.Repermissioned
+	run.Skipped = stats.Skipped
+	run.Bytes = stats.Bytes
+	if err != nil {
+		run.Error = err.Error()
+	}
+}
+
+// State is what the API reports, and is the function handed to
+// [api.WithOperations].
+func (o *operations) State() api.Operations {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	out := api.Operations{Connectors: make([]api.Connector, 0, len(o.order))}
+	for _, source := range o.order {
+		s := o.sources[source]
+		c := s.info
+		c.Syncing = s.syncing
+		// Copied rather than shared. The caller encodes this while syncs keep
+		// running, and a slice handed out under a lock is a slice read without
+		// one.
+		c.Runs = append([]api.Run(nil), s.runs...)
+		c.Permissions = mappingOf(s.policy)
+		out.Connectors = append(out.Connectors, c)
+	}
+	return out
+}
+
+// mappingOf is what a source's permission policy has seen, or nil for one that
+// does not count.
+//
+// The interface is the same one [reportMapping] asserts on, which is the point:
+// this screen and that log line report the same numbers from the same place,
+// so a deployment that reads its logs and a deployment that reads its screens
+// cannot be told two different things.
+func mappingOf(policy any) *api.Mapping {
+	counter, ok := policy.(aclCounter)
+	if !ok {
+		return nil
+	}
+	c := counter.Counts()
+	return &api.Mapping{
+		Mapped:         c.Mapped,
+		ForeignDomain:  c.ForeignDomain,
+		UnmappableDeny: c.UnmappableDeny,
+		Malformed:      c.Malformed,
+		Ignored:        c.Ignored,
+	}
+}
+
+// refreshOf is how a sync interval reads on the screen, and is empty for a
+// source that syncs once and never again.
+func refreshOf(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	return d.String()
+}

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,11 @@ type Config struct {
 	// deployments leave it empty and resolve the tenant per request.
 	Tenant string
 
+	// Admins are the subjects that may see how the deployment is running. It is
+	// empty by default, which means nobody, and the reason it is not everybody
+	// is written on [api.HeaderAuth].
+	Admins []string
+
 	// ReadTimeout and WriteTimeout bound a request. They exist so that one slow
 	// connector or one enormous export cannot hold a connection open forever.
 	ReadTimeout  time.Duration
@@ -118,6 +123,9 @@ func Load(getenv func(string) string) (Config, error) {
 	str(getenv, "GENBA_DSN", &c.DSN)
 	str(getenv, "GENBA_TENANT", &c.Tenant)
 	str(getenv, "GENBA_LOG_LEVEL", &c.LogLevel)
+	if v := getenv("GENBA_ADMINS"); v != "" {
+		c.Admins = list(v)
+	}
 	if v := getenv("GENBA_STORE"); v != "" {
 		c.Store = Store(strings.ToLower(v))
 	}
@@ -230,4 +238,17 @@ func dur(getenv func(string) string, key string, dst *time.Duration) error {
 	}
 	*dst = d
 	return nil
+}
+
+// list reads a comma separated setting, dropping the empty entries a trailing
+// comma or a stray space leaves behind.
+func list(v string) []string {
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/connector/aclmap/aclmap.go
+++ b/connector/aclmap/aclmap.go
@@ -341,7 +341,7 @@ func (n *Normalizer) Normalize(grants []Grant) (acl.Permissions, error) {
 	for _, g := range grants {
 		if err := n.apply(&perm, g, &owners); err != nil {
 			n.count(err)
-			return n.unresolved(), err
+			return n.unresolved(err), err
 		}
 	}
 
@@ -460,11 +460,24 @@ func (n *Normalizer) widen(perm *acl.Permissions, m acl.Mode) {
 	}
 }
 
-// unresolved is the descriptor a quarantined document gets. It names its source
-// so that a report can say which connector the document came from, and says
-// nothing else, because nothing else was established.
-func (n *Normalizer) unresolved() acl.Permissions {
-	return acl.Permissions{Mode: acl.ModeUnknown, Source: n.rules.Source}
+// unresolved is the descriptor a quarantined document gets.
+//
+// It names its source so that a report can say which connector the document
+// came from, and it carries why it failed, and it says nothing else, because
+// nothing else was established. The reason is the whole of what an operator can
+// act on: eleven hundred documents held back on a foreign domain is a tenant
+// boundary doing its job, and eleven hundred held back on a malformed grant is
+// a connector to go and fix. Without it both are the same number.
+func (n *Normalizer) unresolved(err error) acl.Permissions {
+	perm := acl.Permissions{Mode: acl.ModeUnknown, Source: n.rules.Source}
+	var e *Error
+	if errors.As(err, &e) {
+		// The reason and the statement it gave up on, which is the difference
+		// between a screen that says a document could not be mapped and one that
+		// says which line of which access control list to go and look at.
+		perm.Reason = e.Reason.String() + ": " + e.Detail
+	}
+	return perm
 }
 
 // confers reports whether a role grants reading.

--- a/connector/checkpoint_test.go
+++ b/connector/checkpoint_test.go
@@ -163,7 +163,7 @@ func TestACheckpointDirectoryIsCreated(t *testing.T) {
 }
 
 func TestUnresolvedNeverAllowsAnybody(t *testing.T) {
-	perm := connector.Unresolved("wiki")
+	perm := connector.Unresolved("wiki", "the test says so")
 	if perm.Mode != acl.ModeUnknown {
 		t.Errorf("mode is %v, want ModeUnknown", perm.Mode)
 	}

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -259,14 +259,23 @@ type Cursor struct {
 func (c Cursor) IsZero() bool { return c.Value == "" }
 
 // Unresolved returns the permission descriptor for a document whose access
-// control list a connector could not work out.
+// control list a connector could not work out, and why.
 //
 // Use it rather than leaving the field zero. Both produce [acl.ModeUnknown] and
 // both quarantine the document, but this one says at the call site that the
 // connector considered the question and failed, which is a different bug from
 // having forgotten to set the field at all.
-func Unresolved(source string) acl.Permissions {
-	return acl.Permissions{Mode: acl.ModeUnknown, Source: source}
+//
+// The reason is not optional and it is not decoration. A document held back is
+// invisible from every angle except a counter, and a counter cannot tell a
+// token that may not list a channel from a connector that has stopped
+// understanding a permission scheme. Every call site here already knows which
+// it was, usually because it is about to log it, so it says so once and the
+// sentence travels with the document to whoever has to fix it. Write it as
+// something a person can act on: name the thing that failed, not the function
+// that noticed.
+func Unresolved(source, reason string) acl.Permissions {
+	return acl.Permissions{Mode: acl.ModeUnknown, Source: source, Reason: reason}
 }
 
 // Checkpoints is where resume points are kept between runs.

--- a/connector/connectortest/connectortest_test.go
+++ b/connector/connectortest/connectortest_test.go
@@ -130,7 +130,7 @@ func (m *memsource) unresolvable(name string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if e, ok := m.entries[name]; ok {
-		e.perms = connector.Unresolved(m.name)
+		e.perms = connector.Unresolved(m.name, "the fixture says so")
 		e.shared = m.tick()
 	}
 }

--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -552,7 +552,7 @@ func (s *Source) syncWatched(ctx context.Context, from connector.Cursor, since t
 		if ops := changed[rel]; ops.chmod && !ops.write && !ops.remove {
 			perms, err := s.permissions(ctx, rel, info)
 			if err != nil {
-				perms = connector.Unresolved(s.name)
+				perms = connector.Unresolved(s.name, "the file mode changed and the new rule did not resolve: "+err.Error())
 				s.skipped(full, err)
 			}
 			if err := emit(ctx, connector.Change{
@@ -623,7 +623,7 @@ func (s *Source) refresh(ctx context.Context, rel string, info fs.FileInfo, sinc
 		// The rule that used to govern this file stopped resolving. Quarantining
 		// is the only safe reading: a document nobody can currently say who may
 		// read is not a document to keep serving on last week's answer.
-		perms = connector.Unresolved(s.name)
+		perms = connector.Unresolved(s.name, "the rule that used to govern this file stopped resolving: "+err.Error())
 		s.skipped(rel, err)
 	}
 	return at, emit(ctx, connector.Change{
@@ -645,7 +645,7 @@ func (s *Source) refresh(ctx context.Context, rel string, info fs.FileInfo, sinc
 // quarantines every document rather than publishing the tree.
 func (s *Source) permissions(ctx context.Context, rel string, info fs.FileInfo) (acl.Permissions, error) {
 	if s.policy == nil {
-		return connector.Unresolved(s.name), nil
+		return connector.Unresolved(s.name, "this source was built without a permission policy, so nothing in the tree resolves"), nil
 	}
 	if p, ok := s.policy.(statPolicy); ok {
 		return p.permissionsFor(ctx, rel, info)
@@ -701,7 +701,7 @@ func (s *Source) read(ctx context.Context, full, rel string, info fs.FileInfo) (
 	if err != nil {
 		// The document keeps the unresolved descriptor and is quarantined by the
 		// pipeline. Failing to answer is not permission to publish.
-		perms = connector.Unresolved(s.name)
+		perms = connector.Unresolved(s.name, "who may read this file did not resolve: "+err.Error())
 		s.skipped(full, err)
 	}
 

--- a/connector/jirasource/permissions.go
+++ b/connector/jirasource/permissions.go
@@ -106,7 +106,7 @@ func (s *Service) access(ctx context.Context, p project) (acl.Permissions, error
 		// sites, and this account may only be a user. Quarantining is the only
 		// safe answer and staying quiet about it is the only unsafe one.
 		s.skip(p.Key, fmt.Errorf("who may browse %s: %w", p.Key, err))
-		return connector.Unresolved(s.name), nil
+		return connector.Unresolved(s.name, fmt.Sprintf("reading the permission scheme for %s needs an administrator and this account is not one", p.Key)), nil
 	default:
 		return acl.Permissions{}, err
 	}
@@ -152,7 +152,7 @@ func (s *Service) access(ctx context.Context, p project) (acl.Permissions, error
 		// A scheme that grants browse to nothing is not a project everybody can
 		// read, it is a project we failed to understand. Say so.
 		s.skip(p.Key, fmt.Errorf("the permission scheme for %s grants %s to nobody", p.Key, browse))
-		return connector.Unresolved(s.name), nil
+		return connector.Unresolved(s.name, fmt.Sprintf("the permission scheme for %s grants %s to nobody, which is a scheme we failed to understand rather than a project everybody may read", p.Key, browse)), nil
 	}
 
 	return acl.Permissions{
@@ -310,7 +310,7 @@ func (l *security) resolve(ctx context.Context, id, name string) acl.Permissions
 	})
 	if err != nil {
 		s.skip("security level "+id, fmt.Errorf("who may read issues at security level %q: %w", name, err))
-		return connector.Unresolved(s.name)
+		return connector.Unresolved(s.name, fmt.Sprintf("the members of security level %q could not be listed", name))
 	}
 
 	var users, groups []acl.Ref
@@ -329,13 +329,13 @@ func (l *security) resolve(ctx context.Context, id, name string) acl.Permissions
 			s.skip("security level "+id, fmt.Errorf(
 				"security level %q is granted to project role %d, which cannot be resolved without the project",
 				name, m.Holder.ProjectRole.ID))
-			return connector.Unresolved(s.name)
+			return connector.Unresolved(s.name, fmt.Sprintf("security level %q is granted to a project role, and a role cannot be resolved without knowing which project the issue is in", name))
 		}
 	}
 
 	if len(users) == 0 && len(groups) == 0 {
 		s.skip("security level "+id, fmt.Errorf("security level %q resolves to nobody", name))
-		return connector.Unresolved(s.name)
+		return connector.Unresolved(s.name, fmt.Sprintf("security level %q resolves to nobody", name))
 	}
 
 	return acl.Permissions{

--- a/connector/objectsource/objectsource.go
+++ b/connector/objectsource/objectsource.go
@@ -382,7 +382,7 @@ func (s *Source) refresh(ctx context.Context, o object, start syncPoint, emit fu
 		// Quarantining is the only safe reading: a document nobody can
 		// currently say who may read is not one to keep serving on last week's
 		// answer.
-		perms = connector.Unresolved(s.name)
+		perms = connector.Unresolved(s.name, "the rule that used to govern this object stopped resolving: "+err.Error())
 		s.skipped(o.Key, err)
 	}
 	return at, emit(ctx, connector.Change{
@@ -417,7 +417,7 @@ func (s *Source) wanted(o object) bool {
 // quarantines every document rather than publishing the bucket.
 func (s *Source) permissions(ctx context.Context, key string) (acl.Permissions, error) {
 	if s.policy == nil {
-		return connector.Unresolved(s.name), nil
+		return connector.Unresolved(s.name, "this source was built without a permission policy, so nothing in the bucket resolves"), nil
 	}
 	return s.policy.Permissions(ctx, key)
 }
@@ -518,7 +518,7 @@ func (s *Source) document(ctx context.Context, o object, raw []byte) (doc.Docume
 	if err != nil {
 		// The document keeps the unresolved descriptor and is quarantined by
 		// the pipeline. Failing to answer is not permission to publish.
-		perms = connector.Unresolved(s.name)
+		perms = connector.Unresolved(s.name, "who may read this object did not resolve: "+err.Error())
 		s.skipped(o.Key, err)
 	}
 

--- a/connector/objectsource/policy.go
+++ b/connector/objectsource/policy.go
@@ -160,7 +160,7 @@ func (p *BucketPolicy) load(ctx context.Context) (acl.Permissions, error) {
 		// Recorded rather than retried per object. A bucket whose list cannot be
 		// read has one problem, and asking it a million more times turns one
 		// failure into a denial of service against the store.
-		p.loaded, p.perms, p.err = true, connector.Unresolved(p.source), err
+		p.loaded, p.perms, p.err = true, connector.Unresolved(p.source, "the access control list of the bucket could not be read: "+err.Error()), err
 		return p.perms, p.err
 	}
 
@@ -209,7 +209,7 @@ func NewObjectPolicy(c *Client, source, identity string, domains ...string) (*Ob
 func (p *ObjectPolicy) Permissions(ctx context.Context, key string) (acl.Permissions, error) {
 	list, _, err := p.client.acl(ctx, key)
 	if err != nil {
-		return connector.Unresolved(p.source), err
+		return connector.Unresolved(p.source, "the access control list of this object could not be read: "+err.Error()), err
 	}
 	return p.acls.Normalize(grantsOf(list))
 }

--- a/connector/slacksource/service.go
+++ b/connector/slacksource/service.go
@@ -112,7 +112,7 @@ func (s *Service) access(ctx context.Context, ch channel) (acl.Permissions, time
 		// channel, this token cannot list it, and there is nothing in the index
 		// from it to reapply anything to: the same refusal keeps its
 		// conversations out in the first place.
-		return connector.Unresolved(s.name), at, nil
+		return connector.Unresolved(s.name, fmt.Sprintf("who may read #%s: %s", ch.Name, err)), at, nil
 	default:
 		return acl.Permissions{}, time.Time{}, err
 	}

--- a/connector/threadsource/fake_test.go
+++ b/connector/threadsource/fake_test.go
@@ -171,7 +171,7 @@ func (f *fake) restrict(roomID, id string, p acl.Permissions) {
 
 // quarantine puts one thread's rule beyond working out.
 func (f *fake) quarantine(roomID, id string) {
-	f.restrict(roomID, id, connector.Unresolved(source))
+	f.restrict(roomID, id, connector.Unresolved(source, "the fake says so"))
 }
 
 // unruled takes the rule off a room entirely, which is the state a source

--- a/connector/threadsource/threadsource.go
+++ b/connector/threadsource/threadsource.go
@@ -582,7 +582,7 @@ func (s *Source) access(th Thread, c Container) acl.Permissions {
 	case resolved(c.Access):
 		return c.Access
 	default:
-		return connector.Unresolved(s.name)
+		return connector.Unresolved(s.name, "neither the conversation nor the container it is in said who may read it")
 	}
 }
 

--- a/ingest/ingest_test.go
+++ b/ingest/ingest_test.go
@@ -144,7 +144,7 @@ func TestUnresolvedPermissionsAreQuarantinedNotIndexed(t *testing.T) {
 	ch := changes(10)
 	for i := range ch {
 		if i%2 == 0 {
-			ch[i].Document.Permissions = connector.Unresolved("test")
+			ch[i].Document.Permissions = connector.Unresolved("test", "the test says so")
 		}
 	}
 	stats := run(t, p, &fakeSource{name: "test", changes: ch})

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -600,6 +600,82 @@ async function walk(session) {
     "location.search.includes('q=cache')",
   );
 
+  // Administration. The gate names the browser's development subject as an
+  // administrator, so the rail offers it here and offers it to nobody else,
+  // which is the half of this that cannot be checked from a screen that already
+  // has the role.
+  await visit(session, `${BASE}/?q=cache`, "document.querySelectorAll('.result').length > 0");
+  await check(
+    session,
+    "the rail offers administration to somebody who holds the role",
+    "document.querySelectorAll('.rail__link[data-route=\"admin\"]').length === 1",
+  );
+
+  await evaluate(session, "document.querySelector('.rail__link[data-route=\"admin\"]').click()");
+  await settle(session, "location.pathname === '/admin'");
+  await check(
+    session,
+    "the rail entry reaches administration and the screen takes the focus",
+    `document.querySelector('.rail__link[data-route="admin"]').getAttribute('aria-current') === 'page' &&
+      document.activeElement === document.querySelector('.admin__title')`,
+  );
+
+  await settle(session, "document.querySelectorAll('.admin .stat__value').length >= 2");
+  await check(
+    session,
+    "the corpus is reported as what is servable and what is held back",
+    `(() => {
+      const labels = [...document.querySelectorAll('.admin__corpus .stat__label')].map((s) => s.textContent);
+      const values = [...document.querySelectorAll('.admin__corpus .stat__value')].map((s) => s.textContent);
+      return labels.includes('Servable') && labels.includes('Held back') &&
+        values.every((v) => v.trim().length > 0);
+    })()`,
+  );
+
+  // The connector the gate started, reported back. A screen that draws its
+  // cards from a fixture would pass this and say nothing.
+  await check(
+    session,
+    "the connector this process is running is named with its history",
+    `(() => {
+      const card = document.querySelector('.connector');
+      if (!card) return false;
+      const title = card.querySelector('.connector__title').textContent.trim();
+      const rows = card.querySelectorAll('.connector__runs tbody tr').length;
+      return title === 'repo' && rows >= 1;
+    })()`,
+  );
+
+  // A table whose headers are not headers reads as a grid of unrelated cells,
+  // and there is no way to tell from looking at it.
+  await check(
+    session,
+    "every column on this screen is headed by a real header cell",
+    `[...document.querySelectorAll('.admin__table')].every((t) =>
+      t.tHead && [...t.tHead.rows[0].cells].every((c) =>
+        c.tagName === 'TH' && c.getAttribute('scope') === 'col'))`,
+  );
+
+  // The corpus here is a checkout that everybody in the tenant may read, so
+  // nothing is held back and the screen has to say so rather than drawing an
+  // empty table under a heading.
+  await check(
+    session,
+    "an empty quarantine is said out loud rather than drawn as an empty table",
+    `(() => {
+      const note = document.querySelector('.admin__note-title');
+      return Boolean(note) && note.textContent.includes('Nothing is being held back');
+    })()`,
+  );
+
+  await evaluate(session, "document.querySelector('.admin .page__back-link').click()");
+  await settle(session, "location.pathname === '/'");
+  await check(
+    session,
+    "the way out of administration leads back to the search it was opened from",
+    "location.search.includes('q=cache')",
+  );
+
   // The answer above the results.
   //
   // The query is one this corpus can answer. A repository is mostly source

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -148,7 +148,7 @@ node scripts/gate-images.mjs "$IMAGES" 24
 # than printing none: it read as the product being two hundred times over its
 # budget, and the budget was never being watched on the path anybody is on.
 "$BIN" -addr "127.0.0.1:$PORT" -store sqlite -dsn "$STATE/corpus.db" \
-	-tenant "$TENANT" -corpus . -corpus-name repo -log-level error &
+	-tenant "$TENANT" -corpus . -corpus-name repo -admins dev -log-level error &
 SERVER=$!
 
 # The same binary with nothing to index. It is one more process rather than a
@@ -235,7 +235,7 @@ if [ -n "${CHROMEDRIVER:-}" ]; then
 	DRIVER="--chromedriver-path $CHROMEDRIVER"
 fi
 
-# Eleven screens, and they are states rather than layouts. Three of them, the
+# Twelve screens, and they are states rather than layouts. Three of them, the
 # empty index, the query that matched nothing and the filter that matched
 # nothing, produce markup no other screen produces, and that markup is where an
 # accessibility bug survives longest: nobody looks at an empty page twice.
@@ -248,6 +248,12 @@ fi
 # The settings screen is the tenth. It is the only screen in the product built
 # out of form controls, and a radio group that has lost its label is the kind of
 # thing that reads perfectly to whoever wrote it and not at all to anybody else.
+#
+# The twelfth is administration. It is the only screen in the product built out
+# of tables, and a table whose headers are not headers is unreadable to anybody
+# using a screen reader and looks perfect to everybody else. It is also the only
+# screen that repaints itself on a timer, so it is the one place a focus ring
+# can be quietly taken away from somebody five seconds after they put it there.
 for url in \
 	"$BASE/" \
 	"$EMPTY/" \
@@ -259,7 +265,8 @@ for url in \
 	"$BASE/?q=gatepix&kind=image&view=grid" \
 	"$BASE/d/$ID" \
 	"$BASE/recent" \
-	"$BASE/settings"; do
+	"$BASE/settings" \
+	"$BASE/admin"; do
 	echo "ui-gate: axe $url"
 	# The interface renders after a fetch, so the audit waits for the first
 	# paint to have happened. Auditing an empty document passes and proves

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -320,6 +320,45 @@ func (s *Store) Stats(ctx context.Context) (store.Stats, error) {
 	return st, nil
 }
 
+// Quarantined returns documents this driver is holding back.
+//
+// The map is walked in whatever order Go feels like, which is unspecified and
+// is what the interface promises. It is also, on this driver, a different
+// hundred documents each time it is asked, and that is worth knowing rather
+// than worth fixing: nothing above it may assume the list is stable, and a
+// driver whose order happened to be stable would let something start assuming
+// it.
+func (s *Store) Quarantined(ctx context.Context, tenant string, limit int) ([]store.Held, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, genba.ErrClosed
+	}
+	out := make([]store.Held, 0, min(limit, len(s.docs)))
+	for _, d := range s.docs {
+		if d.Queryable() || d.Tenant != tenant {
+			continue
+		}
+		out = append(out, store.Held{
+			ID:     d.ID,
+			Title:  d.Title,
+			Source: d.Permissions.Source,
+			Reason: d.Permissions.Reason,
+			At:     d.ModifiedAt,
+		})
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
 // Close releases the store.
 func (s *Store) Close() error {
 	s.mu.Lock()

--- a/store/memstore/memstore_test.go
+++ b/store/memstore/memstore_test.go
@@ -16,6 +16,7 @@ func TestConformance(t *testing.T) {
 
 func TestMaintenanceConformance(t *testing.T) {
 	storetest.RunMaintenance(t, newStore)
+	storetest.RunQuarantine(t, newStore)
 }
 
 // memstore implements store.Statistician and neither of the other two, so most

--- a/store/pgstore/maintain.go
+++ b/store/pgstore/maintain.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -14,6 +15,80 @@ import (
 )
 
 var _ store.Maintenance = (*Store)(nil)
+var _ store.Quarantine = (*Store)(nil)
+
+// Quarantined returns documents this driver is holding back, newest first.
+//
+// The title and the reason are pulled out of the stored JSON in SQL rather than
+// by decoding the row, for the same reason [Store.Inventory] reads two columns:
+// the body is in that JSON, a held document is as large as any other, and a
+// hundred of them is megabytes read and parsed to reach two short strings. The
+// cast to json is per row and it is a hundred rows, which is the whole of what
+// this pays and is a great deal less than shipping the bodies.
+//
+// Newest first because the question somebody has when they open this screen is
+// whether the connector they just fixed has stopped producing them, and that is
+// answered by the top of the list rather than by a hundred entries from
+// whenever the corpus was first crawled. A document whose source never gave a
+// date sorts last, because the alternative in Postgres is for it to sort first
+// and push the answer off the screen.
+func (s *Store) Quarantined(ctx context.Context, tenant string, limit int) ([]store.Held, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	var out []store.Held
+	err := s.retry(ctx, func(ctx context.Context) error {
+		rows, err := s.query(ctx, `
+			SELECT
+				d.id,
+				d.source,
+				d.modified_at,
+				dd.data::json ->> 'Title',
+				dd.data::json -> 'Permissions' ->> 'Reason'
+			FROM document d
+			JOIN document_data dd ON dd.doc_id = d.id
+			WHERE d.tenant = $1 AND NOT d.queryable
+			ORDER BY d.modified_at DESC NULLS LAST
+			LIMIT $2`, tenant, limit)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		// Cleared on every attempt. A retry that appended to what the failed
+		// attempt had already read would return the first page twice.
+		out = make([]store.Held, 0, limit)
+		for rows.Next() {
+			var (
+				h        store.Held
+				modified *int64
+				title    *string
+				reason   *string
+			)
+			if err := rows.Scan(&h.ID, &h.Source, &modified, &title, &reason); err != nil {
+				return err
+			}
+			if title != nil {
+				h.Title = *title
+			}
+			if reason != nil {
+				h.Reason = *reason
+			}
+			if modified != nil {
+				h.At = time.Unix(0, *modified).UTC()
+			}
+			out = append(out, h)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: quarantined: %w", err)
+	}
+	return out, nil
+}
 
 // Inventory calls fn for every document held for one tenant and source.
 //

--- a/store/pgstore/pgstore_test.go
+++ b/store/pgstore/pgstore_test.go
@@ -117,6 +117,7 @@ func TestConformance(t *testing.T) {
 
 func TestMaintenanceConformance(t *testing.T) {
 	storetest.RunMaintenance(t, newStore)
+	storetest.RunQuarantine(t, newStore)
 }
 
 func TestRetrieverConformance(t *testing.T) {

--- a/store/quarantine.go
+++ b/store/quarantine.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// Held is one document the index is holding back.
+//
+// A quarantined document is the one thing in this system that is invisible from
+// every angle. It is not in a result, not in a facet count, not in a suggestion
+// and not in the statistics a search reports, which is exactly right and is also
+// why the only trace of it anywhere is a single number on the stats endpoint.
+// Somebody who has been told there are fourteen hundred of them has been told
+// nothing they can act on.
+//
+// So this is the small amount of a held document that an operator needs to act:
+// which one it is, where it came from, and why it did not resolve. It is not
+// content and it does not become content. The body, the extracted text, the
+// author, the access control lists and everything else stay where they are.
+type Held struct {
+	// ID is the document id, which is what an operator quotes in a bug against
+	// whichever connector produced it.
+	ID string
+
+	// Title is what the source called it. It is the one piece of the document
+	// itself that crosses this interface, and it does so because a list of
+	// opaque ids is a list nobody can look at and recognise the pattern in,
+	// which is the whole task: forty held documents that turn out to all be in
+	// one folder is an answer, and forty ids is not.
+	Title string
+
+	// Source is the connector it came from.
+	Source string
+
+	// Reason is [acl.Permissions.Reason], which is whatever gave up on it
+	// saying so in its own words. It is empty for a document quarantined by
+	// something that did not record one, and a screen showing it should say
+	// that plainly rather than inventing a reason.
+	Reason string
+
+	// At is when the source last changed the document, and is zero where the
+	// source never said. It is here so that a list can be read newest first,
+	// which is how somebody watching a connector they have just fixed sees
+	// whether it is still producing them.
+	At time.Time
+}
+
+// Quarantine is the capability that lists what is being held back.
+//
+// It is optional, like every other capability outside [Store], because a driver
+// over a service that only keeps an inverted index has no way to walk the
+// documents it is not indexing. A caller checks for it and says the driver
+// cannot answer, which is a better screen than one that pretends the quarantine
+// is empty.
+//
+// It is not principal scoped and it cannot be. A held document is one whose
+// permissions did not resolve, so there is no principal it could be scoped to:
+// the question "who may see this" is the question that failed. That is the same
+// bargain [Maintenance] makes and it is paid for the same way, by handing back
+// the least that answers the question. See [Held].
+type Quarantine interface {
+	// Quarantined returns at most limit documents that are being held back for
+	// one tenant. The order is unspecified and a limit of zero or less returns
+	// nothing.
+	//
+	// The count is deliberately not here. [Stats.Quarantined] already has it,
+	// every caller of this already asks for stats, and a second count taken a
+	// moment later would let a screen print a list of a hundred under a total
+	// of ninety nine.
+	Quarantined(ctx context.Context, tenant string, limit int) ([]Held, error)
+}

--- a/store/sqlitestore/maintain.go
+++ b/store/sqlitestore/maintain.go
@@ -6,12 +6,74 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/store"
 )
 
 var _ store.Maintenance = (*Store)(nil)
+var _ store.Quarantine = (*Store)(nil)
+
+// Quarantined returns documents this driver is holding back, newest first.
+//
+// The two fields that come out of the stored JSON are pulled out in SQL rather
+// than by decoding the row. Decoding is how every other read path here gets at
+// a document, and it is the wrong tool for this one: the body is in that JSON,
+// a held document is as large as any other, and a hundred of them is megabytes
+// read and parsed to reach two short strings. json_extract reads the same
+// column and returns the two.
+//
+// Newest first because the question somebody has when they open this screen is
+// whether the connector they just fixed has stopped producing them, and that is
+// answered by the top of the list rather than by a hundred entries from
+// whenever the corpus was first crawled.
+func (s *Store) Quarantined(ctx context.Context, tenant string, limit int) ([]store.Held, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	rows, err := s.query(ctx, `
+		SELECT
+			d.id,
+			d.source,
+			d.modified_at,
+			json_extract(dd.data, '$.Title'),
+			json_extract(dd.data, '$.Permissions.Reason')
+		FROM document d
+		JOIN document_data dd ON dd.doc_id = d.id
+		WHERE d.tenant = ? AND d.queryable = 0
+		ORDER BY d.modified_at DESC
+		LIMIT ?`, tenant, limit)
+	if err != nil {
+		return nil, fmt.Errorf("sqlitestore: quarantined: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]store.Held, 0, limit)
+	for rows.Next() {
+		var (
+			h        store.Held
+			modified sql.NullInt64
+			title    sql.NullString
+			reason   sql.NullString
+		)
+		if err := rows.Scan(&h.ID, &h.Source, &modified, &title, &reason); err != nil {
+			return nil, fmt.Errorf("sqlitestore: quarantined: %w", err)
+		}
+		h.Title, h.Reason = title.String, reason.String
+		if modified.Valid {
+			h.At = time.Unix(0, modified.Int64).UTC()
+		}
+		out = append(out, h)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlitestore: quarantined: %w", err)
+	}
+	return out, nil
+}
 
 // Inventory calls fn for every document held for one tenant and source.
 //

--- a/store/sqlitestore/sqlitestore_test.go
+++ b/store/sqlitestore/sqlitestore_test.go
@@ -32,6 +32,7 @@ func TestConformance(t *testing.T) {
 
 func TestMaintenanceConformance(t *testing.T) {
 	storetest.RunMaintenance(t, newStore)
+	storetest.RunQuarantine(t, newStore)
 }
 
 func TestRetrieverConformance(t *testing.T) {

--- a/store/storetest/quarantine.go
+++ b/store/storetest/quarantine.go
@@ -1,0 +1,150 @@
+package storetest
+
+import (
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// RunQuarantine checks a driver's [store.Quarantine] against what the
+// administration screen relies on.
+//
+// The suite is small and every case in it is a way of returning the wrong
+// documents while looking correct. Listing the queryable ones is the obvious
+// one and is caught by the first case. The two that are not obvious are the
+// tenant filter, which a driver that reaches straight for the queryable column
+// forgets because the quarantine of a shared deployment is not one list, and
+// the reason, which is the only field on the screen anybody acts on and is the
+// one a driver drops when it builds the row out of columns instead of out of
+// the document.
+func RunQuarantine(t *testing.T, newStore Factory) {
+	t.Helper()
+	for _, c := range quarantineCases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newStore(t)
+			t.Cleanup(func() { _ = s.Close() })
+
+			q, ok := s.(store.Quarantine)
+			if !ok {
+				t.Skip("this driver does not implement store.Quarantine")
+			}
+			c.run(t, s, q)
+		})
+	}
+}
+
+type quarantineCase struct {
+	name string
+	run  func(t *testing.T, s store.Store, q store.Quarantine)
+}
+
+var quarantineCases = []quarantineCase{
+	{"only held documents are listed", testQuarantinedOnlyHeld},
+	{"the reason survives the round trip", testQuarantinedReason},
+	{"another tenant's held documents are not listed", testQuarantinedTenant},
+	{"the limit is honoured and a limit of zero returns nothing", testQuarantinedLimit},
+	{"a document that resolves later leaves the list", testQuarantinedReleased},
+}
+
+// held is a document whose permissions did not resolve, with the reason the
+// connector gave.
+func held(id, reason string) doc.Document {
+	d := document(id, acl.Permissions{Mode: acl.ModeUnknown, Source: "gdrive", Reason: reason})
+	d.ModifiedAt = time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+	return d
+}
+
+// quarantined collects the list, sorted by id, so a driver is free to return
+// its documents in whatever order its storage puts them in.
+func quarantined(t *testing.T, q store.Quarantine, tenant string, limit int) []store.Held {
+	t.Helper()
+	out, err := q.Quarantined(t.Context(), tenant, limit)
+	if err != nil {
+		t.Fatalf("Quarantined: %v", err)
+	}
+	slices.SortFunc(out, func(a, b store.Held) int { return strings.Compare(a.ID, b.ID) })
+	return out
+}
+
+func ids(list []store.Held) []string {
+	out := make([]string, len(list))
+	for i, h := range list {
+		out[i] = h.ID
+	}
+	return out
+}
+
+func testQuarantinedOnlyHeld(t *testing.T, s store.Store, q store.Quarantine) {
+	mustPut(t, s, document("d1", readable()), held("d2", "a deny aimed at everybody"), document("d3", readable()))
+
+	got := ids(quarantined(t, q, "acme", 10))
+	if !slices.Equal(got, []string{"d2"}) {
+		t.Fatalf("held documents = %v, want [d2]", got)
+	}
+}
+
+func testQuarantinedReason(t *testing.T, s store.Store, q store.Quarantine) {
+	const reason = "foreign domain: a grant to @contractor.example"
+	mustPut(t, s, held("d1", reason))
+
+	got := quarantined(t, q, "acme", 10)
+	if len(got) != 1 {
+		t.Fatalf("held documents = %d, want 1", len(got))
+	}
+	if got[0].Reason != reason {
+		t.Fatalf("reason = %q, want %q", got[0].Reason, reason)
+	}
+	// The title is the other half of what makes the list readable. A screen of
+	// opaque ids cannot be looked at and recognised.
+	if got[0].Title != "runbook d1" {
+		t.Fatalf("title = %q, want %q", got[0].Title, "runbook d1")
+	}
+	if got[0].Source != "gdrive" {
+		t.Fatalf("source = %q, want gdrive", got[0].Source)
+	}
+}
+
+func testQuarantinedTenant(t *testing.T, s store.Store, q store.Quarantine) {
+	other := held("d2", "a deny aimed at everybody")
+	other.Tenant = "other"
+	mustPut(t, s, held("d1", "a deny aimed at everybody"), other)
+
+	got := ids(quarantined(t, q, "acme", 10))
+	if !slices.Equal(got, []string{"d1"}) {
+		t.Fatalf("held documents = %v, want [d1]", got)
+	}
+}
+
+func testQuarantinedLimit(t *testing.T, s store.Store, q store.Quarantine) {
+	mustPut(t, s, held("d1", "malformed grant"), held("d2", "malformed grant"), held("d3", "malformed grant"))
+
+	if got := quarantined(t, q, "acme", 2); len(got) != 2 {
+		t.Fatalf("held documents at limit 2 = %d, want 2", len(got))
+	}
+	// Zero is not "no limit". A screen that asks for none must not be handed
+	// the whole quarantine of a corpus.
+	if got := quarantined(t, q, "acme", 0); len(got) != 0 {
+		t.Fatalf("held documents at limit 0 = %d, want 0", len(got))
+	}
+}
+
+func testQuarantinedReleased(t *testing.T, s store.Store, q store.Quarantine) {
+	mustPut(t, s, held("d1", "malformed grant"))
+	if got := quarantined(t, q, "acme", 10); len(got) != 1 {
+		t.Fatalf("held documents before the fix = %d, want 1", len(got))
+	}
+
+	// The same document, indexed again by a connector that now understands its
+	// access control list. This is what an operator does after fixing the thing
+	// the reason named, and a driver that keeps the row in the list would have
+	// them chasing a document that is already being served.
+	mustPut(t, s, document("d1", readable()))
+	if got := quarantined(t, q, "acme", 10); len(got) != 0 {
+		t.Fatalf("held documents after the fix = %d, want 0", len(got))
+	}
+}

--- a/web/dist/assets/admin.js
+++ b/web/dist/assets/admin.js
@@ -1,0 +1,496 @@
+// The administration screen.
+//
+// It answers one question, which is whether this deployment is working, and it
+// answers it for somebody who can do something about the answer. Three parts:
+// what each connector is doing and which of its syncs failed, what the corpus
+// holds, and which documents are being held back and why.
+//
+// Nothing on it writes. That is deliberate for now and it is not a permanent
+// shape: adding and starting connectors from here is the other half of the
+// screen and it is a change to the server as much as to this file, so it is a
+// separate piece of work rather than a button that half exists.
+//
+// The one rule this screen keeps that no other screen has to is that the
+// numbers on it have to agree with each other. That is why it is one request:
+// the count of held documents above the table and the table itself are read at
+// the same moment, so a sync finishing between two fetches cannot make the
+// screen contradict itself.
+
+import { h, replace, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { bytes, duration, exact, icon, label, number, when } from "genba/format.js";
+import { failed as failedState } from "genba/states.js";
+
+// REFRESH is how often the screen asks again while somebody is looking at it.
+//
+// Five seconds, which is short enough that a sync starting is something you
+// watch happen rather than something you reload to find out about, and long
+// enough that a screen left open on a wall does not make a request a second
+// forever. The endpoint reads memory and one aggregate, so the cost of being
+// wrong here is small in one direction and a stale operations screen in the
+// other.
+const REFRESH = 5000;
+
+export class Admin {
+  constructor({ onBack }) {
+    this.onBack = onBack;
+    this.data = null;
+    this.error = null;
+    this.timer = 0;
+    this.title = null;
+    this.el = h("div", { class: "admin" });
+  }
+
+  /** key is the entry this screen paints from, which the offline banner names. */
+  key() {
+    return cache.key("admin", {});
+  }
+
+  /**
+   * render paints what was held and then what the server says.
+   *
+   * The held copy is painted first for the same reason every other screen does
+   * it, and it matters slightly less here: an operator coming back to this
+   * screen wants the current answer, and the current answer is a request away.
+   * What the cache buys is that the layout is on screen while that request is
+   * in flight, so the numbers land in place rather than after a blank.
+   */
+  async render() {
+    const k = this.key();
+    const held = cache.read(k).data || null;
+    if (held) {
+      this.data = held;
+      this.paint();
+    } else {
+      this.paint();
+    }
+    await this.refresh();
+    this.watch();
+  }
+
+  /** refresh reads the endpoint once and repaints. */
+  async refresh() {
+    try {
+      const res = await api.admin();
+      if (!this.el.isConnected && this.data) return;
+      if (res.modified) cache.write(this.key(), res.data, res.etag);
+      this.data = res.data || this.data;
+      this.error = null;
+    } catch (err) {
+      if (err.name === "AbortError") return;
+      // A failed check behind a screen that is already painted keeps the
+      // screen. What is on it was true when it was painted, and an operator
+      // reading a sync failure should not lose it because the next poll
+      // happened to arrive during a restart.
+      this.error = err;
+      if (this.data) {
+        this.paint();
+        return;
+      }
+    }
+    this.paint();
+  }
+
+  /**
+   * watch keeps the screen current while it is on the page.
+   *
+   * The timer checks whether the screen is still in the document rather than
+   * being cancelled by whatever navigated away, because there is no unmount
+   * hook to hang that on and a poll that keeps running behind another screen is
+   * a request nobody asked for.
+   */
+  watch() {
+    clearTimeout(this.timer);
+    this.timer = setTimeout(async () => {
+      if (!this.el.isConnected) return;
+      await this.refresh();
+      this.watch();
+    }, REFRESH);
+  }
+
+  /** stop ends the polling, for a screen being taken off the page. */
+  stop() {
+    clearTimeout(this.timer);
+    this.timer = 0;
+  }
+
+  paint() {
+    // Whether anything on this screen already has focus, read before the paint
+    // takes it away. This screen repaints every five seconds on its own, so
+    // pulling focus back to the heading each time would make it impossible to
+    // read the table with a keyboard.
+    const held = this.el.contains(document.activeElement) && document.activeElement !== this.title;
+
+    this.title = h("h1", { class: "admin__title", tabindex: "-1" }, "Administration");
+    // Nothing arrived and nothing was held, so there is nothing to draw. The
+    // three zeroes this screen would otherwise print are not the state of the
+    // deployment, they are the state of this browser, and on the one screen
+    // somebody reads to decide whether anything is wrong that is the worst
+    // thing it could say. It is also what somebody who typed this address
+    // without the role sees, and the server's own refusal is a better sentence
+    // than anything written here.
+    const failed = !this.data && this.error;
+    const data = this.data || {};
+    replace(
+      this.el,
+      this.backLink(),
+      h(
+        "header",
+        { class: "admin__head" },
+        this.title,
+        h(
+          "p",
+          { class: "admin__lead" },
+          "What this deployment is doing, and what it is holding back.",
+        ),
+      ),
+      failed ? failedState(this.error, () => this.retry()) : null,
+      failed ? null : this.banner(),
+      failed ? null : this.corpus(data),
+      failed ? null : this.connectors(data),
+      failed ? null : this.quarantine(data),
+    );
+    if (!held) this.title.focus();
+  }
+
+  /** retry reads again after a failure, from the button the failure offers. */
+  async retry() {
+    await this.refresh();
+    this.watch();
+  }
+
+  /**
+   * banner says the screen is not current, and only once it is not.
+   *
+   * An operations screen that quietly keeps showing the last good answer while
+   * the server is down is the one screen where that is actively dangerous, so
+   * the failure is on the screen rather than in the console.
+   */
+  banner() {
+    if (!this.error) return null;
+    return h(
+      "p",
+      { class: "admin__stale", role: "status" },
+      svg(icon("clock"), 16),
+      `This is the last answer that arrived. The server said: ${this.error.message}`,
+    );
+  }
+
+  backLink() {
+    const to = this.onBack();
+    return h(
+      "div",
+      { class: "page__back" },
+      h(
+        "a",
+        {
+          class: "page__back-link",
+          href: to.href,
+          onClick: (e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+            e.preventDefault();
+            this.stop();
+            to.go();
+          },
+        },
+        svg(icon("arrow-left"), 16),
+        to.title,
+      ),
+    );
+  }
+
+  /**
+   * corpus is the two numbers the whole screen hangs off.
+   *
+   * Servable and held rather than one total, because they are the two halves of
+   * what was indexed and the second one is the number nobody has a way of
+   * seeing anywhere else. A corpus with eleven hundred held documents and a
+   * healthy sync log looks perfect from every other screen in the product.
+   */
+  corpus(data) {
+    return h(
+      "section",
+      { class: "panel admin__corpus" },
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Corpus")),
+      h(
+        "div",
+        { class: "admin__figures" },
+        figure("Servable", number(data.documents || 0), "Documents a search can reach"),
+        figure(
+          "Held back",
+          number(data.quarantined || 0),
+          "Documents whose permissions did not resolve",
+          (data.quarantined || 0) > 0,
+        ),
+      ),
+    );
+  }
+
+  connectors(data) {
+    const list = data.connectors || [];
+    return h(
+      "section",
+      { class: "panel" },
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Connectors")),
+      list.length
+        ? list.map((c) => this.connector(c))
+        : note(
+            "This process runs no connectors.",
+            "Its index is filled by something else, so there is nothing to report here.",
+          ),
+    );
+  }
+
+  connector(c) {
+    const runs = c.runs || [];
+    const last = runs[0] || null;
+    const failing = Boolean(last && last.error);
+    return h(
+      "article",
+      { class: "connector" },
+      h(
+        "div",
+        { class: "connector__head" },
+        h(
+          "div",
+          { class: "connector__name" },
+          h("h3", { class: "connector__title" }, c.source || "unnamed"),
+          h("span", { class: "connector__kind" }, label(c.kind || "")),
+        ),
+        // The state of the connector as a word rather than a colour, because a
+        // colour is not a fact and half the people reading this cannot use it.
+        c.syncing
+          ? h("span", { class: "pill pill--busy" }, "Syncing")
+          : failing
+            ? h("span", { class: "pill pill--bad" }, "Last sync failed")
+            : runs.length
+              ? h("span", { class: "pill pill--good" }, "Healthy")
+              : h("span", { class: "pill" }, "Not run yet"),
+      ),
+      facts([
+        ["Reads", c.target],
+        ["Tenant", c.tenant],
+        ["Refreshes", c.refresh ? `every ${c.refresh}` : "once at startup"],
+      ]),
+      this.mapping(c.permissions),
+      runs.length ? this.runs(runs) : null,
+    );
+  }
+
+  /**
+   * mapping is what the permission mapping made of this source, by reason.
+   *
+   * Three separate numbers because they want three different actions. A foreign
+   * domain is a decision somebody has to make about the tenant, an unmappable
+   * deny is usually a feature of the source nobody has written the mapping for
+   * yet, and a malformed grant is a bug in the connector.
+   */
+  mapping(m) {
+    if (!m) return null;
+    const held = (m.foreign_domain || 0) + (m.unmappable_deny || 0) + (m.malformed || 0);
+    if (!m.mapped && !held) return null;
+    return h(
+      "div",
+      { class: "connector__mapping" },
+      h("h4", { class: "connector__subtitle" }, "Permissions"),
+      h(
+        "div",
+        { class: "admin__figures admin__figures--tight" },
+        figure("Mapped", number(m.mapped || 0), "Access control lists this source resolved"),
+        figure("Foreign domain", number(m.foreign_domain || 0), "Grants to somebody outside the tenant", Boolean(m.foreign_domain)),
+        figure("Unmappable deny", number(m.unmappable_deny || 0), "A deny this model cannot carry", Boolean(m.unmappable_deny)),
+        figure("Malformed", number(m.malformed || 0), "Grants the source wrote in a way nothing understood", Boolean(m.malformed)),
+        figure("Ignored roles", number(m.ignored || 0), "Statements whose role does not confer read"),
+      ),
+    );
+  }
+
+  /**
+   * runs is the sync history, newest first.
+   *
+   * A single last run cannot answer the question somebody comes here with,
+   * which is not whether a sync failed but whether the failures started this
+   * morning or have been there since the process came up.
+   */
+  runs(runs) {
+    return h(
+      "div",
+      { class: "connector__runs" },
+      h("h4", { class: "connector__subtitle" }, "Recent syncs"),
+      h(
+        "table",
+        { class: "admin__table" },
+        h(
+          "thead",
+          {},
+          h(
+            "tr",
+            {},
+            h("th", { scope: "col" }, "Started"),
+            h("th", { scope: "col" }, "Took"),
+            h("th", { scope: "col", class: "admin__num" }, "Indexed"),
+            h("th", { scope: "col", class: "admin__num" }, "Held back"),
+            h("th", { scope: "col", class: "admin__num" }, "Deleted"),
+            h("th", { scope: "col", class: "admin__num" }, "Read"),
+            h("th", { scope: "col" }, "Outcome"),
+          ),
+        ),
+        h(
+          "tbody",
+          {},
+          runs.map((r) =>
+            h(
+              "tr",
+              { class: r.error ? "admin__row admin__row--bad" : "admin__row" },
+              h("td", {}, h("time", { datetime: r.started, title: exact(r.started) }, when(r.started))),
+              h("td", {}, r.duration_ms ? duration(r.duration_ms) : "still going"),
+              h("td", { class: "admin__num" }, number(r.indexed || 0)),
+              h("td", { class: "admin__num" }, number(r.quarantined || 0)),
+              h("td", { class: "admin__num" }, number(r.deleted || 0)),
+              h("td", { class: "admin__num" }, bytes(r.bytes || 0)),
+              // The whole message rather than a code. The failures here are a
+              // directory that disappeared, a bucket refusing a signature and a
+              // token that expired, and the sentence is the entire value.
+              h("td", { class: "admin__outcome" }, r.error || "Finished"),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * quarantine is which documents are being held back and why.
+   *
+   * It is the only place in the product where a document nobody may read is
+   * named, and it names nothing about the contents: the title, where it came
+   * from, when it last changed and the reason it did not resolve. That is what
+   * an operator needs to go and fix the access control list at the source, and
+   * nothing beyond it.
+   */
+  quarantine(data) {
+    const list = data.held || [];
+    const total = data.quarantined || 0;
+    return h(
+      "section",
+      { class: "panel" },
+      h(
+        "div",
+        { class: "panel__head" },
+        h("h2", { class: "panel__title" }, "Held back"),
+        // Said out loud when the list is a sample, so nobody reads a hundred
+        // rows as the whole of a corpus of fourteen hundred.
+        total > list.length && list.length
+          ? h("span", { class: "panel__note" }, `${number(list.length)} of ${number(total)}`)
+          : null,
+      ),
+      !total
+        ? note(
+            "Nothing is being held back.",
+            "Every document that was indexed resolved to a permission this deployment understands.",
+          )
+        : !data.listable
+          ? note(
+              "This storage driver cannot list what it is holding back.",
+              `The count is ${number(total)}. The sync log names the reasons in aggregate.`,
+            )
+          : this.heldTable(list),
+    );
+  }
+
+  heldTable(list) {
+    return h(
+      "table",
+      { class: "admin__table" },
+      h(
+        "thead",
+        {},
+        h(
+          "tr",
+          {},
+          h("th", { scope: "col" }, "Document"),
+          h("th", { scope: "col" }, "Source"),
+          h("th", { scope: "col" }, "Changed"),
+          h("th", { scope: "col" }, "Why it did not resolve"),
+        ),
+      ),
+      h(
+        "tbody",
+        {},
+        list.map((d) =>
+          h(
+            "tr",
+            { class: "admin__row" },
+            h(
+              "td",
+              {},
+              h("span", { class: "admin__doc" }, d.title || d.id),
+              d.title ? h("span", { class: "admin__id" }, d.id) : null,
+            ),
+            h("td", {}, label(d.source || "")),
+            h(
+              "td",
+              {},
+              d.modified_at
+                ? h("time", { datetime: d.modified_at, title: exact(d.modified_at) }, when(d.modified_at))
+                : "",
+            ),
+            // The reason is the only thing on this screen anybody acts on, so
+            // it gets the room. A list of held documents with no reasons is the
+            // count again, drawn as a table.
+            h("td", { class: "admin__reason" }, d.reason || "The connector did not say."),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/**
+ * figure is one number with its name and what it counts.
+ *
+ * The same element the home screen prints a corpus size with, because a number
+ * on a screen is a number on a screen and a second way of drawing one is a
+ * second thing to keep in step. warn colours it, and only ever for a count that
+ * is not zero, because a warning that is always on is not a warning.
+ */
+function figure(name, value, hint, warn = false) {
+  return h(
+    "div",
+    { class: warn ? "stat admin__stat--warn" : "stat" },
+    h("span", { class: "stat__value" }, value),
+    h("span", { class: "stat__label" }, name),
+    h("span", { class: "admin__hint" }, hint),
+  );
+}
+
+/** note is an empty state, which on this screen is usually the good news. */
+function note(title, body) {
+  return h(
+    "div",
+    { class: "admin__note" },
+    h("p", { class: "admin__note-title" }, title),
+    h("p", { class: "admin__note-body" }, body),
+  );
+}
+
+/**
+ * facts is a list of named values, with the ones nobody answered left out.
+ *
+ * An empty row would be a fact this screen claims to know and does not, which
+ * on the screen somebody comes to for the truth about a deployment is the worst
+ * thing it could print.
+ */
+function facts(rows) {
+  return h(
+    "dl",
+    { class: "facts" },
+    rows
+      .filter(([, value]) => value)
+      .map(([name, value]) => [
+        h("dt", { class: "facts__name" }, name),
+        h("dd", { class: "facts__value" }, value),
+      ]),
+  );
+}

--- a/web/dist/assets/api.js
+++ b/web/dist/assets/api.js
@@ -194,6 +194,10 @@ async function bytes(path, opts = {}) {
 export const api = {
   me: (opts) => get("/me", {}, opts),
   stats: (opts) => get("/stats", {}, opts),
+  // One request for the whole administration screen, because every number on
+  // it is a snapshot of the same moment and three requests would let the count
+  // of held documents disagree with the list under it.
+  admin: (opts) => get("/admin/operations", {}, opts),
   search: (query, opts) => get("/search", query, opts),
   // One request for both halves of the recent screen, because the screen asks
   // both questions at once and a screen that paints in two stages paints twice.

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -2825,6 +2825,237 @@ h6.prose__h {
   overflow-wrap: anywhere;
 }
 
+/* Administration --------------------------------------------------------- */
+
+/* The operations screen. Same measure and the same rhythm as settings, because
+   they are both screens somebody reads rather than works in, and a second page
+   shape for a second such screen is a second thing to keep in step. */
+.admin {
+  max-width: var(--page-max);
+  margin: 0 auto;
+  padding: var(--space-16) var(--gutter) var(--space-24);
+}
+
+.admin__head {
+  margin-bottom: var(--space-12);
+}
+
+.admin__title {
+  font-size: var(--text-display);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-display);
+  letter-spacing: var(--display-tracking);
+}
+
+/* The heading takes focus when the screen opens so that a screen reader starts
+   at the top of it. It is not a control, so it does not draw a ring. */
+.admin__title:focus {
+  outline: none;
+}
+
+.admin__lead {
+  max-width: var(--measure);
+  margin-top: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-lead);
+  line-height: var(--leading-lead);
+}
+
+/* The one place on this screen that shouts, and only when the answer on screen
+   is out of date. An operations screen quietly showing the last good answer
+   while the server is down is worse than one that says so. */
+.admin__stale {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-8);
+  color: var(--warning-700);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.admin .panel {
+  margin-bottom: var(--space-16);
+}
+
+.admin__figures {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-8) var(--space-12);
+}
+
+/* The permission counts, which are five numbers about one connector rather than
+   two about the whole corpus, so they are smaller and closer together. */
+.admin__figures--tight {
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--space-4) var(--space-8);
+}
+
+.admin__figures--tight .stat__value {
+  font-size: var(--text-heading);
+  line-height: var(--leading-heading);
+}
+
+.admin__hint {
+  max-width: var(--measure);
+  color: var(--text-muted);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+/* Colour on a count only while the count is not zero. A warning that is always
+   on is not a warning, and the word beside it says the same thing anyway. */
+.admin__stat--warn .stat__value {
+  color: var(--warning-700);
+}
+
+.connector {
+  padding: var(--space-8) 0;
+  border-top: 1px solid var(--border);
+}
+
+.connector:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+
+.connector__head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.connector__name {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.connector__title {
+  font-size: var(--text-title);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-heading);
+}
+
+.connector__kind {
+  color: var(--text-muted);
+  font-size: var(--text-small);
+}
+
+.connector__subtitle {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+}
+
+.connector__mapping,
+.connector__runs {
+  margin-top: var(--space-8);
+}
+
+/* The state of a connector as a word. The colour is a second reading of the
+   same fact rather than the only one, because half the people reading this
+   cannot use it. */
+.pill {
+  margin-left: auto;
+  flex: none;
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+}
+
+.pill--good {
+  color: var(--success-700);
+}
+
+.pill--bad {
+  color: var(--danger-700);
+}
+
+.pill--busy {
+  color: var(--text-link);
+}
+
+/* Borderless, like every other table here. The rules are the horizontal ones
+   under the head and between rows, and nothing else. */
+.admin__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-small);
+  line-height: var(--leading-body);
+}
+
+.admin__table th {
+  padding: 0 var(--space-4) var(--space-2) 0;
+  border-bottom: 1px solid var(--border-control);
+  color: var(--text-secondary);
+  font-weight: var(--weight-semibold);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.admin__table td {
+  padding: var(--space-3) var(--space-4) var(--space-3) 0;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.admin__table tr:last-child td {
+  border-bottom: none;
+}
+
+/* Numbers line up on the right so a column of them can be compared by eye, and
+   they are tabular so the digits do not shift between rows. */
+.admin__num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.admin__row--bad .admin__outcome {
+  color: var(--danger-700);
+}
+
+/* The reason is the only thing on this screen anybody acts on, so it gets the
+   room and it wraps rather than being cut off. */
+.admin__reason,
+.admin__outcome {
+  max-width: var(--measure);
+  overflow-wrap: anywhere;
+}
+
+.admin__doc {
+  display: block;
+  font-weight: var(--weight-semibold);
+}
+
+.admin__id {
+  display: block;
+  color: var(--text-muted);
+  font-size: var(--text-caption);
+  overflow-wrap: anywhere;
+}
+
+/* An empty state, which on this screen is usually the good news. */
+.admin__note {
+  max-width: var(--measure);
+}
+
+.admin__note-title {
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-body);
+}
+
+.admin__note-body {
+  margin-top: var(--space-1);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
 /* Responsive ------------------------------------------------------------- */
 
 /*

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -20,6 +20,7 @@ import { Drawer } from "genba/drawer.js";
 import { Page } from "genba/page.js";
 import { Home } from "genba/home.js";
 import { Recent } from "genba/recent.js";
+import { Admin } from "genba/admin.js";
 import { Settings } from "genba/settings.js";
 import { forget, remember } from "genba/queries.js";
 import { failed } from "genba/states.js";
@@ -131,6 +132,7 @@ class App {
       onIdentity: () => this.switchIdentity(),
       onSay: (text) => this.say(text),
     });
+    this.admin = new Admin({ onBack: () => this.backFromAdmin() });
 
     this.main = h("main", {
       class: "main",
@@ -328,6 +330,11 @@ class App {
           h("span", { class: "rail__label" }, "Settings"),
         ),
       ),
+      // Filled once the session says whether this person holds the role. It is
+      // empty for everybody else rather than a link that leads to a refusal,
+      // because a rail entry is a promise and one that always fails is worse
+      // than no entry at all.
+      h("div", { class: "rail__section", id: "rail-admin" }),
       // Both of these are filled once the session says what the corpus holds.
       // They are empty until then rather than full of guesses, because a rail
       // that shortens a moment after it paints is worse than one that arrives a
@@ -377,7 +384,8 @@ class App {
     // Where the settings screen was opened from, taken before the address
     // moves. No other screen needs this: the rest either carry their own state
     // in the address or have a list behind them to go back to.
-    if (path === urlState.SETTINGS && urlState.route().name !== "settings") {
+    const aside = path === urlState.SETTINGS || path === urlState.ADMIN;
+    if (aside && !["settings", "admin"].includes(urlState.route().name)) {
       this.lastScreen = location.pathname + location.search;
     }
     if (location.pathname !== path || location.search) history.pushState(null, "", path);
@@ -394,6 +402,7 @@ class App {
       cache.as(this.session.view || "");
       this.results.verticals = verticalsFor(this.session.kinds);
       this.results.knows({ sources: this.session.sources || [] });
+      this.renderAdmin();
       this.renderVerticals();
       this.renderSources();
     } catch (err) {
@@ -423,6 +432,38 @@ class App {
       // An interface that cannot count what is indexed says nothing about it,
       // which is what it said before this ran.
     }
+  }
+
+  /**
+   * renderAdmin puts the administration entry on the rail, for the people who
+   * can reach it.
+   *
+   * The role is the server's answer rather than this browser's, because it is
+   * the server that decides and a client that guessed would either hide a
+   * screen from somebody who has it or offer one that refuses.
+   */
+  renderAdmin() {
+    const holder = this.rail.querySelector("#rail-admin");
+    const roles = (this.session && this.session.roles) || [];
+    if (!roles.includes("admin")) {
+      replace(holder);
+      return;
+    }
+    replace(
+      holder,
+      h(
+        "a",
+        {
+          class: "rail__link",
+          href: urlState.ADMIN,
+          title: "Administration",
+          dataset: { route: "admin" },
+          onClick: (e) => this.follow(e, urlState.ADMIN),
+        },
+        svg(icon("slider"), 20),
+        h("span", { class: "rail__label" }, "Admin"),
+      ),
+    );
   }
 
   /** renderVerticals fills the rail with the verticals the corpus has. */
@@ -547,6 +588,10 @@ class App {
       this.showSettings();
       return;
     }
+    if (route.name === "admin") {
+      this.showAdmin();
+      return;
+    }
 
     document.title = "genba";
     this.omnibox.value = this.query.q;
@@ -629,6 +674,36 @@ class App {
   }
 
   /**
+   * showAdmin renders what the deployment is doing.
+   *
+   * It polls while it is on screen, which no other screen does, and it stops
+   * itself by noticing it has been taken off the page. The endpoint refuses
+   * anybody without the role, so somebody who typed the address rather than
+   * following the rail entry lands on the error the server gave rather than on
+   * a screen that pretends.
+   */
+  async showAdmin() {
+    this.currentKey = this.admin.key();
+    this.drawer.currentId = null;
+    if (this.drawer.open) this.drawer.close({ notify: false, focus: false });
+    document.title = "Administration \u00b7 genba";
+    if (this.main.firstChild !== this.admin.el) replace(this.main, this.admin.el);
+    await this.admin.render();
+  }
+
+  /** backFromAdmin is the way out, which is the same one settings offers. */
+  backFromAdmin() {
+    const back = this.backFromSettings();
+    return {
+      ...back,
+      go: () => {
+        this.admin.stop();
+        back.go();
+      },
+    };
+  }
+
+  /**
    * backFromSettings is the way out, which is wherever this screen was opened
    * from.
    *
@@ -681,7 +756,7 @@ class App {
     const searching = Boolean(this.query.q) || urlState.count(this.query) > 0 || Boolean(this.query.sort);
     const route = urlState.route();
     const here =
-      route.name === "recent" || route.name === "settings"
+      route.name === "recent" || route.name === "settings" || route.name === "admin"
         ? route.name
         : route.name === "search" && !searching
           ? "home"

--- a/web/dist/assets/state.js
+++ b/web/dist/assets/state.js
@@ -7,7 +7,7 @@
 
 const LIST_KEYS = ["source", "kind", "container", "author", "owner"];
 
-// The three screens that are a path rather than a query string.
+// The four screens that are a path rather than a query string.
 //
 // A document is the thing somebody pastes into a message, so it gets an address
 // that survives being read out loud and does not carry the state of whoever
@@ -16,10 +16,14 @@ const LIST_KEYS = ["source", "kind", "container", "author", "owner"];
 // of a search: it answers what has been going on rather than what matches, and
 // a rail entry that ran a recency sorted search was answering the wrong
 // question with the right rows. Settings is a path because none of the query
-// state means anything on it.
+// state means anything on it. Administration is a path for the same reason and
+// for one more: it is not about the corpus at all, it is about the process, and
+// carrying a search filter onto it would be carrying it onto a screen where it
+// means nothing.
 const DOCUMENT = "/d/";
 export const RECENT = "/recent";
 export const SETTINGS = "/settings";
+export const ADMIN = "/admin";
 
 /**
  * route says which screen the path names.
@@ -30,6 +34,7 @@ export const SETTINGS = "/settings";
 export function route(pathname = location.pathname) {
   if (pathname === RECENT) return { name: "recent", id: "" };
   if (pathname === SETTINGS) return { name: "settings", id: "" };
+  if (pathname === ADMIN) return { name: "admin", id: "" };
   if (!pathname.startsWith(DOCUMENT)) return { name: "search", id: "" };
   const id = decode(pathname.slice(DOCUMENT.length));
   return id ? { name: "document", id } : { name: "search", id: "" };

--- a/web/dist/assets/tokens.css
+++ b/web/dist/assets/tokens.css
@@ -316,6 +316,14 @@
   --border-control: #3c4045;
   --border-strong: #e8eaed;
 
+  /* The functional hues lift on this ground. The light values are chosen to
+     clear the contrast ratio against white and none of them clears it against
+     a near black one, so the same three meanings get lighter shades here
+     rather than the screens that use them getting a second rule each. */
+  --success-700: #34d399;
+  --warning-700: #fbbf24;
+  --danger-700: #f87171;
+
   --accent: var(--brand-400);
   --focus-ring: var(--brand-400);
 

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -23,6 +23,7 @@
     <script type="importmap">
       {
         "imports": {
+          "genba/admin.js": "/assets/admin.js",
           "genba/answer.js": "/assets/answer.js",
           "genba/api.js": "/assets/api.js",
           "genba/app.js": "/assets/app.js",
@@ -59,9 +60,10 @@
     <!--
       The whole module graph, flattened. Without this the browser learns about
       markdown.js only after content.js has arrived, which is four levels deep
-      on a graph that is twenty eight files wide. graph_test.go computes the
+      on a graph that is thirty files wide. graph_test.go computes the
       closure from app.js and fails if this list is not exactly it.
     -->
+    <link rel="modulepreload" href="/assets/admin.js" />
     <link rel="modulepreload" href="/assets/answer.js" />
     <link rel="modulepreload" href="/assets/api.js" />
     <link rel="modulepreload" href="/assets/app.js" />


### PR DESCRIPTION
Part of #40, the read side of it.

## Why

An operator running this had two ways to find out whether it was working: read the process log, or notice that a search stopped returning something.
Neither is a screen.
The quarantine was worse than invisible, it was a single number, and a number cannot tell one connector's broken role mapping from a tenant boundary doing exactly what it should.
Those two want opposite actions.

## What is in it

A permission descriptor that did not resolve now carries a sentence saying why, written at the point where resolution failed rather than logged and thrown away.
Every call site already knew which failure it was, usually because it was about to log it, so it says so once and the sentence travels with the document to whoever has to fix it.

The stores learn to list what they are holding back, with that reason on each row, sqlite and postgres and the reference driver alike, and the conformance suite covers it for all three.

The daemon records every sync it runs: when it started, how long it took, what it indexed, what it deleted, what it held back and whether it failed.
It keeps the last ten runs per connector in memory, which is the same arrangement the first crawl progress already uses.

One endpoint, `GET /api/v1/admin/operations`, reports all of it in a single request, because every number on the screen is a snapshot of the same moment and three requests would let the count of held documents disagree with the list under it.

One screen at `/admin` draws it: what is servable and what is held back, each connector with its mapping and its run history, and the quarantine with a reason per row.

## The role

`admin` is new and it grants nothing over documents.
An operator sees the same search results with it as without, because being allowed to read the corpus is a decision about a person and not about a job, and the day the two are the same role is the day nobody can be given the second without the first.

It comes from `X-Genba-Roles`, which is how a proxy that has already authenticated somebody passes it down, or from `GENBA_ADMINS` and the `-admins` flag, which is how a deployment with no proxy in front of it still has an administrator.
The default is that nobody holds it.
A deployment that has not decided who operates it has not decided, and guessing everybody is the answer that cannot be taken back.
Both the reads and the refusals are logged with the subject.

The rail entry appears only when the server says the person holds the role, rather than always appearing and leading to a refusal.

## Caching

The response carries no entity tag, for the same reason the stats endpoint carries none.
Half of what it reports is what the connectors are doing right now, so a tag over the body could never match and a tag computed over the parts that hold still would pin an operator to the first answer they ever saw.
It carries the private caching headers and it varies on the credential headers, because the body names documents and who may see them is exactly what a shared cache does not know.
The screen repaints itself every five seconds instead, reading focus before it repaints so the poll cannot take a focus ring away from somebody five seconds after they put it there.

`BenchmarkAPIAdmin` measures it at roughly the same cost as the stats endpoint on the benchmark corpus, which is the two queries under it rather than anything this adds.

## Checks

`go test ./...` passes against sqlite and against PostgreSQL 18.
The UI gate passes on a real server with a real corpus: administration is the twelfth screen axe audits, and the keyboard walk opens it against the connector the gate's own server is running, so a screen drawing from a fixture would fail it.
The screen is the only one in the product built out of tables, so the walk asserts that every column is headed by a real header cell and that an empty quarantine is said out loud rather than drawn as an empty table.

## Not in this one

Adding and configuring a connector from the interface, and the view of what a given user can see.
Both are the write side of #40 and both are the next change.