### PR TITLE
Answer whether one person can read one document

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,14 +130,20 @@ Everything the interface does is an HTTP call, and there is nothing it can reach
 | `GET /api/v1/me` | the caller, and the sources and kinds that caller can actually see |
 | `GET /api/v1/stats` | how much is indexed and how much is quarantined |
 | `GET /api/v1/admin/operations` | what the connectors are doing, and what is being held back and why |
+| `GET /api/v1/admin/access` | whether one named person can read one document, and why |
 | `GET /healthz`, `GET /readyz` | liveness, and whether the store answers |
 
 `search` takes `q` for the text and the operators, and `source`, `kind`, `container`, `author` and `owner` as repeated or comma separated parameters, plus `since`, `until`, `sort`, `limit` and `offset`.
 The snippet comes back as marked passages rather than as offsets, so a client highlights what the analyzer matched without reimplementing the analyzer.
 
-`admin/operations` needs the `admin` role, which comes from `X-Genba-Roles` or from `GENBA_ADMINS`, and the default is that nobody has it.
+Both `admin` endpoints need the `admin` role, which comes from `X-Genba-Roles` or from `GENBA_ADMINS`, and the default is that nobody has it.
 The role grants nothing over documents and it must not start to.
 Both the reads and the refusals are logged with the subject.
+
+`admin/access` takes `subject`, `groups` and `identities` for the person being asked about, `id` to ask about one document, and `counts=1` to also count what that person can reach.
+It answers as that person, by the same rule a search applies, and it never returns a document or a title.
+A yes about a document says which clause admitted them and which group or account it matched; a no says nothing further, because the difference between held back, another tenant, not on the list and not there would prove a document exists.
+The counts are asked for rather than always returned because they are an aggregate over every document in the tenant, and the log line names both the operator and the person they asked about.
 
 By default every file in the corpus is readable by everybody in the tenant, which is the right rule for a public checkout and the wrong one for almost anything else.
 If the tree has OWNERS files in it, `-corpus-acl owners` reads them instead, and a query then returns different results depending on who is asking.

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -242,29 +242,106 @@ type Permissions struct {
 	Reason string `json:",omitempty"`
 }
 
+// Rule names the clause of the permission rule that settled a question.
+type Rule string
+
+// The clauses, in the order [Permissions.Decide] applies them.
+const (
+	// RuleNoPrincipal is nobody asking, which is a programming error rather
+	// than an anonymous reader.
+	RuleNoPrincipal Rule = "no-principal"
+
+	// RuleUnresolved is a descriptor the source's rules never resolved into.
+	// The document is held back from everybody.
+	RuleUnresolved Rule = "unresolved"
+
+	// RuleDenied is an explicit deny, which beats every allow.
+	RuleDenied Rule = "denied"
+
+	// RuleOwner is the subject owning the document.
+	RuleOwner Rule = "owner"
+
+	// RuleOwnerOnly is a document only its owner may read, read by somebody
+	// else.
+	RuleOwnerOnly Rule = "owner-only"
+
+	// RuleTenant is a document the source said everybody in the deployment may
+	// read.
+	RuleTenant Rule = "tenant"
+
+	// RuleListed and RuleNotListed are the access control list admitting the
+	// subject, and failing to.
+	RuleListed    Rule = "listed"
+	RuleNotListed Rule = "not-listed"
+)
+
+// Decision is the answer [Permissions.Allows] gives, with the reason for it.
+//
+// It exists for the administration screen that answers what a given person can
+// see, where "no" on its own is not an answer somebody can act on. What they
+// need is which clause settled it and which reference it matched, because the
+// action is different for each: a deny is a decision somebody made, an empty
+// access control list is usually a connector that has not finished, and an
+// unresolved descriptor is a bug in whichever mapping gave up.
+//
+// It is a separate type rather than three return values because it is served on
+// the wire, and it does not carry a sentence because the words belong on the
+// screen that shows them rather than in the package that decides.
+type Decision struct {
+	// Allowed is the answer, and it is exactly what Allows returns.
+	Allowed bool
+
+	// Rule is the clause that settled it.
+	Rule Rule
+
+	// Ref is the reference that matched, where one did. It is the deny that
+	// won, the allow that admitted them, or the owner, and it is zero for the
+	// clauses that match nothing.
+	Ref Ref
+}
+
 // Allows reports whether the principal may read the document.
+func (perm Permissions) Allows(p *Principal) bool { return perm.Decide(p).Allowed }
+
+// Decide answers whether the principal may read the document, and why.
 //
 // The order is fixed and is the whole point of the function: an unresolved
 // descriptor denies, then an explicit deny denies, then an allow allows.
