### PR TITLE
Add and start a connector without restarting the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,17 @@ Everything the interface does is an HTTP call, and there is nothing it can reach
 | `GET /api/v1/stats` | how much is indexed and how much is quarantined |
 | `GET /api/v1/admin/operations` | what the connectors are doing, and what is being held back and why |
 | `GET /api/v1/admin/access` | whether one named person can read one document, and why |
+| `POST /api/v1/admin/connectors` | adds a connector, or replaces one, and starts it |
+| `DELETE /api/v1/admin/connectors/{source}` | stops a connector and forgets how it was configured |
+| `POST /api/v1/admin/connectors/{source}/start` | switches one back on |
+| `POST /api/v1/admin/connectors/{source}/stop` | switches one off and keeps its settings |
+| `POST /api/v1/admin/connectors/{source}/sync` | asks a running connector for a run now |
 | `GET /healthz`, `GET /readyz` | liveness, and whether the store answers |
 
 `search` takes `q` for the text and the operators, and `source`, `kind`, `container`, `author` and `owner` as repeated or comma separated parameters, plus `since`, `until`, `sort`, `limit` and `offset`.
 The snippet comes back as marked passages rather than as offsets, so a client highlights what the analyzer matched without reimplementing the analyzer.
 
-Both `admin` endpoints need the `admin` role, which comes from `X-Genba-Roles` or from `GENBA_ADMINS`, and the default is that nobody has it.
+Every `admin` endpoint needs the `admin` role, which comes from `X-Genba-Roles` or from `GENBA_ADMINS`, and the default is that nobody has it.
 The role grants nothing over documents and it must not start to.
 Both the reads and the refusals are logged with the subject.
 
@@ -144,6 +149,14 @@ Both the reads and the refusals are logged with the subject.
 It answers as that person, by the same rule a search applies, and it never returns a document or a title.
 A yes about a document says which clause admitted them and which group or account it matched; a no says nothing further, because the difference between held back, another tenant, not on the list and not there would prove a document exists.
 The counts are asked for rather than always returned because they are an aggregate over every document in the tenant, and the log line names both the operator and the person they asked about.
+
+The `connectors` endpoints take a source name, a kind of `corpus` or `bucket`, and the settings for that kind as a JSON object, and they answer with the same connector list `admin/operations` returns.
+Settings that cannot be run are refused before they are written down, so a directory that is not there is a message about that directory rather than a connector that fails in a log line a minute later.
+The configuration is kept in the store, which is what lets three servers behind a load balancer agree on what is being crawled, and it needs a driver that can hold it: `sqlite` and `postgres` can, `memory` forgets it at the next restart, and a deployment whose driver cannot is told so by `manageable` on the same response.
+Removing a connector forgets how a corpus was read and leaves the corpus, because the two are different decisions and a full crawl is an expensive undo.
+Credentials are not part of any of this and are never stored: a bucket added here uses the keys the process already has in its environment.
+A connector named on the command line is on the screen because it is running and cannot be changed here, since the next restart would read the command line again and undo whatever was typed.
+`sync` returns as soon as the run has been asked for, because a crawl of a real source takes minutes and a request that waited for one would time out in the middle of it.
 
 By default every file in the corpus is readable by everybody in the tenant, which is the right rule for a public checkout and the wrong one for almost anything else.
 If the tree has OWNERS files in it, `-corpus-acl owners` reads them instead, and a query then returns different results depending on who is asking.

