### PR TITLE
Keep the cursor on administration once its answer lands

### DIFF
--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -622,6 +622,15 @@ async function walk(session) {
   );
 
   await settle(session, "document.querySelectorAll('.admin .stat__value').length >= 2");
+  // The screen opens on a held copy and repaints when the server answers, which
+  // is a fifth of a second later and is where the cursor used to be dropped.
+  // The check above ran in that window and passed, so this is the same claim
+  // made after the answer has landed rather than before it.
+  await check(
+    session,
+    "the answer landing leaves the cursor where opening the screen put it",
+    "document.activeElement === document.querySelector('.admin__title')",
+  );
   await check(
     session,
     "the corpus is reported as what is servable and what is held back",

--- a/web/dist/assets/admin.js
+++ b/web/dist/assets/admin.js
@@ -157,9 +157,13 @@ export class Admin {
 
   paint() {
     // Whether the cursor is on something here, read before the paint takes it
-    // away. The heading is left out because that is where the cursor is put
-    // when the screen opens rather than somewhere anybody chose to be.
-    const held = this.el.contains(document.activeElement) && document.activeElement !== this.title;
+    // away. The heading counts. It is not somewhere anybody chose to be, it is
+    // where this screen puts the cursor when it opens, and the first thing that
+    // happens after it opens is the server answering and this painting again.
+    // Leaving the heading out of this dropped the cursor to the document a
+    // fifth of a second after landing, so a keyboard arriving on the screen was
+    // put back at the top of the page without having pressed anything.
+    const held = this.el.contains(document.activeElement);
     // Which element, and where the caret was in it. The access panel below is
     // the same node across repaints, so its contents survive, but a node that
     // is detached and reattached loses focus and a five second timer that takes


### PR DESCRIPTION
Opening administration from the rail puts the cursor on the heading, and a fifth of a second later the screen repaints with the answer from the server. The repaint was dropping the cursor to the document body, so a keyboard that had just arrived on the screen was put back at the top of the page without having pressed anything. It is only visible from a keyboard or a screen reader.

The repaint already reads where the cursor is before it paints and puts it back afterwards. It was leaving the heading out of that, on the grounds that the heading is not somewhere anybody chose to be. That holds for the poll on the timer and it does not hold for the first repaint after opening, which is the server answering while the cursor is still where the screen put it a moment earlier. The heading is the same node across repaints, so it is detached and reattached, and a detached node loses focus.

The walk was asserting this in the window before the answer landed, which is the window where it was already true. It now asserts it again after the answer has landed, which is the check that fails on the code before this change.

Verified on the gate machine by driving the screen and reading the active element every half second for four seconds after opening it. Before: the heading for the first sample and the body for every one after it. After: the heading for all eight.

Closes #154