-func (perm Permissions) Allows(p *Principal) bool {
-	if p == nil || perm.Mode == ModeUnknown {
-		return false
+//
+// It is the one implementation of that order. Allows is written in terms of it
+// rather than beside it, because two copies of a rule drift and the way this
+// one drifts is that somebody sees a document.
+func (perm Permissions) Decide(p *Principal) Decision {
+	if p == nil {
+		return Decision{Rule: RuleNoPrincipal}
 	}
-	if perm.matchesUser(p, perm.DenyUsers) || perm.matchesGroup(p, perm.DenyGroups) {
-		return false
+	if perm.Mode == ModeUnknown {
+		return Decision{Rule: RuleUnresolved}
+	}
+	if r, ok := perm.matchesUser(p, perm.DenyUsers); ok {
+		return Decision{Rule: RuleDenied, Ref: r}
+	}
+	if r, ok := perm.matchesGroup(p, perm.DenyGroups); ok {
+		return Decision{Rule: RuleDenied, Ref: r}
 	}
 	if perm.isOwner(p) {
-		return true
+		return Decision{Allowed: true, Rule: RuleOwner, Ref: perm.Owner}
 	}
 	switch perm.Mode {
 	case ModeOwnerOnly:
-		return false
+		return Decision{Rule: RuleOwnerOnly}
 	case ModePublicToTenant:
-		return true
+		return Decision{Allowed: true, Rule: RuleTenant}
 	case ModeACL:
-		return perm.matchesUser(p, perm.AllowUsers) || perm.matchesGroup(p, perm.AllowGroups)
+		if r, ok := perm.matchesUser(p, perm.AllowUsers); ok {
+			return Decision{Allowed: true, Rule: RuleListed, Ref: r}
+		}
+		if r, ok := perm.matchesGroup(p, perm.AllowGroups); ok {
+			return Decision{Allowed: true, Rule: RuleListed, Ref: r}
+		}
+		return Decision{Rule: RuleNotListed}
 	default:
-		return false
+		return Decision{Rule: RuleNotListed}
 	}
 }
 
@@ -272,16 +349,22 @@ func (perm Permissions) isOwner(p *Principal) bool {
 	if perm.Owner.Value == "" {
 		return false
 	}
-	return perm.matchesUser(p, []Ref{perm.Owner})
+	_, ok := perm.matchesUser(p, []Ref{perm.Owner})
+	return ok
 }
 
 // matchesUser and matchesGroup are the same set membership a storage driver
 // runs inside its own query, expressed over the key forms in ref.go so that
 // there is one definition of the rule rather than one per driver.
-func (perm Permissions) matchesUser(p *Principal, refs []Ref) bool {
+//
+// They return which reference matched as well as whether one did. The decision
+// does not need it and the screen that explains the decision does, and working
+// it out a second time afterwards would be a second implementation of the
+// comparison.
+func (perm Permissions) matchesUser(p *Principal, refs []Ref) (Ref, bool) {
 	return matchesKey(p.UserKeys(), refs, Ref.UserKey)
 }
 
-func (perm Permissions) matchesGroup(p *Principal, refs []Ref) bool {
+func (perm Permissions) matchesGroup(p *Principal, refs []Ref) (Ref, bool) {
 	return matchesKey(p.GroupKeys(), refs, Ref.GroupKey)
 }

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -131,7 +131,87 @@ func TestAllows(t *testing.T) {
 			if got := tt.perm.Allows(p); got != tt.want {
 				t.Errorf("Allows() = %v, want %v", got, tt.want)
 			}
+			// The two answers are one answer. Allows is written in terms of
+			// Decide, and this is what says so out loud, so that a later change
+			// that gives Decide its own copy of the order fails here rather than
+			// on somebody's screen.
+			if got := tt.perm.Decide(p); got.Allowed != tt.want {
+				t.Errorf("Decide() = %+v, want allowed %v", got, tt.want)
+			}
 		})
+	}
+}
+
+// TestDecideNamesTheClauseAndTheReference is the half of the decision the
+// screen shows. Which clause settled it is the difference between a deny
+// somebody wrote on purpose and an access control list a connector never
+// finished filling in, and those two want opposite actions.
+func TestDecideNamesTheClauseAndTheReference(t *testing.T) {
+	tests := []struct {
+		name string
+		perm acl.Permissions
+		want acl.Decision
+	}{
+		{
+			name: "unresolved says so rather than saying not listed",
+			perm: acl.Permissions{Mode: acl.ModeUnknown, AllowGroups: []acl.Ref{{Source: "slack", Value: "S-platform"}}},
+			want: acl.Decision{Rule: acl.RuleUnresolved},
+		},
+		{
+			name: "a deny names the deny that won",
+			perm: acl.Permissions{
+				Mode:        acl.ModeACL,
+				AllowGroups: []acl.Ref{{Source: "slack", Value: "S-platform"}},
+				DenyUsers:   []acl.Ref{{Source: "gdrive", Value: "mei@acme.com"}},
+			},
+			want: acl.Decision{Rule: acl.RuleDenied, Ref: acl.Ref{Source: "gdrive", Value: "mei@acme.com"}},
+		},
+		{
+			name: "an allow names the group that admitted them",
+			perm: acl.Permissions{
+				Mode:        acl.ModeACL,
+				AllowGroups: []acl.Ref{{Source: "slack", Value: "S-legal"}, {Source: "slack", Value: "S-platform"}},
+			},
+			want: acl.Decision{Allowed: true, Rule: acl.RuleListed, Ref: acl.Ref{Source: "slack", Value: "S-platform"}},
+		},
+		{
+			name: "an empty access control list is not listed rather than denied",
+			perm: acl.Permissions{Mode: acl.ModeACL},
+			want: acl.Decision{Rule: acl.RuleNotListed},
+		},
+		{
+			name: "public to the tenant names no reference because none decided",
+			perm: acl.Permissions{Mode: acl.ModePublicToTenant},
+			want: acl.Decision{Allowed: true, Rule: acl.RuleTenant},
+		},
+		{
+			name: "the owner is named",
+			perm: acl.Permissions{Mode: acl.ModeOwnerOnly, Owner: acl.Ref{Source: "gdrive", Value: "mei@acme.com"}},
+			want: acl.Decision{Allowed: true, Rule: acl.RuleOwner, Ref: acl.Ref{Source: "gdrive", Value: "mei@acme.com"}},
+		},
+		{
+			name: "somebody else's private document",
+			perm: acl.Permissions{Mode: acl.ModeOwnerOnly, Owner: acl.Ref{Source: "gdrive", Value: "kenji@acme.com"}},
+			want: acl.Decision{Rule: acl.RuleOwnerOnly},
+		},
+	}
+
+	p := person()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.perm.Decide(p); got != tt.want {
+				t.Errorf("Decide() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDecideWithNoPrincipalSaysWhichMistakeItWas keeps the one case that is a
+// programming error apart from the cases that are ordinary refusals.
+func TestDecideWithNoPrincipalSaysWhichMistakeItWas(t *testing.T) {
+	got := acl.Permissions{Mode: acl.ModePublicToTenant}.Decide(nil)
+	if got.Allowed || got.Rule != acl.RuleNoPrincipal {
+		t.Errorf("Decide(nil) = %+v, want a refusal that says there was no principal", got)
 	}
 }
 

--- a/acl/ref.go
+++ b/acl/ref.go
@@ -71,13 +71,13 @@ func (p *Principal) GroupKeys() []string {
 	return p.Groups.Members
 }
 
-// matchesKey reports whether any of the references names the principal, using
-// the key form for the side of the rule it is on.
-func matchesKey(keys []string, refs []Ref, key func(Ref) string) bool {
+// matchesKey returns the first reference that names the principal, using the
+// key form for the side of the rule it is on, and reports whether one did.
+func matchesKey(keys []string, refs []Ref, key func(Ref) string) (Ref, bool) {
 	for _, r := range refs {
 		if slices.Contains(keys, key(r)) {
-			return true
+			return r, true
 		}
 	}
-	return false
+	return Ref{}, false
 }

--- a/api/access.go
+++ b/api/access.go
@@ -1,0 +1,267 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+// GroupLimit is how many groups one access question may name.
+//
+// A real expansion of a large directory is hundreds of groups and this is above
+// that. It is here because the groups arrive in a query string that somebody
+// can type, and a question naming ten thousand of them is a request to build a
+// ten thousand element predicate, which is a way of making one screen expensive
+// for everybody else on the deployment.
+const GroupLimit = 512
+
+// accessResponse is what one person can reach, as an operator sees it.
+//
+// It is counts and never content. The administrator role grants nothing over
+// documents, and a screen that answered this question with a list of titles
+// would be a way of reading any corpus through somebody else's eyes, which is
+// exactly the thing the role is careful not to be. Counts answer what the
+// question is really for: whether somebody's access is the shape it should be,
+// and whether it changed.
+type accessResponse struct {
+	// The principal as it was assembled, echoed back. An operator who typed a
+	// group name wrongly gets an answer of zero, and the only way to tell that
+	// apart from somebody genuinely having no access is to see what was asked.
+	Subject    string   `json:"subject"`
+	Tenant     string   `json:"tenant"`
+	Groups     []string `json:"groups"`
+	Identities []string `json:"identities"`
+
+	// Documents is the total, and Sources is the same total broken up by
+	// connector, largest first. Both are empty unless the question asked for
+	// them, so read Counted rather than reading a zero.
+	Documents int      `json:"documents"`
+	Sources   []source `json:"sources"`
+
+	// Countable says the driver can answer the count at all. A screen showing
+	// zero under a corpus of a million documents has to be able to say the
+	// driver cannot count rather than that this person can see nothing.
+	Countable bool `json:"countable"`
+
+	// Counted says this answer carries the counts.
+	//
+	// They are asked for rather than always computed, because they are an
+	// aggregate over every document in the tenant and the check beside them is
+	// two indexed reads. Charging the second for the first would make the
+	// question an operator asks constantly wait on the one they ask
+	// occasionally. See [Server.handleAccess].
+	Counted bool `json:"counted"`
+
+	// Document is the answer about one document, present only when the question
+	// named one.
+	Document *documentAccess `json:"document,omitempty"`
+}
+
+// source is one connector and how much of it this person can reach.
+type source struct {
+	Source    string `json:"source"`
+	Documents int    `json:"documents"`
+}
+
+// documentAccess is whether one person can read one document, and why.
+//
+// The why is only ever filled in for a document they can read. That asymmetry
+// is deliberate and it is the line this endpoint does not cross: explaining a
+// refusal means reading the descriptor of a document the operator has no right
+// to, and the difference between "the rules do not admit them", "it is held
+// back" and "it is not there" is exactly the difference somebody could use to
+// prove a document exists.
+type documentAccess struct {
+	ID      string `json:"id"`
+	Visible bool   `json:"visible"`
+
+	// Rule is [acl.Rule], the clause that admitted them, and Matched is the
+	// group or the account it matched, in the form the rule compares. Both are
+	// empty for a document they cannot read.
+	Rule    string `json:"rule,omitempty"`
+	Matched string `json:"matched,omitempty"`
+}
+
+// handleAccess answers what one person can see.
+//
+// It is the question every operator eventually asks, usually in the shape of
+// "why can the contractor find that" or "why can nobody in support find
+// anything". Answering it by logging in as somebody else is what people do
+// without this, and that is worse in every way: it is not audited, it needs
+// their credentials, and it reads their documents.
+//
+// The audit line is the point of the endpoint as much as the answer is. The
+// wrapper has already recorded that an administrator read something, and this
+// records which person they asked about, because those are two different things
+// to have to explain afterwards.
+//
+// There are two answers here and they cost very different amounts. Whether one
+// person can read one document is two indexed reads and it is the question an
+// operator asks over and over, usually with a document id somebody has just
+// pasted to them. How much of the corpus that person can reach is an aggregate
+// over every document in the tenant, which is tens of milliseconds on a corpus
+// of twenty thousand and grows with it. So the counts are asked for with
+// counts=1 rather than computed every time, and the screen loads the answer it
+// needs immediately and fetches the aggregate behind a button. See #149 for
+// what it would take to make the aggregate cheap enough not to have to.
+func (s *Server) handleAccess(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	q := r.URL.Query()
+	subject := strings.TrimSpace(q.Get("subject"))
+	if subject == "" {
+		writeError(w, http.StatusBadRequest, "invalid", "name the subject to ask about")
+		return
+	}
+	groups := splitCSV(q.Get("groups"))
+	if len(groups) > GroupLimit {
+		writeError(w, http.StatusBadRequest, "invalid", "that is more groups than a directory expansion produces")
+		return
+	}
+	id := strings.TrimSpace(q.Get("id"))
+	counts := q.Get("counts") == "1"
+
+	// The tenant is the operator's own and is not a parameter. An administrator
+	// of one tenant asking about a subject in another is a question this
+	// deployment does not answer, and the way to be sure of that is not to read
+	// a tenant from the request.
+	about := &acl.Principal{
+		Tenant:     p.Tenant,
+		Subject:    subject,
+		Kind:       acl.KindUser,
+		Groups:     acl.GroupSet{Version: 1, Members: groups},
+		Identities: identitiesOf(splitCSV(q.Get("identities"))),
+	}
+
+	s.log.Info("administration access check",
+		"subject", p.Subject, "tenant", p.Tenant, "about", subject,
+		"groups", len(about.Groups.Members), "document", id, "counts", counts)
+
+	res := accessResponse{
+		Subject:    about.Subject,
+		Tenant:     about.Tenant,
+		Groups:     about.Groups.Members,
+		Identities: identityKeys(about.Identities),
+		Sources:    []source{},
+	}
+	if res.Groups == nil {
+		res.Groups = []string{}
+	}
+
+	// The counting is a capability, like the quarantine listing, because a
+	// driver that ranks for itself may have no way to count a match set it did
+	// not produce. See [store.Access].
+	a, ok := s.store.(store.Access)
+	res.Countable = ok
+	if ok && counts {
+		res.Counted = true
+		reach, err := a.Reachable(r.Context(), about)
+		if err != nil {
+			s.log.Error("counting what a subject can reach",
+				"tenant", p.Tenant, "about", subject, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal", "the counts are not available")
+			return
+		}
+		res.Sources = sourcesOf(reach)
+		for _, one := range res.Sources {
+			res.Documents += one.Documents
+		}
+	}
+
+	if id != "" {
+		access, err := s.documentAccess(r, about, id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "that document could not be read")
+			return
+		}
+		res.Document = access
+	}
+
+	h := w.Header()
+	h.Set("Cache-Control", cacheControl)
+	h.Set(varyHeader, varyValue)
+	writeJSON(w, http.StatusOK, res)
+}
+
+// documentAccess answers the question about one document, as that person.
+//
+// It is the store's own read path with their principal rather than a second
+// evaluation of the rule beside it, which is what makes the answer worth
+// anything: it is the same call a search makes, so an answer of yes here and a
+// document missing from their results is a bug in one place rather than a
+// disagreement between two.
+func (s *Server) documentAccess(r *http.Request, about *acl.Principal, id string) (*documentAccess, error) {
+	out := &documentAccess{ID: id}
+	d, err := s.store.Get(r.Context(), about, id)
+	switch {
+	case err == nil:
+		decision := d.Permissions.Decide(about)
+		out.Visible = decision.Allowed
+		out.Rule = string(decision.Rule)
+		out.Matched = matchedKey(decision)
+	case errors.Is(err, genba.ErrNotFound):
+		// Not there, not theirs, or held back, and the answer says none of the
+		// three. See [documentAccess].
+	default:
+		return nil, err
+	}
+	return out, nil
+}
+
+// matchedKey is the reference that decided, in the form the rule compares it
+// in, and is empty where nothing was matched.
+func matchedKey(d acl.Decision) string {
+	if d.Ref.Value == "" {
+		return ""
+	}
+	if d.Rule == acl.RuleOwner {
+		return d.Ref.UserKey()
+	}
+	return d.Ref.GroupKey()
+}
+
+// sourcesOf puts the counts on the wire, largest first so that the connector
+// somebody has most of is the one they read first, and by name within a tie so
+// that two readings of an unchanged corpus are the same list.
+func sourcesOf(in []store.Reach) []source {
+	out := make([]source, len(in))
+	for i, r := range in {
+		out[i] = source{Source: r.Source, Documents: r.Documents}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Documents != out[j].Documents {
+			return out[i].Documents > out[j].Documents
+		}
+		return out[i].Source < out[j].Source
+	})
+	return out
+}
+
+// identitiesOf reads the source:value pairs a question names, dropping anything
+// that is not one. A malformed identity is not an error, because the answer to
+// a question with one is the same shape as the answer without it and a screen
+// asking about somebody with a half typed identity should see the count fall
+// rather than see a refusal.
+func identitiesOf(raw []string) []acl.Identity {
+	out := make([]acl.Identity, 0, len(raw))
+	for _, one := range raw {
+		source, value, ok := strings.Cut(one, ":")
+		if !ok || source == "" || value == "" {
+			continue
+		}
+		out = append(out, acl.Identity{Source: source, Value: value})
+	}
+	return out
+}
+
+// identityKeys echoes the identities back in the form they were given in.
+func identityKeys(ids []acl.Identity) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, acl.Ref(id).UserKey())
+	}
+	return out
+}

--- a/api/access_test.go
+++ b/api/access_test.go
@@ -1,0 +1,334 @@
+package api_test
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// What one person can see, as an operator asks it.
+//
+// The endpoint answers a question people otherwise answer by borrowing
+// somebody's account, so the two things it has to get right are the answer and
+// the trail it leaves. Both are here, and so is the line it does not cross: it
+// counts, it never lists, and it explains a yes and never a no.
+
+type accessBody struct {
+	Subject    string   `json:"subject"`
+	Tenant     string   `json:"tenant"`
+	Groups     []string `json:"groups"`
+	Identities []string `json:"identities"`
+	Documents  int      `json:"documents"`
+	Countable  bool     `json:"countable"`
+	Counted    bool     `json:"counted"`
+	Sources    []struct {
+		Source    string `json:"source"`
+		Documents int    `json:"documents"`
+	} `json:"sources"`
+	Document *struct {
+		ID      string `json:"id"`
+		Visible bool   `json:"visible"`
+		Rule    string `json:"rule"`
+		Matched string `json:"matched"`
+	} `json:"document"`
+}
+
+// newAccessServer holds a small corpus with three kinds of document in it: one
+// everybody in the tenant may read, two an engineering group may read, one only
+// sales may read, and one nobody may read because its rules never resolved.
+func newAccessServer(t *testing.T) (http.Handler, *bytes.Buffer) {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	page := func(id, source string, perm acl.Permissions) doc.Document {
+		return doc.Document{
+			ID: id, Tenant: "acme", Source: source, Kind: doc.KindPage,
+			Title: "runbook " + id, Body: "how to fail over the payments queue",
+			Permissions: perm,
+		}
+	}
+	group := func(name string) acl.Permissions {
+		return acl.Permissions{
+			Mode:        acl.ModeACL,
+			Source:      "gdrive",
+			AllowGroups: []acl.Ref{{Source: "gdrive", Value: name}},
+			Version:     1,
+		}
+	}
+	docs := []doc.Document{
+		page("d1", "gdrive", acl.Permissions{Mode: acl.ModePublicToTenant, Source: "gdrive", Version: 1}),
+		page("d2", "gdrive", group("eng@acme.com")),
+		page("d3", "slack", group("eng@acme.com")),
+		page("d4", "gdrive", group("sales@acme.com")),
+		page("d5", "gdrive", acl.Permissions{
+			Mode: acl.ModeUnknown, Source: "gdrive",
+			Reason: "foreign domain: a grant to @contractor.example",
+		}),
+	}
+	if err := st.Put(t.Context(), docs...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	var logged bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}, api.WithLogger(log))
+	return s.Handler(), &logged
+}
+
+// ask puts one access question, as an operator.
+func ask(t *testing.T, h http.Handler, params url.Values) accessBody {
+	t.Helper()
+	w := request(t, h, http.MethodGet, "/api/v1/admin/access?"+params.Encode(), operator())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body)
+	}
+	return decode[accessBody](t, w)
+}
+
+func TestAccessNeedsTheAdministratorRole(t *testing.T) {
+	h, logged := newAccessServer(t)
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/access?subject=u_mei", engineer())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	// The refusal matters more here than on the screen next door. This is the
+	// endpoint that answers questions about other people, so somebody reaching
+	// it without the role is the thing a deployment most wants recorded.
+	if got := logged.String(); !strings.Contains(got, "administration refused") || !strings.Contains(got, "u_mei") {
+		t.Errorf("the refusal was not audited: %s", got)
+	}
+}
+
+func TestAccessAuditsWhoWasAskedAbout(t *testing.T) {
+	h, logged := newAccessServer(t)
+
+	ask(t, h, url.Values{"subject": {"u_kenji"}, "groups": {"gdrive:sales@acme.com"}})
+
+	got := logged.String()
+	if !strings.Contains(got, "administration access check") {
+		t.Fatalf("the check was not audited: %s", got)
+	}
+	// Both names. That an administrator read something is one fact and which
+	// person they asked about is another, and afterwards it is the second one
+	// somebody has to explain.
+	if !strings.Contains(got, "u_ops") || !strings.Contains(got, "u_kenji") {
+		t.Errorf("the audit line names %q, want both the operator and the subject", got)
+	}
+}
+
+func TestAccessNeedsASubjectToAskAbout(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/access", operator())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestAccessCountsWhatThePersonCanReach(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	body := ask(t, h, url.Values{
+		"subject": {"u_mei"},
+		"groups":  {"gdrive:eng@acme.com"},
+		"counts":  {"1"},
+	})
+	if !body.Countable || !body.Counted {
+		t.Fatal("the counts were asked for and the driver can produce them, so the answer should carry them")
+	}
+	// The public one and the two engineering ones. Not the sales one and not
+	// the held one.
+	if body.Documents != 3 {
+		t.Errorf("documents = %d, want 3", body.Documents)
+	}
+	if len(body.Sources) != 2 {
+		t.Fatalf("sources = %+v, want two", body.Sources)
+	}
+	// Largest first, so the connector somebody has most of is read first.
+	if body.Sources[0].Source != "gdrive" || body.Sources[0].Documents != 2 {
+		t.Errorf("the first source is %+v, want two documents in gdrive", body.Sources[0])
+	}
+	if body.Sources[1].Source != "slack" || body.Sources[1].Documents != 1 {
+		t.Errorf("the second source is %+v, want one document in slack", body.Sources[1])
+	}
+}
+
+// TestAccessLeavesTheCountsAloneUnlessAsked is the shape of the screen in one
+// assertion. The check is two indexed reads and the counts are an aggregate
+// over the whole tenant, so the answer an operator waits for on every keystroke
+// does not pay for the one they ask for occasionally.
+func TestAccessLeavesTheCountsAloneUnlessAsked(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	body := ask(t, h, url.Values{"subject": {"u_mei"}, "groups": {"gdrive:eng@acme.com"}})
+	if body.Counted {
+		t.Error("the counts were not asked for and the answer says it carries them")
+	}
+	if body.Documents != 0 || len(body.Sources) != 0 {
+		t.Errorf("the answer carries %d documents in %v without being asked", body.Documents, body.Sources)
+	}
+	// The driver can still count, and the screen needs to know that to decide
+	// whether to offer the button at all.
+	if !body.Countable {
+		t.Error("the driver can count and the answer does not say so")
+	}
+}
+
+// TestAccessCountsNothingForSomebodyInNoGroups is the answer an operator gets
+// when they have typed a group name wrongly, which is why the question is
+// echoed back with the answer.
+func TestAccessCountsNothingForSomebodyInNoGroups(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	body := ask(t, h, url.Values{"subject": {"u_new"}, "groups": {"gdrive:eng@acme.example"}, "counts": {"1"}})
+	if body.Documents != 1 {
+		t.Errorf("documents = %d, want 1: only what the whole tenant may read", body.Documents)
+	}
+	if len(body.Groups) != 1 || body.Groups[0] != "gdrive:eng@acme.example" {
+		t.Errorf("the question was echoed back as %v, want the group that was asked about", body.Groups)
+	}
+	if body.Subject != "u_new" || body.Tenant != "acme" {
+		t.Errorf("the answer is about %s in %s, want u_new in acme", body.Subject, body.Tenant)
+	}
+}
+
+// TestAccessNeverCountsAHeldDocument is the property the whole quarantine rests
+// on, asserted from the one screen that could plausibly be given an exception.
+// An operator holding the role is not a reader, and the count they see of
+// somebody else's access is the count that person would see.
+func TestAccessNeverCountsAHeldDocument(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	// Somebody in every group in the corpus, which is the most access anybody
+	// here has. The held document is still not theirs.
+	body := ask(t, h, url.Values{
+		"subject": {"u_mei"},
+		"groups":  {"gdrive:eng@acme.com,gdrive:sales@acme.com"},
+		"counts":  {"1"},
+	})
+	if body.Documents != 4 {
+		t.Errorf("documents = %d, want 4: the held one belongs to nobody", body.Documents)
+	}
+}
+
+func TestAccessExplainsWhySomebodyCanReadADocument(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	body := ask(t, h, url.Values{
+		"subject": {"u_mei"},
+		"groups":  {"gdrive:eng@acme.com"},
+		"id":      {"d2"},
+	})
+	if body.Document == nil {
+		t.Fatal("the question named a document and the answer did not")
+	}
+	if !body.Document.Visible {
+		t.Fatalf("d2 is %+v, want visible", body.Document)
+	}
+	// Which group admitted them, which is the answer to why the contractor can
+	// find that document, and is the only useful form of the answer.
+	if body.Document.Rule != string(acl.RuleListed) {
+		t.Errorf("rule = %q, want %q", body.Document.Rule, acl.RuleListed)
+	}
+	if body.Document.Matched != "gdrive:eng@acme.com" {
+		t.Errorf("matched = %q, want the group on the access control list", body.Document.Matched)
+	}
+}
+
+func TestAccessSaysTheTenantWideRuleByName(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	body := ask(t, h, url.Values{"subject": {"u_new"}, "id": {"d1"}})
+	if body.Document == nil || !body.Document.Visible {
+		t.Fatalf("d1 is %+v, want visible to anybody in the tenant", body.Document)
+	}
+	if body.Document.Rule != string(acl.RuleTenant) {
+		t.Errorf("rule = %q, want %q", body.Document.Rule, acl.RuleTenant)
+	}
+	// Nothing matched, because nothing had to. A reference here would be an
+	// invented one.
+	if body.Document.Matched != "" {
+		t.Errorf("matched = %q, want nothing: no reference decided", body.Document.Matched)
+	}
+}
+
+// TestAccessDoesNotExplainARefusal is the line this endpoint does not cross.
+// A document held back, a document in another tenant, a document belonging to a
+// group this person is not in and a document that was never indexed are one
+// answer, because an operator who can tell them apart can use the difference to
+// prove that a document exists.
+func TestAccessDoesNotExplainARefusal(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	for _, id := range []string{"d4", "d5", "d-never-existed"} {
+		body := ask(t, h, url.Values{
+			"subject": {"u_mei"},
+			"groups":  {"gdrive:eng@acme.com"},
+			"id":      {id},
+		})
+		if body.Document == nil {
+			t.Fatalf("%s: the question named a document and the answer did not", id)
+		}
+		if body.Document.Visible {
+			t.Errorf("%s is reported visible", id)
+		}
+		if body.Document.Rule != "" || body.Document.Matched != "" {
+			t.Errorf("%s says %+v, want a refusal that explains nothing", id, body.Document)
+		}
+	}
+}
+
+// TestAccessCarriesNoTitles is the other line. The role grants nothing over
+// documents, and a count that came back with a list of what was counted would
+// be a way of reading any corpus through somebody else's eyes.
+func TestAccessCarriesNoTitles(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	w := request(t, h, http.MethodGet,
+		"/api/v1/admin/access?subject=u_mei&groups=gdrive%3Aeng%40acme.com&id=d2", operator())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	for _, word := range []string{"runbook", "payments queue"} {
+		if strings.Contains(w.Body.String(), word) {
+			t.Errorf("the answer carries %q, which is the document rather than the count: %s", word, w.Body)
+		}
+	}
+}
+
+func TestAccessRefusesAnAbsurdNumberOfGroups(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	groups := make([]string, api.GroupLimit+1)
+	for i := range groups {
+		groups[i] = "gdrive:g" + string(rune('a'+i%26))
+	}
+	w := request(t, h, http.MethodGet,
+		"/api/v1/admin/access?subject=u_mei&groups="+url.QueryEscape(strings.Join(groups, ",")), operator())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+// TestAccessAsksAboutTheOperatorsOwnTenant keeps one administrator out of
+// another tenant's corpus. The tenant is not a parameter, so a question that
+// names one gets an answer about the tenant the operator is on.
+func TestAccessAsksAboutTheOperatorsOwnTenant(t *testing.T) {
+	h, _ := newAccessServer(t)
+
+	body := ask(t, h, url.Values{"subject": {"u_mei"}, "tenant": {"globex"}})
+	if body.Tenant != "acme" {
+		t.Errorf("tenant = %q, want acme", body.Tenant)
+	}
+}

--- a/api/api.go
+++ b/api/api.go
@@ -225,6 +225,7 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("GET /api/v1/stats", s.authenticated(s.handleStats))
 	mux.Handle("GET /api/v1/events", s.authenticated(s.handleEvents))
 	mux.Handle("GET /api/v1/admin/operations", s.admin(s.handleAdmin))
+	mux.Handle("GET /api/v1/admin/access", s.admin(s.handleAccess))
 	if s.assets != nil {
 		mux.Handle("GET /", s.assets)
 	}

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -204,6 +205,50 @@ func BenchmarkAPIAdmin(b *testing.B) {
 	for b.Loop() {
 		get(b, h, "/api/v1/admin/operations", hdr)
 	}
+}
+
+// BenchmarkAPIAccess is the question an operator asks over and over: can this
+// person read this document. It is measured with the full group expansion the
+// corpus generates rather than with one group, because the permission predicate
+// is built from the membership and a question about somebody in two groups is
+// not the question anybody asks about a long serving employee.
+//
+// This is the one that has to be quick, and it is the reason the counts beside
+// it are asked for rather than always computed.
+func BenchmarkAPIAccess(b *testing.B) {
+	h, hdr := handler(b, api.WithLogger(slog.New(slog.DiscardHandler)))
+	hdr[api.HeaderRoles] = acl.RoleAdmin
+	target := accessTarget(hdr) + "&id=b0"
+	get(b, h, target, hdr)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		get(b, h, target, hdr)
+	}
+}
+
+// BenchmarkAPIAccessCounts is the aggregate: how much of the corpus that person
+// can reach, by connector. It is a pass over every document in the tenant and
+// it is measured here because the number is the argument for keeping it behind
+// counts=1 rather than on the first paint. See #149.
+func BenchmarkAPIAccessCounts(b *testing.B) {
+	h, hdr := handler(b, api.WithLogger(slog.New(slog.DiscardHandler)))
+	hdr[api.HeaderRoles] = acl.RoleAdmin
+	target := accessTarget(hdr) + "&counts=1"
+	get(b, h, target, hdr)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		get(b, h, target, hdr)
+	}
+}
+
+// accessTarget is the access question with the principal from the headers put
+// into the query string, which is how an operator asks about somebody else.
+func accessTarget(hdr map[string]string) string {
+	return "/api/v1/admin/access?subject=u_bench" +
+		"&groups=" + url.QueryEscape(hdr[api.HeaderGroups]) +
+		"&identities=" + url.QueryEscape(hdr[api.HeaderIdentities])
 }
 
 // urlQuery escapes a query for the q parameter. The benchmark queries are

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -127,33 +127,44 @@ func TestStatsCarryNoTagBecauseReadingThemMovesThem(t *testing.T) {
 	}
 }
 