--- a/api/admin.go
+++ b/api/admin.go
@@ -55,6 +55,19 @@ type Connector struct {
 	// worked it out by comparing timestamps would flicker.
 	Syncing bool `json:"syncing"`
 
+	// Enabled says it is meant to be running at all, which is not the same as
+	// Syncing above. A connector somebody switched off is enabled false and
+	// syncing false, and one that is on but between runs is enabled true and
+	// syncing false, and a screen that had only the one flag would draw those
+	// two the same.
+	Enabled bool `json:"enabled"`
+
+	// Managed says this connector was configured through the interface and can
+	// be changed through it. One that came from the command line is reported
+	// here and is not editable, because the next restart would read the command
+	// line again and undo whatever was typed. See [ErrUnmanaged].
+	Managed bool `json:"managed"`
+
 	// Runs are the syncs this process has done, most recent first and bounded.
 	// A source that has not finished one yet has none, which is not an error
 	// and is what a screen should say rather than drawing a zero.
@@ -148,6 +161,13 @@ type adminResponse struct {
 	// able to say the driver cannot list them rather than that there are none.
 	Held     []held `json:"held"`
 	Listable bool   `json:"listable"`
+
+	// Manageable says a connector can be added from here at all. It is false for
+	// a deployment whose driver cannot remember one across a restart and for an
+	// embedder that wires its own crawlers, and it is what lets the screen say
+	// where the connectors are configured instead of drawing a form whose answers
+	// go nowhere. See [WithSupervisor].
+	Manageable bool `json:"manageable"`
 }
 
 // held is one quarantined document on the wire.
@@ -204,6 +224,7 @@ func (s *Server) handleAdmin(w http.ResponseWriter, r *http.Request, p *acl.Prin
 		Documents:   st.Documents,
 		Quarantined: st.Quarantined,
 		Held:        []held{},
+		Manageable:  s.supervisor != nil,
 	}
 	if s.operations != nil {
 		res.Connectors = s.operations().Connectors

--- a/api/api.go
+++ b/api/api.go
@@ -92,6 +92,11 @@ type Server struct {
 	// same answer as no connectors.
 	operations func() Operations
 
+	// supervisor is what can change the connectors. It is nil for a deployment
+	// that configures them on the command line, and a nil one is what makes the
+	// administration screen say so rather than draw a form nothing is behind.
+	supervisor Supervisor
+
 	// heartbeat is how often an idle event stream sends a comment.
 	heartbeat time.Duration
 
@@ -226,6 +231,11 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("GET /api/v1/events", s.authenticated(s.handleEvents))
 	mux.Handle("GET /api/v1/admin/operations", s.admin(s.handleAdmin))
 	mux.Handle("GET /api/v1/admin/access", s.admin(s.handleAccess))
+	mux.Handle("POST /api/v1/admin/connectors", s.admin(s.handleAddConnector))
+	mux.Handle("DELETE /api/v1/admin/connectors/{source}", s.admin(s.handleDropConnector))
+	mux.Handle("POST /api/v1/admin/connectors/{source}/start", s.admin(s.handleStartConnector))
+	mux.Handle("POST /api/v1/admin/connectors/{source}/stop", s.admin(s.handleStopConnector))
+	mux.Handle("POST /api/v1/admin/connectors/{source}/sync", s.admin(s.handleSyncConnector))
 	if s.assets != nil {
 		mux.Handle("GET /", s.assets)
 	}

--- a/api/connectors.go
+++ b/api/connectors.go
@@ -1,0 +1,241 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+// connectorBodyLimit is how large a connector's configuration may be.
+//
+// Sixteen kilobytes, which is a hundred times the largest configuration any
+// connector here has and small enough that a request nobody meant to send is
+// refused before it is read. The settings are a directory, an endpoint and a
+// handful of names, not a document.
+const connectorBodyLimit = 16 << 10
+
+// ErrUnmanaged and ErrBadConnector are what a [Supervisor] returns for the two
+// refusals that are not a server fault.
+//
+// A missing connector is [genba.ErrNotFound], which is the sentinel the rest of
+// this system already uses for it.
+var (
+	// ErrUnmanaged is a connector this process was started with. It is on the
+	// screen because it is running and it cannot be changed from there, because
+	// the next restart would read the command line again and undo whatever was
+	// typed. Saying so is better than either lying about it or hiding it.
+	ErrUnmanaged = errors.New("connector was configured on the command line")
+
+	// ErrBadConnector is settings that cannot be run: a directory that is not
+	// there, an access control policy nobody has written, a bucket with no
+	// endpoint. It is the caller's mistake and the message says which.
+	ErrBadConnector = errors.New("connector configuration is not valid")
+)
+
+// Supervisor is whatever runs the connectors, from this package's side.
+//
+// It is supplied by the caller through [WithSupervisor] for the same reason
+// [Operations] is supplied through [WithOperations]: the thing that knows how
+// to build a crawler out of a directory name is the process that owns the
+// crawlers, and this package deliberately does not. What is here is the role
+// check, the audit line and the shape of the request.
+//
+// Every method takes the tenant separately from the source because that pair is
+// the key, and because an administrator of one deployment must not be able to
+// reach another tenant's connectors by naming one. The tenant is the
+// administrator's own and this package fills it in.
+//
+// The methods are expected to return only after the change has been written
+// down. A call that came back and then lost the connector on the next restart
+// would be the one failure this whole capability exists to remove.
+type Supervisor interface {
+	// Add saves a connector and starts it if it is enabled. Adding one that is
+	// already there replaces its settings, which is what makes editing a field
+	// the same request as creating it.
+	Add(ctx context.Context, f store.Feed) error
+
+	// Remove stops a connector and forgets how it was configured. The documents
+	// it indexed stay, because forgetting how a corpus was read is not a
+	// decision to delete the corpus.
+	Remove(ctx context.Context, tenant, source string) error
+
+	// Start and Stop turn a configured connector on and off without losing its
+	// settings, which is the difference between silencing a source that is
+	// producing errors and having to type it in again afterwards.
+	Start(ctx context.Context, tenant, source string) error
+	Stop(ctx context.Context, tenant, source string) error
+
+	// Sync asks for a run now rather than at the next interval. It returns as
+	// soon as the run has been asked for, not when it finishes: a crawl of a
+	// real source takes minutes and a request that waited for one would time
+	// out somewhere in between and leave nobody able to say whether it ran.
+	Sync(ctx context.Context, tenant, source string) error
+}
+
+// WithSupervisor supplies the thing that can change the connectors.
+//
+// Without it the administration screen still lists what this process is doing
+// and says the connectors cannot be changed from here, which is the truth for
+// an embedder that wires its own crawlers and is a better answer than a form
+// whose answers go nowhere.
+func WithSupervisor(sup Supervisor) Option {
+	return func(s *Server) { s.supervisor = sup }
+}
+
+// connectorRequest is a connector as it arrives from the interface.
+//
+// It is not [store.Feed]. The wire shape carries no timestamps and no author,
+// because both of those are facts the server records rather than claims the
+// caller gets to make, and a request that could set them would be a request
+// that could rewrite who configured what.
+type connectorRequest struct {
+	Source string `json:"source"`
+	Kind   string `json:"kind"`
+
+	// Enabled says whether it should start. It defaults to false when it is
+	// absent, which reads backwards until you write it out: a connector arrives
+	// from a form that has the box on it, and a client that forgot to send the
+	// field is a client whose connector does not start, rather than one that
+	// starts crawling somebody's file server because a field was missing.
+	Enabled bool `json:"enabled"`
+
+	// Config is the kind specific settings, passed through untouched. This
+	// package does not know what is in it and does not look.
+	Config json.RawMessage `json:"config"`
+}
+
+// handleAddConnector saves a connector and starts it.
+//
+// The audit line names the source and the person, which the wrapper's line
+// cannot: it records that an administrator changed something, and this records
+// what. Those are two different things to have to explain afterwards.
+func (s *Server) handleAddConnector(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	sup := s.supervisor
+	if sup == nil {
+		writeError(w, http.StatusNotImplemented, "unsupported", "this deployment configures its connectors on the command line")
+		return
+	}
+
+	var body connectorRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, connectorBodyLimit)).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "the body must be a JSON object with a source, a kind and a config")
+		return
+	}
+	body.Source = strings.TrimSpace(body.Source)
+	body.Kind = strings.TrimSpace(body.Kind)
+	if body.Source == "" || body.Kind == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "a connector needs a source and a kind")
+		return
+	}
+
+	f := store.Feed{
+		Tenant:  p.Tenant,
+		Source:  body.Source,
+		Kind:    body.Kind,
+		Enabled: body.Enabled,
+		Config:  body.Config,
+		By:      p.Subject,
+	}
+	s.log.Info("connector saved", "subject", p.Subject, "tenant", p.Tenant, "source", f.Source, "kind", f.Kind, "enabled", f.Enabled)
+	if err := sup.Add(r.Context(), f); err != nil {
+		s.connectorError(w, "saving a connector", f.Source, err)
+		return
+	}
+	s.writeConnectors(w)
+}
+
+// handleDropConnector forgets a connector.
+func (s *Server) handleDropConnector(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	s.connectorAction(w, r, p, "connector removed", func(sup Supervisor, source string) error {
+		return sup.Remove(r.Context(), p.Tenant, source)
+	})
+}
+
+// handleStartConnector switches a configured connector on.
+func (s *Server) handleStartConnector(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	s.connectorAction(w, r, p, "connector started", func(sup Supervisor, source string) error {
+		return sup.Start(r.Context(), p.Tenant, source)
+	})
+}
+
+// handleStopConnector switches a configured connector off and keeps it.
+func (s *Server) handleStopConnector(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	s.connectorAction(w, r, p, "connector stopped", func(sup Supervisor, source string) error {
+		return sup.Stop(r.Context(), p.Tenant, source)
+	})
+}
+
+// handleSyncConnector asks for a run now.
+func (s *Server) handleSyncConnector(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	s.connectorAction(w, r, p, "connector sync asked for", func(sup Supervisor, source string) error {
+		return sup.Sync(r.Context(), p.Tenant, source)
+	})
+}
+
+// connectorAction is the part the four one word endpoints have in common: is
+// there a supervisor, is there a source in the path, say who did what, do it,
+// and answer with the list the screen redraws from.
+func (s *Server) connectorAction(w http.ResponseWriter, r *http.Request, p *acl.Principal, what string, do func(Supervisor, string) error) {
+	sup := s.supervisor
+	if sup == nil {
+		writeError(w, http.StatusNotImplemented, "unsupported", "this deployment configures its connectors on the command line")
+		return
+	}
+	source := strings.TrimSpace(r.PathValue("source"))
+	if source == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "name the connector")
+		return
+	}
+	s.log.Info(what, "subject", p.Subject, "tenant", p.Tenant, "source", source)
+	if err := do(sup, source); err != nil {
+		s.connectorError(w, what, source, err)
+		return
+	}
+	s.writeConnectors(w)
+}
+
+// writeConnectors answers with what the connectors are doing now.
+//
+// A mutation answers with the whole list rather than with nothing, because the
+// screen that sent it draws that list and the alternative is a second request
+// for state the server had in its hand. It is the same body the administration
+// endpoint reports under connectors, so the screen has one way of reading it.
+func (s *Server) writeConnectors(w http.ResponseWriter) {
+	out := Operations{Connectors: []Connector{}}
+	if s.operations != nil {
+		out = s.operations()
+	}
+	h := w.Header()
+	h.Set("Cache-Control", cacheControl)
+	h.Set(varyHeader, varyValue)
+	writeJSON(w, http.StatusOK, out)
+}
+
+// connectorError turns a supervisor's refusal into a status.
+//
+// The three that are not a server fault say so, because each of them wants a
+// different thing from whoever is reading: a name that is not there is a typo,
+// a connector from the command line is a unit file to edit, and settings that
+// cannot be run are a field to correct. Anything else is this deployment's
+// problem and is logged with the source rather than shown.
+func (s *Server) connectorError(w http.ResponseWriter, what, source string, err error) {
+	switch {
+	case errors.Is(err, genba.ErrNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "there is no connector called "+source)
+	case errors.Is(err, ErrUnmanaged):
+		writeError(w, http.StatusConflict, "unmanaged", "this connector was configured on the command line and has to be changed there")
+	case errors.Is(err, ErrBadConnector):
+		// The message is the supervisor's, because the useful half of it is the
+		// part this package cannot write: which field is wrong and why.
+		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+	default:
+		s.log.Error(what+" failed", "source", source, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal", "the connector could not be changed")
+	}
+}

--- a/api/connectors_test.go
+++ b/api/connectors_test.go
@@ -1,0 +1,314 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// Changing the connectors from the interface.
+//
+// The endpoint itself is thin on purpose: it checks the role, reads the shape
+// of the request, records who asked for what, and hands the work to whatever
+// runs the crawlers. So what is tested here is the gate, the shape and the way
+// a refusal from below turns into a status somebody can act on, and none of it
+// needs a real crawler.
+
+// fakeSupervisor records what it was asked to do and answers with whatever it
+// was told to.
+type fakeSupervisor struct {
+	mu    sync.Mutex
+	calls []string
+	err   error
+}
+
+func (f *fakeSupervisor) record(call string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, call)
+	return f.err
+}
+
+func (f *fakeSupervisor) seen() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+func (f *fakeSupervisor) Add(_ context.Context, fd store.Feed) error {
+	return f.record(fmt.Sprintf("add %s/%s kind=%s enabled=%t by=%s config=%s",
+		fd.Tenant, fd.Source, fd.Kind, fd.Enabled, fd.By, fd.Config))
+}
+
+func (f *fakeSupervisor) Remove(_ context.Context, tenant, source string) error {
+	return f.record("remove " + tenant + "/" + source)
+}
+
+func (f *fakeSupervisor) Start(_ context.Context, tenant, source string) error {
+	return f.record("start " + tenant + "/" + source)
+}
+
+func (f *fakeSupervisor) Stop(_ context.Context, tenant, source string) error {
+	return f.record("stop " + tenant + "/" + source)
+}
+
+func (f *fakeSupervisor) Sync(_ context.Context, tenant, source string) error {
+	return f.record("sync " + tenant + "/" + source)
+}
+
+// newConnectorServer is a server with one connector already running and a
+// supervisor that can be asked to change it.
+func newConnectorServer(t *testing.T, sup api.Supervisor) http.Handler {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	ops := func() api.Operations {
+		return api.Operations{Connectors: []api.Connector{
+			{Source: "handbook", Kind: "corpus", Target: "/srv/handbook", Tenant: "acme", Enabled: true, Managed: true},
+		}}
+	}
+	opts := []api.Option{api.WithOperations(ops)}
+	if sup != nil {
+		opts = append(opts, api.WithSupervisor(sup))
+	}
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}, opts...)
+	return s.Handler()
+}
+
+// post is request with a body, which the shared helper has no room for.
+func post(t *testing.T, h http.Handler, method, target, body string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequestWithContext(t.Context(), method, target, strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+// The gate is the same one the rest of the administration is behind, and it is
+// worth checking on the write half rather than assuming, because this is the
+// half where being wrong means somebody else's search index gets a new crawler.
+func TestChangingAConnectorNeedsTheRole(t *testing.T) {
+	sup := &fakeSupervisor{}
+	h := newConnectorServer(t, sup)
+
+	for _, c := range []struct {
+		method, target, body string
+	}{
+		{http.MethodPost, "/api/v1/admin/connectors", `{"source":"x","kind":"corpus"}`},
+		{http.MethodDelete, "/api/v1/admin/connectors/handbook", ""},
+		{http.MethodPost, "/api/v1/admin/connectors/handbook/start", ""},
+		{http.MethodPost, "/api/v1/admin/connectors/handbook/stop", ""},
+		{http.MethodPost, "/api/v1/admin/connectors/handbook/sync", ""},
+	} {
+		w := post(t, h, c.method, c.target, c.body, engineer())
+		if w.Code != http.StatusForbidden {
+			t.Errorf("%s %s: status = %d, want 403", c.method, c.target, w.Code)
+		}
+	}
+	if calls := sup.seen(); len(calls) != 0 {
+		t.Fatalf("a request that was refused still reached the supervisor: %v", calls)
+	}
+}
+
+// The tenant is the operator's own and is never read out of the request. An
+// administrator of one deployment naming another tenant would otherwise be able
+// to point a crawler at a corpus that is not theirs.
+func TestAddingAConnectorFilesItUnderTheOperatorsOwnTenant(t *testing.T) {
+	sup := &fakeSupervisor{}
+	h := newConnectorServer(t, sup)
+
+	body := `{"source":"archive","kind":"bucket","enabled":true,"config":{"bucket":"docs","endpoint":"https://s3.example"},"tenant":"other"}`
+	w := post(t, h, http.MethodPost, "/api/v1/admin/connectors", body, operator())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body)
+	}
+
+	calls := sup.seen()
+	if len(calls) != 1 {
+		t.Fatalf("calls = %v, want one", calls)
+	}
+	if !strings.HasPrefix(calls[0], "add acme/archive kind=bucket enabled=true by=u_ops") {
+		t.Errorf("the supervisor was asked for %q", calls[0])
+	}
+	// The settings go through untouched, because the API does not know what a
+	// bucket needs and a field it reformatted is a field a connector cannot
+	// read.
+	if !strings.Contains(calls[0], `"endpoint":"https://s3.example"`) {
+		t.Errorf("the configuration did not arrive intact: %q", calls[0])
+	}
+}
+
+// A mutation answers with the list the screen draws, so that adding a connector
+// is one request rather than one to change it and one to find out what changed.
+func TestChangingAConnectorAnswersWithTheConnectors(t *testing.T) {
+	h := newConnectorServer(t, &fakeSupervisor{})
+
+	w := post(t, h, http.MethodPost, "/api/v1/admin/connectors/handbook/sync", "", operator())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body)
+	}
+	var body struct {
+		Connectors []struct {
+			Source  string `json:"source"`
+			Enabled bool   `json:"enabled"`
+			Managed bool   `json:"managed"`
+		} `json:"connectors"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding: %v\nbody: %s", err, w.Body)
+	}
+	if len(body.Connectors) != 1 || body.Connectors[0].Source != "handbook" {
+		t.Fatalf("connectors = %+v", body.Connectors)
+	}
+	if !body.Connectors[0].Enabled || !body.Connectors[0].Managed {
+		t.Errorf("the connector came back as %+v, want it enabled and managed", body.Connectors[0])
+	}
+	// Never cached. This is the state of a deployment somebody is changing, and
+	// an answer a proxy kept would be an answer that outlives the change.
+	if got := w.Header().Get("Cache-Control"); !strings.Contains(got, "no-cache") && !strings.Contains(got, "max-age=0") {
+		t.Errorf("Cache-Control = %q", got)
+	}
+}
+
+// The three refusals that are not a server fault each want a different thing
+// from whoever is reading, so each one gets its own status.
+func TestAConnectorRefusalSaysWhichKindItIs(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"a connector nobody configured", fmt.Errorf("%w: nope", genba.ErrNotFound), http.StatusNotFound},
+		{"a connector from the command line", api.ErrUnmanaged, http.StatusConflict},
+		{"settings that cannot be run", fmt.Errorf("%w: refresh is not a duration", api.ErrBadConnector), http.StatusBadRequest},
+		{"anything else", errString("the disk is full"), http.StatusInternalServerError},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			h := newConnectorServer(t, &fakeSupervisor{err: c.err})
+			w := post(t, h, http.MethodPost, "/api/v1/admin/connectors/handbook/start", "", operator())
+			if w.Code != c.want {
+				t.Fatalf("status = %d, want %d: %s", w.Code, c.want, w.Body)
+			}
+		})
+	}
+}
+
+// Settings that cannot be run come back with the supervisor's own message,
+// because the useful half of it is the part the API cannot write: which field
+// is wrong and why.
+func TestBadSettingsSayWhichFieldIsWrong(t *testing.T) {
+	sup := &fakeSupervisor{err: fmt.Errorf("%w: refresh is not a duration, try 30s or 5m", api.ErrBadConnector)}
+	h := newConnectorServer(t, sup)
+
+	w := post(t, h, http.MethodPost, "/api/v1/admin/connectors/handbook/start", "", operator())
+	if !strings.Contains(w.Body.String(), "try 30s or 5m") {
+		t.Fatalf("the answer does not say what to do: %s", w.Body)
+	}
+}
+
+// A deployment that wires its own crawlers says so rather than accepting a
+// connector and dropping it.
+func TestAServerWithNoSupervisorSaysConnectorsAreConfiguredElsewhere(t *testing.T) {
+	h := newConnectorServer(t, nil)
+
+	w := post(t, h, http.MethodPost, "/api/v1/admin/connectors", `{"source":"x","kind":"corpus"}`, operator())
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501: %s", w.Code, w.Body)
+	}
+	// And the screen is told the same thing, so it does not draw a form.
+	w = request(t, h, http.MethodGet, "/api/v1/admin/operations", operator())
+	var body struct {
+		Manageable bool `json:"manageable"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if body.Manageable {
+		t.Error("the screen was told it can add a connector to a deployment that has nothing to add it to")
+	}
+}
+
+func TestAConnectorNeedsASourceAndAKind(t *testing.T) {
+	sup := &fakeSupervisor{}
+	h := newConnectorServer(t, sup)
+
+	for _, body := range []string{
+		`{"kind":"corpus"}`,
+		`{"source":"x"}`,
+		`{"source":"   ","kind":"corpus"}`,
+		`not json at all`,
+	} {
+		w := post(t, h, http.MethodPost, "/api/v1/admin/connectors", body, operator())
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400", body, w.Code)
+		}
+	}
+	if calls := sup.seen(); len(calls) != 0 {
+		t.Fatalf("a request that could not be read still reached the supervisor: %v", calls)
+	}
+}
+
+// A configuration larger than any connector has is refused before it is read,
+// rather than decoded into memory first.
+func TestAnEnormousConfigurationIsRefused(t *testing.T) {
+	sup := &fakeSupervisor{}
+	h := newConnectorServer(t, sup)
+
+	huge := `{"source":"x","kind":"corpus","config":{"dir":"` + strings.Repeat("a", 64<<10) + `"}}`
+	w := post(t, h, http.MethodPost, "/api/v1/admin/connectors", huge, operator())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if calls := sup.seen(); len(calls) != 0 {
+		t.Fatalf("an oversized body still reached the supervisor: %v", calls)
+	}
+}
+
+// Who changed what is in the log, because the wrapper's line only records that
+// an administrator changed something and those are two different things to have
+// to explain afterwards.
+func TestChangingAConnectorIsAudited(t *testing.T) {
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	var logged bytes.Buffer
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"},
+		api.WithLogger(slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelInfo}))),
+		api.WithSupervisor(&fakeSupervisor{}),
+	)
+	h := s.Handler()
+
+	post(t, h, http.MethodPost, "/api/v1/admin/connectors",
+		`{"source":"archive","kind":"bucket","enabled":true}`, operator())
+
+	out := logged.String()
+	for _, want := range []string{"connector saved", "u_ops", "archive", "bucket"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the log does not say %q:\n%s", want, out)
+		}
+	}
+}
+
+// errString is an error that is nothing in particular, for the case where the
+// deployment's own problem must not be shown to the caller.
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/api/thumbnail.go
+++ b/api/thumbnail.go
@@ -80,12 +80,13 @@ func (s *Server) handleThumbnail(w http.ResponseWriter, r *http.Request, p *acl.
 	// that one produced, which matters here because the first paint of a grid
 	// asks for twenty four of these at once and a browser will happily open six
 	// connections to do it.
+	ctx := r.Context()
 	got, err := s.thumbs.Do(thumbnailKey(d, size), func() (thumb.Thumbnail, error) {
-		c, err := cs.Content(r.Context(), p, id)
+		c, err := cs.Content(ctx, p, id)
 		if err != nil {
 			return thumb.Thumbnail{}, err
 		}
-		return thumb.Render(r.Context(), c.Bytes, size)
+		return thumb.Render(ctx, c.Bytes, size)
 	})
 	if err != nil {
 		// A document with no bytes, a document in a format nobody decodes and a

--- a/cmd/genbad/bucket.go
+++ b/cmd/genbad/bucket.go
@@ -204,6 +204,20 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 		return nil, errors.New("ingesting a bucket needs -tenant")
 	}
 
+	f, err := bucketFeed(cfg, tenant, track, ops, log)
+	if err != nil {
+		return nil, err
+	}
+	f.Managed = false
+	return runFeed(ctx, st, f, log)
+}
+
+// bucketFeed builds the object storage connector, ready to run.
+//
+// It is split out for the same reason [corpusFeed] is: a connector added from
+// the interface has to be built the same way as one named on the command line,
+// and the way that goes wrong is two copies of this that drift apart.
+func bucketFeed(cfg bucketOptions, tenant string, track *indexing, ops *operations, log *slog.Logger) (feed, error) {
 	// Every request the bucket makes, for listings, for permissions and for the
 	// objects themselves, goes out through one transport, because the quota they
 	// are spending is one quota. Sharing it is the whole reason the limiter is a
@@ -223,7 +237,7 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 		Timeout:   patience(cfg.limits()),
 	}))
 	if err != nil {
-		return nil, err
+		return feed{}, err
 	}
 
 	// The policy is built on the same client as the source, so that what the
