### PR TITLE
Add and change connectors from the administration screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,12 @@ The words that were searched for are marked in the body with a count beside them
 The identity switcher at the bottom of the rail sends a different subject, tenant and set of groups with every request.
 It is there because the permission model is the part of this system worth checking by hand, and the fastest way to check it is to run the same query as two different people and watch the results change.
 
+The administration screen reports what every connector is doing, what the corpus holds, which documents are being held back and why, and what one named person can see.
+It is also the one screen that writes: a connector is added, switched off, asked to sync and removed from there, and the change takes effect without a restart.
+A connector that was named on the command line is on that screen because it is running, and says where it is configured rather than offering a button that cannot work.
+
 The whole interface is hand written HTML, CSS and ES modules, committed exactly as they are served, so a clone builds a working interface with the Go toolchain and nothing else.
-There is no bundler and there is not going to be one, since the graph is twenty five modules of our own with no third party dependency anywhere in it.
+There is no bundler and there is not going to be one, since the graph is thirty two modules of our own with no third party dependency anywhere in it.
 What a bundler would have bought is done by the server instead.
 Every file is hashed as it is read and served under a second name that says what is in it, cacheable for a year, and the document is rewritten on the way out so that its import map and its preload list point at those names.
 Bodies are compressed with brotli and gzip once at startup rather than once per request.

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -669,6 +669,91 @@ async function walk(session) {
     })()`,
   );
 
+  // The connector this process was started with cannot be changed from here,
+  // because the next restart would read the command line again and undo it. A
+  // screen that offered the buttons anyway would be offering a refusal.
+  await check(
+    session,
+    "a connector from the command line says where it is configured instead of offering buttons",
+    `(() => {
+      const card = [...document.querySelectorAll('.connector')].find(
+        (c) => c.querySelector('.connector__title').textContent.trim() === 'repo');
+      if (!card) return false;
+      return card.querySelector('.connector__controls') === null &&
+        card.querySelector('.connector__fixed').textContent.includes('command line');
+    })()`,
+  );
+
+  // Adding one. The connector this adds is deliberately switched off and is
+  // removed again below, because the corpus this gate measures is the checkout
+  // itself and a second crawler over it would move every number the rest of the
+  // gate checks.
+  await settle(session, "document.querySelector('#connector-source') !== null");
+  await evaluate(session, "document.querySelector('#connector-source').focus()");
+  await type(session, "walk");
+  await evaluate(session, "document.querySelector('#connector-corpus-dir').value = '/no/such/directory'");
+  await evaluate(session, "document.querySelector('#connector-enabled').checked = false");
+  await evaluate(session, "document.querySelector('.connectors .button--primary').click()");
+  await settle(session, "document.querySelector('.connectors__output--bad') !== null");
+  await check(
+    session,
+    "settings that cannot be run are refused in the server's own words, with the form left as it was",
+    `(() => {
+      const said = document.querySelector('.connectors__output--bad').textContent.trim();
+      return said.length > 0 &&
+        document.querySelector('#connector-source').value === 'walk' &&
+        document.querySelector('#connector-corpus-dir').value === '/no/such/directory';
+    })()`,
+  );
+
+  await evaluate(session, "document.querySelector('#connector-corpus-dir').value = '/tmp'");
+  await evaluate(session, "document.querySelector('.connectors .button--primary').click()");
+  await settle(
+    session,
+    "[...document.querySelectorAll('.connector__title')].some((t) => t.textContent.trim() === 'walk')",
+  );
+  await check(
+    session,
+    "a connector added from the form is on the screen, off because that is what was asked for",
+    `(() => {
+      const card = [...document.querySelectorAll('.connector')].find(
+        (c) => c.querySelector('.connector__title').textContent.trim() === 'walk');
+      const buttons = [...card.querySelectorAll('.connector__controls .button')].map((b) => b.textContent.trim());
+      return card.querySelector('.pill').textContent.trim() === 'Switched off' &&
+        buttons.includes('Start') && buttons.includes('Remove') &&
+        document.querySelector('.connectors__output--good').textContent.includes('walk') &&
+        document.querySelector('#connector-source').value === '';
+    })()`,
+  );
+
+  // Removing forgets how a connector was configured and nothing here can undo
+  // it, so it asks twice. The second question replaces the button the first
+  // press was on, which is what puts a keyboard on it without going looking.
+  await evaluate(session, 'document.querySelector(\'[data-focus-key="remove:walk"]\').focus()');
+  await press(session, "Enter", "Enter", 13);
+  await check(
+    session,
+    "removing asks again, on the button the press was on",
+    `(() => {
+      const now = document.querySelector('[data-focus-key="remove:walk"]');
+      return Boolean(now) && now.textContent.trim() === 'Remove it' && document.activeElement === now;
+    })()`,
+  );
+
+  await press(session, "Enter", "Enter", 13);
+  await settle(
+    session,
+    "[...document.querySelectorAll('.connector__title')].every((t) => t.textContent.trim() !== 'walk')",
+  );
+  await check(
+    session,
+    "a removal is said out loud and the keyboard lands on the line that says it",
+    `(() => {
+      const said = document.querySelector('.connectors__output');
+      return Boolean(said) && said.textContent.includes('walk') && document.activeElement === said;
+    })()`,
+  );
+
   // The access check. The subject to ask about is the gate's own, because it is
   // the only identity in this corpus whose answer is known: it is the one the
   // browser has been searching as all the way down this walk.
@@ -721,6 +806,17 @@ async function walk(session) {
     `document.activeElement === document.querySelector('#access-groups') &&
       document.querySelector('#access-groups').value === 'eng' &&
       document.querySelector('#access-groups').selectionStart === 3`,
+  );
+
+  // The same timer, from outside the screen. A poll that arrived while somebody
+  // was typing the next search would have taken the cursor back to the heading,
+  // which is a screen that fights the person reading it.
+  await evaluate(session, "document.querySelector('.omnibox__input').focus()");
+  await sleep(6000);
+  await check(
+    session,
+    "a repaint on the timer leaves the cursor alone when it is not on this screen",
+    "document.activeElement === document.querySelector('.omnibox__input')",
   );
 
   await evaluate(session, "document.querySelector('.admin .page__back-link').click()");

--- a/web/dist/assets/admin.js
+++ b/web/dist/assets/admin.js
@@ -6,10 +6,10 @@
 // holds, which documents are being held back and why, and what one named person
 // can actually see.
 //
-// Nothing on it writes. That is deliberate for now and it is not a permanent
-// shape: adding and starting connectors from here is the other half of the
-// screen and it is a change to the server as much as to this file, so it is a
-// separate piece of work rather than a button that half exists.
+// Doing something about it is the fifth part and it lives in connectors.js. The
+// two are kept apart because everything on this file is a read that can be
+// repainted whenever an answer arrives, and everything in that one is a write
+// with a form in front of it that must survive the repaint.
 //
 // The one rule this screen keeps that no other screen has to is that the
 // numbers on it have to agree with each other. That is why it is one request:
@@ -23,6 +23,7 @@ import { cache } from "genba/cache.js";
 import { bytes, duration, exact, icon, label, number, when } from "genba/format.js";
 import { failed as failedState } from "genba/states.js";
 import { Access } from "genba/access.js";
+import { Connectors } from "genba/connectors.js";
 
 // REFRESH is how often the screen asks again while somebody is looking at it.
 //
@@ -40,11 +41,39 @@ export class Admin {
     this.data = null;
     this.error = null;
     this.timer = 0;
-    this.title = null;
-    // Built once and reused by every paint, because it holds a form and this
-    // screen repaints itself on a timer. See paint.
+    // Whether this paint is the one that opened the screen. Only that one takes
+    // the focus. See paint.
+    this.opening = false;
+    // The heading is one node for the life of the screen rather than one per
+    // paint, so that the check below for whether the cursor is already on it
+    // still means something after the second paint.
+    this.title = h("h1", { class: "admin__title", tabindex: "-1" }, "Administration");
+    // Both built once and reused by every paint, because they hold forms and
+    // this screen repaints itself on a timer. See paint.
     this.access = new Access();
+    this.writes = new Connectors({ onChanged: (ops) => this.changed(ops) });
     this.el = h("div", { class: "admin" });
+  }
+
+  /**
+   * changed takes what a write answered with and repaints from it.
+   *
+   * The answer is the connector list and nothing else, so it is merged into
+   * what was already on the screen rather than replacing it: the corpus counts
+   * and the quarantine were read a moment ago and are still the best thing this
+   * screen knows. The next poll brings the rest along.
+   *
+   * A null is a change to this screen rather than to the server, such as asking
+   * to confirm a removal, and only needs the paint.
+   */
+  changed(ops) {
+    if (ops && ops.connectors) {
+      this.data = { ...(this.data || {}), connectors: ops.connectors };
+      // Not written to the cache. What is held there is the whole screen as one
+      // entity tag's worth of answer, and half of one written under that tag
+      // would be served on the next visit as though the server had said it.
+    }
+    this.paint();
   }
 
   /** key is the entry this screen paints from, which the offline banner names. */
@@ -62,6 +91,12 @@ export class Admin {
    * in flight, so the numbers land in place rather than after a blank.
    */
   async render() {
+    // The screen is being opened, so the first paint of it takes the focus and
+    // no paint after it does. The ones that follow are a poll on a timer and a
+    // write coming back, and a heading that took the cursor every five seconds
+    // would make the screen unusable from a keyboard and unreadable with a
+    // screen reader.
+    this.opening = true;
     const k = this.key();
     const held = cache.read(k).data || null;
     if (held) {
@@ -121,10 +156,9 @@ export class Admin {
   }
 
   paint() {
-    // Whether anything on this screen already has focus, read before the paint
-    // takes it away. This screen repaints every five seconds on its own, so
-    // pulling focus back to the heading each time would make it impossible to
-    // read the table with a keyboard.
+    // Whether the cursor is on something here, read before the paint takes it
+    // away. The heading is left out because that is where the cursor is put
+    // when the screen opens rather than somewhere anybody chose to be.
     const held = this.el.contains(document.activeElement) && document.activeElement !== this.title;
     // Which element, and where the caret was in it. The access panel below is
     // the same node across repaints, so its contents survive, but a node that
@@ -132,8 +166,12 @@ export class Admin {
     // the caret out of a half typed group name is a form nobody can use.
     const focused = held ? document.activeElement : null;
     const caret = selectionOf(focused);
+    // What the focused thing was, for the controls that are rebuilt on every
+    // paint. A button cannot be put back by holding on to it, because the node
+    // that comes back is a different one, so the ones that matter carry a name
+    // and are found again by it. See regain.
+    const key = (focused && focused.dataset && focused.dataset.focusKey) || "";
 
-    this.title = h("h1", { class: "admin__title", tabindex: "-1" }, "Administration");
     // Nothing arrived and nothing was held, so there is nothing to draw. The
     // three zeroes this screen would otherwise print are not the state of the
     // deployment, they are the state of this browser, and on the one screen
@@ -160,14 +198,39 @@ export class Admin {
       failed ? null : this.banner(),
       failed ? null : this.corpus(data),
       failed ? null : this.connectors(data),
+      failed ? null : this.adder(data),
       failed ? null : this.quarantine(data),
       failed ? null : this.access.el,
     );
-    if (!held) {
+    if (this.opening) {
+      this.opening = false;
       this.title.focus();
       return;
     }
-    if (focused && focused.isConnected) restore(focused, caret);
+    // Focus is somewhere else on the page, such as the search box in the rail,
+    // and this paint was the server answering rather than anything somebody
+    // did. Leave it where it is.
+    if (!held) return;
+    if (focused && focused.isConnected) {
+      restore(focused, caret);
+      return;
+    }
+    if (key) this.regain(key);
+  }
+
+  /**
+   * regain puts focus back on a control that was rebuilt, by name.
+   *
+   * The fallback is what a removal needs. The button that was pressed is gone
+   * along with the connector it was on, and dropping focus to the top of the
+   * document would leave somebody with a keyboard where they started. What it
+   * lands on instead is the line that says the connector was removed.
+   */
+  regain(key) {
+    const back =
+      this.el.querySelector(`[data-focus-key="${CSS.escape(key)}"]`) ||
+      this.el.querySelector("[data-focus-fallback]");
+    if (back) back.focus();
   }
 
   /** retry reads again after a failure, from the button the failure offers. */
@@ -249,16 +312,41 @@ export class Admin {
       "section",
       { class: "panel" },
       h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Connectors")),
+      // What the last write did, above the list it changed. It is the one node
+      // on this screen that does not move when a connector appears or goes
+      // away, which is what makes it the place to say that one did.
+      this.writes.output,
       list.length
-        ? list.map((c) => this.connector(c))
+        ? list.map((c) => this.connector(c, Boolean(data.manageable)))
         : note(
             "This process runs no connectors.",
-            "Its index is filled by something else, so there is nothing to report here.",
+            "Nothing is being indexed here yet.",
           ),
     );
   }
 
-  connector(c) {
+  /**
+   * adder is the form, or the reason there is not one.
+   *
+   * A deployment whose storage driver cannot remember a connector across a
+   * restart gets the sentence rather than the form, because a form whose
+   * answers disappear at the next deployment is worse than no form at all.
+   */
+  adder(data) {
+    if (data.manageable) return this.writes.el;
+    if (!this.data) return null;
+    return h(
+      "section",
+      { class: "panel" },
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Adding a connector")),
+      note(
+        "Connectors are configured where this server is started.",
+        "Either they were named on the command line, or this storage driver cannot remember one across a restart, so there is nothing here that could add one.",
+      ),
+    );
+  }
+
+  connector(c, manageable) {
     const runs = c.runs || [];
     const last = runs[0] || null;
     const failing = Boolean(last && last.error);
@@ -280,15 +368,18 @@ export class Admin {
           ? h("span", { class: "pill pill--busy" }, "Syncing")
           : failing
             ? h("span", { class: "pill pill--bad" }, "Last sync failed")
-            : runs.length
-              ? h("span", { class: "pill pill--good" }, "Healthy")
-              : h("span", { class: "pill" }, "Not run yet"),
+            : !c.enabled
+              ? h("span", { class: "pill" }, "Switched off")
+              : runs.length
+                ? h("span", { class: "pill pill--good" }, "Healthy")
+                : h("span", { class: "pill" }, "Not run yet"),
       ),
       facts([
         ["Reads", c.target],
         ["Tenant", c.tenant],
         ["Refreshes", c.refresh ? `every ${c.refresh}` : "once at startup"],
       ]),
+      manageable ? this.writes.controls(c) : null,
       this.mapping(c.permissions),
       runs.length ? this.runs(runs) : null,
     );

--- a/web/dist/assets/api.js
+++ b/web/dist/assets/api.js
@@ -86,22 +86,57 @@ async function get(path, params, opts = {}) {
   if (opts.etag) sent["If-None-Match"] = opts.etag;
   const res = await fetch(url, { headers: sent, signal: opts.signal });
   if (res.status === 304) return { modified: false, etag: opts.etag };
-  if (!res.ok) {
-    let code = "error";
-    let message = `the server returned ${res.status}`;
-    try {
-      const body = await res.json();
-      if (body && body.error) {
-        code = body.error.code || code;
-        message = body.error.message || message;
-      }
-    } catch {
-      // A response that is not JSON is still a failure, and the status line
-      // above is a better message than a parse error.
-    }
-    throw new ApiError(res.status, code, message, res.headers.get("X-Request-Id") || "");
-  }
+  if (!res.ok) throw await failure(res);
   return { modified: true, etag: res.headers.get("ETag") || "", data: await res.json() };
+}
+
+/**
+ * failure turns a refusal into the error a screen prints.
+ *
+ * The server's own sentence is used wherever there is one, because it is the
+ * only part of this that knows why. A connector that was configured on the
+ * command line comes back from here saying where to change it, and no message
+ * written in this file could have known that.
+ */
+async function failure(res) {
+  let code = "error";
+  let message = `the server returned ${res.status}`;
+  try {
+    const body = await res.json();
+    if (body && body.error) {
+      code = body.error.code || code;
+      message = body.error.message || message;
+    }
+  } catch {
+    // A response that is not JSON is still a failure, and the status line
+    // above is a better message than a parse error.
+  }
+  return new ApiError(res.status, code, message, res.headers.get("X-Request-Id") || "");
+}
+
+/**
+ * send is a write, and returns the state that resulted from it.
+ *
+ * Every one of these endpoints answers with the whole connector list rather
+ * than with an acknowledgement, so a screen paints what is true after the
+ * change instead of guessing and then asking. Nothing here is cached and
+ * nothing here is retried: a retried start is a second crawler.
+ */
+async function send(method, path, body) {
+  const sent = headers();
+  if (body) sent["Content-Type"] = "application/json";
+  const res = await fetch(BASE + path, {
+    method,
+    headers: sent,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw await failure(res);
+  return res.json();
+}
+
+/** connector is one source's path under the administration endpoints. */
+function connector(source, action = "") {
+  return `/admin/connectors/${encodeURIComponent(source)}${action}`;
 }
 
 /**
@@ -203,6 +238,14 @@ export const api = {
   // beside them is two indexed reads, so a screen that wants the check does not
   // wait on the aggregate.
   access: (question, opts) => get("/admin/access", question, opts),
+  // The five writes on the administration screen. The tenant is not sent with
+  // any of them: the server uses the operator's own, so a form cannot be used
+  // to reach into somebody else's corpus.
+  addConnector: (c) => send("POST", "/admin/connectors", c),
+  dropConnector: (source) => send("DELETE", connector(source)),
+  startConnector: (source) => send("POST", connector(source, "/start")),
+  stopConnector: (source) => send("POST", connector(source, "/stop")),
+  syncConnector: (source) => send("POST", connector(source, "/sync")),
   search: (query, opts) => get("/search", query, opts),
   // One request for both halves of the recent screen, because the screen asks
   // both questions at once and a screen that paints in two stages paints twice.

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -3208,6 +3208,190 @@ h6.prose__h {
   line-height: var(--leading-body);
 }
 
+/* Connectors ------------------------------------------------------------- */
+
+/* The write half of the administration screen. It borrows the access panel's
+   measurements on purpose: two forms on one page that size their fields
+   differently read as two applications stitched together. */
+.connectors__lead {
+  max-width: var(--measure);
+  margin-bottom: var(--space-6);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.connectors__fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-5) var(--space-8);
+}
+
+/* The kind's own fields sit under the three that every kind has, so the row
+   that changes when the kind changes is a block rather than a reflow of the
+   whole form. */
+.connectors__form > .connectors__fields + .connectors__fields {
+  margin-top: var(--space-5);
+}
+
+.connectors__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+/* A checkbox is the only field whose label goes beside it rather than above,
+   because the box is the thing being labelled and a label above it would sit
+   over an empty column. */
+.connectors__field--check {
+  justify-content: center;
+}
+
+.connectors__box {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 40px;
+}
+
+.connectors__label {
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-small);
+}
+
+.connectors__input {
+  height: 40px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-control);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--text-body);
+}
+
+.connectors__input:hover {
+  border-color: var(--border-strong);
+}
+
+.connectors__check {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  accent-color: var(--bg-inverse);
+}
+
+.connectors__hint {
+  color: var(--text-muted);
+  font-size: var(--text-caption);
+  line-height: var(--leading-small);
+  overflow-wrap: anywhere;
+}
+
+.connectors__note:empty {
+  display: none;
+}
+
+.connectors__aside {
+  max-width: var(--measure);
+  margin-top: var(--space-5);
+  color: var(--text-muted);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.connectors__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}
+
+/* What the last write did, above the list it changed. It takes focus after a
+   removal, which is why it draws no ring: it is a sentence rather than a
+   control, and the sentence is the point. */
+.connectors__output {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-6);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.connectors__output:empty {
+  display: none;
+}
+
+.connectors__output:focus {
+  outline: none;
+}
+
+.connectors__output--good {
+  color: var(--success-700);
+}
+
+.connectors__output--bad {
+  color: var(--danger-700);
+}
+
+.connectors__output--busy {
+  color: var(--text-muted);
+}
+
+.connector__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
+}
+
+/* Said on the connector rather than only in the panel below, because this is
+   where somebody looks for the button that is not there. */
+.connector__fixed {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-5);
+  color: var(--text-muted);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+/* The whole line, so the warning is beside the button that acts on it rather
+   than in a dialog somebody dismisses without reading. */
+.connector__warn {
+  flex-basis: 100%;
+  max-width: var(--measure);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+/* Smaller than the buttons on the forms, because there are three of them on
+   every connector and a row of full sized ones would outweigh the connector. */
+.button--small {
+  height: 32px;
+  padding: 0 var(--space-4);
+  font-size: var(--text-small);
+}
+
+/* Colour on the confirmation only. The first press opens it and is an ordinary
+   button, because it does nothing on its own. */
+.button--danger {
+  border-color: var(--danger-700);
+  color: var(--danger-700);
+}
+
+.button--danger:hover,
+.button--danger:active {
+  background: var(--danger-700);
+  color: var(--text-inverse);
+}
+
 /* Responsive ------------------------------------------------------------- */
 
 /*

--- a/web/dist/assets/connectors.js
+++ b/web/dist/assets/connectors.js
@@ -1,0 +1,558 @@
+// The half of the administration screen that changes something.
+//
+// Everything else on that screen reports. This adds a connector, switches one
+// on and off, asks for a sync now and forgets one, which between them are the
+// operations that today mean editing a unit file and restarting the server.
+// Doing them here is not a convenience: a restart drops every connector for as
+// long as it takes to come back, so the cost of adding a second directory is
+// paid by the first one.
+//
+// Two rules run through the whole file. The server's own sentence is what gets
+// printed, because the useful half of a refusal is the part this file cannot
+// write: which field is wrong, or that the connector came from the command line
+// and there is a unit file to edit. And every write answers with the connector
+// list that resulted from it, so the screen paints what is true afterwards
+// rather than guessing and then asking.
+
+import { h, replace, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { icon } from "genba/format.js";
+
+// The directory connector's settings, in the order somebody fills them in.
+//
+// These are written out here rather than asked for, because the server has no
+// endpoint that describes its own connectors, and every key in this list is a
+// field the supervisor actually reads. That matters more than it looks: the
+// settings are passed through untouched, so a key invented in this file would
+// be accepted by the decoder, ignored by the connector, and never mentioned
+// again by anybody.
+const CORPUS = [
+  {
+    key: "dir",
+    name: "Directory",
+    hint: "An absolute path on the server, not on the machine this browser is on",
+  },
+  {
+    key: "acl",
+    name: "Who may read it",
+    type: "choice",
+    choices: [
+      ["tenant", "Everybody in the tenant"],
+      ["owners", "Whoever the OWNERS files name"],
+      ["os", "Whoever the file permissions allow"],
+    ],
+    hint: "The tenant rule is the right one for documentation everybody may read",
+  },
+  {
+    key: "identity",
+    name: "Identity source",
+    hint: "Which directory the account names on those files belong to, such as unix. The file permissions rule needs one",
+  },
+  {
+    key: "domain",
+    name: "Domain",
+    hint: "The domain a world readable file grants to. Empty leaves it granting nothing",
+  },
+  {
+    key: "refresh",
+    name: "Sync every",
+    hint: "Like 30s or 5m. Empty syncs once, when it starts",
+  },
+  {
+    key: "reconcile",
+    name: "Sweep every",
+    hint: "How often to count the index against the tree. Empty sweeps after every sync",
+  },
+  {
+    key: "watch",
+    name: "Watch for changes",
+    type: "check",
+    hint: "Ask the operating system what moved instead of walking the tree. Needs a sync interval to be any use",
+  },
+];
+
+// The object storage connector's settings.
+const BUCKET = [
+  { key: "bucket", name: "Bucket", hint: "The bucket to read" },
+  {
+    key: "endpoint",
+    name: "Endpoint",
+    hint: "Where the request goes, like https://s3.eu-west-1.amazonaws.com",
+  },
+  { key: "region", name: "Region", hint: "Part of what the signature covers. Empty means us-east-1" },
+  { key: "prefix", name: "Prefix", hint: "Narrows the listing to one part of the bucket" },
+  {
+    key: "acl",
+    name: "Who may read it",
+    type: "choice",
+    choices: [
+      ["tenant", "Everybody in the tenant"],
+      ["bucket", "Whoever the bucket policy names"],
+      ["object", "Whoever each object's own policy names"],
+    ],
+    hint: "The object rule reads one policy per object, which on a large bucket is the slowest thing this server does",
+  },
+  {
+    key: "identity",
+    name: "Identity source",
+    hint: "Which directory the names in those policies belong to. The bucket and object rules need one",
+  },
+  {
+    key: "domain",
+    name: "Domain",
+    hint: "The mail domain that counts as this tenant. Empty leaves every grant written as an address foreign",
+  },
+  {
+    key: "path_style",
+    name: "Bucket in the path",
+    type: "check",
+    hint: "What MinIO and Ceph need, and what S3 itself does not",
+  },
+  { key: "refresh", name: "Sync every", hint: "Like 5m or 1h. Empty lists once, when it starts" },
+  {
+    key: "reconcile",
+    name: "Sweep every",
+    hint: "How often to count the index against the bucket. Empty sweeps after every sync",
+  },
+  {
+    key: "rate",
+    name: "Requests a second",
+    type: "number",
+    hint: "The ceiling the crawl keeps itself under. Empty takes a cautious default",
+  },
+  {
+    key: "burst",
+    name: "Burst",
+    type: "number",
+    hint: "How many requests may go out back to back before the rate binds",
+  },
+  {
+    key: "retries",
+    name: "Retries",
+    type: "number",
+    hint: "How many times a refused request is tried again before the sync gives up on it",
+  },
+];
+
+const KINDS = [
+  { value: "corpus", name: "Directory", fields: CORPUS },
+  {
+    value: "bucket",
+    name: "Object storage",
+    fields: BUCKET,
+    // Said on the screen because somebody looking for a field to type a secret
+    // into needs to be told there is not one, rather than left to conclude the
+    // form is unfinished.
+    note: "The keys come from the environment this server was started in, so a bucket added here is read with the credentials it already holds. Nothing typed on this screen is stored as a secret.",
+  },
+];
+
+export class Connectors {
+  /**
+   * onChanged is called after every write with the list that came back, or
+   * with null for a change that was only to this screen, such as asking to
+   * confirm a removal. The screen around this one repaints from it.
+   */
+  constructor({ onChanged }) {
+    this.onChanged = onChanged;
+    this.kind = KINDS[0].value;
+
+    // Which source is being changed, or "form" for the one being added. A name
+    // rather than a flag, because the line that reports it says which connector
+    // is changing, and because a second press has to be dropped for that one
+    // write rather than for the whole screen.
+    this.busy = "";
+    this.error = null;
+    this.said = "";
+
+    // The source whose removal has been asked for once. Removing forgets how a
+    // connector was configured, which nothing here can undo, so it is asked
+    // twice. The confirmation replaces the button that opened it, which means a
+    // keyboard lands on it without having to go looking.
+    this.confirming = "";
+
+    // Every field ever built, by kind and key, so that switching from one kind
+    // to the other and back does not empty what was typed into it.
+    this.made = new Map();
+
+    // The nodes that outlive a paint. The screen around this repaints itself
+    // every five seconds, and a form rebuilt on that timer would be a form that
+    // empties itself while somebody is filling it in.
+    this.el = h("section", { class: "panel connectors" });
+    this.fields = h("div", { class: "connectors__fields" });
+    this.aside = h("div", { class: "connectors__note" });
+    this.output = h("p", {
+      class: "connectors__output",
+      role: "status",
+      "aria-live": "polite",
+      tabindex: "-1",
+      "data-focus-fallback": "",
+    });
+
+    const form = this.build();
+    replace(
+      this.el,
+      h(
+        "div",
+        { class: "panel__head" },
+        h("h2", { class: "panel__title" }, "Add a connector"),
+        h("span", { class: "panel__note" }, "Takes effect without a restart"),
+      ),
+      h(
+        "p",
+        { class: "connectors__lead" },
+        "It is remembered across restarts, and starts crawling as soon as it is added unless the box says otherwise.",
+      ),
+      form,
+    );
+    this.fill();
+    this.say();
+  }
+
+  /** build is the form, made once and kept. */
+  build() {
+    const form = h("form", {
+      class: "connectors__form",
+      onSubmit: (e) => {
+        e.preventDefault();
+        this.add();
+      },
+    });
+
+    this.source = field({
+      key: "source",
+      name: "Name",
+      hint: "What the documents are filed under, like handbook. An existing name replaces that connector",
+    });
+    this.picker = h(
+      "select",
+      {
+        class: "connectors__input",
+        id: "connector-kind",
+        onChange: (e) => {
+          this.kind = e.target.value;
+          this.fill();
+        },
+      },
+      KINDS.map((k) => h("option", { value: k.value }, k.name)),
+    );
+    this.enabled = field({
+      key: "enabled",
+      name: "Start it now",
+      type: "check",
+      hint: "Leave it off to add the settings and start it later",
+    });
+    this.enabled.input.checked = true;
+    const submit = h("button", { class: "button button--primary", type: "submit" }, "Add connector");
+
+    replace(
+      form,
+      h(
+        "div",
+        { class: "connectors__fields" },
+        this.source.el,
+        wrap("Kind", "connector-kind", "What sort of source it is", this.picker),
+        this.enabled.el,
+      ),
+      this.fields,
+      this.aside,
+      h("div", { class: "connectors__actions" }, submit),
+    );
+    return form;
+  }
+
+  /** fill paints the fields the chosen kind needs, keeping what was typed. */
+  fill() {
+    const kind = this.chosen();
+    replace(this.fields, ...kind.fields.map((spec) => this.field(kind.value, spec).el));
+    replace(this.aside, kind.note ? h("p", { class: "connectors__aside" }, kind.note) : null);
+  }
+
+  chosen() {
+    return KINDS.find((k) => k.value === this.kind) || KINDS[0];
+  }
+
+  /** field is one setting's input, built the first time it is asked for. */
+  field(kind, spec) {
+    const id = `connector-${kind}-${spec.key}`;
+    let made = this.made.get(id);
+    if (!made) {
+      made = field({ ...spec, id });
+      this.made.set(id, made);
+    }
+    return made;
+  }
+
+  /**
+   * config reads the fields into the settings the connector is given.
+   *
+   * An empty field is left out rather than sent as an empty string, because the
+   * server reads absent as take the default and a form that sent every key
+   * would be a form that overwrote a region with nothing.
+   */
+  config() {
+    const kind = this.chosen();
+    const out = {};
+    for (const spec of kind.fields) {
+      const { input } = this.field(kind.value, spec);
+      if (spec.type === "check") {
+        if (input.checked) out[spec.key] = true;
+        continue;
+      }
+      const value = input.value.trim();
+      if (!value) continue;
+      out[spec.key] = spec.type === "number" ? Number(value) : value;
+    }
+    return out;
+  }
+
+  /** add sends the form. */
+  async add() {
+    const source = this.source.input.value.trim();
+    if (!source) {
+      this.error = new Error("Name the connector.");
+      this.said = "";
+      this.say();
+      this.source.input.focus();
+      return;
+    }
+    const body = {
+      source,
+      kind: this.kind,
+      enabled: this.enabled.input.checked,
+      config: this.config(),
+    };
+    const ok = await this.write("form", () => api.addConnector(body), `${source} was added.`);
+    // Cleared only on the way through, so that a refusal leaves every field
+    // where it was and the one that is wrong can be corrected rather than typed
+    // again.
+    if (ok) this.clear();
+  }
+
+  /**
+   * clear empties the form after a connector was added.
+   *
+   * The kind and the start box are left where they were, because adding a
+   * second directory after a first one is the common thing to do and both of
+   * those are on the screen where somebody can see what they are set to. Focus
+   * goes back to the name, which is where the next one starts.
+   */
+  clear() {
+    this.source.input.value = "";
+    for (const { input } of this.made.values()) {
+      if (input.type === "checkbox") input.checked = false;
+      else if (input.tagName === "SELECT") input.selectedIndex = 0;
+      else input.value = "";
+    }
+    this.source.input.focus();
+  }
+
+  sync(source) {
+    return this.write(source, () => api.syncConnector(source), `${source} was asked to sync.`);
+  }
+
+  start(source) {
+    return this.write(source, () => api.startConnector(source), `${source} was started.`);
+  }
+
+  stop(source) {
+    return this.write(source, () => api.stopConnector(source), `${source} was stopped.`);
+  }
+
+  remove(source) {
+    return this.write(source, () => api.dropConnector(source), `${source} was removed.`);
+  }
+
+  /**
+   * write does one change and hands the result to the screen.
+   *
+   * Nothing is retried and nothing is sent twice. A retried start is a second
+   * crawler against the same source, writing the same document ids from the
+   * same tree, and the index is then whichever of the two finished last. That
+   * is also why a second press while one is in flight is dropped here rather
+   * than by disabling the button: a disabled button loses focus, and a keyboard
+   * that pressed Sync would be thrown back to the top of the page for it.
+   */
+  async write(about, run, said) {
+    if (this.busy) return false;
+    this.busy = about;
+    this.error = null;
+    this.said = "";
+    this.confirming = "";
+    this.say();
+
+    let result = null;
+    try {
+      result = await run();
+      this.said = said;
+    } catch (err) {
+      this.error = err;
+    }
+    this.busy = "";
+    this.say();
+    this.onChanged(result);
+    return !this.error;
+  }
+
+  /**
+   * say prints the outcome of the last write, wherever it came from.
+   *
+   * One place for all of them, rather than a message beside each button. It is
+   * the only spot on the screen that does not move when a connector is added or
+   * removed, which is what makes it the right place to say that one was, and it
+   * is what a screen reader announces without anybody having to go and look.
+   */
+  say() {
+    if (this.error) {
+      replace(
+        this.output,
+        svg(icon("alert"), 16),
+        // The server's sentence, which for a connector configured on the
+        // command line says where to change it instead, and for settings that
+        // cannot be run names the field.
+        this.error.message,
+      );
+      this.output.className = "connectors__output connectors__output--bad";
+      return;
+    }
+    if (this.busy) {
+      replace(this.output, this.busy === "form" ? "Adding it." : `Changing ${this.busy}.`);
+      this.output.className = "connectors__output connectors__output--busy";
+      return;
+    }
+    if (this.said) {
+      replace(this.output, svg(icon("check"), 16), this.said);
+      this.output.className = "connectors__output connectors__output--good";
+      return;
+    }
+    replace(this.output);
+    this.output.className = "connectors__output";
+  }
+
+  /**
+   * controls are the buttons on one connector.
+   *
+   * They carry a key that survives the repaint, because this screen redraws
+   * itself every five seconds and these are rebuilt each time. Without one, a
+   * keyboard would be thrown back to the top of the page twice a minute, and
+   * pressing Remove would lose the confirmation it just opened.
+   */
+  controls(c) {
+    const source = c.source || "";
+    if (!c.managed) {
+      return h(
+        "p",
+        { class: "connector__fixed" },
+        svg(icon("lock"), 16),
+        "Configured on the command line, so it is changed where this server is started.",
+      );
+    }
+    const confirming = this.confirming === source;
+    return h(
+      "div",
+      { class: "connector__controls" },
+      c.enabled
+        ? [
+            action("Sync now", `sync:${source}`, () => this.sync(source)),
+            action("Stop", `stop:${source}`, () => this.stop(source)),
+          ]
+        : action("Start", `start:${source}`, () => this.start(source)),
+      confirming
+        ? action("Remove it", `remove:${source}`, () => this.remove(source), "button--danger")
+        : action("Remove", `remove:${source}`, () => this.ask(source)),
+      confirming ? action("Keep it", `keep:${source}`, () => this.ask("")) : null,
+      confirming
+        ? h(
+            "p",
+            { class: "connector__warn" },
+            "This forgets how it was configured. The documents it indexed stay where they are.",
+          )
+        : null,
+    );
+  }
+
+  /** ask opens or closes the confirmation on one connector's removal. */
+  ask(source) {
+    this.confirming = source;
+    this.onChanged(null);
+  }
+}
+
+/**
+ * field is one labelled control, returned with the control so it can be read.
+ *
+ * Three shapes rather than three functions, because the label, the hint and the
+ * identifier that ties them together are the same in all of them, and a hint
+ * that is a label's sibling in one and a fieldset's child in another is two
+ * things to get right in the accessibility tree instead of one.
+ */
+function field(spec) {
+  const id = spec.id || `connector-${spec.key}`;
+  const hint = `${id}-hint`;
+  if (spec.type === "check") {
+    const input = h("input", { class: "connectors__check", id, type: "checkbox", "aria-describedby": hint });
+    return {
+      input,
+      el: h(
+        "div",
+        { class: "connectors__field connectors__field--check" },
+        h("span", { class: "connectors__box" }, input, h("label", { class: "connectors__label", for: id }, spec.name)),
+        h("span", { class: "connectors__hint", id: hint }, spec.hint),
+      ),
+    };
+  }
+  if (spec.type === "choice") {
+    const input = h(
+      "select",
+      { class: "connectors__input", id, "aria-describedby": hint },
+      spec.choices.map(([value, name]) => h("option", { value }, name)),
+    );
+    return { input, el: labelled(spec, id, hint, input) };
+  }
+  const input = h("input", {
+    class: "connectors__input",
+    id,
+    type: spec.type === "number" ? "number" : "text",
+    autocomplete: "off",
+    spellcheck: "false",
+    "aria-describedby": hint,
+  });
+  return { input, el: labelled(spec, id, hint, input) };
+}
+
+function labelled(spec, id, hint, input) {
+  return h(
+    "div",
+    { class: "connectors__field" },
+    h("label", { class: "connectors__label", for: id }, spec.name),
+    input,
+    h("span", { class: "connectors__hint", id: hint }, spec.hint),
+  );
+}
+
+/** wrap puts a label and a hint around a control that was built elsewhere. */
+function wrap(name, id, hint, control) {
+  const described = `${id}-hint`;
+  control.setAttribute("aria-describedby", described);
+  return labelled({ name, hint }, id, described, control);
+}
+
+/**
+ * action is one button on one connector.
+ *
+ * The key is what the screen puts focus back on after it repaints, and it names
+ * the connector as well as the verb because two connectors have a Stop button
+ * each and focus belongs on the one it was on.
+ */
+function action(name, key, onClick, extra = "") {
+  return h(
+    "button",
+    {
+      class: extra ? `button button--small ${extra}` : "button button--small",
+      type: "button",
+      dataset: { focusKey: key },
+      onClick,
+    },
+    name,
+  );
+}

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -30,6 +30,7 @@
           "genba/app.js": "/assets/app.js",
           "genba/cache.js": "/assets/cache.js",
           "genba/clipboard.js": "/assets/clipboard.js",
+          "genba/connectors.js": "/assets/connectors.js",
           "genba/content.js": "/assets/content.js",
           "genba/dom.js": "/assets/dom.js",
           "genba/drawer.js": "/assets/drawer.js",
@@ -71,6 +72,7 @@
     <link rel="modulepreload" href="/assets/app.js" />
     <link rel="modulepreload" href="/assets/cache.js" />
     <link rel="modulepreload" href="/assets/clipboard.js" />
+    <link rel="modulepreload" href="/assets/connectors.js" />
     <link rel="modulepreload" href="/assets/content.js" />
     <link rel="modulepreload" href="/assets/dom.js" />
     <link rel="modulepreload" href="/assets/drawer.js" />


### PR DESCRIPTION
Part of #40.

Adding a second directory to a running server meant editing a unit file and restarting.
A restart drops every connector for as long as it takes to come back, so the cost of adding the second one is paid by the first.
The administration screen now adds a connector, switches one on and off, asks for a sync now and forgets one, which between them are the four operations that needed the restart.

## What is on the screen

The connectors panel gains a form and each card gains its controls.

The form is written out in the interface rather than described by the server.
The settings are handed to the connector untouched, so a key invented here would be accepted by the decoder, ignored by the connector, and never mentioned again.
There is one set of fields for a directory and one for object storage, and the screen swaps between them when the kind changes.
Object storage says out loud that the keys come from the environment the server was started in.

A connector that came from the command line says where it is configured instead of showing buttons that would fail.
A connector that is switched off says so on the card, and offers Start rather than Stop.
Removing asks a second time, on the button the press was on.

## What it says when it goes wrong

The server's own sentence is what gets printed.
The useful half of a refusal is the part this code cannot write: which field is wrong, or that there is a unit file to edit.
On a refusal the form is left exactly as it was, so the fix is one field away rather than a retype.

Every write answers with the connector list that resulted from it, so the screen paints what is true afterwards rather than guessing and then asking.
That answer is merged into what is on screen and deliberately not written to the cache, because the cache entry stands for a whole admin response under one entity tag.

## Keyboard and focus

The outcome of every write goes to one live region at the top of the list.
It is the only node on the screen that does not move when a connector appears or goes away, and it gives a removal somewhere to put the keyboard.

Buttons are never disabled while a write is in flight.
A disabled button cannot hold focus, so the repaint that follows the write would drop the keyboard to the body.
A guard on the write does that job instead.

This also fixes a focus theft that predates the change.
The screen rebuilt its heading on every paint and pulled the keyboard to it, including on the five second poll, so a cursor anywhere else in the page was taken away every five seconds.
The heading is now a stable node and only takes focus when the screen opens.

## Checks

Seven new keyboard walk checks cover the work: a command line connector offering no buttons, a refusal printed in the server's words with the form left as it was, an added connector on screen and switched off, the good message naming it, the emptied name field, the two step removal with focus landing on the line that announces it, and the timer leaving the cursor alone from another screen.

The full UI gate passes on a real Chrome: keyboard walk, render check, state check, budget check, latency report, axe over twelve URLs with no violations, and Lighthouse at accessibility 99 and best practices 100.
Transfer is 128294 bytes of gzipped JavaScript against a budget of 184320 and 24624 bytes of CSS against 40960.