-// TestAdministrationCarriesNoTagForTheSameReasonStatsDoNot covers the second
-// and last endpoint excused the tag. Half of what it reports is what the
+// TestAdministrationCarriesNoTagForTheSameReasonStatsDoNot covers the endpoints
+// excused the tag. Half of what the operations screen reports is what the
 // connectors are doing right now, and a sync that starts between two requests
 // changes the body without changing anything a tag could be computed over
 // cheaply. Tagging it would either produce a tag that never matches, which is a
 // revalidation that can never succeed, or a tag computed over the parts that
 // hold still, which would pin an operator to the first answer they ever saw on
-// the one screen they open to find out whether anything is wrong.
+// the one screen they open to find out whether anything is wrong. The access
+// screen is the same argument reached from the other side: the answer moves
+// whenever a connector reindexes anything the subject can reach, which is a
+// change nowhere near the request that would have to notice it.
 //
 // The headers that keep the answer out of a shared cache still apply, because
-// this body names documents that are being held back and who is allowed to see
-// them is exactly what a proxy in the middle does not know.
+// one body names documents that are being held back and the other says what a
+// named person can reach, and who is allowed to see either is exactly what a
+// proxy in the middle does not know.
 func TestAdministrationCarriesNoTagForTheSameReasonStatsDoNot(t *testing.T) {
 	_, h := cachingServer(t)
 
-	w := request(t, h, http.MethodGet, "/api/v1/admin/operations", operator())
-	if w.Code != http.StatusOK {
-		t.Fatalf("got %d, want 200: %s", w.Code, w.Body)
-	}
-	if got := w.Header().Get("ETag"); got != "" {
-		t.Errorf("administration carries ETag %q, which no later request can match", got)
-	}
-	if got := w.Header().Get("Cache-Control"); got != "private, max-age=0, must-revalidate" {
-		t.Errorf("Cache-Control is %q, want a private response that must be revalidated", got)
-	}
-	if got := w.Header().Get("Vary"); !strings.Contains(got, "Authorization") || !strings.Contains(got, "Cookie") {
-		t.Errorf("Vary is %q, want the credential headers: without them a cache may serve this to somebody without the role", got)
+	for _, path := range []string{
+		"/api/v1/admin/operations",
+		"/api/v1/admin/access?subject=u_mei",
+	} {
+		t.Run(path, func(t *testing.T) {
+			w := request(t, h, http.MethodGet, path, operator())
+			if w.Code != http.StatusOK {
+				t.Fatalf("got %d, want 200: %s", w.Code, w.Body)
+			}
+			if got := w.Header().Get("ETag"); got != "" {
+				t.Errorf("administration carries ETag %q, which no later request can match", got)
+			}
+			if got := w.Header().Get("Cache-Control"); got != "private, max-age=0, must-revalidate" {
+				t.Errorf("Cache-Control is %q, want a private response that must be revalidated", got)
+			}
+			if got := w.Header().Get("Vary"); !strings.Contains(got, "Authorization") || !strings.Contains(got, "Cookie") {
+				t.Errorf("Vary is %q, want the credential headers: without them a cache may serve this to somebody without the role", got)
+			}
+		})
 	}
 }
 

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -17,6 +17,7 @@ import {
   reporter,
   settle,
   SHIFT,
+  sleep,
   type,
   visit,
 } from "./chrome.mjs";
@@ -666,6 +667,60 @@ async function walk(session) {
       const note = document.querySelector('.admin__note-title');
       return Boolean(note) && note.textContent.includes('Nothing is being held back');
     })()`,
+  );
+
+  // The access check. The subject to ask about is the gate's own, because it is
+  // the only identity in this corpus whose answer is known: it is the one the
+  // browser has been searching as all the way down this walk.
+  await settle(session, "document.querySelector('#access-subject') !== null");
+  await evaluate(session, "document.querySelector('#access-subject').focus()");
+  await type(session, "dev");
+  await evaluate(session, "document.querySelector('.access .button--primary').click()");
+  await check(
+    session,
+    "the access check answers about the person it was asked about",
+    `(() => {
+      const values = [...document.querySelectorAll('.access__asked .facts__value')].map((d) => d.textContent);
+      return values[0] === 'dev' && values.length === 3;
+    })()`,
+  );
+
+  // Nothing was asked for yet, so nothing is counted. The aggregate is behind
+  // its own button because it reads every document in the tenant, and a screen
+  // that quietly ran it would be a screen nobody can keep open.
+  await check(
+    session,
+    "the reach is not counted until somebody asks for it",
+    "document.querySelector('.access__reach') === null",
+  );
+
+  await evaluate(
+    session,
+    "[...document.querySelectorAll('.access__actions .button')].find((b) => b.textContent.includes('Count')).click()",
+  );
+  await settle(session, "document.querySelector('.access__reach') !== null");
+  await check(
+    session,
+    "the count of what one person can reach is a real count of this corpus",
+    `(() => {
+      const total = Number(document.querySelector('.access__total strong').textContent.replace(/[^0-9]/g, ''));
+      const rows = document.querySelectorAll('.access__reach tbody tr').length;
+      return total > 0 && rows >= 1;
+    })()`,
+  );
+
+  // This screen asks the server again every five seconds. A repaint that took
+  // the caret out of a half typed group name would be a form nobody could use,
+  // so the wait here is longer than the interval on purpose.
+  await evaluate(session, "document.querySelector('#access-groups').focus()");
+  await type(session, "eng");
+  await sleep(6000);
+  await check(
+    session,
+    "a repaint on the timer leaves the half typed question and the caret alone",
+    `document.activeElement === document.querySelector('#access-groups') &&
+      document.querySelector('#access-groups').value === 'eng' &&
+      document.querySelector('#access-groups').selectionStart === 3`,
   );
 
   await evaluate(session, "document.querySelector('.admin .page__back-link').click()");

--- a/store/access.go
+++ b/store/access.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"context"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// Reach is how much of one source a principal can read.
+//
+// It is a count and nothing else on purpose. The question an operator opens
+// this for is whether somebody's access is roughly the shape it should be, and
+// a list of titles would answer that question by handing the operator the
+// documents themselves, which is the one thing the administrator role does not
+// grant. Counts answer it without becoming a way to read a corpus through
+// somebody else's eyes.
+type Reach struct {
+	// Source is the connector the documents came from, which is the same name a
+	// search filters on.
+	Source string
+
+	// Documents is how many of that source's documents this principal may read,
+	// counted exactly rather than sampled. A number that says "at least four
+	// hundred" cannot be compared with the same number taken last week, and
+	// comparing it with last week is the whole use of it.
+	Documents int
+}
+
+// Access is the capability that answers what one principal can reach.
+//
+// It is optional like every capability outside [Store], because a driver over a
+// service that ranks for itself may have no way to count a match set it did not
+// produce. A caller checks for it and says the driver cannot answer, which is a
+// better screen than one that walks the corpus in the request and calls it a
+// count.
+//
+// It is a capability rather than a use of [Store.Scan] because Scan hands back
+// every document the principal may read, and counting them means decoding a
+// whole corpus to reach a handful of numbers that a database can produce as one
+// aggregate.
+//
+// Be plain about what it still costs. The aggregate is over every document in
+// the tenant, and on the twenty thousand document benchmark corpus it takes
+// tens of milliseconds, which is outside what an interactive request is allowed
+// to spend here. That is why the interface asks for it rather than showing it
+// with everything else, and #149 is what would have to change for it not to
+// have to.
+type Access interface {
+	Store
+
+	// Reachable reports, per source, how many documents the principal may read.
+	//
+	// The permission rule is the same one every other read path applies and it
+	// is applied the same way, inside the driver's own query. A driver that
+	// counts everything and filters afterwards is not conformant, and the
+	// suite in store/storetest will say so.
+	//
+	// Sources the principal can reach nothing in are left out rather than
+	// returned as zero, because a source that has nothing in it for somebody
+	// and a source that does not exist are the same answer to the person
+	// looking at the screen.
+	//
+	// The order is unspecified. A caller drawing a list sorts it into whatever
+	// order that list is read in.
+	Reachable(ctx context.Context, p *acl.Principal) ([]Reach, error)
+}

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -58,6 +58,8 @@ var (
 	_ store.Statistician = (*Store)(nil)
 	_ store.Speller      = (*Store)(nil)
 	_ store.Notifier     = (*Store)(nil)
+	_ store.Quarantine   = (*Store)(nil)
+	_ store.Access       = (*Store)(nil)
 )
 
 // Put inserts or replaces documents.
@@ -355,6 +357,37 @@ func (s *Store) Quarantined(ctx context.Context, tenant string, limit int) ([]st
 		if len(out) == limit {
 			break
 		}
+	}
+	return out, nil
+}
+
+// Reachable counts what one principal may read, by source.
+//
+// It is the same decision Scan makes, taken over the same map, and it is a
+// separate method because the counting is the point: Scan hands back documents
+// and this hands back four numbers, and on a driver whose documents are already
+// in memory that difference is the whole cost of the answer.
+func (s *Store) Reachable(ctx context.Context, p *acl.Principal) ([]store.Reach, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, genba.ErrClosed
+	}
+	counts := make(map[string]int)
+	for _, d := range s.docs {
+		if visible(p, d) {
+			counts[d.Source]++
+		}
+	}
+	out := make([]store.Reach, 0, len(counts))
+	for source, n := range counts {
+		out = append(out, store.Reach{Source: source, Documents: n})
 	}
 	return out, nil
 }

--- a/store/memstore/memstore_test.go
+++ b/store/memstore/memstore_test.go
@@ -17,6 +17,7 @@ func TestConformance(t *testing.T) {
 func TestMaintenanceConformance(t *testing.T) {
 	storetest.RunMaintenance(t, newStore)
 	storetest.RunQuarantine(t, newStore)
+	storetest.RunReachable(t, newStore)
 }
 
 // memstore implements store.Statistician and neither of the other two, so most

--- a/store/pgstore/access.go
+++ b/store/pgstore/access.go
@@ -1,0 +1,60 @@
+package pgstore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Access = (*Store)(nil)
+
+// Reachable counts what one principal may read, by source.
+//
+// The permission rule is the same clause every read path here builds, so there
+// is one definition of who may see what and this is not a second one that can
+// drift from it. The counting is an aggregate over it rather than a walk: the
+// answer to "how much of this corpus can this person reach" is a handful of
+// numbers, and reading a million documents to arrive at a handful of numbers is
+// how a screen that has to answer in ten milliseconds ends up taking a second.
+func (s *Store) Reachable(ctx context.Context, p *acl.Principal) ([]store.Reach, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+
+	var out []store.Reach
+	err := s.retry(ctx, func(ctx context.Context) error {
+		c := visible(p)
+		rows, err := s.query(ctx, `
+			SELECT d.source, count(*) FROM document d
+			WHERE `+c.where()+`
+			GROUP BY d.source`, c.args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		// Cleared on every attempt, for the same reason the quarantine listing
+		// clears its own: a retry that appended to what the failed attempt had
+		// already read would count half the corpus twice.
+		out = nil
+		for rows.Next() {
+			var r store.Reach
+			if err := rows.Scan(&r.Source, &r.Documents); err != nil {
+				return err
+			}
+			s.counters.rows.Add(1)
+			out = append(out, r)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: reachable: %w", err)
+	}
+	return out, nil
+}

--- a/store/pgstore/pgstore_test.go
+++ b/store/pgstore/pgstore_test.go
@@ -118,6 +118,7 @@ func TestConformance(t *testing.T) {
 func TestMaintenanceConformance(t *testing.T) {
 	storetest.RunMaintenance(t, newStore)
 	storetest.RunQuarantine(t, newStore)
+	storetest.RunReachable(t, newStore)
 }
 
 func TestRetrieverConformance(t *testing.T) {

--- a/store/sqlitestore/access.go
+++ b/store/sqlitestore/access.go
@@ -1,0 +1,53 @@
+package sqlitestore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Access = (*Store)(nil)
+
+// Reachable counts what one principal may read, by source.
+//
+// The counting is an aggregate rather than a walk: the answer to "how much of
+// this corpus can this person reach" is a handful of numbers, and reading a
+// hundred thousand documents to arrive at a handful of numbers is how a screen
+// that has to answer in ten milliseconds ends up taking a second. The rule it
+// aggregates over is [reachable], which is the rule [visible] applies in the
+// order it applies it.
+func (s *Store) Reachable(ctx context.Context, p *acl.Principal) ([]store.Reach, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+
+	q, args := reachable(p)
+	rows, err := s.query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlitestore: reachable: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []store.Reach
+	for rows.Next() {
+		var r store.Reach
+		if err := rows.Scan(&r.Source, &r.Documents); err != nil {
+			return nil, fmt.Errorf("sqlitestore: reachable: %w", err)
+		}
+		// One per source rather than one per document, which is the difference
+		// this method exists for and is worth counting honestly: a change that
+		// turned this back into a walk would show up here first.
+		s.counters.rows.Add(1)
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlitestore: reachable: %w", err)
+	}
+	return out, nil
+}

--- a/store/sqlitestore/query.go
+++ b/store/sqlitestore/query.go
@@ -90,7 +90,7 @@ func visible(p *acl.Principal) *clause {
 // It is a second expression of the rule and that is the thing to be careful
 // about, so it is held to the first by storetest.RunReachable, which walks the
 // order clause by clause against every driver.
-func reachable(p *acl.Principal) (string, []any) {
+func reachable(p *acl.Principal) (query string, args []any) {
 	users, _ := json.Marshal(nonEmpty(p.UserKeys()))
 	groups, _ := json.Marshal(nonEmpty(p.GroupKeys()))
 

--- a/store/sqlitestore/query.go
+++ b/store/sqlitestore/query.go
@@ -70,6 +70,63 @@ func visible(p *acl.Principal) *clause {
 	return c
 }
 
+// reachable is the same rule as [visible], written for the one query that has
+// to apply it to every row rather than to a candidate set.
+//
+// Every other read path here reaches [visible] with a match set already in
+// hand, so the correlated subqueries in it run over the few hundred documents a
+// query produced. Counting what somebody can reach has no match set, and the
+// same clause over a whole corpus re-reads the principal's keys once per
+// document, which on twenty thousand documents is most of a tenth of a second
+// for an answer of six numbers.
+//
+// So the keys are read once into a set and joined against the reference table
+// once, and what comes out is the two document sets the rule asks about: the
+// documents a deny names and the documents an allow names. The order after that
+// is the order [visible] applies and the order acl.Permissions.Allows applies:
+// unresolved is already excluded by queryable, then a deny denies, then the
+// owner is allowed, then the mode decides.
+//
+// It is a second expression of the rule and that is the thing to be careful
+// about, so it is held to the first by storetest.RunReachable, which walks the
+// order clause by clause against every driver.
+func reachable(p *acl.Principal) (string, []any) {
+	users, _ := json.Marshal(nonEmpty(p.UserKeys()))
+	groups, _ := json.Marshal(nonEmpty(p.GroupKeys()))
+
+	// The two halves are separate SELECTs rather than one with an OR because an
+	// OR over two columns cannot use document_ref_key and a scan of the whole
+	// reference table is what this is avoiding. MATERIALIZED is not decoration
+	// either: without it SQLite is free to inline the whole thing back into the
+	// places it is used, which is the shape being replaced.
+	const q = `
+		WITH named(doc_id, effect) AS MATERIALIZED (
+			SELECT doc_id, effect FROM document_ref
+			WHERE scope = 0 AND key IN (SELECT value FROM json_each(?))
+			UNION
+			SELECT doc_id, effect FROM document_ref
+			WHERE scope = 1 AND key IN (SELECT value FROM json_each(?))
+		)
+		SELECT d.source, count(*) FROM document d
+		WHERE d.queryable = 1
+		  AND d.tenant = ?
+		  AND d.id NOT IN (SELECT doc_id FROM named WHERE effect = 1)
+		  AND (
+		    (d.owner_key <> '' AND d.owner_key IN (SELECT value FROM json_each(?)))
+		    OR d.mode = ?
+		    OR (d.mode = ? AND d.id IN (SELECT doc_id FROM named WHERE effect = 0))
+		  )
+		GROUP BY d.source`
+
+	return q, []any{
+		string(users), string(groups),
+		p.Tenant,
+		string(users),
+		int(acl.ModePublicToTenant),
+		int(acl.ModeACL),
+	}
+}
+
 // filters is store.Request without the terms, in SQL.
 //
 // Each field is a membership test against a bound JSON array, which keeps the

--- a/store/sqlitestore/sqlitestore_test.go
+++ b/store/sqlitestore/sqlitestore_test.go
@@ -33,6 +33,7 @@ func TestConformance(t *testing.T) {
 func TestMaintenanceConformance(t *testing.T) {
 	storetest.RunMaintenance(t, newStore)
 	storetest.RunQuarantine(t, newStore)
+	storetest.RunReachable(t, newStore)
 }
 
 func TestRetrieverConformance(t *testing.T) {

--- a/store/storetest/access.go
+++ b/store/storetest/access.go
@@ -1,0 +1,240 @@
+package storetest
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// RunReachable checks a driver's [store.Access] against what the screen that
+// answers "what can this person see" relies on.
+//
+// Every case here is a way of counting the wrong documents while looking
+// correct, and all of them matter more than an ordinary miscount because of
+// what the number is used for: an operator compares it against what they expect
+// somebody's access to be, and a count that is too high sends them looking for
+// a leak that is not there while a count that is too low hides one that is.
+//
+// The case that is easy to skip is the quarantine. A held document is invisible
+// to every principal, and a driver that counts with an aggregate rather than
+// with the read path is exactly the sort of driver that forgets to say so.
+func RunReachable(t *testing.T, newStore Factory) {
+	t.Helper()
+	for _, c := range reachableCases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newStore(t)
+			t.Cleanup(func() { _ = s.Close() })
+
+			a, ok := s.(store.Access)
+			if !ok {
+				t.Skip("this driver does not implement store.Access")
+			}
+			c.run(t, s, a)
+		})
+	}
+}
+
+type reachableCase struct {
+	name string
+	run  func(t *testing.T, s store.Store, a store.Access)
+}
+
+var reachableCases = []reachableCase{
+	{"only what the principal may read is counted", testReachableCounts},
+	{"held documents are counted for nobody", testReachableQuarantine},
+	{"another tenant's documents are not counted", testReachableTenant},
+	{"a principal who may see nothing gets nothing", testReachableEmpty},
+	{"the counts are per source", testReachableSources},
+	{"the whole rule is applied in order", testReachableRuleOrder},
+	{"the count is the read path's own answer", testReachableAgreesWithScan},
+}
+
+// reach collects the counts as a map, because the order is unspecified and a
+// test that depended on it would pass on one driver and fail on the next.
+func reach(t *testing.T, a store.Access, p *acl.Principal) map[string]int {
+	t.Helper()
+	list, err := a.Reachable(t.Context(), p)
+	if err != nil {
+		t.Fatalf("Reachable: %v", err)
+	}
+	out := make(map[string]int, len(list))
+	for _, r := range list {
+		if _, seen := out[r.Source]; seen {
+			t.Fatalf("source %q is counted twice, so the driver is grouping by something else", r.Source)
+		}
+		out[r.Source] = r.Documents
+	}
+	return out
+}
+
+// sourced is a document from a named connector.
+func sourced(id, source string, perm acl.Permissions) doc.Document {
+	d := document(id, perm)
+	d.Source = source
+	return d
+}
+
+func testReachableCounts(t *testing.T, s store.Store, a store.Access) {
+	// Two the engineer may read and one belonging to a group they are not in.
+	mustPut(t, s,
+		document("d1", readable()),
+		document("d2", readable()),
+		document("d3", acl.Permissions{
+			Mode:        acl.ModeACL,
+			Source:      "gdrive",
+			AllowGroups: []acl.Ref{{Source: "gdrive", Value: "sales@acme.com"}},
+			Version:     1,
+		}),
+	)
+
+	if got := reach(t, a, reader()); got["gdrive"] != 2 {
+		t.Fatalf("the engineer reaches %v, want two documents in gdrive", got)
+	}
+	// The same corpus from the other side. A driver that counted the corpus and
+	// filtered afterwards would give both of them three.
+	if got := reach(t, a, stranger()); got["gdrive"] != 1 {
+		t.Fatalf("the seller reaches %v, want one document in gdrive", got)
+	}
+}
+
+func testReachableQuarantine(t *testing.T, s store.Store, a store.Access) {
+	mustPut(t, s, document("d1", readable()), held("d2", "a deny aimed at everybody"))
+
+	// The engineer is the person the servable document is for, so the only way
+	// to reach two here is by counting the held one.
+	if got := reach(t, a, reader()); got["gdrive"] != 1 {
+		t.Fatalf("the engineer reaches %v, want one document: the held one is nobody's", got)
+	}
+}
+
+func testReachableTenant(t *testing.T, s store.Store, a store.Access) {
+	other := document("d2", acl.Permissions{Mode: acl.ModePublicToTenant, Source: "gdrive", Version: 1})
+	other.Tenant = "other"
+	mustPut(t, s, document("d1", readable()), other)
+
+	// Public to the tenant means public to that tenant. A driver that reads the
+	// mode without reading the tenant column counts the other one here, which
+	// on a shared deployment is a leak reported as a number.
+	if got := reach(t, a, reader()); got["gdrive"] != 1 {
+		t.Fatalf("the engineer reaches %v, want one document from their own tenant", got)
+	}
+}
+
+func testReachableEmpty(t *testing.T, s store.Store, a store.Access) {
+	mustPut(t, s, document("d1", readable()))
+
+	// Nobody's groups, which is what an operator typing a name with no
+	// membership yet is asking about. Nothing, rather than an error and rather
+	// than a source counted at zero.
+	nobody := &acl.Principal{Tenant: "acme", Subject: "u_new"}
+	if got := reach(t, a, nobody); len(got) != 0 {
+		t.Fatalf("a principal in no groups reaches %v, want nothing at all", got)
+	}
+}
+
+// ruleCorpus is one document per clause of the permission rule, named after the
+// clause it exercises and put in a source of its own so that a miscount says
+// which clause was got wrong rather than only that a total is out by one.
+func ruleCorpus() []doc.Document {
+	mei := acl.Ref{Source: "gdrive", Value: "mei@acme.com"}
+	eng := acl.Ref{Source: "gdrive", Value: "eng@acme.com"}
+	return []doc.Document{
+		sourced("listed", "listed", readable()),
+		sourced("tenant", "tenant", acl.Permissions{
+			Mode: acl.ModePublicToTenant, Source: "gdrive", Version: 1,
+		}),
+		sourced("owner", "owner", acl.Permissions{
+			Mode: acl.ModeOwnerOnly, Source: "gdrive", Owner: mei, Version: 1,
+		}),
+		sourced("stranger-owner", "stranger-owner", acl.Permissions{
+			Mode: acl.ModeOwnerOnly, Source: "gdrive",
+			Owner:   acl.Ref{Source: "gdrive", Value: "kenji@acme.com"},
+			Version: 1,
+		}),
+		// A deny beats the group that would otherwise admit them.
+		sourced("denied-user", "denied-user", acl.Permissions{
+			Mode: acl.ModeACL, Source: "gdrive",
+			AllowGroups: []acl.Ref{eng}, DenyUsers: []acl.Ref{mei}, Version: 1,
+		}),
+		sourced("denied-group", "denied-group", acl.Permissions{
+			Mode: acl.ModeACL, Source: "gdrive",
+			AllowGroups: []acl.Ref{eng}, DenyGroups: []acl.Ref{eng}, Version: 1,
+		}),
+		// A deny beats ownership too, which is the clause a driver that checks
+		// the owner column first gets wrong.
+		sourced("denied-owner", "denied-owner", acl.Permissions{
+			Mode: acl.ModeOwnerOnly, Source: "gdrive",
+			Owner: mei, DenyUsers: []acl.Ref{mei}, Version: 1,
+		}),
+		// A list nobody is on, which is the ordinary refusal and has to stay
+		// distinct from a deny.
+		sourced("not-listed", "not-listed", acl.Permissions{
+			Mode: acl.ModeACL, Source: "gdrive",
+			AllowGroups: []acl.Ref{{Source: "gdrive", Value: "legal@acme.com"}}, Version: 1,
+		}),
+	}
+}
+
+// testReachableRuleOrder walks the permission rule clause by clause.
+//
+// A driver is free to count with an aggregate instead of with its read path,
+// and the ones that can are the ones that will, because that is the difference
+// between a query and a walk over the whole corpus. What that buys in speed it
+// costs in having the rule written down twice, and this is the case that keeps
+// the second copy honest: every clause of it, in the order that decides which
+// one wins.
+func testReachableRuleOrder(t *testing.T, s store.Store, a store.Access) {
+	mustPut(t, s, ruleCorpus()...)
+
+	got := reach(t, a, reader())
+	want := map[string]int{"listed": 1, "tenant": 1, "owner": 1}
+	if !maps.Equal(got, want) {
+		t.Fatalf("the engineer reaches %v, want %v", got, want)
+	}
+}
+
+// testReachableAgreesWithScan is the assertion underneath all of the others.
+//
+// The count is worth something only because it is the same answer the read path
+// gives, so an operator reading it can tell somebody what they can see. Here
+// both answers are taken over the same corpus and compared, which catches a
+// driver whose aggregate is self consistent and wrong.
+func testReachableAgreesWithScan(t *testing.T, s store.Store, a store.Access) {
+	corpus := append(ruleCorpus(), held("held", "a deny aimed at everybody"))
+	mustPut(t, s, corpus...)
+
+	for _, p := range []*acl.Principal{reader(), stranger()} {
+		counted := reach(t, a, p)
+		walked := map[string]int{}
+		if err := s.Scan(t.Context(), p, func(d doc.Document) bool {
+			walked[d.Source]++
+			return true
+		}); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		if !maps.Equal(counted, walked) {
+			t.Errorf("%s is counted %v and reads %v, so the two rules disagree", p.Subject, counted, walked)
+		}
+	}
+}
+
+func testReachableSources(t *testing.T, s store.Store, a store.Access) {
+	mustPut(t, s,
+		sourced("d1", "gdrive", readable()),
+		sourced("d2", "slack", readable()),
+		sourced("d3", "slack", readable()),
+	)
+
+	got := reach(t, a, reader())
+	sources := slices.Sorted(maps.Keys(got))
+	if !slices.Equal(sources, []string{"gdrive", "slack"}) {
+		t.Fatalf("the sources are %v, want gdrive and slack", sources)
+	}
+	if got["gdrive"] != 1 || got["slack"] != 2 {
+		t.Fatalf("the counts are %v, want one in gdrive and two in slack", got)
+	}
+}

--- a/web/dist/assets/access.js
+++ b/web/dist/assets/access.js
@@ -1,0 +1,326 @@
+// The access check on the administration screen.
+//
+// It answers the question every operator eventually asks, which arrives in one
+// of two shapes: why can that person find this document, or why can that person
+// find nothing. Both are usually answered today by borrowing somebody's account,
+// which is not audited, needs their password and reads their documents. This
+// asks the server the same question the search path asks, as them, and records
+// that it was asked.
+//
+// Two things it does not do, both on purpose. It never lists documents, only
+// counts them, because the administrator role grants nothing over documents and
+// a list here would be a way of reading a corpus through somebody else's eyes.
+// And it explains a yes and never a no: a document held back, a document in
+// another tenant, a document nobody listed them on and a document that does not
+// exist all come back as the same refusal, because an operator who can tell
+// those apart can use the difference to prove a document exists.
+
+import { h, replace, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { icon, label, number } from "genba/format.js";
+
+export class Access {
+  constructor() {
+    // The root is built once and handed back to every paint of the screen
+    // around it, which repaints itself every five seconds. A panel rebuilt on
+    // that timer would be a form that empties itself while somebody is typing
+    // into it.
+    this.el = h("section", { class: "panel access" });
+    this.answer = null;
+    this.error = null;
+    this.busy = "";
+    this.form = null;
+    this.output = h("div", { class: "access__answer", role: "status", "aria-live": "polite" });
+    this.paint();
+  }
+
+  paint() {
+    this.form = this.form || this.buildForm();
+    replace(
+      this.el,
+      h(
+        "div",
+        { class: "panel__head" },
+        h("h2", { class: "panel__title" }, "What one person can see"),
+        h("span", { class: "panel__note" }, "Every check is recorded"),
+      ),
+      h(
+        "p",
+        { class: "access__lead" },
+        "Answered as that person, by the same rule a search applies. It reports counts and never documents.",
+      ),
+      this.form,
+      this.output,
+    );
+    this.fill();
+    return this.el;
+  }
+
+  /**
+   * buildForm is the question, kept alive across repaints.
+   *
+   * The groups field is the one that matters and the one people get wrong, so
+   * it says what a group looks like rather than leaving somebody to guess: the
+   * keys are compared exactly as the directory wrote them, and a name typed in
+   * the wrong case is a different group.
+   */
+  buildForm() {
+    const form = h("form", {
+      class: "access__form",
+      onSubmit: (e) => {
+        e.preventDefault();
+        this.ask(false);
+      },
+    });
+    this.subject = field("Subject", "access-subject", "The account identifier, as the login gives it");
+    this.groups = field("Groups", "access-groups", "Comma separated, as the directory writes them, like gdrive:eng@acme.com");
+    this.identities = field("Identities", "access-identities", "Comma separated, like slack:U04AB");
+    this.document = field("Document", "access-document", "Optional, to ask about one document");
+
+    this.check = h("button", { class: "button button--primary", type: "submit" }, "Check");
+    this.count = h(
+      "button",
+      {
+        class: "button",
+        type: "button",
+        onClick: () => this.ask(true),
+      },
+      "Count what they can reach",
+    );
+    replace(
+      form,
+      h("div", { class: "access__fields" }, this.subject.el, this.groups.el, this.identities.el, this.document.el),
+      h(
+        "div",
+        { class: "access__actions" },
+        this.check,
+        this.count,
+        // Said next to the button rather than in a tooltip, because the reason
+        // it is a separate button is a cost somebody is about to pay.
+        h("span", { class: "access__aside" }, "Counting reads every document in the tenant, so it takes a moment."),
+      ),
+    );
+    return form;
+  }
+
+  /** ask puts the question, with or without the counts. */
+  async ask(counts) {
+    const subject = this.subject.input.value.trim();
+    if (!subject) {
+      this.error = new Error("Name the subject to ask about.");
+      this.answer = null;
+      this.fill();
+      this.subject.input.focus();
+      return;
+    }
+    this.busy = counts ? "count" : "check";
+    this.error = null;
+    this.fill();
+    try {
+      const res = await api.access({
+        subject,
+        groups: this.groups.input.value.trim(),
+        identities: this.identities.input.value.trim(),
+        id: this.document.input.value.trim(),
+        counts: counts ? "1" : "",
+      });
+      this.answer = res.data;
+      this.error = null;
+    } catch (err) {
+      if (err.name === "AbortError") return;
+      this.error = err;
+      this.answer = null;
+    } finally {
+      this.busy = "";
+      this.fill();
+    }
+  }
+
+  /** fill paints the answer, leaving the form above it alone. */
+  fill() {
+    this.check.disabled = Boolean(this.busy);
+    this.count.disabled = Boolean(this.busy) || (this.answer ? !this.answer.countable : false);
+    if (this.error) {
+      replace(
+        this.output,
+        h("p", { class: "access__error" }, svg(icon("alert"), 16), this.error.message),
+      );
+      return;
+    }
+    if (this.busy) {
+      replace(
+        this.output,
+        h(
+          "p",
+          { class: "access__busy" },
+          this.busy === "count" ? "Counting what they can reach." : "Asking.",
+        ),
+      );
+      return;
+    }
+    if (!this.answer) {
+      replace(this.output, h("p", { class: "access__idle" }, "Nothing asked yet."));
+      return;
+    }
+    replace(this.output, this.asked(this.answer), this.verdict(this.answer), this.reach(this.answer));
+  }
+
+  /**
+   * asked echoes the question back.
+   *
+   * An operator who typed a group name wrongly gets an answer of nothing, and
+   * the only way to tell that apart from somebody who genuinely has no access
+   * is to see what was asked. The tenant is on here for the same reason: it is
+   * the operator's own and never what they typed.
+   */
+  asked(a) {
+    const groups = a.groups || [];
+    return h(
+      "div",
+      { class: "access__asked" },
+      h("h3", { class: "access__subtitle" }, "Asked about"),
+      h(
+        "dl",
+        { class: "facts" },
+        h("dt", { class: "facts__name" }, "Subject"),
+        h("dd", { class: "facts__value" }, a.subject),
+        h("dt", { class: "facts__name" }, "Tenant"),
+        h(
+          "dd",
+          { class: "facts__value" },
+          // A deployment that never named a tenant is one tenant, and an empty
+          // row here would be a fact this screen claims to know and does not.
+          a.tenant || "Not named, so the whole deployment",
+        ),
+        h("dt", { class: "facts__name" }, "Groups"),
+        h(
+          "dd",
+          { class: "facts__value" },
+          groups.length ? groups.join(", ") : "None, so only what the whole tenant can read",
+        ),
+      ),
+    );
+  }
+
+  /**
+   * verdict is the answer about one document.
+   *
+   * A yes says which clause admitted them and which group or account it
+   * matched, which is the whole of what somebody needs to go and change it at
+   * the source. A no says nothing further, and the sentence says so out loud so
+   * that a bare no does not read as a bug.
+   */
+  verdict(a) {
+    if (!a.document) return null;
+    const d = a.document;
+    return h(
+      "div",
+      { class: d.visible ? "access__verdict access__verdict--yes" : "access__verdict" },
+      h("h3", { class: "access__subtitle" }, "That document"),
+      h(
+        "p",
+        { class: "access__call" },
+        svg(icon(d.visible ? "check" : "lock"), 18),
+        h("span", { class: "access__doc" }, d.id),
+        d.visible ? "can be read by them" : "cannot be read by them",
+      ),
+      d.visible
+        ? h(
+            "dl",
+            { class: "facts" },
+            h("dt", { class: "facts__name" }, "Because"),
+            h("dd", { class: "facts__value" }, rule(d.rule)),
+            d.matched ? h("dt", { class: "facts__name" }, "Matched") : null,
+            d.matched ? h("dd", { class: "facts__value" }, d.matched) : null,
+          )
+        : h(
+            "p",
+            { class: "access__aside" },
+            "Held back, in another tenant, not on the list, or not indexed. This screen does not say which, because the difference would tell you whether the document exists.",
+          ),
+    );
+  }
+
+  /** reach is how much of the corpus they can read, once somebody asked. */
+  reach(a) {
+    if (!a.counted) {
+      return a.countable
+        ? null
+        : h("p", { class: "access__aside" }, "This storage driver cannot count what somebody can reach.");
+    }
+    const sources = a.sources || [];
+    return h(
+      "div",
+      { class: "access__reach" },
+      h("h3", { class: "access__subtitle" }, "Can reach"),
+      h(
+        "p",
+        { class: "access__total" },
+        h("strong", {}, number(a.documents || 0)),
+        a.documents === 1 ? " document" : " documents",
+      ),
+      sources.length
+        ? h(
+            "table",
+            { class: "admin__table" },
+            h(
+              "thead",
+              {},
+              h(
+                "tr",
+                {},
+                h("th", { scope: "col" }, "Source"),
+                h("th", { scope: "col", class: "admin__num" }, "Documents"),
+              ),
+            ),
+            h(
+              "tbody",
+              {},
+              sources.map((s) =>
+                h(
+                  "tr",
+                  { class: "admin__row" },
+                  h("td", {}, label(s.source || "")),
+                  h("td", { class: "admin__num" }, number(s.documents || 0)),
+                ),
+              ),
+            ),
+          )
+        : h("p", { class: "access__aside" }, "Nothing at all, from any connector."),
+    );
+  }
+}
+
+/** field is one labelled input, returned with the input so it can be read. */
+function field(name, id, hint) {
+  const input = h("input", { class: "access__input", id, type: "text", autocomplete: "off", spellcheck: "false" });
+  const el = h(
+    "div",
+    { class: "access__field" },
+    h("label", { class: "access__label", for: id }, name),
+    input,
+    h("span", { class: "access__hint" }, hint),
+  );
+  return { el, input };
+}
+
+/**
+ * rule turns the clause the server named into a sentence.
+ *
+ * The wire values are the permission rule's own names and they are the right
+ * thing to send, but "owner-only" on a screen is a fragment rather than an
+ * answer. Anything unrecognised is printed as it arrived, because a server
+ * ahead of this file should still say something true.
+ */
+function rule(name) {
+  switch (name) {
+    case "owner":
+      return "They own it";
+    case "tenant":
+      return "It is readable by everybody in the tenant";
+    case "listed":
+      return "They are on its access control list";
+    default:
+      return name || "The server did not say";
+  }
+}

--- a/web/dist/assets/admin.js
+++ b/web/dist/assets/admin.js
@@ -1,9 +1,10 @@
 // The administration screen.
 //
 // It answers one question, which is whether this deployment is working, and it
-// answers it for somebody who can do something about the answer. Three parts:
+// answers it for somebody who can do something about the answer. Four parts:
 // what each connector is doing and which of its syncs failed, what the corpus
-// holds, and which documents are being held back and why.
+// holds, which documents are being held back and why, and what one named person
+// can actually see.
 //
 // Nothing on it writes. That is deliberate for now and it is not a permanent
 // shape: adding and starting connectors from here is the other half of the
@@ -21,6 +22,7 @@ import { api } from "genba/api.js";
 import { cache } from "genba/cache.js";
 import { bytes, duration, exact, icon, label, number, when } from "genba/format.js";
 import { failed as failedState } from "genba/states.js";
+import { Access } from "genba/access.js";
 
 // REFRESH is how often the screen asks again while somebody is looking at it.
 //
@@ -39,6 +41,9 @@ export class Admin {
     this.error = null;
     this.timer = 0;
     this.title = null;
+    // Built once and reused by every paint, because it holds a form and this
+    // screen repaints itself on a timer. See paint.
+    this.access = new Access();
     this.el = h("div", { class: "admin" });
   }
 
@@ -121,6 +126,12 @@ export class Admin {
     // pulling focus back to the heading each time would make it impossible to
     // read the table with a keyboard.
     const held = this.el.contains(document.activeElement) && document.activeElement !== this.title;
+    // Which element, and where the caret was in it. The access panel below is
+    // the same node across repaints, so its contents survive, but a node that
+    // is detached and reattached loses focus and a five second timer that takes
+    // the caret out of a half typed group name is a form nobody can use.
+    const focused = held ? document.activeElement : null;
+    const caret = selectionOf(focused);
 
     this.title = h("h1", { class: "admin__title", tabindex: "-1" }, "Administration");
     // Nothing arrived and nothing was held, so there is nothing to draw. The
@@ -150,8 +161,13 @@ export class Admin {
       failed ? null : this.corpus(data),
       failed ? null : this.connectors(data),
       failed ? null : this.quarantine(data),
+      failed ? null : this.access.el,
     );
-    if (!held) this.title.focus();
+    if (!held) {
+      this.title.focus();
+      return;
+    }
+    if (focused && focused.isConnected) restore(focused, caret);
   }
 
   /** retry reads again after a failure, from the button the failure offers. */
@@ -444,6 +460,34 @@ export class Admin {
         ),
       ),
     );
+  }
+}
+
+/**
+ * selectionOf reads where the caret is, for an element that has one.
+ *
+ * Null for anything else, including a button or a link, because those are put
+ * back by focusing them and have no position to keep.
+ */
+function selectionOf(el) {
+  if (!el || typeof el.selectionStart !== "number") return null;
+  return { start: el.selectionStart, end: el.selectionEnd, direction: el.selectionDirection };
+}
+
+/**
+ * restore puts focus and the caret back after a repaint.
+ *
+ * Guarded, because setSelectionRange throws on an input whose type does not
+ * carry a selection, and an email field somebody is typing into is worth
+ * keeping focus on even if the caret has to go to the end of it.
+ */
+function restore(el, caret) {
+  el.focus();
+  if (!caret) return;
+  try {
+    el.setSelectionRange(caret.start, caret.end, caret.direction || "none");
+  } catch {
+    // Focus is the part that matters and it is already back.
   }
 }
 

--- a/web/dist/assets/api.js
+++ b/web/dist/assets/api.js
@@ -198,6 +198,11 @@ export const api = {
   // it is a snapshot of the same moment and three requests would let the count
   // of held documents disagree with the list under it.
   admin: (opts) => get("/admin/operations", {}, opts),
+  // What one named person can see. The counts are asked for rather than always
+  // returned, because they are an aggregate over the whole tenant and the check
+  // beside them is two indexed reads, so a screen that wants the check does not
+  // wait on the aggregate.
+  access: (question, opts) => get("/admin/access", question, opts),
   search: (query, opts) => get("/search", query, opts),
   // One request for both halves of the recent screen, because the screen asks
   // both questions at once and a screen that paints in two stages paints twice.

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -1449,6 +1449,15 @@ mark.hit--current::after {
   letter-spacing: var(--display-tracking);
 }
 
+/* What the panel is showing, beside its name. It is a caption rather than a
+   second heading, so it sits on the baseline of the title without competing
+   with it. */
+.panel__note {
+  color: var(--text-muted);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
 .panel__link {
   margin-left: auto;
   color: var(--text-link);
@@ -3054,6 +3063,149 @@ h6.prose__h {
   color: var(--text-secondary);
   font-size: var(--text-small);
   line-height: var(--leading-small);
+}
+
+/* Access ----------------------------------------------------------------- */
+
+/* The only panel on this screen somebody works in rather than reads, so it is
+   the only one with a form. It keeps the same measure and the same rhythm as
+   the panels above it, because a form that looks like a different application
+   reads as one. */
+.access__lead {
+  max-width: var(--measure);
+  margin-bottom: var(--space-6);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+/* Two columns while there is room, because subject and groups are asked
+   together and a single column of four fields puts the button off the screen. */
+.access__fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-5) var(--space-8);
+}
+
+.access__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.access__label {
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-small);
+}
+
+.access__input {
+  height: 40px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-control);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  font-size: var(--text-body);
+}
+
+.access__input:hover {
+  border-color: var(--border-strong);
+}
+
+.access__hint {
+  color: var(--text-muted);
+  font-size: var(--text-caption);
+  line-height: var(--leading-small);
+  overflow-wrap: anywhere;
+}
+
+.access__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}
+
+/* Said beside the button rather than in a tooltip, because it is a cost
+   somebody is about to pay. */
+.access__aside {
+  max-width: var(--measure);
+  color: var(--text-muted);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.access__answer {
+  margin-top: var(--space-8);
+}
+
+.access__answer:empty {
+  margin-top: 0;
+}
+
+.access__subtitle {
+  margin-bottom: var(--space-3);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-small);
+}
+
+.access__asked,
+.access__verdict,
+.access__reach {
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--border);
+}
+
+.access__asked {
+  padding-top: 0;
+  border-top: none;
+}
+
+.access__call {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  font-size: var(--text-lead);
+  line-height: var(--leading-lead);
+}
+
+/* Colour only on the yes. A refusal is the ordinary answer here and printing it
+   in red would read as a fault rather than as the permission model working. */
+.access__verdict--yes .access__call {
+  color: var(--success-700);
+}
+
+.access__doc {
+  font-weight: var(--weight-semibold);
+  overflow-wrap: anywhere;
+}
+
+.access__total {
+  margin-bottom: var(--space-4);
+  font-size: var(--text-heading);
+  line-height: var(--leading-heading);
+  font-variant-numeric: tabular-nums;
+}
+
+.access__error {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--danger-700);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+}
+
+.access__busy,
+.access__idle {
+  color: var(--text-muted);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
 }
 
 /* Responsive ------------------------------------------------------------- */

--- a/web/dist/assets/format.js
+++ b/web/dist/assets/format.js
@@ -18,6 +18,7 @@ const ICONS = {
   keyboard: "M4 7h16v10H4V7ZM7 11h.01M11 11h.01M15 11h.01M8 14h8",
   menu: "M4 7h16M4 12h16M4 17h16",
   check: "m5 12 5 5 9-10",
+  alert: "M12 4 2.5 20h19L12 4ZM12 10v4M12 17.5h.01",
   rows: "M4 6h16M4 10h16M4 14h16M4 18h16",
   grid: "M4 4h7v7H4V4ZM13 4h7v7h-7V4ZM4 13h7v7H4v-7ZM13 13h7v7h-7v-7Z",
   preview: "M4 6h16v12H4zM4 10h16",

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -23,6 +23,7 @@
     <script type="importmap">
       {
         "imports": {
+          "genba/access.js": "/assets/access.js",
           "genba/admin.js": "/assets/admin.js",
           "genba/answer.js": "/assets/answer.js",
           "genba/api.js": "/assets/api.js",
@@ -63,6 +64,7 @@
       on a graph that is thirty files wide. graph_test.go computes the
       closure from app.js and fails if this list is not exactly it.
     -->
+    <link rel="modulepreload" href="/assets/access.js" />
     <link rel="modulepreload" href="/assets/admin.js" />
     <link rel="modulepreload" href="/assets/answer.js" />
     <link rel="modulepreload" href="/assets/api.js" />


### PR DESCRIPTION
Part of #40, and it closes the last box on it that does not need a write path.

## What this is

An operator who is asked why somebody cannot find a document has two ways to answer today. Read the process log and reason about it, or log in as that person. The second one works and it is the reason this exists: it needs their password, it reads their documents and nothing anywhere records that anybody looked.

This asks the server the same question the search path asks, as them.

`GET /api/v1/admin/access` takes `subject`, `groups` and `identities` for the person being asked about, `id` to ask about one document, and `counts=1` to also count what that person can reach. It answers by the same rule a search applies, in the driver's own query, and it needs the `admin` role. Both the reads and the refusals are logged, and the log line names the operator and the person they asked about, because an audit that only says who asked cannot answer who was asked about.

On the screen it is a fourth panel on `/admin`.

## What it will not do

It never returns a document or a title. The administrator role grants nothing over documents and it must not start to, and a list here would be exactly that, arrived at sideways.

It explains a yes and never a no. A document held back by quarantine, a document in another tenant, a document nobody listed them on and a document that was never indexed all come back as the same bare refusal. An operator who can tell those apart can use the difference to prove a document exists, which is the thing the permission model is for. The screen says so out loud rather than leaving a bare no reading as a bug.

## The two costs

They are very different and the endpoint does not pretend otherwise.

| Question | Cost on the twenty thousand document corpus |
| --- | --- |
| Can this person read this document | 0.15 ms, 152 allocations |
| How much of the corpus can they reach | about 100 ms |

The first is two indexed reads and it is the question an operator asks over and over, usually with an id somebody has just pasted to them. The second is an aggregate over every document in the tenant and it grows with the tenant. Charging the second for the first would make the common question wait on the rare one, so the counts are asked for with `counts=1` and on the screen they are behind their own button with the reason written next to it.

For what it is worth, the slowness is not something this endpoint introduces. An unfiltered `Rank` with counts on the same corpus is 201 ms, and splitting the aggregate apart shows the time is the join from the reference table to `document` through a text primary key rather than the permission predicate. That is written up with the measurements in #149, which also unblocks #142. The query here already took the shortest shape I could measure under the driver we actually run, which is `modernc.org/sqlite` rather than the C library, and that turned out to matter: the shape that was 33 times faster in the `sqlite3` command line tool was no faster at all under modernc.

## Keeping the count honest

`reachable` is a second expression of the permission rule and that is the thing to be careful about here, because a rule that drifts in one of two places is a rule that lies on one screen. Two new conformance cases hold it to the first, against every driver:

- one walks the order clause by clause, over a corpus with a document for each of listed, tenant wide, owned, owned by a stranger, denied by user, denied by group, denied as owner, and simply not listed
- one compares the count with the tally the ordinary read path produces from `Scan` for the same principal

A held document is never counted and never explained, which has a test of its own.

## The form on a screen that repaints itself

`/admin` asks the server again every five seconds. The panel holds the first form on that screen, so it is built once and kept across paints, and the paint reads focus and the caret before it repaints and puts them back afterwards. A form that empties itself while somebody is halfway through typing a group name is a form nobody can use twice.

The keyboard walk types into it, checks that the reach is not counted until somebody asks, counts it, and then waits out a full repaint and asserts the half typed question and the caret position are both still there.

## Checks

- `go test ./...` on server3 against sqlite, postgres and the reference driver, all green except the known watcher flake in #148
- `scripts/ui-gate.sh` on server2, which is 77 keyboard walk checks, the render, state, budget and latency checks and axe over 12 screens, 0 violations
- the first gate run failed one unrelated prefetch check and the second passed it, which is a race in the check rather than in the code, so that is #150