@@ -231,7 +245,7 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 	// counters rather than two that have to be added up by hand.
 	policy, err := bucketPolicyFor(client, cfg)
 	if err != nil {
-		return nil, err
+		return feed{}, err
 	}
 
 	src, err := objectsource.New(client, cfg.Name, policy,
@@ -245,10 +259,10 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 		}),
 	)
 	if err != nil {
-		return nil, err
+		return feed{}, err
 	}
 
-	return runFeed(ctx, st, feed{
+	return feed{
 		Kind:      "bucket",
 		Source:    src,
 		Target:    cfg.Bucket,
@@ -261,7 +275,7 @@ func ingestBucket(ctx context.Context, st store.Store, cfg bucketOptions, tenant
 		Track:     track,
 		Ops:       ops,
 		Release:   func() { _ = src.Close() },
-	}, log)
+	}, nil
 }
 
 // requesting is what the bucket cost, for the sync log line.

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -157,9 +157,26 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 		return nil, errors.New("ingesting a corpus needs -tenant")
 	}
 
-	policy, err := policyFor(cfg)
+	f, err := corpusFeed(cfg, tenant, track, ops, log)
 	if err != nil {
 		return nil, err
+	}
+	f.Managed = false
+	return runFeed(ctx, st, f, log)
+}
+
+// corpusFeed builds the directory connector, ready to run.
+//
+// It is separate from the function above because there are two ways a
+// connector arrives now. One is the command line, which is this file, and the
+// other is somebody adding it from the interface, which is [supervisor]. Both
+// want the same watcher, the same policy and the same feed, and the way that
+// goes wrong is two copies that drift until a connector added from the screen
+// behaves subtly differently from the same connector in a unit file.
+func corpusFeed(cfg corpusOptions, tenant string, track *indexing, ops *operations, log *slog.Logger) (feed, error) {
+	policy, err := policyFor(cfg)
+	if err != nil {
+		return feed{}, err
 	}
 	// A watcher that cannot be built is a line in the log and nothing else. The
 	// machine is at its inotify limit, or the tree is on a filesystem the
@@ -176,10 +193,13 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 
 	src, err := fssource.New(cfg.Dir, cfg.Name, policy, fssource.WithWatcher(watcher))
 	if err != nil {
-		return nil, err
+		if watcher != nil {
+			_ = watcher.Close()
+		}
+		return feed{}, err
 	}
 
-	return runFeed(ctx, st, feed{
+	return feed{
 		Kind:      "corpus",
 		Source:    src,
 		Target:    cfg.Dir,
@@ -197,7 +217,7 @@ func ingestCorpus(ctx context.Context, st store.Store, cfg corpusOptions, tenant
 			}
 			_ = src.Close()
 		},
-	}, log)
+	}, nil
 }
 
 // watching is what the watcher has to say, for the sync log line.

--- a/cmd/genbad/feed.go
+++ b/cmd/genbad/feed.go
@@ -46,6 +46,16 @@ type feed struct {
 	// after every sync.
 	Reconcile time.Duration
 
+	// Managed says this feed was configured through the interface rather than
+	// on the command line, which is what decides whether it can be changed from
+	// there. See [supervisor].
+	Managed bool
+
+	// Trigger asks for a sync now rather than at the next interval. A nil one
+	// is a feed nothing can hurry, which is every feed that came from a flag:
+	// there is nothing on the command line to press.
+	Trigger <-chan struct{}
+
 	// Fields say where the documents came from and are on every line this feed
 	// logs.
 	Fields []any
@@ -118,6 +128,8 @@ func runFeed(ctx context.Context, st store.Store, f feed, log *slog.Logger) (fun
 			Target:  f.Target,
 			Tenant:  f.Tenant,
 			Refresh: refreshOf(f.Refresh),
+			Enabled: true,
+			Managed: f.Managed,
 		}, f.Policy)
 	}
 
@@ -196,16 +208,26 @@ func runFeed(ctx context.Context, st store.Store, f feed, log *slog.Logger) (fun
 		if tracked {
 			f.Track.finished(source)
 		}
-		if f.Refresh <= 0 {
+		// A nil channel blocks forever in a select, which is what gives a feed
+		// with no interval and nothing to hurry it the same shape as one with
+		// both, instead of an early return that would have to be undone the
+		// moment either of them exists.
+		var tick <-chan time.Time
+		if f.Refresh > 0 {
+			t := time.NewTicker(f.Refresh)
+			defer t.Stop()
+			tick = t.C
+		}
+		if tick == nil && f.Trigger == nil {
 			return
 		}
-		t := time.NewTicker(f.Refresh)
-		defer t.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-t.C:
+			case <-tick:
+				sync(ctx)
+			case <-f.Trigger:
 				sync(ctx)
 			}
 		}

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -159,6 +159,21 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		api.WithIndexing(track.State),
 		api.WithOperations(ops.State),
 	}
+
+	// A connector can be added from the interface only where the driver can
+	// remember one across a restart. Offering the form on a driver that cannot
+	// would be offering somebody a connector that disappears at the next
+	// deployment, so a deployment without the capability is told where its
+	// connectors are configured instead. See [supervisor].
+	var sup *supervisor
+	if feeds, ok := st.(store.Feeds); ok && cfg.Tenant != "" {
+		creds := credentials{Access: bucket.Access, Secret: bucket.Secret, Session: bucket.Session}
+		sup = newSupervisor(st, feeds, cfg.Tenant, creds, track, ops, log)
+		opts = append(opts, api.WithSupervisor(sup))
+	} else {
+		log.Info("connectors are configured on the command line",
+			"store", cfg.Store, "tenant", cfg.Tenant)
+	}
 	if h := web.Handler(); h != nil {
 		opts = append(opts, api.WithAssets(h))
 	}
@@ -192,6 +207,24 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		return err
 	}
 	defer waitForBucket()
+
+	// The connectors that were configured through the interface start after the
+	// ones on the command line, and after those have claimed their names. A
+	// stored connector that has since been given the same name in a unit file
+	// does not start, because two crawlers writing the same document ids from
+	// two different places leave an index that is whichever of them ran last.
+	if sup != nil {
+		if corpus.Dir != "" {
+			sup.fix(corpus.Name)
+		}
+		if bucket.Bucket != "" {
+			sup.fix(bucket.Name)
+		}
+		if err := sup.restore(ctx); err != nil {
+			return err
+		}
+		defer sup.stop()
+	}
 
 	httpSrv := &http.Server{
 		Addr:              cfg.Addr,

--- a/cmd/genbad/operations.go
+++ b/cmd/genbad/operations.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"slices"
 	"sync"
 	"time"
 
@@ -74,11 +75,54 @@ func newOperations() *operations {
 func (o *operations) register(info api.Connector, policy any) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	if _, seen := o.sources[info.Source]; seen {
+	if s, seen := o.sources[info.Source]; seen {
+		// A connector that was stopped and started again is the same row with
+		// the same history rather than a second connector, so the settings are
+		// replaced and the runs are left alone. An operator who switched a
+		// source off to change a directory and switched it back on wants the
+		// failures that made them do it to still be on the screen.
+		s.info = info
+		s.policy = policy
 		return
 	}
 	o.sources[info.Source] = &sourceOps{info: info, policy: policy}
 	o.order = append(o.order, info.Source)
+}
+
+// enable records whether a connector is meant to be running.
+//
+// It is separate from register because stopping one keeps everything else about
+// it: the settings, the run history and the place in the order. Losing those on
+// a stop would make switching a noisy source off cost the evidence of why.
+func (o *operations) enable(source string, on bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	s, ok := o.sources[source]
+	if !ok {
+		return
+	}
+	s.info.Enabled = on
+	if !on {
+		// Nothing is running, so nothing is syncing. The goroutine that would
+		// have said so has been cancelled, and a row left saying it is syncing
+		// forever is worse than one that says nothing.
+		s.syncing = false
+	}
+}
+
+// forget drops a connector that has been removed.
+//
+// The run history goes with it, which is the one place this screen loses
+// something on purpose: the connector is gone, and a history of a source
+// nothing feeds any more is a row nobody can act on.
+func (o *operations) forget(source string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if _, ok := o.sources[source]; !ok {
+		return
+	}
+	delete(o.sources, source)
+	o.order = slices.DeleteFunc(o.order, func(s string) bool { return s == source })
 }
 
 // starting records that a sync has begun.

--- a/cmd/genbad/supervisor.go
+++ b/cmd/genbad/supervisor.go
@@ -1,0 +1,590 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/store"
+)
+
+// The kinds a stored connector can have. They are the same words the log lines
+// and the administration screen already use for the two connectors this binary
+// ships, so a row somebody added from the interface reads the same as a row
+// that came from a flag.
+const (
+	kindCorpus = "corpus"
+	kindBucket = "bucket"
+)
+
+// supervisor runs the connectors and remembers how they were configured.
+//
+// It is the half of the connector story the command line cannot do. A flag is
+// read once, at startup, by somebody with a shell on the machine, and every
+// change to it is a deployment. This is the other way round: the configuration
+// is in the store, it is changed by somebody with the administrator role, and
+// the change takes effect without a restart because this is what starts and
+// stops the crawlers.
+//
+// The two coexist and they are not equal. A connector named on the command line
+// is marked here and cannot be changed from the interface, because the next
+// restart would read the command line again and undo whatever was typed. Saying
+// so is [api.ErrUnmanaged], and it is better than either lying about it or
+// hiding a running connector from the screen that lists them.
+type supervisor struct {
+	store  store.Store
+	feeds  store.Feeds
+	tenant string
+	track  *indexing
+	ops    *operations
+	log    *slog.Logger
+
+	// creds are the object storage credentials, read from the environment at
+	// startup. They are held here rather than stored with the connector because
+	// a database is backed up, replicated and read by more people than a process
+	// environment is, and a secret that reaches one of those places cannot be
+	// recalled from it. A bucket added from the interface uses the credentials
+	// this process already holds, which also means a deployment that has none
+	// cannot be talked into crawling a private bucket through the API.
+	creds credentials
+
+	mu      sync.Mutex
+	config  map[string]store.Feed
+	running map[string]*runner
+	fixed   map[string]bool
+}
+
+// runner is one connector that is going.
+type runner struct {
+	cancel  context.CancelFunc
+	wait    func()
+	trigger chan struct{}
+}
+
+// credentials are the object storage keys, as the environment gave them.
+type credentials struct {
+	Access  string
+	Secret  string
+	Session string
+}
+
+var _ api.Supervisor = (*supervisor)(nil)
+
+// newSupervisor builds one. The store has to be able to remember a connector
+// across a restart, which is why the caller checks for [store.Feeds] first: a
+// deployment whose driver cannot is better told that than offered a form whose
+// answers disappear at the next deployment.
+func newSupervisor(st store.Store, feeds store.Feeds, tenant string, creds credentials, track *indexing, ops *operations, log *slog.Logger) *supervisor {
+	return &supervisor{
+		store:   st,
+		feeds:   feeds,
+		tenant:  tenant,
+		track:   track,
+		ops:     ops,
+		log:     log,
+		creds:   creds,
+		config:  make(map[string]store.Feed),
+		running: make(map[string]*runner),
+		fixed:   make(map[string]bool),
+	}
+}
+
+// fix marks a source as configured on the command line.
+//
+// Called for every flag configured connector before the stored ones are
+// restored, so that a stored connector that has since been given the same name
+// on the command line does not quietly start a second crawler against the same
+// source name and write two sets of documents over each other.
+func (s *supervisor) fix(source string) {
+	if source == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.fixed[source] = true
+}
+
+// restore starts the connectors that were configured before this process came
+// up.
+//
+// A connector that cannot be built is a line in the log and a row on the screen
+// rather than a refusal to start. The directory it points at may be on a volume
+// that is not mounted yet, and a server that will not come up because of one
+// connector is a server whose search is down for a reason that has nothing to
+// do with search.
+func (s *supervisor) restore(ctx context.Context) error {
+	saved, err := s.feeds.Feeds(ctx, s.tenant)
+	if err != nil {
+		return fmt.Errorf("reading the configured connectors: %w", err)
+	}
+	for _, f := range saved {
+		s.mu.Lock()
+		clash := s.fixed[f.Source]
+		s.config[f.Source] = f
+		s.mu.Unlock()
+		if clash {
+			s.log.Warn("a stored connector has the same name as one on the command line, the command line wins",
+				"source", f.Source)
+			continue
+		}
+		if !f.Enabled {
+			// Registered anyway, so that a connector somebody switched off is
+			// on the screen with an off switch rather than gone from it.
+			s.ops.register(api.Connector{
+				Source: f.Source, Kind: f.Kind, Tenant: f.Tenant, Managed: true,
+			}, nil)
+			continue
+		}
+		if err := s.launch(ctx, f); err != nil {
+			s.log.Error("starting a configured connector", "source", f.Source, "error", err)
+		}
+	}
+	return nil
+}
+
+// stop cancels every connector this supervisor started and waits for them.
+//
+// It is deferred by the caller in the same place the flag configured feeds are
+// waited for, and for the same reason: a process that returned from run while a
+// crawler was still writing would be a process whose last sync is half in the
+// store.
+func (s *supervisor) stop() {
+	s.mu.Lock()
+	running := make([]*runner, 0, len(s.running))
+	for source, r := range s.running {
+		running = append(running, r)
+		delete(s.running, source)
+	}
+	s.mu.Unlock()
+	for _, r := range running {
+		r.cancel()
+		r.wait()
+	}
+}
+
+// Add saves a connector and starts it.
+//
+// The order is deliberate: build it first, so that settings nobody can run are
+// refused before they are written down; then write it down, so that a process
+// that dies in the next instant comes back up with it; then start it. A start
+// that fails after the write leaves a configured connector that is not running,
+// which is what the screen says and what an operator can fix, and is a great
+// deal better than a connector that is running and will be gone after a
+// restart.
+func (s *supervisor) Add(ctx context.Context, f store.Feed) error {
+	if err := s.owns(f.Tenant, f.Source); err != nil {
+		return err
+	}
+	if err := f.Check(); err != nil {
+		return fmt.Errorf("%w: %w", api.ErrBadConnector, err)
+	}
+
+	built, err := s.build(f)
+	if err != nil {
+		return err
+	}
+	// Built to find out whether it can be, then released. What is being tested
+	// is the directory, the policy and the credentials, and holding a watcher
+	// open between here and the start below would leak one every time somebody
+	// edits a field of a connector that is switched off.
+	release(built)
+
+	f.Tenant = s.tenant
+	if err := s.feeds.SaveFeed(ctx, f); err != nil {
+		return fmt.Errorf("saving the connector: %w", err)
+	}
+	s.mu.Lock()
+	s.config[f.Source] = f
+	s.mu.Unlock()
+
+	s.halt(f.Source)
+	if !f.Enabled {
+		s.ops.register(api.Connector{
+			Source: f.Source, Kind: f.Kind, Tenant: f.Tenant, Managed: true,
+		}, nil)
+		s.ops.enable(f.Source, false)
+		return nil
+	}
+	return s.launch(ctx, f)
+}
+
+// Remove stops a connector and forgets how it was configured.
+//
+// The documents it indexed stay. Forgetting how a corpus was read is not a
+// decision to delete the corpus, and a call that did both would make an
+// operator's undo cost a full crawl, which on a large source is hours.
+func (s *supervisor) Remove(ctx context.Context, tenant, source string) error {
+	if err := s.owns(tenant, source); err != nil {
+		return err
+	}
+	if err := s.known(source); err != nil {
+		return err
+	}
+	s.halt(source)
+	if err := s.feeds.DropFeed(ctx, s.tenant, source); err != nil {
+		return fmt.Errorf("forgetting the connector: %w", err)
+	}
+	s.mu.Lock()
+	delete(s.config, source)
+	s.mu.Unlock()
+	s.ops.forget(source)
+	return nil
+}
+
+// Start switches a configured connector on.
+func (s *supervisor) Start(ctx context.Context, tenant, source string) error {
+	return s.switchTo(ctx, tenant, source, true)
+}
+
+// Stop switches a configured connector off and keeps its settings.
+func (s *supervisor) Stop(ctx context.Context, tenant, source string) error {
+	return s.switchTo(ctx, tenant, source, false)
+}
+
+// switchTo is start and stop, which differ in one bool and in nothing else.
+func (s *supervisor) switchTo(ctx context.Context, tenant, source string, on bool) error {
+	if err := s.owns(tenant, source); err != nil {
+		return err
+	}
+	if err := s.known(source); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	f := s.config[source]
+	s.mu.Unlock()
+	if f.Enabled == on {
+		// Already in the state it was asked for. Not an error, so that two
+		// operators pressing the same button do not have to explain a failure
+		// to each other, and no write, so that the row's own age is not moved
+		// by a request that changed nothing.
+		return nil
+	}
+
+	f.Enabled = on
+	if err := s.feeds.SaveFeed(ctx, f); err != nil {
+		return fmt.Errorf("saving the connector: %w", err)
+	}
+	s.mu.Lock()
+	s.config[source] = f
+	s.mu.Unlock()
+
+	if !on {
+		s.halt(source)
+		s.ops.enable(source, false)
+		return nil
+	}
+	return s.launch(ctx, f)
+}
+
+// Sync asks a running connector for a run now.
+//
+// It returns as soon as the run has been asked for. A crawl of a real source
+// takes minutes, and a request that waited for one would time out somewhere in
+// the middle and leave nobody able to say whether it ran.
+//
+// A connector that is already syncing is not asked twice. The trigger has room
+// for one waiting run, so pressing the button during a crawl means one more
+// crawl after it rather than a queue of them, which is the behaviour somebody
+// pressing a button that appears to do nothing will produce.
+func (s *supervisor) Sync(_ context.Context, tenant, source string) error {
+	if err := s.owns(tenant, source); err != nil {
+		return err
+	}
+	if err := s.known(source); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	r, running := s.running[source]
+	s.mu.Unlock()
+	if !running {
+		return fmt.Errorf("%w: %s is switched off, so there is nothing to sync", api.ErrBadConnector, source)
+	}
+	select {
+	case r.trigger <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+// owns rejects a request about somebody else's connector.
+//
+// This binary serves one tenant, so the only way the tenant can differ is a
+// caller naming another one, and the answer is the same as for a connector that
+// does not exist. A connector on the command line is refused separately,
+// because that one is worth explaining: there is a unit file to edit.
+func (s *supervisor) owns(tenant, source string) error {
+	if tenant != s.tenant {
+		return fmt.Errorf("%w: %s", genba.ErrNotFound, source)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fixed[source] {
+		return api.ErrUnmanaged
+	}
+	return nil
+}
+
+// known rejects a request about a connector nobody configured.
+func (s *supervisor) known(source string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.config[source]; !ok {
+		return fmt.Errorf("%w: %s", genba.ErrNotFound, source)
+	}
+	return nil
+}
+
+// launch starts one connector under its own context.
+//
+// Its own, so that stopping one connector does not stop the others, and
+// deliberately not the caller's: the call that starts a connector is an
+// administration request whose context ends when the response is written, and a
+// crawler that ended with it would stop a few milliseconds after it started.
+// What it keeps from the caller is the values, so a request id follows the
+// crawl into the log, and what it drops is the deadline. Shutdown is
+// [supervisor.stop], which cancels these by hand and waits for them.
+func (s *supervisor) launch(ctx context.Context, f store.Feed) error {
+	built, err := s.build(f)
+	if err != nil {
+		return err
+	}
+	trigger := make(chan struct{}, 1)
+	built.Managed = true
+	built.Trigger = trigger
+
+	run, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	wait, err := runFeed(run, s.store, built, s.log)
+	if err != nil {
+		cancel()
+		release(built)
+		return err
+	}
+	s.mu.Lock()
+	s.running[f.Source] = &runner{cancel: cancel, wait: wait, trigger: trigger}
+	s.mu.Unlock()
+	s.ops.enable(f.Source, true)
+	return nil
+}
+
+// halt stops one connector if it is running, and waits for its last sync.
+//
+// Waiting is the part that matters. A source that is being replaced has to have
+// stopped writing before the replacement starts, or two crawlers write the same
+// document ids from two different directories and the index is whichever of
+// them was last.
+func (s *supervisor) halt(source string) {
+	s.mu.Lock()
+	r, ok := s.running[source]
+	delete(s.running, source)
+	s.mu.Unlock()
+	if !ok {
+		return
+	}
+	r.cancel()
+	r.wait()
+}
+
+// build turns a stored configuration into a feed ready to run.
+//
+// Everything it can refuse is refused here, which is what makes adding a
+// connector from the interface answer immediately with the field that is wrong
+// rather than accepting it and failing in a log line a minute later.
+func (s *supervisor) build(f store.Feed) (feed, error) {
+	switch f.Kind {
+	case kindCorpus:
+		var c corpusConfig
+		if err := decodeConfig(f.Config, &c); err != nil {
+			return feed{}, err
+		}
+		opts, err := c.options(f.Source)
+		if err != nil {
+			return feed{}, err
+		}
+		if err := opts.validate(); err != nil {
+			return feed{}, fmt.Errorf("%w: %w", api.ErrBadConnector, err)
+		}
+		built, err := corpusFeed(opts, s.tenant, s.track, s.ops, s.log)
+		if err != nil {
+			return feed{}, fmt.Errorf("%w: %w", api.ErrBadConnector, err)
+		}
+		return built, nil
+	case kindBucket:
+		var c bucketConfig
+		if err := decodeConfig(f.Config, &c); err != nil {
+			return feed{}, err
+		}
+		opts, err := c.options(f.Source, s.creds)
+		if err != nil {
+			return feed{}, err
+		}
+		if err := opts.validate(); err != nil {
+			return feed{}, fmt.Errorf("%w: %w", api.ErrBadConnector, err)
+		}
+		built, err := bucketFeed(opts, s.tenant, s.track, s.ops, s.log)
+		if err != nil {
+			return feed{}, fmt.Errorf("%w: %w", api.ErrBadConnector, err)
+		}
+		return built, nil
+	default:
+		return feed{}, fmt.Errorf("%w: there is no connector of kind %q, only %q and %q",
+			api.ErrBadConnector, f.Kind, kindCorpus, kindBucket)
+	}
+}
+
+// release gives back whatever a built feed is holding.
+func release(f feed) {
+	if f.Release != nil {
+		f.Release()
+	}
+}
+
+// decodeConfig reads a connector's settings, and says so when it cannot.
+//
+// An absent config is an empty object rather than an error, so that a kind
+// whose fields all have defaults can be added with nothing but a name, and so
+// that the message about the field that is missing comes from validation rather
+// than from the JSON decoder.
+func decodeConfig(raw json.RawMessage, into any) error {
+	if len(raw) == 0 {
+		raw = json.RawMessage("{}")
+	}
+	if err := json.Unmarshal(raw, into); err != nil {
+		return fmt.Errorf("%w: the settings are not readable: %w", api.ErrBadConnector, err)
+	}
+	return nil
+}
+
+// corpusConfig is the directory connector's settings, as they are stored and as
+// they arrive from the interface.
+//
+// It is not [corpusOptions]. The intervals here are strings such as "30s"
+// because that is what somebody types and what reads back out of a database as
+// what they typed, where a duration on the wire is a count of nanoseconds that
+// nobody can check by eye. There is no name either: the source name is the
+// connector's key and is not a setting that can disagree with it.
+type corpusConfig struct {
+	Dir       string `json:"dir"`
+	ACL       string `json:"acl,omitempty"`
+	Identity  string `json:"identity,omitempty"`
+	Domain    string `json:"domain,omitempty"`
+	Refresh   string `json:"refresh,omitempty"`
+	Watch     bool   `json:"watch,omitempty"`
+	Reconcile string `json:"reconcile,omitempty"`
+}
+
+func (c corpusConfig) options(source string) (corpusOptions, error) {
+	refresh, err := interval(c.Refresh, "refresh")
+	if err != nil {
+		return corpusOptions{}, err
+	}
+	reconcile, err := interval(c.Reconcile, "reconcile")
+	if err != nil {
+		return corpusOptions{}, err
+	}
+	o := corpusOptions{
+		Dir:       c.Dir,
+		Name:      source,
+		ACL:       c.ACL,
+		Identity:  c.Identity,
+		Domain:    c.Domain,
+		Refresh:   refresh,
+		Watch:     c.Watch,
+		Reconcile: reconcile,
+	}
+	if o.Dir == "" {
+		return corpusOptions{}, fmt.Errorf("%w: a directory connector needs a dir", api.ErrBadConnector)
+	}
+	// The same defaults the flags carry, so that the shortest thing somebody
+	// can add from the interface is the shortest thing they could type.
+	if o.ACL == "" {
+		o.ACL = aclTenant
+	}
+	if o.ACL == aclOS && o.Identity == "" {
+		o.Identity = "unix"
+	}
+	return o, nil
+}
+
+// bucketConfig is the object storage connector's settings.
+//
+// There is nothing here for the keys. See [supervisor.creds].
+type bucketConfig struct {
+	Bucket    string  `json:"bucket"`
+	Endpoint  string  `json:"endpoint"`
+	Region    string  `json:"region,omitempty"`
+	Prefix    string  `json:"prefix,omitempty"`
+	ACL       string  `json:"acl,omitempty"`
+	Identity  string  `json:"identity,omitempty"`
+	Domain    string  `json:"domain,omitempty"`
+	PathStyle bool    `json:"path_style,omitempty"`
+	Refresh   string  `json:"refresh,omitempty"`
+	Reconcile string  `json:"reconcile,omitempty"`
+	Rate      float64 `json:"rate,omitempty"`
+	Burst     int     `json:"burst,omitempty"`
+	Retries   int     `json:"retries,omitempty"`
+}
+
+func (c bucketConfig) options(source string, creds credentials) (bucketOptions, error) {
+	refresh, err := interval(c.Refresh, "refresh")
+	if err != nil {
+		return bucketOptions{}, err
+	}
+	reconcile, err := interval(c.Reconcile, "reconcile")
+	if err != nil {
+		return bucketOptions{}, err
+	}
+	o := bucketOptions{
+		Bucket:    c.Bucket,
+		Endpoint:  c.Endpoint,
+		Region:    c.Region,
+		Prefix:    c.Prefix,
+		Name:      source,
+		ACL:       c.ACL,
+		Identity:  c.Identity,
+		Domain:    c.Domain,
+		PathStyle: c.PathStyle,
+		Refresh:   refresh,
+		Reconcile: reconcile,
+		Rate:      c.Rate,
+		Burst:     c.Burst,
+		Retries:   c.Retries,
+		Access:    creds.Access,
+		Secret:    creds.Secret,
+		Session:   creds.Session,
+	}
+	if o.Bucket == "" {
+		return bucketOptions{}, fmt.Errorf("%w: an object storage connector needs a bucket", api.ErrBadConnector)
+	}
+	if o.Region == "" {
+		o.Region = "us-east-1"
+	}
+	if o.ACL == "" {
+		o.ACL = aclTenant
+	}
+	return o, nil
+}
+
+// interval parses one of the durations a connector is configured with.
+//
+// Empty is zero, which every caller reads as once and never again, and a
+// negative one is refused here rather than by the validation below so that the
+// message names the field.
+func interval(s, name string) (time.Duration, error) {
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s is not a duration, try 30s or 5m", api.ErrBadConnector, name)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("%w: %s is negative", api.ErrBadConnector, name)
+	}
+	return d, nil
+}

--- a/cmd/genbad/supervisor_test.go
+++ b/cmd/genbad/supervisor_test.go
@@ -1,0 +1,487 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/store"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// Connectors added without restarting the server.
+//
+// The happy path is the least interesting half of this. What is worth testing
+// hardest is what happens to a corpus when a connector is removed, what happens
+// to a connector when the process comes back, and what happens when somebody
+// tries to change one that came off the command line. Those are the three ways
+// a feature like this loses somebody's index.
+
+// newTestSupervisor builds one over the reference driver, which remembers
+// connectors for exactly as long as the test does.
+func newTestSupervisor(t *testing.T) (*supervisor, *memstore.Store, *operations) {
+	t.Helper()
+	st := newTestStore(t)
+	ops := newOperations()
+	sup := newSupervisor(st, st, "acme", credentials{}, newIndexing(t.Context(), st), ops, quietLog())
+	t.Cleanup(sup.stop)
+	return sup, st, ops
+}
+
+func newTestStore(t *testing.T) *memstore.Store {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func quietLog() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// corpusFeedFor is a directory connector over a tree, as the interface sends
+// one.
+func corpusFeedFor(t *testing.T, source, dir string, enabled bool) store.Feed {
+	t.Helper()
+	return store.Feed{
+		Tenant:  "acme",
+		Source:  source,
+		Kind:    kindCorpus,
+		Enabled: enabled,
+		Config:  settings(t, corpusConfig{Dir: dir, ACL: aclTenant}),
+		By:      "u_ops",
+	}
+}
+
+// settings is a connector's settings as they cross the interface.
+func settings(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// indexed waits for the store to hold documents and says how many.
+//
+// A crawl runs behind the call that started it on purpose, so every assertion
+// about what is in the index has to wait for one. The deadline is generous
+// because this is a real walk of a real directory on whatever machine the tests
+// are running on.
+func indexed(t *testing.T, st *memstore.Store, want int) int {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		seen := held(t, st)
+		if seen >= want || !time.Now().Before(deadline) {
+			return seen
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// held is how many documents the store has right now.
+func held(t *testing.T, st *memstore.Store) int {
+	t.Helper()
+	stats, err := st.Stats(t.Context())
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	return stats.Documents
+}
+
+// screen is one row of the administration screen, and fails the test if the
+// connector is not on it.
+func screen(t *testing.T, ops *operations, source string) api.Connector {
+	t.Helper()
+	for _, c := range ops.State().Connectors {
+		if c.Source == source {
+			return c
+		}
+	}
+	t.Fatalf("%q is not on the administration screen", source)
+	return api.Connector{}
+}
+
+// The whole point, in one test: a directory named through the interface is
+// crawled, and it is still configured after the process that was told about it
+// has gone.
+func TestAConnectorAddedFromTheInterfaceIsCrawledAndRemembered(t *testing.T) {
+	sup, st, ops := newTestSupervisor(t)
+
+	if err := sup.Add(t.Context(), corpusFeedFor(t, "handbook", corpusTree(t), true)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if n := indexed(t, st, 1); n == 0 {
+		t.Fatal("a connector was added and nothing was indexed")
+	}
+
+	// On the screen, and marked as something the screen may change.
+	c := screen(t, ops, "handbook")
+	if !c.Managed || !c.Enabled {
+		t.Errorf("the connector reads as %+v, want it managed and enabled", c)
+	}
+
+	// And written down, which is the part a restart depends on.
+	saved, err := st.Feeds(t.Context(), "acme")
+	if err != nil {
+		t.Fatalf("Feeds: %v", err)
+	}
+	if len(saved) != 1 || saved[0].Source != "handbook" || saved[0].By != "u_ops" {
+		t.Fatalf("the store holds %+v", saved)
+	}
+}
+
+// Switching a source off keeps everything about it except the crawler, which is
+// the difference between silencing a connector that is producing errors and
+// having to type it all in again afterwards.
+func TestStoppingAConnectorKeepsItsSettings(t *testing.T) {
+	sup, st, ops := newTestSupervisor(t)
+
+	if err := sup.Add(t.Context(), corpusFeedFor(t, "handbook", corpusTree(t), true)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	indexed(t, st, 1)
+
+	if err := sup.Stop(t.Context(), "acme", "handbook"); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if c := screen(t, ops, "handbook"); c.Enabled || c.Syncing {
+		t.Errorf("a stopped connector reads as %+v", c)
+	}
+	saved, err := st.Feeds(t.Context(), "acme")
+	if err != nil {
+		t.Fatalf("Feeds: %v", err)
+	}
+	if len(saved) != 1 || saved[0].Enabled {
+		t.Fatalf("the store holds %+v, want the settings kept and switched off", saved)
+	}
+
+	// And on again, which is the same connector rather than a second one.
+	if err := sup.Start(t.Context(), "acme", "handbook"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if c := screen(t, ops, "handbook"); !c.Enabled {
+		t.Errorf("a started connector reads as %+v", c)
+	}
+	if got := len(ops.State().Connectors); got != 1 {
+		t.Errorf("stopping and starting left %d connectors, want one", got)
+	}
+}
+
+// The one that would be expensive to get wrong. Removing a connector forgets
+// how a corpus was read and leaves the corpus, because the alternative makes an
+// operator's undo cost a full crawl.
+func TestRemovingAConnectorLeavesTheDocumentsItIndexed(t *testing.T) {
+	sup, st, ops := newTestSupervisor(t)
+
+	if err := sup.Add(t.Context(), corpusFeedFor(t, "handbook", corpusTree(t), true)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	before := indexed(t, st, 1)
+	if before == 0 {
+		t.Fatal("nothing was indexed to begin with")
+	}
+
+	if err := sup.Remove(t.Context(), "acme", "handbook"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if after := held(t, st); after != before {
+		t.Errorf("removing the connector took the corpus with it: %d documents left of %d", after, before)
+	}
+	saved, err := st.Feeds(t.Context(), "acme")
+	if err != nil {
+		t.Fatalf("Feeds: %v", err)
+	}
+	if len(saved) != 0 {
+		t.Errorf("the configuration is still there: %+v", saved)
+	}
+	if got := ops.State().Connectors; len(got) != 0 {
+		t.Errorf("the removed connector is still on the screen: %+v", got)
+	}
+}
+
+// A connector that came off the command line is on the screen because it is
+// running, and cannot be changed from there because the next restart would read
+// the command line again and undo whatever was typed.
+func TestAConnectorFromTheCommandLineCannotBeChangedFromTheInterface(t *testing.T) {
+	sup, _, _ := newTestSupervisor(t)
+	sup.fix("files")
+	dir := corpusTree(t)
+
+	for _, c := range []struct {
+		name string
+		call func() error
+	}{
+		{"add", func() error { return sup.Add(t.Context(), corpusFeedFor(t, "files", dir, true)) }},
+		{"remove", func() error { return sup.Remove(t.Context(), "acme", "files") }},
+		{"start", func() error { return sup.Start(t.Context(), "acme", "files") }},
+		{"stop", func() error { return sup.Stop(t.Context(), "acme", "files") }},
+		{"sync", func() error { return sup.Sync(t.Context(), "acme", "files") }},
+	} {
+		if err := c.call(); !errors.Is(err, api.ErrUnmanaged) {
+			t.Errorf("%s returned %v, want it to say the connector is not managed here", c.name, err)
+		}
+	}
+}
+
+// Naming another tenant's connector is answered the same way as naming one that
+// was never configured, because from the caller's side those are the same thing
+// and the difference is what would tell them another deployment has it.
+func TestAConnectorOfAnotherTenantIsNotFound(t *testing.T) {
+	sup, _, _ := newTestSupervisor(t)
+	if err := sup.Add(t.Context(), corpusFeedFor(t, "handbook", corpusTree(t), false)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := sup.Start(t.Context(), "other", "handbook"); !errors.Is(err, genba.ErrNotFound) {
+		t.Errorf("starting another tenant's connector returned %v", err)
+	}
+	if err := sup.Stop(t.Context(), "acme", "never-configured"); !errors.Is(err, genba.ErrNotFound) {
+		t.Errorf("stopping a connector nobody configured returned %v", err)
+	}
+}
+
+// Settings that cannot be run are refused before they are written down, and the
+// message says which field is wrong. A connector that is accepted and then
+// fails in a log line a minute later is the version of this nobody can use.
+func TestSettingsThatCannotBeRunAreRefused(t *testing.T) {
+	sup, st, _ := newTestSupervisor(t)
+	gone := filepath.Join(t.TempDir(), "not-mounted")
+
+	tests := []struct {
+		name string
+		feed store.Feed
+		want string
+	}{
+		{
+			"a kind nobody implements",
+			store.Feed{Tenant: "acme", Source: "x", Kind: "confluence"},
+			"confluence",
+		},
+		{
+			"a connector with no kind at all",
+			store.Feed{Tenant: "acme", Source: "x"},
+			"kind",
+		},
+		{
+			"a directory connector with no directory",
+			store.Feed{Tenant: "acme", Source: "x", Kind: kindCorpus, Config: json.RawMessage(`{}`)},
+			"dir",
+		},
+		{
+			"a directory that is not there",
+			store.Feed{Tenant: "acme", Source: "x", Kind: kindCorpus, Config: settings(t, corpusConfig{Dir: gone})},
+			"not-mounted",
+		},
+		{
+			"an interval that is not a duration",
+			store.Feed{Tenant: "acme", Source: "x", Kind: kindCorpus, Config: settings(t, corpusConfig{Dir: gone, Refresh: "often"})},
+			"duration",
+		},
+		{
+			"settings that are not readable at all",
+			store.Feed{Tenant: "acme", Source: "x", Kind: kindCorpus, Config: json.RawMessage(`[1,2,3]`)},
+			"not readable",
+		},
+		{
+			"a bucket with no bucket",
+			store.Feed{Tenant: "acme", Source: "x", Kind: kindBucket, Config: json.RawMessage(`{}`)},
+			"bucket",
+		},
+		{
+			"a bucket with nowhere to send the request",
+			store.Feed{Tenant: "acme", Source: "x", Kind: kindBucket, Config: json.RawMessage(`{"bucket":"docs"}`)},
+			"endpoint",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sup.Add(t.Context(), tt.feed)
+			if !errors.Is(err, api.ErrBadConnector) {
+				t.Fatalf("Add returned %v, want it refused as settings that cannot be run", err)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("the error is %q, want it to mention %q", err, tt.want)
+			}
+			saved, ferr := st.Feeds(t.Context(), "acme")
+			if ferr != nil {
+				t.Fatalf("Feeds: %v", ferr)
+			}
+			if len(saved) != 0 {
+				t.Errorf("settings that were refused were written down anyway: %+v", saved)
+			}
+		})
+	}
+}
+
+// A connector configured before this process came up starts with it, which is
+// the whole reason the configuration lives in the store rather than in memory.
+func TestConnectorsConfiguredBeforeTheRestartComeBack(t *testing.T) {
+	st := newTestStore(t)
+	root := corpusTree(t)
+
+	// The first process configures one and switches another off.
+	first := newSupervisor(st, st, "acme", credentials{}, newIndexing(t.Context(), st), newOperations(), quietLog())
+	if err := first.Add(t.Context(), corpusFeedFor(t, "handbook", root, true)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := first.Add(t.Context(), corpusFeedFor(t, "archive", root, false)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	first.stop()
+
+	// The second reads them back out of the store.
+	ops := newOperations()
+	second := newSupervisor(st, st, "acme", credentials{}, newIndexing(t.Context(), st), ops, quietLog())
+	t.Cleanup(second.stop)
+	if err := second.restore(t.Context()); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if c := screen(t, ops, "handbook"); !c.Enabled {
+		t.Errorf("the running connector came back as %+v", c)
+	}
+	// The one that was switched off is on the screen with an off switch rather
+	// than gone from it, because a connector nobody can see is a connector
+	// nobody can switch back on.
+	if c := screen(t, ops, "archive"); c.Enabled {
+		t.Errorf("a connector that was switched off came back running: %+v", c)
+	}
+}
+
+// A stored connector that has since been given the same name on the command
+// line does not start. Two crawlers writing the same document ids from two
+// different directories leave an index that is whichever of them ran last.
+func TestACommandLineConnectorWinsAClashOfNames(t *testing.T) {
+	st := newTestStore(t)
+
+	first := newSupervisor(st, st, "acme", credentials{}, newIndexing(t.Context(), st), newOperations(), quietLog())
+	if err := first.Add(t.Context(), corpusFeedFor(t, "files", corpusTree(t), true)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	first.stop()
+
+	ops := newOperations()
+	second := newSupervisor(st, st, "acme", credentials{}, newIndexing(t.Context(), st), ops, quietLog())
+	t.Cleanup(second.stop)
+	second.fix("files")
+	if err := second.restore(t.Context()); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got := ops.State().Connectors; len(got) != 0 {
+		t.Errorf("the stored connector started anyway: %+v", got)
+	}
+}
+
+// Asking a connector that is switched off for a sync says so, rather than
+// answering as though a crawl is on its way.
+func TestSyncingAConnectorThatIsSwitchedOffSaysSo(t *testing.T) {
+	sup, _, _ := newTestSupervisor(t)
+	if err := sup.Add(t.Context(), corpusFeedFor(t, "handbook", corpusTree(t), false)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := sup.Sync(t.Context(), "acme", "handbook"); !errors.Is(err, api.ErrBadConnector) {
+		t.Fatalf("Sync returned %v, want it to say there is nothing to sync", err)
+	}
+}
+
+// A connector's own context is not the context of the request that started it.
+// The request is over in a millisecond and the crawl is not, so a crawler that
+// ended with its request would index nothing and report success.
+func TestACrawlOutlivesTheRequestThatStartedIt(t *testing.T) {
+	sup, st, _ := newTestSupervisor(t)
+
+	request, answered := context.WithCancel(t.Context())
+	if err := sup.Add(request, corpusFeedFor(t, "handbook", corpusTree(t), true)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	answered()
+
+	if n := indexed(t, st, 1); n == 0 {
+		t.Fatal("the crawl was cancelled with the request that asked for it")
+	}
+}
+
+// The end to end version: a running server, a connector added over HTTP by
+// somebody holding the administrator role, and a query that finds what it
+// crawled.
+func TestAConnectorAddedOverTheAPIIsSearchable(t *testing.T) {
+	addr := freeAddr(t)
+	root := corpusTree(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, []string{
+			"-addr", addr,
+			"-tenant", "acme",
+			"-store", "sqlite",
+			"-dsn", filepath.Join(t.TempDir(), "genba.db"),
+			"-admins", "u_ops",
+			"-log-level", "error",
+		}, env(nil), &out, &errOut)
+	}()
+	defer func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("the server returned %v", err)
+			}
+		case <-time.After(30 * time.Second):
+			t.Error("the server did not shut down")
+		}
+	}()
+	waitForIndex(t, "http://"+addr)
+
+	body := `{"source":"handbook","kind":"corpus","enabled":true,"config":{"dir":` +
+		string(settings(t, root)) + `,"acl":"tenant"}}`
+	if code := operate(t, http.MethodPost, "http://"+addr+"/api/v1/admin/connectors", body); code != http.StatusOK {
+		t.Fatalf("adding a connector returned %d", code)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if searchAs(t, addr, "alice", "deploying").Total > 0 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("a connector was added over the API and a query about it found nothing")
+}
+
+// operate sends one administration request and returns the status.
+func operate(t *testing.T, method, url, body string) int {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), method, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Genba-Subject", "u_ops")
+	req.Header.Set("X-Genba-Tenant", "acme")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	out, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Logf("%s %s: %s", method, url, out)
+	}
+	return resp.StatusCode
+}

--- a/store/feed.go
+++ b/store/feed.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Feed is one connector's configuration, written down so it survives a restart.
+//
+// It is deliberately not a connector and it is not a running thing. It is what
+// somebody typed: which source to read, under whose name, how often, and
+// whether it should be running at all. Something else turns that into a
+// connector and keeps it going, and that something else is in the process that
+// owns the crawlers rather than in here.
+//
+// It lives in the store because the store is the only thing in this system that
+// survives a restart and is shared by every copy of the process. A file next to
+// the database would work on a laptop and would quietly give three servers
+// behind a load balancer three different sets of connectors.
+//
+// What is not in it is credentials. A bucket needs a key and a secret and
+// neither of them goes in here, because a database is backed up, replicated and
+// read by more people than a process environment is, and a secret that reaches
+// one of those places cannot be recalled from it. They are read from the
+// environment exactly as they were before this type existed, and a connector
+// added from the interface uses the credentials the process already holds.
+type Feed struct {
+	// Tenant is whose corpus this feeds, and Source is the name its documents
+	// carry. Together they are the key: two tenants may both have a source
+	// called files, and one tenant may not have two.
+	Tenant string
+	Source string
+
+	// Kind says what sort of source it is, and is what decides how Config is
+	// read. It is a string rather than a constant of this package because the
+	// set of connectors is not the store's business.
+	Kind string
+
+	// Enabled says whether it should be running. A feed that is switched off is
+	// still configured, which is the difference between stopping a connector
+	// that is producing errors and losing how it was set up.
+	Enabled bool
+
+	// Config is the kind specific settings, as JSON. It is opaque here on
+	// purpose: a directory has a path and an access control policy, a bucket
+	// has an endpoint and a region, and a store that knew the difference would
+	// need a migration every time a connector grew a field.
+	Config json.RawMessage
+
+	// By is the subject that last wrote this row, which is the question that
+	// gets asked when two operators are changing the same deployment. It is
+	// recorded rather than derived, because the audit log has the action and
+	// this has the current state, and reconstructing one from the other means
+	// reading every line since the process came up.
+	By string
+
+	// Created and Updated are set by the driver, not by the caller. A row's
+	// creation time does not move when it is edited, which is what makes it
+	// possible to tell a connector that was added this morning from one that
+	// has been failing since it was set up last year.
+	Created time.Time
+	Updated time.Time
+}
+
+// ErrNoFeedSource and ErrNoFeedKind are what [Feed.Check] returns.
+var (
+	ErrNoFeedSource = errors.New("feed has no source")
+	ErrNoFeedKind   = errors.New("feed has no kind")
+)
+
+// Check rejects a feed that cannot be stored.
+//
+// It lives here rather than in each driver because every driver keys this on
+// the same two fields, and a source with no name would be a row that can be
+// written and never addressed again. A driver calls it and wraps the result
+// with its own name.
+func (f Feed) Check() error {
+	switch {
+	case f.Source == "":
+		return ErrNoFeedSource
+	case f.Kind == "":
+		return ErrNoFeedKind
+	default:
+		return nil
+	}
+}
+
+// Feeds is the capability that remembers how the connectors were configured.
+//
+// It is optional like every capability outside [Store], and a deployment whose
+// driver does not implement it is not broken: it configures its connectors on
+// the command line the way every deployment did before this existed, and the
+// interface says so rather than offering a form whose answers go nowhere.
+//
+// It is not principal scoped. A connector is a property of the deployment
+// rather than of a document, nothing in it is readable by an ordinary caller,
+// and the one role that reaches it is checked in front of the store. That is
+// the same bargain [Maintenance] and [Quarantine] make.
+type Feeds interface {
+	Store
+
+	// Feeds returns every configured feed for one tenant, in an unspecified
+	// order. A caller drawing a list sorts it into whatever order that list is
+	// read in.
+	Feeds(ctx context.Context, tenant string) ([]Feed, error)
+
+	// SaveFeed inserts or replaces one feed, keyed by tenant and source.
+	//
+	// Replacing rather than failing on a duplicate is what makes editing one
+	// field the same call as adding it, and it is what lets a deployment
+	// describe its connectors declaratively later without a read first.
+	// Created is preserved across a replace and Updated is set to now.
+	SaveFeed(ctx context.Context, f Feed) error
+
+	// DropFeed forgets one feed. Dropping one that is not there is not an
+	// error, so that removing a connector twice is the same as removing it
+	// once.
+	//
+	// It removes the configuration and nothing else. The documents that feed
+	// indexed stay exactly where they are, because forgetting how a corpus was
+	// read is not a decision to delete the corpus, and a call that did both
+	// would make an operator's undo cost a full crawl.
+	DropFeed(ctx context.Context, tenant, source string) error
+}

--- a/store/memstore/feed.go
+++ b/store/memstore/feed.go
@@ -1,0 +1,90 @@
+package memstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Feeds = (*Store)(nil)
+
+// Feeds returns every configured feed for one tenant.
+//
+// The reference driver keeps them in memory like everything else it holds, so
+// they last exactly as long as the process. That is the wrong behaviour for a
+// deployment and the right behaviour for this driver, which is documented as
+// holding nothing across a restart, and a connector configuration that survived
+// one here would be the only thing in the store that did.
+func (s *Store) Feeds(ctx context.Context, tenant string) ([]store.Feed, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, genba.ErrClosed
+	}
+	out := make([]store.Feed, 0, len(s.feeds))
+	for key, f := range s.feeds {
+		if key[0] != tenant {
+			continue
+		}
+		out = append(out, clone(f))
+	}
+	return out, nil
+}
+
+// SaveFeed inserts or replaces one feed.
+func (s *Store) SaveFeed(ctx context.Context, f store.Feed) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := f.Check(); err != nil {
+		return fmt.Errorf("memstore: save feed: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return genba.ErrClosed
+	}
+
+	now := time.Now().UTC()
+	f.Updated = now
+	f.Created = now
+	// A replace keeps the row's own age. When it was first configured and when
+	// it was last touched are two different answers and an operator reading a
+	// connector that has been failing for a year wants both.
+	if old, ok := s.feeds[feedKey(f)]; ok {
+		f.Created = old.Created
+	}
+	s.feeds[feedKey(f)] = clone(f)
+	return nil
+}
+
+// DropFeed forgets one feed, and forgets nothing else.
+func (s *Store) DropFeed(ctx context.Context, tenant, source string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return genba.ErrClosed
+	}
+	delete(s.feeds, [2]string{tenant, source})
+	return nil
+}
+
+func feedKey(f store.Feed) [2]string { return [2]string{f.Tenant, f.Source} }
+
+// clone copies the JSON out with the row, because the caller owns the slice it
+// passed in and a stored feed that shared it would change when they reused it.
+func clone(f store.Feed) store.Feed {
+	f.Config = json.RawMessage(slices.Clone([]byte(f.Config)))
+	return f
+}

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -41,6 +41,11 @@ type Store struct {
 	// opens is what each person has been reading, keyed by tenant and subject.
 	opens map[[2]string]*opened
 
+	// feeds is how the connectors were configured, keyed by tenant and source.
+	// It is in memory like everything else here, so a restart forgets it, which
+	// is the documented behaviour of this driver rather than an oversight.
+	feeds map[[2]string]store.Feed
+
 	closed bool
 }
 
@@ -50,6 +55,7 @@ func New() *Store {
 		docs:    make(map[string]doc.Document),
 		content: make(map[string]doc.Content),
 		opens:   make(map[[2]string]*opened),
+		feeds:   make(map[[2]string]store.Feed),
 	}
 }
 
@@ -60,6 +66,7 @@ var (
 	_ store.Notifier     = (*Store)(nil)
 	_ store.Quarantine   = (*Store)(nil)
 	_ store.Access       = (*Store)(nil)
+	_ store.Feeds        = (*Store)(nil)
 )
 
 // Put inserts or replaces documents.

--- a/store/memstore/memstore_test.go
+++ b/store/memstore/memstore_test.go
@@ -18,6 +18,7 @@ func TestMaintenanceConformance(t *testing.T) {
 	storetest.RunMaintenance(t, newStore)
 	storetest.RunQuarantine(t, newStore)
 	storetest.RunReachable(t, newStore)
+	storetest.RunFeeds(t, newStore)
 }
 
 // memstore implements store.Statistician and neither of the other two, so most

--- a/store/pgstore/feed.go
+++ b/store/pgstore/feed.go
@@ -1,0 +1,110 @@
+package pgstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Feeds = (*Store)(nil)
+
+// Feeds returns every configured feed for one tenant.
+//
+// There are as many rows here as somebody has configured connectors, which is
+// tens at the outside, so this reads them all rather than paging. It is inside
+// the retry because it collects the whole answer before returning it, so a
+// second attempt has not already handed the caller half a list.
+func (s *Store) Feeds(ctx context.Context, tenant string) ([]store.Feed, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+
+	var out []store.Feed
+	err := s.retry(ctx, func(ctx context.Context) error {
+		rows, err := s.query(ctx, `
+			SELECT source, kind, enabled, config, by_subject, created, updated
+			FROM feed WHERE tenant = ?`, tenant)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		out = nil
+		for rows.Next() {
+			f := store.Feed{Tenant: tenant}
+			var config string
+			var created, updated int64
+			if err := rows.Scan(&f.Source, &f.Kind, &f.Enabled, &config, &f.By, &created, &updated); err != nil {
+				return err
+			}
+			f.Config = json.RawMessage(config)
+			f.Created = time.Unix(0, created).UTC()
+			f.Updated = time.Unix(0, updated).UTC()
+			s.counters.rows.Add(1)
+			out = append(out, f)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: feeds: %w", err)
+	}
+	return out, nil
+}
+
+// SaveFeed inserts or replaces one feed.
+func (s *Store) SaveFeed(ctx context.Context, f store.Feed) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if err := f.Check(); err != nil {
+		return fmt.Errorf("pgstore: save feed: %w", err)
+	}
+
+	now := time.Now().UTC().UnixNano()
+	err := s.retry(ctx, func(ctx context.Context) error {
+		s.counters.statements.Add(1)
+		// One statement rather than a read and a write, so that the row keeps
+		// its own age without two operators editing the same connector racing
+		// for which of them read the older created. The answer to that is in
+		// the database and this leaves it there.
+		_, err := s.pool.Exec(ctx, rebind(`
+			INSERT INTO feed (tenant, source, kind, enabled, config, by_subject, created, updated)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT (tenant, source) DO UPDATE SET
+				kind = excluded.kind,
+				enabled = excluded.enabled,
+				config = excluded.config,
+				by_subject = excluded.by_subject,
+				updated = excluded.updated`),
+			f.Tenant, f.Source, f.Kind, f.Enabled, string(f.Config), f.By, now, now)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("pgstore: save feed %s: %w", f.Source, err)
+	}
+	return nil
+}
+
+// DropFeed forgets one feed, and forgets nothing else.
+//
+// There is no reference from document to feed and this statement touches one
+// table, which is the point: the documents that feed indexed are still there
+// afterwards, because forgetting how a corpus was read is not a decision to
+// delete the corpus.
+func (s *Store) DropFeed(ctx context.Context, tenant, source string) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	err := s.retry(ctx, func(ctx context.Context) error {
+		s.counters.statements.Add(1)
+		_, err := s.pool.Exec(ctx, rebind(`DELETE FROM feed WHERE tenant = ? AND source = ?`), tenant, source)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("pgstore: drop feed %s: %w", source, err)
+	}
+	return nil
+}

--- a/store/pgstore/migrations/0005_feed.down.sql
+++ b/store/pgstore/migrations/0005_feed.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE feed;

--- a/store/pgstore/migrations/0005_feed.up.sql
+++ b/store/pgstore/migrations/0005_feed.up.sql
@@ -1,0 +1,45 @@
+-- feed is how the connectors were configured, so that a connector somebody
+-- added from the interface is still there after a restart.
+--
+-- It is the first table in this schema that is not a document or derived from
+-- one, and it is the only one with no reference to document on purpose. A feed
+-- and the documents it produced are joinable by (tenant, source) and are
+-- deliberately not tied together: dropping a feed forgets how a corpus was read
+-- and leaves the corpus, because the alternative makes an operator's undo cost
+-- a full crawl, and on a large source that is hours.
+--
+-- It is also the reason this table exists in the database rather than in a file
+-- next to it. A file works on a laptop and quietly gives three servers behind a
+-- load balancer three different sets of connectors.
+CREATE TABLE feed (
+    tenant     text    NOT NULL,
+    source     text    NOT NULL,
+    kind       text    NOT NULL,
+    enabled    boolean NOT NULL,
+
+    -- The connector's own settings, as JSON this schema never reads. A bucket
+    -- has an endpoint and a region, a directory has a path and a policy, and a
+    -- column per setting would be a migration every time a connector grew a
+    -- field. It is text rather than jsonb for the same reason document_data is:
+    -- it is handed back byte for byte and nothing queries inside it.
+    --
+    -- Credentials are not in here and are not anywhere in this database. A
+    -- database is backed up, replicated and read by more people than a process
+    -- environment is, and a secret that reaches one of those places cannot be
+    -- recalled from it.
+    config     text    NOT NULL,
+
+    -- Who last wrote the row, which is the question that gets asked when two
+    -- operators are changing the same deployment.
+    by_subject text    NOT NULL,
+
+    -- Unix nanoseconds, for the same reason document.modified_at is: a
+    -- timestamptz keeps microseconds, and a time read back out of one does not
+    -- compare equal to the time that went in.
+    created    bigint  NOT NULL,
+    updated    bigint  NOT NULL,
+
+    -- Two tenants may both have a source called files, and one tenant may not
+    -- have two.
+    PRIMARY KEY (tenant, source)
+);

--- a/store/pgstore/pgstore_test.go
+++ b/store/pgstore/pgstore_test.go
@@ -119,6 +119,7 @@ func TestMaintenanceConformance(t *testing.T) {
 	storetest.RunMaintenance(t, newStore)
 	storetest.RunQuarantine(t, newStore)
 	storetest.RunReachable(t, newStore)
+	storetest.RunFeeds(t, newStore)
 }
 
 func TestRetrieverConformance(t *testing.T) {

--- a/store/sqlitestore/feed.go
+++ b/store/sqlitestore/feed.go
@@ -1,0 +1,94 @@
+package sqlitestore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Feeds = (*Store)(nil)
+
+// Feeds returns every configured feed for one tenant.
+//
+// There are as many rows here as somebody has configured connectors, which is
+// tens at the outside, so this reads them all rather than paging. A deployment
+// that needs a page of connectors has a different problem than this method.
+func (s *Store) Feeds(ctx context.Context, tenant string) ([]store.Feed, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.query(ctx, `
+		SELECT source, kind, enabled, config, by_subject, created, updated
+		FROM feed WHERE tenant = ?`, tenant)
+	if err != nil {
+		return nil, fmt.Errorf("sqlitestore: feeds: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []store.Feed
+	for rows.Next() {
+		f := store.Feed{Tenant: tenant}
+		var config string
+		var created, updated int64
+		if err := rows.Scan(&f.Source, &f.Kind, &f.Enabled, &config, &f.By, &created, &updated); err != nil {
+			return nil, fmt.Errorf("sqlitestore: feeds: %w", err)
+		}
+		f.Config = json.RawMessage(config)
+		f.Created = time.Unix(0, created).UTC()
+		f.Updated = time.Unix(0, updated).UTC()
+		out = append(out, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlitestore: feeds: %w", err)
+	}
+	return out, nil
+}
+
+// SaveFeed inserts or replaces one feed.
+func (s *Store) SaveFeed(ctx context.Context, f store.Feed) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if err := f.Check(); err != nil {
+		return fmt.Errorf("sqlitestore: save feed: %w", err)
+	}
+
+	now := time.Now().UTC().UnixNano()
+	// The upsert keeps the row's own age and moves nothing else backwards. It
+	// is one statement rather than a read and a write because two operators
+	// editing the same connector at once would otherwise race for which of
+	// them read the older created, and the answer to that is in the database.
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO feed (tenant, source, kind, enabled, config, by_subject, created, updated)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (tenant, source) DO UPDATE SET
+			kind = excluded.kind,
+			enabled = excluded.enabled,
+			config = excluded.config,
+			by_subject = excluded.by_subject,
+			updated = excluded.updated`,
+		f.Tenant, f.Source, f.Kind, f.Enabled, string(f.Config), f.By, now, now)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: save feed %s: %w", f.Source, err)
+	}
+	return nil
+}
+
+// DropFeed forgets one feed, and forgets nothing else.
+//
+// There is no foreign key from document to feed and this statement touches one
+// table, which is the point: the documents that feed indexed are still there
+// afterwards, because forgetting how a corpus was read is not a decision to
+// delete the corpus.
+func (s *Store) DropFeed(ctx context.Context, tenant, source string) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM feed WHERE tenant = ? AND source = ?`, tenant, source); err != nil {
+		return fmt.Errorf("sqlitestore: drop feed %s: %w", source, err)
+	}
+	return nil
+}

--- a/store/sqlitestore/schema.go
+++ b/store/sqlitestore/schema.go
@@ -232,6 +232,34 @@ var migrations = []step{
 	// partial index it offers one equality column, a source filter beats it on
 	// its own index, and the browse query still gets its ordering for free.
 	ddl(`CREATE INDEX document_recent ON document (tenant, modified_at DESC, id) WHERE queryable = 1`),
+
+	// feed is how the connectors were configured, so that a connector somebody
+	// added from the interface is still there after a restart.
+	//
+	// It is the first table here that is not a document or derived from one,
+	// and it is the only one with no foreign key to document on purpose. A feed
+	// and the documents it produced are joinable by (tenant, source) and are
+	// deliberately not tied together: dropping a feed forgets how a corpus was
+	// read and leaves the corpus, because the alternative makes an operator's
+	// undo cost a full crawl.
+	//
+	// config is JSON the store never reads. A bucket has an endpoint and a
+	// region, a directory has a path and a policy, and a column per setting
+	// would be a migration every time a connector grew a field. Credentials are
+	// not in it and are not anywhere in this database.
+	//
+	// created and updated are unix nanoseconds, the same as modified_at above.
+	ddl(`CREATE TABLE feed (
+		tenant  TEXT    NOT NULL,
+		source  TEXT    NOT NULL,
+		kind    TEXT    NOT NULL,
+		enabled INTEGER NOT NULL,
+		config  TEXT    NOT NULL,
+		by_subject TEXT NOT NULL,
+		created INTEGER NOT NULL,
+		updated INTEGER NOT NULL,
+		PRIMARY KEY (tenant, source)
+	) WITHOUT ROWID`),
 }
 
 // backfill recomputes the ranking statistics for every document already stored.

--- a/store/sqlitestore/sqlitestore_test.go
+++ b/store/sqlitestore/sqlitestore_test.go
@@ -34,6 +34,7 @@ func TestMaintenanceConformance(t *testing.T) {
 	storetest.RunMaintenance(t, newStore)
 	storetest.RunQuarantine(t, newStore)
 	storetest.RunReachable(t, newStore)
+	storetest.RunFeeds(t, newStore)
 }
 
 func TestRetrieverConformance(t *testing.T) {

--- a/store/storetest/feed.go
+++ b/store/storetest/feed.go
@@ -1,0 +1,221 @@
+package storetest
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/store"
+)
+
+// RunFeeds checks a driver's [store.Feeds] against what an operator configuring
+// a connector from the interface relies on.
+//
+// The cases here are all versions of one worry. This is the only thing in the
+// store that is not a document, so it is the only thing a driver can get wrong
+// without a search noticing, and the way somebody finds out is that a connector
+// they configured last month is not running after a restart.
+func RunFeeds(t *testing.T, newStore Factory) {
+	t.Helper()
+	for _, c := range feedCases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newStore(t)
+			t.Cleanup(func() { _ = s.Close() })
+
+			f, ok := s.(store.Feeds)
+			if !ok {
+				t.Skip("this driver does not implement store.Feeds")
+			}
+			c.run(t, s, f)
+		})
+	}
+}
+
+type feedCase struct {
+	name string
+	run  func(t *testing.T, s store.Store, f store.Feeds)
+}
+
+var feedCases = []feedCase{
+	{"a feed comes back the way it went in", testFeedRoundTrip},
+	{"saving again replaces it and keeps its age", testFeedReplace},
+	{"another tenant's feeds are somebody else's", testFeedTenant},
+	{"dropping one leaves the rest alone", testFeedDrop},
+	{"dropping one that was never there is not an error", testFeedDropMissing},
+	{"dropping a feed keeps the documents it indexed", testFeedDropKeepsDocuments},
+	{"a feed with no source is refused", testFeedNeedsSource},
+}
+
+// feed is a saved feed read back by source, and fails the test if it is gone.
+func feed(t *testing.T, f store.Feeds, tenant, source string) store.Feed {
+	t.Helper()
+	list, err := f.Feeds(t.Context(), tenant)
+	if err != nil {
+		t.Fatalf("Feeds: %v", err)
+	}
+	i := slices.IndexFunc(list, func(x store.Feed) bool { return x.Source == source })
+	if i < 0 {
+		t.Fatalf("feed %q is not in %v", source, sources(list))
+	}
+	return list[i]
+}
+
+func sources(list []store.Feed) []string {
+	out := make([]string, 0, len(list))
+	for _, f := range list {
+		out = append(out, f.Source)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func save(t *testing.T, f store.Feeds, in store.Feed) {
+	t.Helper()
+	if err := f.SaveFeed(t.Context(), in); err != nil {
+		t.Fatalf("SaveFeed(%q): %v", in.Source, err)
+	}
+}
+
+func testFeedRoundTrip(t *testing.T, _ store.Store, f store.Feeds) {
+	in := store.Feed{
+		Tenant:  "acme",
+		Source:  "handbook",
+		Kind:    "files",
+		Enabled: true,
+		Config:  json.RawMessage(`{"dir":"/srv/handbook","acl":"owners","watch":true}`),
+		By:      "u_ops",
+	}
+	save(t, f, in)
+
+	got := feed(t, f, "acme", "handbook")
+	if got.Kind != in.Kind || got.Enabled != in.Enabled || got.By != in.By {
+		t.Errorf("saved %+v, read back %+v", in, got)
+	}
+	// Byte for byte, not decoded and compared. The store is told this is opaque
+	// and a driver that reformatted it would be a driver that decides what a
+	// connector's settings mean.
+	if string(got.Config) != string(in.Config) {
+		t.Errorf("config came back as %s, want %s", got.Config, in.Config)
+	}
+	if got.Created.IsZero() || got.Updated.IsZero() {
+		t.Errorf("the driver did not stamp the row: created %v, updated %v", got.Created, got.Updated)
+	}
+	if got.Updated.Before(got.Created) {
+		t.Errorf("updated %v is before created %v", got.Updated, got.Created)
+	}
+}
+
+func testFeedReplace(t *testing.T, _ store.Store, f store.Feeds) {
+	in := store.Feed{Tenant: "acme", Source: "handbook", Kind: "files", Enabled: true, By: "u_ops"}
+	save(t, f, in)
+	first := feed(t, f, "acme", "handbook")
+
+	in.Enabled = false
+	in.By = "u_kenji"
+	in.Config = json.RawMessage(`{"dir":"/srv/handbook"}`)
+	save(t, f, in)
+
+	got := feed(t, f, "acme", "handbook")
+	if got.Enabled {
+		t.Error("the feed was switched off and came back switched on")
+	}
+	if got.By != "u_kenji" {
+		t.Errorf("the row says %q wrote it, want u_kenji", got.By)
+	}
+	// The age of the row does not move when it is edited. An operator reading a
+	// connector that has been failing since it was set up needs to be able to
+	// tell that from one somebody added this morning, and if editing reset this
+	// then every connector would look new.
+	if !got.Created.Equal(first.Created) {
+		t.Errorf("created moved from %v to %v when the feed was edited", first.Created, got.Created)
+	}
+	if got.Updated.Before(first.Updated) {
+		t.Errorf("updated went backwards from %v to %v", first.Updated, got.Updated)
+	}
+	if list, err := f.Feeds(t.Context(), "acme"); err != nil {
+		t.Fatalf("Feeds: %v", err)
+	} else if len(list) != 1 {
+		t.Errorf("saving the same source twice left %v, want one row", sources(list))
+	}
+}
+
+func testFeedTenant(t *testing.T, _ store.Store, f store.Feeds) {
+	save(t, f, store.Feed{Tenant: "acme", Source: "handbook", Kind: "files"})
+	save(t, f, store.Feed{Tenant: "other", Source: "handbook", Kind: "files"})
+
+	// The same source name under two tenants is two connectors, not one. It is
+	// the case a driver keyed on the source alone passes every other test and
+	// fails here, by handing one company's configuration to another.
+	acme, err := f.Feeds(t.Context(), "acme")
+	if err != nil {
+		t.Fatalf("Feeds: %v", err)
+	}
+	if len(acme) != 1 || acme[0].Tenant != "acme" {
+		t.Fatalf("acme sees %+v, want its own one row", acme)
+	}
+	other, err := f.Feeds(t.Context(), "other")
+	if err != nil {
+		t.Fatalf("Feeds: %v", err)
+	}
+	if len(other) != 1 || other[0].Tenant != "other" {
+		t.Fatalf("other sees %+v, want its own one row", other)
+	}
+}
+
+func testFeedDrop(t *testing.T, _ store.Store, f store.Feeds) {
+	save(t, f, store.Feed{Tenant: "acme", Source: "handbook", Kind: "files"})
+	save(t, f, store.Feed{Tenant: "acme", Source: "archive", Kind: "bucket"})
+	save(t, f, store.Feed{Tenant: "other", Source: "handbook", Kind: "files"})
+
+	if err := f.DropFeed(t.Context(), "acme", "handbook"); err != nil {
+		t.Fatalf("DropFeed: %v", err)
+	}
+	list, err := f.Feeds(t.Context(), "acme")
+	if err != nil {
+		t.Fatalf("Feeds: %v", err)
+	}
+	if want := []string{"archive"}; !slices.Equal(sources(list), want) {
+		t.Errorf("acme has %v, want %v", sources(list), want)
+	}
+	// Dropped for one tenant and not for the other, which is the same key
+	// mistake as above seen from the delete side.
+	if list, err := f.Feeds(t.Context(), "other"); err != nil {
+		t.Fatalf("Feeds: %v", err)
+	} else if len(list) != 1 {
+		t.Errorf("dropping acme's handbook left other with %v", sources(list))
+	}
+}
+
+func testFeedDropMissing(t *testing.T, _ store.Store, f store.Feeds) {
+	// Removing a connector twice is the same as removing it once, so that a
+	// retry after a timeout is not an error somebody has to read.
+	if err := f.DropFeed(t.Context(), "acme", "never-configured"); err != nil {
+		t.Errorf("dropping a feed that was never there: %v", err)
+	}
+}
+
+func testFeedDropKeepsDocuments(t *testing.T, s store.Store, f store.Feeds) {
+	// The document and the feed carry the same source, which is the whole point
+	// of the case: these two rows are joinable and a driver that joined them on
+	// delete would pass every other test here.
+	if err := s.Put(t.Context(), document("gdrive:1", readable())); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	save(t, f, store.Feed{Tenant: "acme", Source: "gdrive", Kind: "files"})
+
+	if err := f.DropFeed(t.Context(), "acme", "gdrive"); err != nil {
+		t.Fatalf("DropFeed: %v", err)
+	}
+	// Forgetting how a corpus was read is not a decision to delete the corpus.
+	// A driver that cascaded here would make an operator's undo cost a full
+	// crawl, and on a large source that is hours.
+	if _, err := s.Get(t.Context(), reader(), "gdrive:1"); err != nil {
+		t.Errorf("dropping the feed took its documents with it: %v", err)
+	}
+}
+
+func testFeedNeedsSource(t *testing.T, _ store.Store, f store.Feeds) {
+	if err := f.SaveFeed(t.Context(), store.Feed{Tenant: "acme", Kind: "files"}); err == nil {
+		t.Error("a feed with no source was accepted, so it can be written and never addressed again")
+	}
+}


### PR DESCRIPTION
Closes the first box of #40.

Until now a connector was a flag, so every new source was a deployment and the person who knows which directory should be indexed had to find the person who can restart the process.
This is the other half.
An administrator can add a source, switch it off, switch it back on, ask it for a sync now, and remove it, and none of that touches the command line.

## Where the configuration lives

In the store, not in a file next to it.
A file works on a laptop and quietly gives three servers behind a load balancer three different sets of connectors, which is the sort of thing nobody notices until a search is missing a source on one server out of three.
The key is the tenant and the source name, the settings are an opaque JSON object so a connector growing a field is not a migration, and credentials are not in there at all.
A bucket added this way uses the keys the process already has in its environment, because a database is backed up, replicated and read by more people than a process environment is, and a secret that reaches one of those places cannot be recalled from it.

Removing a connector forgets how a corpus was read and leaves the corpus.
The two are different decisions, and a call that did both would make an operator's undo cost a full crawl, which on a large source is hours.

## Flags and the interface together

They coexist and they are not equal.
A connector named on the command line is on the screen because it is running, and any attempt to change it is refused with a 409 that says where to change it, because the next restart would read the command line again and undo whatever was typed.
A stored connector whose name clashes with a flag one does not start, so two crawlers never write the same document ids from two different directories.

Settings that cannot be run are refused before they are written down, so a directory that is not there is a message about that directory rather than a connector that is accepted and then fails in a log line a minute later.
A start that fails after the write leaves a connector that is configured and not running, which is what the screen says and what somebody can fix, rather than one that is running and gone after a restart.

Sync returns as soon as the run has been asked for.
A crawl of a real source takes minutes and a request that waited for one would time out in the middle of it, so the trigger has room for one waiting run and a second press during a crawl is dropped.

## What is in here

The store side is a new optional capability with a conformance suite that memstore, sqlitestore and pgstore all pass, one sqlite migration and one postgres migration.
A driver that cannot hold connectors is not offered the form: the response says `manageable` false and the endpoints answer 501, because a form whose answers disappear at the next deployment is worse than no form.

| Endpoint | What it does |
| --- | --- |
| `POST /api/v1/admin/connectors` | adds a connector, or replaces one, and starts it |
| `DELETE /api/v1/admin/connectors/{source}` | stops it and forgets how it was configured |
| `POST /api/v1/admin/connectors/{source}/start` | switches one back on |
| `POST /api/v1/admin/connectors/{source}/stop` | switches one off and keeps its settings |
| `POST /api/v1/admin/connectors/{source}/sync` | asks a running connector for a run now |

All five need the `admin` role, the tenant is always the operator's own rather than anything in the body, and every call is logged with the subject.

The screen for this comes next, in a separate change.

## Checks

`go test ./...` including the postgres conformance suite, `golangci-lint run`, and `scripts/ui-gate.sh`.
The only failure is `TestALostRecordMakesTheNextSyncWalk`, which is the watcher flake in #148 and fails on main as well.