### PR TITLE
Show who vouched for a document and when that stops counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Everything the interface does is an HTTP call, and there is nothing it can reach
 | `GET /api/v1/search` | ranked hits, facet counts, the total and the server side timing |
 | `GET /api/v1/suggest` | operator completions and documents matching a prefix |
 | `GET /api/v1/documents/{id}` | one document, or the same error as one that does not exist |
+| `POST /api/v1/documents/{id}/verify` | records that the caller vouches for a document, with an optional note and expiry |
+| `DELETE /api/v1/documents/{id}/verify` | withdraws the claim |
 | `GET /api/v1/me` | the caller, and the sources and kinds that caller can actually see |
 | `GET /api/v1/stats` | how much is indexed and how much is quarantined |
 | `GET /api/v1/admin/operations` | what the connectors are doing, and what is being held back and why |
@@ -144,6 +146,10 @@ Everything the interface does is an HTTP call, and there is nothing it can reach
 
 `search` takes `q` for the text and the operators, and `source`, `kind`, `container`, `author` and `owner` as repeated or comma separated parameters, plus `since`, `until`, `sort`, `limit` and `offset`.
 The snippet comes back as marked passages rather than as offsets, so a client highlights what the analyzer matched without reimplementing the analyzer.
+
+A verification is a named claim with a date on it rather than a flag, so search results and the document itself carry who vouched for it, when, and when that stops counting.
+It lasts six months unless the verifier says otherwise, and only the owner or the author of a document can make one, because a badge anybody can apply is a badge that means somebody read the title.
+A driver that cannot record one leaves the badge off rather than failing the search behind it.
 
 Every `admin` endpoint needs the `admin` role, which comes from `X-Genba-Roles` or from `GENBA_ADMINS`, and the default is that nobody has it.
 The role grants nothing over documents and it must not start to.

--- a/api/api.go
+++ b/api/api.go
@@ -223,6 +223,8 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("GET /api/v1/search", s.authenticated(s.handleSearch))
 	mux.Handle("GET /api/v1/suggest", s.authenticated(s.handleSuggest))
 	mux.Handle("GET /api/v1/documents/{id}", s.authenticated(s.handleDocument))
+	mux.Handle("POST /api/v1/documents/{id}/verify", s.authenticated(s.handleVerify))
+	mux.Handle("DELETE /api/v1/documents/{id}/verify", s.authenticated(s.handleUnverify))
 	mux.Handle("GET /api/v1/documents/{id}/content", s.authenticated(s.handleContent))
 	mux.Handle("GET /api/v1/documents/{id}/thumbnail", s.authenticated(s.handleThumbnail))
 	mux.Handle("GET /api/v1/recent", s.authenticated(s.handleRecent))
@@ -413,6 +415,12 @@ type searchHit struct {
 	// search of its own and highlighting the wrong halves of words.
 	Passages []passage `json:"passages,omitempty"`
 	Score    float64   `json:"score"`
+
+	// Verified is who vouched for this document and until when, and is absent
+	// when nobody has. It is on the row rather than only in the preview because
+	// the whole value of the signal is that it is visible while somebody is
+	// choosing which of ten results to open.
+	Verified *verification `json:"verified,omitempty"`
 }
 
 type passage struct {
@@ -478,9 +486,17 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 		Answer:     answerOf(res.Answer),
 		Correction: res.Correction,
 	}
+	ids := make([]string, 0, len(res.Hits))
+	for _, h := range res.Hits {
+		ids = append(ids, h.Document.ID)
+	}
+	// One question for the whole page rather than one per row, and the badges
+	// are left off rather than the search failing when it cannot be answered.
+	vouched, now := s.verifications(r, p, ids), s.now()
 	for _, h := range res.Hits {
 		hit := hitOf(h.Document)
 		hit.Snippet, hit.Passages, hit.Score = h.Snippet, passages(h.Passages), h.Score
+		hit.Verified = verifiedOf(vouched[h.Document.ID], now)
 		out.Hits = append(out.Hits, hit)
 	}
 	writeConditional(w, r, http.StatusOK, out, out.identity())
@@ -773,7 +789,21 @@ func (s *Server) handleDocument(w http.ResponseWriter, r *http.Request, p *acl.P
 		writeError(w, http.StatusInternalServerError, "internal", "the document could not be read")
 		return
 	}
-	writeConditional(w, r, http.StatusOK, documentResponse(d), nil)
+	body := documentResponse(d)
+	// The preview is where somebody decides whether to trust what they are
+	// reading, so it carries the claim and whether this reader is one of the
+	// people who could make one. Both come from the same request, because a
+	// second one to find out whether to draw a button is a second round trip
+	// before the panel can be painted.
+	if v, ok := s.verifier(); ok {
+		body.CanVerify = store.MayVerify(p, d)
+		if got, err := v.Verifications(r.Context(), p, []string{d.ID}); err != nil {
+			s.log.Error("verifications could not be read", "error", err, "document", d.ID)
+		} else {
+			body.Verified = verifiedOf(got[d.ID], s.now())
+		}
+	}
+	writeConditional(w, r, http.StatusOK, body, nil)
 }
 
 type documentBody struct {
@@ -792,6 +822,14 @@ type documentBody struct {
 	Container  string            `json:"container,omitempty"`
 	ModifiedAt time.Time         `json:"modified_at,omitzero"`
 	Properties map[string]string `json:"properties,omitempty"`
+
+	// Verified is who vouched for this document and until when, absent when
+	// nobody has, and CanVerify says whether this reader is one of the people
+	// who could. Both are absent on a deployment whose driver cannot remember a
+	// claim, which is what makes the interface leave the whole thing out rather
+	// than offer a button that fails.
+	Verified  *verification `json:"verified,omitempty"`
+	CanVerify bool          `json:"can_verify,omitempty"`
 }
 
 // documentResponse is where the wire shape is decided. Permissions are not part

--- a/api/recent.go
+++ b/api/recent.go
@@ -114,6 +114,19 @@ func (s *Server) handleRecent(w http.ResponseWriter, r *http.Request, p *acl.Pri
 	for _, d := range changed {
 		out.Changed = append(out.Changed, hitOf(d))
 	}
+
+	// One question for both halves, because they are one screen. A badge that
+	// showed up in results and not here would read as a bug in the badge rather
+	// than as two endpoints that were written a week apart.
+	if vouched := s.verifications(r, p, recentIDs(out)); len(vouched) > 0 {
+		now := s.now()
+		for i := range out.Opened {
+			out.Opened[i].Verified = verifiedOf(vouched[out.Opened[i].ID], now)
+		}
+		for i := range out.Changed {
+			out.Changed[i].Verified = verifiedOf(vouched[out.Changed[i].ID], now)
+		}
+	}
 	writeConditional(w, r, http.StatusOK, out, out.identity())
 }
 
@@ -143,6 +156,22 @@ func (s *Server) handleRecordOpen(w http.ResponseWriter, r *http.Request, p *acl
 		}
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// recentIDs is every document on the screen, in one slice.
+//
+// A document that is in both halves is in here twice, which costs a repeated id
+// in one query and saves the caller a set. The two lists are twenty rows each
+// and the driver answers on a primary key.
+func recentIDs(out recentResponse) []string {
+	ids := make([]string, 0, len(out.Opened)+len(out.Changed))
+	for _, h := range out.Opened {
+		ids = append(ids, h.ID)
+	}
+	for _, h := range out.Changed {
+		ids = append(ids, h.ID)
+	}
+	return ids
 }
 
 // hitOf is the wire shape of a document on its own, with no search behind it.

--- a/api/verify.go
+++ b/api/verify.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// verifyBodyLimit is how large a verification request may be.
+//
+// Four kilobytes, which is a note, an expiry and nothing else. The note exists
+// for the sentence a badge cannot express, not for a second copy of the
+// document.
+const verifyBodyLimit = 4 << 10
+
+// verification is the wire shape of a claim somebody made about a document.
+//
+// The state is computed here rather than in the browser. It is derived from a
+// date, a cadence and a window, and a client that worked any of the three out
+// for itself would be a second place the policy lives, drawing an amber badge a
+// fortnight after the server thinks it should be red.
+type verification struct {
+	// State is fresh, expiring or expired. It is the only field the interface
+	// needs to decide how the badge looks.
+	State string `json:"state"`
+
+	// By is who put their name to it, and Email is how to reach them, which is
+	// the whole point of a signal that is a person rather than a flag.
+	By    string `json:"by"`
+	Email string `json:"email,omitempty"`
+
+	At    time.Time `json:"at"`
+	Until time.Time `json:"until"`
+
+	// Note is why, in the verifier's own words, and is usually empty.
+	Note string `json:"note,omitempty"`
+}
+
+// verifyRequest is a claim as it arrives from the interface.
+//
+// It carries no verifier and no date. Both are facts the server records rather
+// than claims the caller gets to make, and a request that could set them would
+// be a request that could put somebody else's name on a badge.
+type verifyRequest struct {
+	// Note is the sentence that goes with the claim.
+	Note string `json:"note,omitempty"`
+
+	// Days is how long the claim should last, and is [store.Cadence] when it is
+	// absent or not positive. A verifier who knows their document changes weekly
+	// says so, and everybody else gets the default.
+	Days int `json:"days,omitempty"`
+}
+
+// verifiedOf turns what the driver holds into what the wire carries.
+func verifiedOf(v store.Verification, now time.Time) *verification {
+	if v.Zero() {
+		return nil
+	}
+	return &verification{
+		State: string(v.State(now)),
+		By:    v.By.Name,
+		Email: v.By.Email,
+		At:    v.At,
+		Until: v.Until,
+		Note:  v.Note,
+	}
+}
+
+// verifier returns the driver's verification capability, and reports whether
+// this deployment has one at all.
+func (s *Server) verifier() (store.Verifier, bool) {
+	v, ok := s.store.(store.Verifier)
+	return v, ok
+}
+
+// verifications reads the claims on a page of documents.
+//
+// It is one call for the whole page and it is best effort: a driver that cannot
+// answer leaves the badges off rather than failing the search behind them. A
+// page of twenty results is not worth a five hundred because the table that
+// decorates it is unavailable, and the reader loses a badge rather than the
+// answer they asked for.
+func (s *Server) verifications(r *http.Request, p *acl.Principal, ids []string) map[string]store.Verification {
+	v, ok := s.verifier()
+	if !ok || len(ids) == 0 {
+		return nil
+	}
+	got, err := v.Verifications(r.Context(), p, ids)
+	if err != nil {
+		s.log.Error("verifications could not be read", "error", err, "tenant", p.Tenant)
+		return nil
+	}
+	return got
+}
+
+// handleVerify records that the caller vouches for a document.
+//
+// The three refusals are told apart on purpose here, unlike the ones around
+// reading a document. A caller who may not see the document gets the same not
+// found the document itself would give them, which keeps the endpoint from
+// being a way to ask whether an id exists. A caller who can see it but is not
+// its owner gets a forbidden, because at that point they already know the
+// document is there and the useful answer is why they cannot do this.
+func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	v, ok := s.verifier()
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "unsupported", "this deployment cannot record who verified a document")
+		return
+	}
+
+	var body verifyRequest
+	if r.ContentLength != 0 {
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, verifyBodyLimit)).Decode(&body); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "the body must be a JSON object with an optional note and number of days")
+			return
+		}
+	}
+
+	d, ok := s.verifiable(w, r, p)
+	if !ok {
+		return
+	}
+
+	now := s.now()
+	until := now.Add(store.Cadence)
+	if body.Days > 0 {
+		until = now.AddDate(0, 0, body.Days)
+	}
+	claim := store.Verification{
+		Doc:   d.ID,
+		By:    who(p, d),
+		At:    now,
+		Until: until,
+		Note:  body.Note,
+	}
+	s.log.Info("document verified", "subject", p.Subject, "tenant", p.Tenant, "document", d.ID, "until", until)
+	if err := v.Verify(r.Context(), p, claim); err != nil {
+		s.log.Error("verify failed", "error", err, "document", d.ID)
+		writeError(w, http.StatusInternalServerError, "internal", "the verification could not be recorded")
+		return
+	}
+	writeJSON(w, http.StatusOK, verifiedOf(claim, now))
+}
+
+// handleUnverify withdraws the claim.
+func (s *Server) handleUnverify(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	v, ok := s.verifier()
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "unsupported", "this deployment cannot record who verified a document")
+		return
+	}
+	d, ok := s.verifiable(w, r, p)
+	if !ok {
+		return
+	}
+	s.log.Info("verification withdrawn", "subject", p.Subject, "tenant", p.Tenant, "document", d.ID)
+	if err := v.Unverify(r.Context(), p, d.ID); err != nil {
+		s.log.Error("unverify failed", "error", err, "document", d.ID)
+		writeError(w, http.StatusInternalServerError, "internal", "the verification could not be withdrawn")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// verifiable reads the document named in the path and checks that this caller is
+// allowed to make a claim about it, writing the refusal itself when they are
+// not.
+func (s *Server) verifiable(w http.ResponseWriter, r *http.Request, p *acl.Principal) (doc.Document, bool) {
+	d, err := s.store.Get(r.Context(), p, r.PathValue("id"))
+	switch {
+	case errors.Is(err, genba.ErrNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "no such document")
+		return doc.Document{}, false
+	case err != nil:
+		s.log.Error("document lookup failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal", "the document could not be read")
+		return doc.Document{}, false
+	case !store.MayVerify(p, d):
+		writeError(w, http.StatusForbidden, "forbidden",
+			"only the owner or the author of a document can say it is current, and an administrator can do it for them")
+		return doc.Document{}, false
+	}
+	return d, true
+}
+
+// who is the principal as the person a badge names.
+//
+// The document is consulted first, because a principal is a subject and a list
+// of identities and none of that is a name anybody recognises, while the owner
+// and the author fields on the document carry the name the source knows the
+// person by. Somebody verifying a document they own therefore gets their real
+// name on the badge without this package having to learn about a directory.
+//
+// Failing that it is the first identity, and failing that the subject. A badge
+// that says u-4181 vouched for this is a poor badge and it is still one
+// somebody can chase down, which is more than an empty one gives them.
+func who(p *acl.Principal, d doc.Document) doc.Person {
+	for _, known := range []doc.Person{d.Owner, d.Author} {
+		if known.Name != "" && store.IsPerson(p, known) {
+			known.Subject = p.Subject
+			return known
+		}
+	}
+	person := doc.Person{Subject: p.Subject, Name: p.Subject}
+	for _, id := range p.Identities {
+		if id.Value == "" {
+			continue
+		}
+		person.Email, person.Name = id.Value, id.Value
+		break
+	}
+	return person
+}

--- a/api/verify_test.go
+++ b/api/verify_test.go
@@ -1,0 +1,289 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// Saying that a document is current.
+//
+// The endpoint is small and the two rules it enforces are not. Only somebody
+// who owns or wrote the document may put their name to it, because a badge
+// anybody can apply is a badge that means somebody read the title. And a person
+// who cannot see the document is told nothing at all, because a refusal that
+// distinguishes forbidden from missing is a way to ask whether a document
+// exists.
+
+// clock is a fixed time, so that an expiry computed from it is the expiry the
+// test asked for rather than whatever the machine managed between two calls.
+func clock() time.Time { return time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC) }
+
+// newVerifyServer holds one document owned by the engineer and one owned by
+// somebody else, both readable by the same group.
+//
+// The second one is the interesting case: being able to read a document is not
+// the same as being able to vouch for it, and this is the pair that tells the
+// two apart.
+func newVerifyServer(t *testing.T) http.Handler {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	perm := acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "gdrive",
+		AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}},
+		Version:     1,
+	}
+	docs := []doc.Document{
+		{
+			ID: "mine", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Payments failover runbook", Body: "Fail the payments queue over to the replica.",
+			Owner:       doc.Person{Name: "Mei Tanaka", Email: "mei@acme.com"},
+			Permissions: perm,
+		},
+		{
+			ID: "theirs", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Payments retention policy", Body: "Payments records are kept for seven years.",
+			Owner:       doc.Person{Name: "Kenji Sato", Email: "kenji@acme.com"},
+			Permissions: perm,
+		},
+	}
+	if err := st.Put(t.Context(), docs...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}, api.WithClock(clock))
+	return s.Handler()
+}
+
+// owner is the engineer, with the identity that makes them the owner of the
+// first document. It is the same person as engineer(), told apart by the
+// identity header rather than by the subject, because that is how a connector
+// names an owner it could not resolve to a subject.
+func owner() map[string]string {
+	return map[string]string{
+		api.HeaderSubject:    "u_mei",
+		api.HeaderGroups:     "gdrive:eng@acme.com",
+		api.HeaderIdentities: "gdrive:mei@acme.com",
+	}
+}
+
+func TestVerifyingPutsANameAndADateOnTheDocument(t *testing.T) {
+	h := newVerifyServer(t)
+
+	w := post(t, h, http.MethodPost, "/api/v1/documents/mine/verify", `{"note":"checked after the failover"}`, owner())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var made struct {
+		State string    `json:"state"`
+		By    string    `json:"by"`
+		Email string    `json:"email"`
+		At    time.Time `json:"at"`
+		Until time.Time `json:"until"`
+		Note  string    `json:"note"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &made); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// The name comes off the document rather than out of the principal, because
+	// a subject is not a name anybody recognises and the owner field already
+	// carries the one the source knows them by.
+	if made.By != "Mei Tanaka" {
+		t.Errorf("the badge names %q, and the document says the owner is Mei Tanaka", made.By)
+	}
+	if made.Email != "mei@acme.com" {
+		t.Errorf("the badge has no way to reach the verifier: %q", made.Email)
+	}
+	if made.State != "fresh" {
+		t.Errorf("a claim made a moment ago is %q", made.State)
+	}
+	if !made.At.Equal(clock()) {
+		t.Errorf("verified at %v, and the request was made at %v", made.At, clock())
+	}
+	if want := clock().Add(180 * 24 * time.Hour); !made.Until.Equal(want) {
+		t.Errorf("expires at %v, and the default cadence puts it at %v", made.Until, want)
+	}
+	if made.Note != "checked after the failover" {
+		t.Errorf("the note came back as %q", made.Note)
+	}
+}
+
+// Reading a document is not the same as being able to vouch for it, and the
+// difference has to be a refusal rather than a quietly ignored write.
+func TestOnlyTheOwnerOrTheAuthorCanVerify(t *testing.T) {
+	h := newVerifyServer(t)
+
+	w := post(t, h, http.MethodPost, "/api/v1/documents/theirs/verify", "", owner())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+	// The refusal says which rule was hit, because the caller can already see
+	// the document and the useful half of the answer is what to do about it.
+	if body := w.Body.String(); !strings.Contains(body, "owner") {
+		t.Errorf("the refusal does not say why: %s", body)
+	}
+}
+
+// A person who cannot see the document is told the same thing they would be
+// told if it were not there. Anything else is a way to ask whether an id is
+// real.
+func TestVerifyingSomethingYouCannotSeeIsANotFound(t *testing.T) {
+	h := newVerifyServer(t)
+
+	seen := post(t, h, http.MethodPost, "/api/v1/documents/mine/verify", "", salesperson())
+	missing := post(t, h, http.MethodPost, "/api/v1/documents/nothing/verify", "", salesperson())
+	if seen.Code != http.StatusNotFound || missing.Code != http.StatusNotFound {
+		t.Fatalf("a hidden document answered %d and a missing one answered %d, and both should be 404",
+			seen.Code, missing.Code)
+	}
+	if seen.Body.String() != missing.Body.String() {
+		t.Errorf("the two answers differ, which is enough to tell that mine exists:\n%s\n%s",
+			seen.Body.String(), missing.Body.String())
+	}
+}
+
+// The badge is on the result row, not only in the preview, because the whole
+// value of the signal is that it is visible while somebody is choosing which of
+// ten results to open.
+func TestAVerifiedDocumentIsMarkedInTheResults(t *testing.T) {
+	h := newVerifyServer(t)
+	if w := post(t, h, http.MethodPost, "/api/v1/documents/mine/verify", "", owner()); w.Code != http.StatusOK {
+		t.Fatalf("verify: %d %s", w.Code, w.Body.String())
+	}
+
+	w := request(t, h, http.MethodGet, "/api/v1/search?q=payments", owner())
+	if w.Code != http.StatusOK {
+		t.Fatalf("search: %d", w.Code)
+	}
+	var res struct {
+		Hits []struct {
+			ID       string `json:"id"`
+			Verified *struct {
+				State string `json:"state"`
+				By    string `json:"by"`
+			} `json:"verified"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(res.Hits) != 2 {
+		t.Fatalf("the query matched %d documents, and two of them say payments", len(res.Hits))
+	}
+	for _, hit := range res.Hits {
+		switch {
+		case hit.ID == "mine" && hit.Verified == nil:
+			t.Errorf("the verified document came back with no badge on it")
+		case hit.ID == "mine" && hit.Verified.By != "Mei Tanaka":
+			t.Errorf("the badge names %q", hit.Verified.By)
+		case hit.ID == "theirs" && hit.Verified != nil:
+			t.Errorf("a document nobody verified came back with a badge on it")
+		}
+	}
+}
+
+// A claim is a fact about a document, so knowing that anyone made one is
+// knowing the document is there.
+func TestAVerificationIsNotVisibleAcrossAPermission(t *testing.T) {
+	h := newVerifyServer(t)
+	if w := post(t, h, http.MethodPost, "/api/v1/documents/mine/verify", "", owner()); w.Code != http.StatusOK {
+		t.Fatalf("verify: %d %s", w.Code, w.Body.String())
+	}
+
+	w := request(t, h, http.MethodGet, "/api/v1/documents/mine", salesperson())
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+// The preview is where somebody decides whether to trust what they are reading,
+// so it carries the claim and whether this reader could make one, in the same
+// response. A second request to find out whether to draw a button is a second
+// round trip before the panel can be painted.
+func TestThePreviewSaysWhoVouchedAndWhetherYouCan(t *testing.T) {
+	h := newVerifyServer(t)
+	if w := post(t, h, http.MethodPost, "/api/v1/documents/mine/verify", "", owner()); w.Code != http.StatusOK {
+		t.Fatalf("verify: %d %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Verified *struct {
+			State string `json:"state"`
+		} `json:"verified"`
+		CanVerify bool `json:"can_verify"`
+	}
+	w := request(t, h, http.MethodGet, "/api/v1/documents/mine", owner())
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Verified == nil || body.Verified.State != "fresh" {
+		t.Errorf("the preview of a verified document says %+v", body.Verified)
+	}
+	if !body.CanVerify {
+		t.Errorf("the owner is not offered the button on their own document")
+	}
+
+	// A fresh value, because the field is left out when it is false and
+	// unmarshalling into the previous one would keep the answer to the last
+	// question.
+	body.CanVerify, body.Verified = false, nil
+	w = request(t, h, http.MethodGet, "/api/v1/documents/theirs", owner())
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.CanVerify {
+		t.Errorf("a reader who is not the owner is offered a button that would be refused")
+	}
+}
+
+func TestWithdrawingAClaimTakesTheBadgeOff(t *testing.T) {
+	h := newVerifyServer(t)
+	if w := post(t, h, http.MethodPost, "/api/v1/documents/mine/verify", "", owner()); w.Code != http.StatusOK {
+		t.Fatalf("verify: %d %s", w.Code, w.Body.String())
+	}
+
+	if w := post(t, h, http.MethodDelete, "/api/v1/documents/mine/verify", "", owner()); w.Code != http.StatusNoContent {
+		t.Fatalf("unverify: %d %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Verified *struct{} `json:"verified"`
+	}
+	w := request(t, h, http.MethodGet, "/api/v1/documents/mine", owner())
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Verified != nil {
+		t.Errorf("the claim was withdrawn and the preview still has a badge on it")
+	}
+}
+
+// A verifier who knows their document changes weekly says so, and everybody
+// else gets the default.
+func TestAVerifierCanSayHowLongTheClaimLasts(t *testing.T) {
+	h := newVerifyServer(t)
+
+	w := post(t, h, http.MethodPost, "/api/v1/documents/mine/verify", `{"days":7}`, owner())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	var made struct {
+		Until time.Time `json:"until"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &made); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if want := clock().AddDate(0, 0, 7); !made.Until.Equal(want) {
+		t.Errorf("expires at %v, and seven days from the request is %v", made.Until, want)
+	}
+}

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -134,6 +134,39 @@ async function walk(session) {
     })()`,
   );
 
+  // The gate put a claim on the first result before the browser started, so the
+  // badge is on the row rather than only in the preview. That is the whole
+  // point of the signal: it is read while somebody is choosing which of ten
+  // results to open, not after they have opened one.
+  await check(
+    session,
+    "a verified result carries the badge on the row",
+    `(() => {
+      const badge = document.querySelector('.result .verified');
+      return Boolean(badge) && badge.classList.contains('verified--fresh') &&
+        badge.textContent.trim() === 'Verified' && (badge.title || '').includes('Current until');
+    })()`,
+  );
+
+  // The other two states, asked of the function, because a corpus read minutes
+  // ago holds nothing that has run out and a badge nobody can produce is a
+  // badge nobody checks. An expired claim has to read as expired: the shape it
+  // would ship in otherwise is a green tick on a document last looked at in
+  // 2023.
+  await check(
+    session,
+    "a claim that has run out reads as run out rather than as a tick",
+    `import('genba/verify.js').then(({ badge }) => {
+      const made = (state) =>
+        badge({ state, by: 'Mei Tanaka', at: '2026-01-01T00:00:00Z', until: '2026-02-01T00:00:00Z' });
+      return made('fresh').textContent === 'Verified' &&
+        made('expiring').textContent.startsWith('Verified, expires') &&
+        made('expired').textContent.startsWith('Verification expired') &&
+        made('expired').classList.contains('verified--expired') &&
+        badge(null) === null && badge({}) === null;
+    })`,
+  );
+
   await press(session, "j", "KeyJ", 74);
   await check(
     session,
@@ -167,6 +200,18 @@ async function walk(session) {
     "beside a visible list the preview does not claim to be modal",
     `window.innerWidth > 720 &&
       document.querySelector('.drawer').getAttribute('aria-modal') === 'false'`,
+  );
+
+  // The preview is where somebody decides whether to trust what they are
+  // reading, so the claim is in the header with a name on it rather than in the
+  // tooltip it carries on a row.
+  await check(
+    session,
+    "the preview names the person who vouched for the document",
+    `(() => {
+      const badge = document.querySelector('.drawer__meta .verified');
+      return Boolean(badge) && badge.textContent.includes('Verified by');
+    })()`,
   );
 
   // The words that were searched for, in the document that came back. This
@@ -302,6 +347,67 @@ async function walk(session) {
       if (!u.pathname.startsWith('/d/')) return true;
       return [...new URLSearchParams(u.search).keys()].every((k) => k === 'q');
     })`,
+  );
+
+  // Verification, from the screen it is decided on. The two writes are here
+  // rather than only in the API tests because what they have to leave alone is
+  // the document underneath them: a page opened at line four hundred that jumps
+  // back to the top because somebody put their name to it is a page nobody
+  // verifies twice.
+  // The note is put on the claim here rather than only by the shell that starts
+  // the server, because the two writes below leave a claim with no note on it,
+  // which is what the button sends. Without this the walk passes once against a
+  // server and fails on the second run against the same one, and a check that
+  // depends on how many times it has been run is a check nobody trusts.
+  await evaluate(
+    session,
+    `import('genba/api.js').then(({ api }) =>
+      api.verify(decodeURIComponent(location.pathname.slice(3)), {
+        note: 'checked against the current deployment',
+      }))`,
+  );
+  await visit(session, BASE + id, "Boolean(document.querySelector('.page__meta .verified'))");
+
+  await check(
+    session,
+    "the document page says who vouched for it and until when",
+    `(() => {
+      const badge = document.querySelector('.page__meta .verified');
+      return Boolean(badge) && badge.classList.contains('verified--fresh') &&
+        badge.textContent.includes('Verified by') && (badge.title || '').includes('Current until');
+    })()`,
+  );
+  await check(
+    session,
+    "the verifier's own sentence is on the page and not only in a tooltip",
+    `(document.querySelector('.verified__note') || {}).textContent === 'checked against the current deployment'`,
+  );
+
+  // A mark on a node the body already had, so that the claim below can be about
+  // this element surviving rather than about the page looking similar.
+  await evaluate(session, "document.querySelector('.page__body > *').dataset.walk = 'kept'");
+  await evaluate(session, foot("Withdraw") + ".click()");
+  await check(
+    session,
+    "withdrawing takes the badge off and leaves the document where it was",
+    `!document.querySelector('.page__meta .verified') &&
+      Boolean(document.querySelector('.page__body [data-walk="kept"]'))`,
+  );
+  await check(
+    session,
+    "the button offers the write that is now available",
+    `Boolean(${foot("Verify")}) && !${foot("Withdraw")}`,
+  );
+
+  await evaluate(session, foot("Verify") + ".click()");
+  await check(
+    session,
+    "verifying again puts the badge back, from this screen, with no reload",
+    `(() => {
+      const badge = document.querySelector('.page__meta .verified');
+      return Boolean(badge) && badge.classList.contains('verified--fresh') &&
+        Boolean(document.querySelector('.page__body [data-walk="kept"]'));
+    })()`,
   );
 
   // The keyboard on its own. Everything above uses it in passing; this is the
@@ -1035,4 +1141,16 @@ async function walk(session) {
     "at 390 pixels the preview covers the list and says it is modal",
     "document.querySelector('.drawer').getAttribute('aria-modal') === 'true'",
   );
+}
+
+/**
+ * foot is an expression naming one button under a document, by the words on it.
+ *
+ * By the words rather than by a class, because the words are what somebody
+ * reading the screen has to press, and a button whose label stopped matching
+ * what it does is exactly the thing this walk is for.
+ */
+function foot(words) {
+  return `[...document.querySelectorAll('.page__foot .button')]
+    .find((b) => b.textContent.trim() === ${JSON.stringify(words)})`;
 }

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -178,6 +178,23 @@ fi
 # encoder rather than into the string.
 ID=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$ID")
 
+# One verified document, so that the badge is on a screen the audit looks at.
+# Nothing in a file corpus is verified by itself and a state nobody produces is
+# a state nobody checks, which is how the expired badge would ship drawn in a
+# colour that fails contrast and read out as nothing at all.
+#
+# dev is the subject the interface sends by default and the administrator this
+# server was started with, so it is the one identity that may vouch for a
+# document the file connector found no owner for.
+curl -fsS -o /dev/null -X POST "$BASE/api/v1/documents/$ID/verify" \
+	-H "X-Genba-Tenant: $TENANT" \
+	-H "X-Genba-Subject: dev" \
+	-H "Content-Type: application/json" \
+	-d '{"note":"checked against the current deployment"}' || {
+	echo "ui-gate: the document could not be verified, so the badge would be on no screen this audits" >&2
+	exit 1
+}
+
 status=0
 
 # The walk runs first and needs nothing downloaded, so it still reports on a

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -41,6 +41,12 @@ type Store struct {
 	// opens is what each person has been reading, keyed by tenant and subject.
 	opens map[[2]string]*opened
 
+	// verified is who vouched for what, keyed by document id. The tenant is not
+	// in the key because the document id already carries it here, and the read
+	// goes through the document anyway so that a claim cannot outlive the
+	// permission to see what it is about.
+	verified map[string]store.Verification
+
 	// feeds is how the connectors were configured, keyed by tenant and source.
 	// It is in memory like everything else here, so a restart forgets it, which
 	// is the documented behaviour of this driver rather than an oversight.
@@ -52,10 +58,11 @@ type Store struct {
 // New returns an empty store.
 func New() *Store {
 	return &Store{
-		docs:    make(map[string]doc.Document),
-		content: make(map[string]doc.Content),
-		opens:   make(map[[2]string]*opened),
-		feeds:   make(map[[2]string]store.Feed),
+		docs:     make(map[string]doc.Document),
+		content:  make(map[string]doc.Content),
+		opens:    make(map[[2]string]*opened),
+		feeds:    make(map[[2]string]store.Feed),
+		verified: make(map[string]store.Verification),
 	}
 }
 
@@ -67,6 +74,7 @@ var (
 	_ store.Quarantine   = (*Store)(nil)
 	_ store.Access       = (*Store)(nil)
 	_ store.Feeds        = (*Store)(nil)
+	_ store.Verifier     = (*Store)(nil)
 )
 
 // Put inserts or replaces documents.
@@ -137,6 +145,7 @@ func (s *Store) remove(ids []string) (map[string][]string, error) {
 		}
 		delete(s.docs, id)
 		delete(s.content, id)
+		delete(s.verified, id)
 	}
 	return removed, nil
 }

--- a/store/memstore/verify.go
+++ b/store/memstore/verify.go
@@ -1,0 +1,93 @@
+package memstore
+
+import (
+	"context"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Verifier = (*Store)(nil)
+
+// Verify records that somebody vouches for a document.
+func (s *Store) Verify(ctx context.Context, p *acl.Principal, v store.Verification) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	if err := v.Check(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return genba.ErrClosed
+	}
+	// Same rule as recording an open: a document this principal cannot see is a
+	// write that does not happen rather than an error naming the id.
+	d, ok := s.docs[v.Doc]
+	if !ok || !visible(p, d) {
+		return nil
+	}
+	s.verified[v.Doc] = v
+	return nil
+}
+
+// Unverify withdraws the claim.
+func (s *Store) Unverify(ctx context.Context, p *acl.Principal, id string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return genba.ErrClosed
+	}
+	d, ok := s.docs[id]
+	if !ok || !visible(p, d) {
+		return nil
+	}
+	delete(s.verified, id)
+	return nil
+}
+
+// Verifications returns the claims on the documents the principal may read.
+func (s *Store) Verifications(ctx context.Context, p *acl.Principal, ids []string) (map[string]store.Verification, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, genba.ErrClosed
+	}
+
+	var out map[string]store.Verification
+	for _, id := range ids {
+		v, ok := s.verified[id]
+		if !ok {
+			continue
+		}
+		d, ok := s.docs[id]
+		if !ok || !visible(p, d) {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]store.Verification, len(ids))
+		}
+		out[id] = v
+	}
+	return out, nil
+}

--- a/store/pgstore/migrations/0006_document_verify.down.sql
+++ b/store/pgstore/migrations/0006_document_verify.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE document_verify;

--- a/store/pgstore/migrations/0006_document_verify.up.sql
+++ b/store/pgstore/migrations/0006_document_verify.up.sql
@@ -1,0 +1,51 @@
+-- document_verify is who vouched for a document and until when.
+--
+-- One row per document rather than a history, because what a reader needs is
+-- the current claim, and reconstructing it from a log would mean reading every
+-- line ever written about the document to draw one badge. Who verified what and
+-- when is the audit log's question, and it is a different table with a
+-- different retention.
+--
+-- The verifier is denormalised into three columns rather than referencing a
+-- person, because there is no person table here: a subject is whatever the
+-- identity provider called them, and the name on the badge is the name at the
+-- moment the claim was made. A claim that silently changes whose name is on it
+-- when somebody's profile is updated is not the same claim.
+--
+-- The cascade is what keeps it honest. A document that leaves the corpus takes
+-- its verification with it, so this table cannot hold an id that nothing else
+-- in the database knows about, and re-crawling a document that was deleted
+-- brings back the document without bringing back a claim nobody made about the
+-- new version. A document that is merely rewritten by a crawl keeps its row,
+-- because a write is an upsert on the same id rather than a delete and an
+-- insert.
+CREATE TABLE document_verify (
+    doc_id      text   PRIMARY KEY REFERENCES document(id) ON DELETE CASCADE,
+
+    -- Who made the claim, carried whole so that a badge has a name on it
+    -- without a second lookup. A badge that says u-4181 vouched for this is
+    -- worse than no badge, because the point of the signal is that a reader
+    -- recognises the name.
+    by_subject  text   NOT NULL,
+    by_name     text   NOT NULL,
+    by_email    text   NOT NULL,
+
+    -- Unix nanoseconds, for the same reason document.modified_at is: a
+    -- timestamptz keeps microseconds, and a time read back out of one does not
+    -- compare equal to the time that went in.
+    --
+    -- expires_at is stored rather than derived from verified_at plus a cadence,
+    -- because the cadence is a policy that will change and a document verified
+    -- under the old one should keep the expiry it was given.
+    verified_at bigint NOT NULL,
+    expires_at  bigint NOT NULL,
+
+    -- Why, in the verifier's own words, and usually empty. It is here for the
+    -- case the badge cannot express: verified except for the section about the
+    -- old cluster, which is the sentence that saves the next reader an hour.
+    note        text   NOT NULL
+);
+
+-- The queue of what is about to go stale is a walk down this index, and it is
+-- the only read of this table that is not keyed by document.
+CREATE INDEX document_verify_expiry ON document_verify (expires_at);

--- a/store/pgstore/verify.go
+++ b/store/pgstore/verify.go
@@ -1,0 +1,138 @@
+package pgstore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Verifier = (*Store)(nil)
+
+// Verify records that somebody vouches for a document.
+//
+// The insert selects from document with the visibility predicate on it, exactly
+// as recording an open does, so a claim about something this principal may not
+// read inserts no rows. One statement rather than a read, a decision in Go and
+// a write, which is also the only form of this that cannot race.
+//
+// It does not take the write lock the ingestion path holds. Verifying is not
+// part of the corpus bookkeeping, and somebody putting their name to a runbook
+// while a crawl is running should not be waiting for the crawl.
+func (s *Store) Verify(ctx context.Context, p *acl.Principal, v store.Verification) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	if err := v.Check(); err != nil {
+		return fmt.Errorf("pgstore: verify: %w", err)
+	}
+
+	c := visible(p)
+	args := append(
+		[]any{v.By.Subject, v.By.Name, v.By.Email, v.At.UnixNano(), v.Until.UnixNano(), v.Note, v.Doc},
+		c.args...,
+	)
+	err := s.retry(ctx, func(ctx context.Context) error {
+		s.counters.statements.Add(1)
+		_, err := s.pool.Exec(ctx, rebind(`
+			INSERT INTO document_verify (doc_id, by_subject, by_name, by_email, verified_at, expires_at, note)
+			SELECT d.id, ?, ?, ?, ?, ?, ? FROM document d WHERE d.id = ? AND `+c.where()+`
+			ON CONFLICT (doc_id) DO UPDATE SET
+				by_subject  = excluded.by_subject,
+				by_name     = excluded.by_name,
+				by_email    = excluded.by_email,
+				verified_at = excluded.verified_at,
+				expires_at  = excluded.expires_at,
+				note        = excluded.note`), args...)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("pgstore: verify: %w", err)
+	}
+	return nil
+}
+
+// Unverify withdraws the claim.
+func (s *Store) Unverify(ctx context.Context, p *acl.Principal, id string) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+
+	c := visible(p)
+	args := append([]any{id}, c.args...)
+	err := s.retry(ctx, func(ctx context.Context) error {
+		s.counters.statements.Add(1)
+		_, err := s.pool.Exec(ctx, rebind(`
+			DELETE FROM document_verify v
+			WHERE v.doc_id IN (SELECT d.id FROM document d WHERE d.id = ? AND `+c.where()+`)`), args...)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("pgstore: unverify: %w", err)
+	}
+	return nil
+}
+
+// Verifications returns the claims on the documents the principal may read.
+//
+// One statement for the whole page. The ids go in as a bound text array rather
+// than as a list of placeholders, which is what the filters in query.go do, and
+// it means a page of twenty and a page of two hundred prepare the same
+// statement.
+func (s *Store) Verifications(ctx context.Context, p *acl.Principal, ids []string) (map[string]store.Verification, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	c := visible(p)
+	args := append([]any{ids}, c.args...)
+
+	var out map[string]store.Verification
+	err := s.retry(ctx, func(ctx context.Context) error {
+		out = nil
+		rows, err := s.query(ctx, `
+			SELECT v.doc_id, v.by_subject, v.by_name, v.by_email, v.verified_at, v.expires_at, v.note
+			FROM document_verify v
+			JOIN document d ON d.id = v.doc_id
+			WHERE v.doc_id = ANY(?) AND `+c.where(), args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var (
+				v                store.Verification
+				verified, expiry int64
+			)
+			if err := rows.Scan(&v.Doc, &v.By.Subject, &v.By.Name, &v.By.Email, &verified, &expiry, &v.Note); err != nil {
+				return err
+			}
+			s.counters.rows.Add(1)
+			v.At, v.Until = unixNano(verified), unixNano(expiry)
+			if out == nil {
+				out = make(map[string]store.Verification, len(ids))
+			}
+			out[v.Doc] = v
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: verifications: %w", err)
+	}
+	return out, nil
+}

--- a/store/sqlitestore/schema.go
+++ b/store/sqlitestore/schema.go
@@ -260,6 +260,36 @@ var migrations = []step{
 		updated INTEGER NOT NULL,
 		PRIMARY KEY (tenant, source)
 	) WITHOUT ROWID`),
+
+	// document_verify is who vouched for a document and until when.
+	//
+	// One row per document rather than a history, because what a reader needs is
+	// the current claim and reconstructing it from a log would mean reading every
+	// line ever written about the document to draw one badge. Who verified what
+	// and when is the audit log's question, and it is a different table with a
+	// different retention.
+	//
+	// The verifier is denormalised into three columns rather than joined to a
+	// person, because there is no person table: a subject is whatever the
+	// identity provider called them and the name on the badge is the name at the
+	// moment the claim was made. A claim that silently changes whose name is on
+	// it when somebody's profile is updated is not the same claim.
+	//
+	// The cascade is what keeps it honest. A document that leaves the corpus
+	// takes its verification with it, so this table cannot hold an id nothing
+	// else in the database knows about, and re-crawling a document that was
+	// deleted brings back the document without bringing back a claim nobody made
+	// about the new version.
+	ddl(`CREATE TABLE document_verify (
+		doc_id      TEXT PRIMARY KEY REFERENCES document(id) ON DELETE CASCADE,
+		by_subject  TEXT    NOT NULL,
+		by_name     TEXT    NOT NULL,
+		by_email    TEXT    NOT NULL,
+		verified_at INTEGER NOT NULL,
+		expires_at  INTEGER NOT NULL,
+		note        TEXT    NOT NULL
+	) WITHOUT ROWID`),
+	ddl(`CREATE INDEX document_verify_expiry ON document_verify (expires_at)`),
 }
 
 // backfill recomputes the ranking statistics for every document already stored.

--- a/store/sqlitestore/verify.go
+++ b/store/sqlitestore/verify.go
@@ -77,6 +77,17 @@ func (s *Store) Unverify(ctx context.Context, p *acl.Principal, id string) error
 // than expanded into a list of placeholders, which is what the filters in
 // query.go do, and it means a page of twenty and a page of two hundred prepare
 // the same statement.
+//
+// The join order is pinned, which is what CROSS JOIN means to SQLite and is the
+// whole performance of this. The visibility clause carries correlated
+// subqueries and is cheap over a match set and ruinous over a corpus, exactly
+// as the comment above reachable says, and the planner has no statistics saying
+// this table is small: written as an ordinary join it read the whole document
+// table and ran those subqueries against every row of it, which measured at 365
+// milliseconds a call on twenty thousand documents and at one millisecond after
+// the order was pinned. Written this way the ids are walked, each one is a
+// primary key probe into a table that is usually empty for them, and the
+// visibility rule is applied to the handful of rows that came back.
 func (s *Store) Verifications(ctx context.Context, p *acl.Principal, ids []string) (map[string]store.Verification, error) {
 	if err := s.ready(ctx); err != nil {
 		return nil, err
@@ -92,9 +103,10 @@ func (s *Store) Verifications(ctx context.Context, p *acl.Principal, ids []strin
 	args := append([]any{jsonList(ids)}, c.args...)
 	rows, err := s.query(ctx, `
 		SELECT v.doc_id, v.by_subject, v.by_name, v.by_email, v.verified_at, v.expires_at, v.note
-		FROM document_verify v
-		JOIN document d ON d.id = v.doc_id
-		WHERE v.doc_id IN (SELECT value FROM json_each(?)) AND `+c.where(), args...)
+		FROM json_each(?) j
+		CROSS JOIN document_verify v ON v.doc_id = j.value
+		CROSS JOIN document d ON d.id = v.doc_id
+		WHERE `+c.where(), args...)
 	if err != nil {
 		return nil, fmt.Errorf("sqlitestore: verifications: %w", err)
 	}

--- a/store/sqlitestore/verify.go
+++ b/store/sqlitestore/verify.go
@@ -1,0 +1,120 @@
+package sqlitestore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Verifier = (*Store)(nil)
+
+// Verify records that somebody vouches for a document.
+//
+// The insert selects from document with the visibility predicate on it, exactly
+// as recording an open does, so a claim about something this principal may not
+// read inserts no rows. One statement rather than a read, a decision in Go and
+// a write, which is also the only form of this that cannot race.
+func (s *Store) Verify(ctx context.Context, p *acl.Principal, v store.Verification) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	if err := v.Check(); err != nil {
+		return fmt.Errorf("sqlitestore: verify: %w", err)
+	}
+
+	c := visible(p)
+	args := append(
+		[]any{v.By.Subject, v.By.Name, v.By.Email, v.At.UnixNano(), v.Until.UnixNano(), v.Note, v.Doc},
+		c.args...,
+	)
+	s.counters.statements.Add(1)
+	if _, err := s.db.ExecContext(ctx, `
+		INSERT INTO document_verify (doc_id, by_subject, by_name, by_email, verified_at, expires_at, note)
+		SELECT d.id, ?, ?, ?, ?, ?, ? FROM document d WHERE d.id = ? AND `+c.where()+`
+		ON CONFLICT (doc_id) DO UPDATE SET
+			by_subject  = excluded.by_subject,
+			by_name     = excluded.by_name,
+			by_email    = excluded.by_email,
+			verified_at = excluded.verified_at,
+			expires_at  = excluded.expires_at,
+			note        = excluded.note`,
+		args...); err != nil {
+		return fmt.Errorf("sqlitestore: verify: %w", err)
+	}
+	return nil
+}
+
+// Unverify withdraws the claim.
+func (s *Store) Unverify(ctx context.Context, p *acl.Principal, id string) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+
+	c := visible(p)
+	args := append([]any{id}, c.args...)
+	s.counters.statements.Add(1)
+	if _, err := s.db.ExecContext(ctx, `
+		DELETE FROM document_verify
+		WHERE doc_id IN (SELECT d.id FROM document d WHERE d.id = ? AND `+c.where()+`)`,
+		args...); err != nil {
+		return fmt.Errorf("sqlitestore: unverify: %w", err)
+	}
+	return nil
+}
+
+// Verifications returns the claims on the documents the principal may read.
+//
+// One statement for the whole page. The ids are bound as a JSON array rather
+// than expanded into a list of placeholders, which is what the filters in
+// query.go do, and it means a page of twenty and a page of two hundred prepare
+// the same statement.
+func (s *Store) Verifications(ctx context.Context, p *acl.Principal, ids []string) (map[string]store.Verification, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	c := visible(p)
+	args := append([]any{jsonList(ids)}, c.args...)
+	rows, err := s.query(ctx, `
+		SELECT v.doc_id, v.by_subject, v.by_name, v.by_email, v.verified_at, v.expires_at, v.note
+		FROM document_verify v
+		JOIN document d ON d.id = v.doc_id
+		WHERE v.doc_id IN (SELECT value FROM json_each(?)) AND `+c.where(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlitestore: verifications: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out map[string]store.Verification
+	for rows.Next() {
+		var (
+			v                store.Verification
+			verified, expiry int64
+		)
+		if err := rows.Scan(&v.Doc, &v.By.Subject, &v.By.Name, &v.By.Email, &verified, &expiry, &v.Note); err != nil {
+			return nil, fmt.Errorf("sqlitestore: verifications: %w", err)
+		}
+		s.counters.rows.Add(1)
+		v.At, v.Until = unixNano(verified), unixNano(expiry)
+		if out == nil {
+			out = make(map[string]store.Verification, len(ids))
+		}
+		out[v.Doc] = v
+	}
+	return out, rows.Err()
+}

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -65,6 +65,15 @@ var cases = []testCase{
 	{"an open is not a licence to keep reading", testOpenLogPermissions},
 	{"a deleted document leaves the history", testOpenLogDelete},
 	{"a history belongs to one tenant", testOpenLogTenants},
+	{"a verification comes back as it went in", testVerifyRoundTrip},
+	{"verifying again replaces the claim", testVerifyReplaces},
+	{"a verification is neither made nor read across a permission", testVerifyPermissions},
+	{"a revoked document takes its badge with it", testVerifyRevocation},
+	{"a rewrite by a crawl leaves the claim alone", testVerifySurvivesRewrite},
+	{"a deleted document forgets who vouched for it", testVerifyDelete},
+	{"a claim can be withdrawn, twice", testUnverify},
+	{"a claim with no name or no expiry is refused", testVerifyRejectsIncomplete},
+	{"a page of ids is one question", testVerifyBatch},
 }
 
 // contentStore skips a case for a driver that does not hold bytes.

--- a/store/storetest/verify.go
+++ b/store/storetest/verify.go
@@ -1,0 +1,239 @@
+package storetest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// A verification is a claim about a document made by somebody other than the
+// crawler, which makes it the first thing in this interface that a driver could
+// plausibly decide is safe to hand out freely. It is not. Who vouched for a
+// document is a fact about the document, so knowing that anyone did is knowing
+// the document exists, and a badge that renders for a reader who cannot open the
+// file is the same existence oracle the not found rule exists to close.
+//
+// The other half of what these cases pin down is what survives what. A crawl
+// rewrites a document and must leave the claim alone, because a source that
+// touches every file every night would otherwise erase the entire signal by
+// morning. A deletion takes the claim with it, because the alternative is a
+// claim about a document that no longer exists, waiting to be reattached to
+// whatever gets written under that id next.
+
+// verifier skips a case for a driver that cannot remember a verification.
+func verifier(t *testing.T, s store.Store) store.Verifier {
+	t.Helper()
+	v, ok := s.(store.Verifier)
+	if !ok {
+		t.Skip("driver does not implement store.Verifier")
+	}
+	return v
+}
+
+// vouch is a claim made at a fixed time, so that a test asserts on the dates it
+// asked for rather than on whatever the machine managed between two calls.
+func vouch(id string) store.Verification {
+	return store.Verification{
+		Doc:   id,
+		By:    doc.Person{Subject: "u_mei", Name: "Mei Tanaka", Email: "mei@acme.com"},
+		At:    at(0),
+		Until: at(0).Add(store.Cadence),
+		Note:  "checked against the failover we ran last week",
+	}
+}
+
+func claims(t *testing.T, v store.Verifier, p *acl.Principal, ids ...string) map[string]store.Verification {
+	t.Helper()
+	got, err := v.Verifications(t.Context(), p, ids)
+	if err != nil {
+		t.Fatalf("Verifications: %v", err)
+	}
+	return got
+}
+
+func testVerifyRoundTrip(t *testing.T, s store.Store) {
+	v := verifier(t, s)
+	mustPut(t, s, document("d1", readable()))
+
+	want := vouch("d1")
+	if err := v.Verify(t.Context(), reader(), want); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	got := claims(t, v, reader(), "d1")
+	back, ok := got["d1"]
+	if !ok {
+		t.Fatalf("the document was verified and came back with no claim on it")
+	}
+	if back.By != want.By {
+		t.Errorf("the badge names %+v, and the claim was made by %+v", back.By, want.By)
+	}
+	if !back.At.Equal(want.At) || !back.Until.Equal(want.Until) {
+		t.Errorf("verified at %v until %v, and %v until %v went in", back.At, back.Until, want.At, want.Until)
+	}
+	if back.Note != want.Note {
+		t.Errorf("the note came back as %q and went in as %q", back.Note, want.Note)
+	}
+}
+
+func testVerifyReplaces(t *testing.T, s store.Store) {
+	v := verifier(t, s)
+	mustPut(t, s, document("d1", readable()))
+
+	first := vouch("d1")
+	if err := v.Verify(t.Context(), reader(), first); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	second := vouch("d1")
+	second.By = doc.Person{Subject: "u_kenji", Name: "Kenji Sato"}
+	second.At = at(30)
+	second.Until = at(30).Add(store.Cadence)
+	if err := v.Verify(t.Context(), reader(), second); err != nil {
+		t.Fatalf("re-verify: %v", err)
+	}
+
+	got := claims(t, v, reader(), "d1")
+	if len(got) != 1 {
+		t.Fatalf("re-verifying produced %d claims, and a document has one", len(got))
+	}
+	if got["d1"].By.Subject != "u_kenji" {
+		t.Errorf("the badge still names %q after somebody else verified it", got["d1"].By.Subject)
+	}
+}
+
+func testVerifyPermissions(t *testing.T, s store.Store) {
+	v := verifier(t, s)
+	mustPut(t, s, document("d1", readable()))
+
+	// A stranger cannot make the claim, and the refusal is silence rather than
+	// an error, for the same reason a missing document and a forbidden one are
+	// the same answer.
+	if err := v.Verify(t.Context(), stranger(), vouch("d1")); err != nil {
+		t.Fatalf("verifying something the stranger cannot see should be quiet, and it said: %v", err)
+	}
+	if got := claims(t, v, reader(), "d1"); len(got) != 0 {
+		t.Fatalf("a reader who cannot see the document verified it anyway")
+	}
+
+	// Nor can a stranger read a claim somebody else made, which is the half that
+	// would otherwise be an existence oracle.
+	if err := v.Verify(t.Context(), reader(), vouch("d1")); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got := claims(t, v, stranger(), "d1"); len(got) != 0 {
+		t.Fatalf("the stranger learned that d1 exists from a badge on it")
+	}
+}
+
+func testVerifyRevocation(t *testing.T, s store.Store) {
+	v := verifier(t, s)
+	mustPut(t, s, document("d1", readable()))
+	if err := v.Verify(t.Context(), reader(), vouch("d1")); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	// The same document, no longer readable. The claim is still stored and is no
+	// longer anybody's to see, which is the same rule the open history follows.
+	cut := document("d1", readable())
+	cut.Permissions.AllowGroups = []acl.Ref{{Source: "gdrive", Value: "legal@acme.com"}}
+	mustPut(t, s, cut)
+
+	if got := claims(t, v, reader(), "d1"); len(got) != 0 {
+		t.Fatalf("a reader who was cut out of the document can still see who vouched for it")
+	}
+}
+
+func testVerifySurvivesRewrite(t *testing.T, s store.Store) {
+	v := verifier(t, s)
+	mustPut(t, s, document("d1", readable()))
+	if err := v.Verify(t.Context(), reader(), vouch("d1")); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	// A crawl that touches every file every night is the normal case, and a
+	// claim that does not survive one is a signal that is erased by morning.
+	again := document("d1", readable())
+	again.Body = "how to fail over the payments queue, second edition"
+	mustPut(t, s, again)
+
+	if got := claims(t, v, reader(), "d1"); len(got) != 1 {
+		t.Fatalf("rewriting the document erased the claim on it")
+	}
+}
+
+func testVerifyDelete(t *testing.T, s store.Store) {
+	v := verifier(t, s)
+	mustPut(t, s, document("d1", readable()))
+	if err := v.Verify(t.Context(), reader(), vouch("d1")); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if err := s.Delete(t.Context(), "d1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// The claim goes with the document. Putting the id back is a new document
+	// that nobody has vouched for yet.
+	mustPut(t, s, document("d1", readable()))
+	if got := claims(t, v, reader(), "d1"); len(got) != 0 {
+		t.Fatalf("a document that was deleted and re-crawled came back carrying a claim about the old one")
+	}
+}
+
+func testUnverify(t *testing.T, s store.Store) {
+	v := verifier(t, s)
+	mustPut(t, s, document("d1", readable()))
+	if err := v.Verify(t.Context(), reader(), vouch("d1")); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	if err := v.Unverify(t.Context(), reader(), "d1"); err != nil {
+		t.Fatalf("Unverify: %v", err)
+	}
+	if got := claims(t, v, reader(), "d1"); len(got) != 0 {
+		t.Fatalf("the claim was withdrawn and is still there")
+	}
+	// Twice, because undoing a mistake should not itself be a mistake.
+	if err := v.Unverify(t.Context(), reader(), "d1"); err != nil {
+		t.Fatalf("withdrawing a claim that is not there: %v", err)
+	}
+}
+
+func testVerifyRejectsIncomplete(t *testing.T, s store.Store) {
+	v := verifier(t, s)
+	mustPut(t, s, document("d1", readable()))
+
+	nameless := vouch("d1")
+	nameless.By = doc.Person{}
+	if err := v.Verify(t.Context(), reader(), nameless); err == nil {
+		t.Errorf("a claim with nobody's name on it was accepted, which is the flag this type exists to avoid")
+	}
+
+	forever := vouch("d1")
+	forever.Until = time.Time{}
+	if err := v.Verify(t.Context(), reader(), forever); err == nil {
+		t.Errorf("a claim that never expires was accepted")
+	}
+}
+
+func testVerifyBatch(t *testing.T, s store.Store) {
+	v := verifier(t, s)
+	mustPut(t, s, document("d1", readable()), document("d2", readable()), document("d3", readable()))
+	for _, id := range []string{"d1", "d3"} {
+		if err := v.Verify(t.Context(), reader(), vouch(id)); err != nil {
+			t.Fatalf("Verify %s: %v", id, err)
+		}
+	}
+
+	got := claims(t, v, reader(), "d1", "d2", "d3")
+	if len(got) != 2 {
+		t.Fatalf("asked about three documents and got %d claims, and two of them were verified", len(got))
+	}
+	// A document with no claim is absent rather than present and empty, so that
+	// a caller drawing badges can range over what came back.
+	if _, ok := got["d2"]; ok {
+		t.Errorf("a document nobody verified came back with a claim on it")
+	}
+}

--- a/store/verify.go
+++ b/store/verify.go
@@ -1,0 +1,224 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+)
+
+// Verification is somebody putting their name to a document.
+//
+// It is the cheapest curation signal there is, because it applies to content
+// that already exists. Writing an answer means writing an answer. Verifying a
+// runbook means reading one somebody already wrote and saying it is still true,
+// which is thirty seconds of work by the person who would have been asked
+// anyway, and it turns a corpus where everything looks equally plausible into
+// one where the current things are marked.
+//
+// It is a claim by a named person with a date on it, not a flag. That is the
+// whole design. A boolean "verified" column decays into noise within a year
+// because nothing ever unsets it, so this carries who said so and when it stops
+// counting, and a reader who disagrees with the claim has somebody to ask.
+//
+// One row per document rather than a history. What a reader needs is the
+// current claim, and reconstructing it from a log means reading every line ever
+// written about the document to draw one badge. The history of who verified
+// what and when is the audit log's job.
+type Verification struct {
+	// Doc is the document this is about.
+	Doc string
+
+	// By is who made the claim, carried whole rather than as a subject id so
+	// that a badge has a name on it without a second lookup. A badge that says
+	// u-4181 vouched for this is worse than no badge, because the point of the
+	// signal is that a reader recognises the name.
+	By doc.Person
+
+	// At is when it was made, and Until is when it stops counting as current.
+	//
+	// Until is stored rather than derived from At plus a cadence, because the
+	// cadence is a policy that will change and a document verified under the
+	// old one should keep the expiry it was given. A verifier who wants a
+	// different one says so at the time.
+	At    time.Time
+	Until time.Time
+
+	// Note is why, in the verifier's own words, and is usually empty. It is
+	// here for the case the badge cannot express: verified except for the
+	// section about the old cluster, which is the sentence that saves the next
+	// reader an hour.
+	Note string
+}
+
+// State is where a verification is in its life.
+type State string
+
+// The verification states.
+const (
+	// Fresh means the claim is current and not close to running out.
+	Fresh State = "fresh"
+
+	// Expiring means it is still current and is within [ExpiringWindow] of not
+	// being. It exists so that the interface can ask for a re-verification
+	// before the badge goes bad rather than after, which is the difference
+	// between a nudge and a correction.
+	Expiring State = "expiring"
+
+	// Expired means nobody has vouched for the document since Until.
+	//
+	// The document keeps the badge and the badge says so, rather than the badge
+	// disappearing. A document that was verified in 2023 and not since is a more
+	// useful thing to know about than a document nobody ever looked at, and
+	// silently dropping the mark tells a reader the second story.
+	Expired State = "expired"
+)
+
+// Cadence is how long a verification lasts when the verifier does not say.
+//
+// Six months, which is the number every system like this converges on for the
+// same reason: a year is long enough that a policy document can be wrong for
+// two quarters, and a quarter is short enough that the reminders become noise
+// and people start clicking verify without reading. It is a default rather than
+// a rule, and a verifier who knows their document changes weekly sets their own.
+const Cadence = 180 * 24 * time.Hour
+
+// ExpiringWindow is how long before the expiry a verification starts saying so.
+//
+// Two weeks, which is roughly the time it takes for a nudge to survive one
+// holiday, one on call rotation and one sprint boundary and still be acted on
+// before the badge goes bad.
+const ExpiringWindow = 14 * 24 * time.Hour
+
+// State reports where the verification is at the given time. The zero
+// [Verification] is expired, which is the safe reading of no claim at all.
+func (v Verification) State(now time.Time) State {
+	switch {
+	case !now.Before(v.Until):
+		return Expired
+	case now.Add(ExpiringWindow).After(v.Until):
+		return Expiring
+	default:
+		return Fresh
+	}
+}
+
+// Zero reports whether there is no claim here at all.
+func (v Verification) Zero() bool { return v.At.IsZero() }
+
+// ErrNoVerifier and ErrNotOwner are what [Verification.Check] and [MayVerify]
+// stand behind.
+var (
+	ErrNoVerifier = errors.New("verification has no verifier")
+	ErrNoExpiry   = errors.New("verification has no expiry")
+)
+
+// Check rejects a verification that cannot be stored.
+//
+// A claim with nobody's name on it is the boolean column this type exists to
+// avoid, and one with no expiry is the same column with an extra field. Both
+// are refused here rather than in each driver, so that two drivers cannot
+// disagree about what a verification is.
+func (v Verification) Check() error {
+	switch {
+	case v.By.Name == "" && v.By.Subject == "":
+		return ErrNoVerifier
+	case v.Until.IsZero():
+		return ErrNoExpiry
+	default:
+		return nil
+	}
+}
+
+// MayVerify reports whether the principal is allowed to vouch for the document.
+//
+// The rule is the document's owner, its author, or an administrator. Not
+// everyone who can read it, because verification means accountability and a
+// badge anybody can apply is a badge that means somebody read the title. Not
+// only the owner, because the owner a connector reports is often a service
+// account or whoever created the folder in 2019, and a rule that strict means
+// half the corpus can never be verified by anyone.
+//
+// It lives here rather than inside a driver because it is a curation policy
+// rather than a permission rule, and the difference matters: a driver enforces
+// that the principal can read the document, which is what stops a verification
+// from being used to prove a document exists. Who among the readers is allowed
+// to make the claim is one decision, made once, above the storage layer.
+func MayVerify(p *acl.Principal, d doc.Document) bool {
+	if p == nil {
+		return false
+	}
+	if p.HasRole(acl.RoleAdmin) {
+		return true
+	}
+	return IsPerson(p, d.Owner) || IsPerson(p, d.Author)
+}
+
+// IsPerson reports whether the principal is the person named, by subject id
+// first and by email second.
+//
+// Email is a fallback rather than the rule because it is the one identifier a
+// connector reports for a person it could not resolve, and without it the owner
+// of every document from a source with no identity mapping is nobody.
+//
+// It is exported because the answer is needed in two places that must not
+// disagree: deciding whether somebody may verify a document, and deciding whose
+// name goes on the badge when they do. Two spellings of the same comparison
+// would eventually let a person verify a document under somebody else's name.
+func IsPerson(p *acl.Principal, who doc.Person) bool {
+	if p == nil {
+		return false
+	}
+	if who.Subject != "" && who.Subject == p.Subject {
+		return true
+	}
+	if who.Email == "" {
+		return false
+	}
+	for _, id := range p.Identities {
+		if strings.EqualFold(id.Value, who.Email) {
+			return true
+		}
+	}
+	return false
+}
+
+// Verifier is the optional capability of a driver that can remember who vouched
+// for a document.
+//
+// It is optional like every capability outside [Store], and a deployment whose
+// driver does not implement it is not broken: it shows results with no badges
+// on them, exactly as it did before this existed, and the interface offers no
+// verify button rather than one that fails.
+//
+// The permission rule does not move. A verification is written and read through
+// the principal, so a caller who may not see a document cannot verify it, cannot
+// learn that somebody else did, and gets the same silence the document itself
+// would give them. Verifying a document that is not there, or that the principal
+// may not read, writes nothing and is not an error, for the same reason
+// recording an open is not: an error that says the id was wrong is a way to find
+// out that an id is right.
+type Verifier interface {
+	Store
+
+	// Verify records the claim, replacing any earlier one for the same
+	// document. Replacing rather than appending is what makes re-verifying the
+	// same call as verifying, and it is why this type is one row per document.
+	Verify(ctx context.Context, p *acl.Principal, v Verification) error
+
+	// Unverify withdraws the claim. Withdrawing one that is not there is not an
+	// error, so that a mistake can be undone twice.
+	Unverify(ctx context.Context, p *acl.Principal, id string) error
+
+	// Verifications returns the claim for each of the given documents that has
+	// one and that the principal may read. A document with no claim is absent
+	// from the map rather than present with a zero value.
+	//
+	// It takes a page of ids rather than one, because the caller is a search
+	// result page and the alternative is twenty round trips to draw twenty
+	// badges.
+	Verifications(ctx context.Context, p *acl.Principal, ids []string) (map[string]Verification, error)
+}

--- a/web/dist/assets/api.js
+++ b/web/dist/assets/api.js
@@ -117,10 +117,10 @@ async function failure(res) {
 /**
  * send is a write, and returns the state that resulted from it.
  *
- * Every one of these endpoints answers with the whole connector list rather
- * than with an acknowledgement, so a screen paints what is true after the
- * change instead of guessing and then asking. Nothing here is cached and
- * nothing here is retried: a retried start is a second crawler.
+ * These endpoints answer with the state that resulted rather than with an
+ * acknowledgement, so a screen paints what is true after the change instead of
+ * guessing and then asking. Nothing here is cached and nothing here is retried:
+ * a retried start is a second crawler.
  */
 async function send(method, path, body) {
   const sent = headers();
@@ -131,7 +131,15 @@ async function send(method, path, body) {
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) throw await failure(res);
+  // A write that removes something has nothing to say back, and reading a body
+  // that is not there is a parse error on a request that worked.
+  if (res.status === 204) return null;
   return res.json();
+}
+
+/** verifyPath is one document's verification, which is written and withdrawn. */
+function verifyPath(id) {
+  return `/documents/${encodeURIComponent(id)}/verify`;
 }
 
 /** connector is one source's path under the administration endpoints. */
@@ -253,6 +261,13 @@ export const api = {
   recordOpen,
   suggest: (q, opts) => get("/suggest", { q }, opts),
   document: (id, opts) => get(`/documents/${encodeURIComponent(id)}`, {}, opts),
+  // Putting a name to a document and taking it off again. Neither sends who is
+  // making the claim: the server takes that from the same headers it
+  // authenticates with, so a request cannot put somebody else's name on a
+  // badge. The note and the expiry are optional and the interface sends
+  // neither, which is what makes the common case one click.
+  verify: (id, claim) => send("POST", verifyPath(id), claim),
+  unverify: (id) => send("DELETE", verifyPath(id)),
   content: (id, opts) => bytes(`/documents/${encodeURIComponent(id)}/content`, opts),
   // The version goes in the URL rather than in a header, because it is what
   // makes the address of a thumbnail stand for one picture forever. The server

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -632,6 +632,56 @@ time {
   color: var(--text);
 }
 
+/* Verification ----------------------------------------------------------- */
+
+/*
+ * Somebody's name on a document, and what it looks like when that has run out.
+ *
+ * Nothing here is filled. A row carrying a green pill is a row where the pill
+ * is the first thing the eye lands on, and the badge is the fifth fact about a
+ * result while the title is the first. So the mark carries the colour, the
+ * words stay the size and the weight of the line they sit on, and a page of
+ * verified results still reads as a page of results.
+ *
+ * Expired is the one state allowed to colour its words as well, because a
+ * document that was checked and is no longer current is a warning and the point
+ * of drawing it at all is that it is read as one.
+ */
+.verified {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.verified svg {
+  flex: none;
+  color: var(--success-700);
+}
+
+.verified--expiring svg,
+.verified--expired svg {
+  color: var(--warning-700);
+}
+
+.verified--expired {
+  color: var(--warning-700);
+  font-weight: var(--weight-semibold);
+}
+
+/*
+ * The verifier's own sentence, on its own line under whatever it belongs to.
+ * It is the case a badge cannot express, which is why it is not squeezed onto
+ * the end of one.
+ */
+.verified__note {
+  flex-basis: 100%;
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
 /* Answer ----------------------------------------------------------------- */
 
 /*
@@ -1670,6 +1720,7 @@ a.panel__row:hover .panel__row-title {
 .drawer__foot {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-4);
   padding: var(--space-4) var(--space-6);
   border-top: 1px solid var(--border);

--- a/web/dist/assets/drawer.js
+++ b/web/dist/assets/drawer.js
@@ -15,6 +15,7 @@ import { copies } from "genba/clipboard.js";
 import { icon, label, sourceColor, when, exact, followable, copyable } from "genba/format.js";
 import { body as renderBody, shapeOf, detailOf } from "genba/content.js";
 import { reveal } from "genba/marks.js";
+import { badge, note, control } from "genba/verify.js";
 import { NOT_AVAILABLE, NO_ACCESS } from "genba/states.js";
 import { documentPath } from "genba/state.js";
 
@@ -168,23 +169,8 @@ export class Drawer {
   }
 
   render(d) {
-    const detail = detailOf(d);
     replace(this.title, d.title || d.id);
-    replace(
-      this.meta,
-      h(
-        "span",
-        { class: "source" },
-        h("span", { class: "source__dot", style: { background: sourceColor(d.source) } }),
-        label(d.source),
-      ),
-      h("span", { class: "crumbs__sep" }, "·"),
-      h("span", {}, label(d.kind)),
-      detail && h("span", { class: "crumbs__sep" }, "·"),
-      detail && h("span", {}, detail),
-      d.container && h("span", { class: "crumbs__sep" }, "·"),
-      d.container && h("span", {}, d.container),
-    );
+    this.stamp(d);
     // The body decides its own shape from the media type, so the drawer only
     // has to say where it goes and how wide it is.
     this.body.dataset.shape = shapeOf(d);
@@ -200,6 +186,36 @@ export class Drawer {
     if (cited) cited.scrollIntoView({ block: "center", inline: "nearest" });
     else reveal(this.body);
     this.matched(cited);
+    this.land();
+  }
+
+  /**
+   * stamp draws everything about the document that is not the document.
+   *
+   * It is its own method because verifying one redraws this and must not redraw
+   * the body: rebuilding the body would lose the scroll position, the marked
+   * words and the match somebody was standing on, all to change a badge in the
+   * header.
+   */
+  stamp(d) {
+    const detail = detailOf(d);
+    replace(
+      this.meta,
+      h(
+        "span",
+        { class: "source" },
+        h("span", { class: "source__dot", style: { background: sourceColor(d.source) } }),
+        label(d.source),
+      ),
+      h("span", { class: "crumbs__sep" }, "·"),
+      h("span", {}, label(d.kind)),
+      detail && h("span", { class: "crumbs__sep" }, "·"),
+      detail && h("span", {}, detail),
+      d.container && h("span", { class: "crumbs__sep" }, "·"),
+      d.container && h("span", {}, d.container),
+      d.verified && h("span", { class: "crumbs__sep" }, "·"),
+      badge(d.verified, { by: true }),
+    );
     // Opening at the source is only offered where a browser would go there. For
     // every document the file connector read it would not, so the path takes
     // its place: a path somebody can paste into a terminal is worth something,
@@ -238,8 +254,18 @@ export class Drawer {
         ),
       d.modified_at &&
         h("span", { class: "meta", title: exact(d.modified_at) }, `Updated ${when(d.modified_at)}`),
+      // The two writes, offered only to somebody the server has already said
+      // may make them. Redrawing this and the header is all a claim changes,
+      // which is why they are the two things in here.
+      control(d, {
+        onSay: this.onSay,
+        onChange: (next) => {
+          d.verified = next;
+          this.stamp(d);
+        },
+      }),
+      note(d.verified),
     );
-    this.land();
   }
 
   /**

--- a/web/dist/assets/page.js
+++ b/web/dist/assets/page.js
@@ -25,6 +25,7 @@ import {
   copyable,
 } from "genba/format.js";
 import { body as renderBody, shapeOf, detailOf } from "genba/content.js";
+import { badge, note, control } from "genba/verify.js";
 import { reveal, toLine } from "genba/marks.js";
 import { notPermitted, failedBody, failureTitle, NOT_AVAILABLE } from "genba/states.js";
 import { documentPath } from "genba/state.js";
@@ -139,9 +140,35 @@ export class Page {
 
   render(d) {
     const heading = d.title || d.id;
-    const detail = detailOf(d);
     replace(this.title, heading);
     document.title = `${heading} · genba`;
+    this.stamp(d);
+
+    this.content.dataset.shape = shapeOf(d);
+    replace(this.content, renderBody(d, { query: this.query }));
+
+    // Focus goes to the heading rather than to the first control, because this
+    // is a document somebody came to read and the top of it is where reading
+    // starts. It carries tabindex="-1" so it can take focus without joining the
+    // tab order.
+    //
+    // Without preventScroll it would also put the top of the document on the
+    // screen, which is the one place a page opened at line four hundred must
+    // not be. Focus and the scroll position are two different questions here:
+    // reading starts at the heading and the eye starts at the match.
+    this.title.focus({ preventScroll: true });
+    if (!reveal(this.content)) this.el.scrollIntoView({ block: "start" });
+  }
+
+  /**
+   * stamp draws everything about the document that is not the document.
+   *
+   * Verifying one redraws this and nothing else. Redrawing the body would lose
+   * the scroll position and the marked words, and a page opened at line four
+   * hundred would jump back to the top because somebody put their name to it.
+   */
+  stamp(d) {
+    const detail = detailOf(d);
     replace(
       this.meta,
       h(
@@ -159,23 +186,21 @@ export class Page {
       d.modified_at && h("span", { class: "crumbs__sep" }, "·"),
       d.modified_at &&
         h("time", { title: exact(d.modified_at), datetime: d.modified_at }, `Updated ${when(d.modified_at)}`),
+      d.verified && h("span", { class: "crumbs__sep" }, "·"),
+      badge(d.verified, { by: true }),
     );
-
-    this.content.dataset.shape = shapeOf(d);
-    replace(this.content, renderBody(d, { query: this.query }));
-    replace(this.foot, actions(d, this.onSay));
-
-    // Focus goes to the heading rather than to the first control, because this
-    // is a document somebody came to read and the top of it is where reading
-    // starts. It carries tabindex="-1" so it can take focus without joining the
-    // tab order.
-    //
-    // Without preventScroll it would also put the top of the document on the
-    // screen, which is the one place a page opened at line four hundred must
-    // not be. Focus and the scroll position are two different questions here:
-    // reading starts at the heading and the eye starts at the match.
-    this.title.focus({ preventScroll: true });
-    if (!reveal(this.content)) this.el.scrollIntoView({ block: "start" });
+    replace(
+      this.foot,
+      actions(d, this.onSay),
+      control(d, {
+        onSay: this.onSay,
+        onChange: (next) => {
+          d.verified = next;
+          this.stamp(d);
+        },
+      }),
+      note(d.verified),
+    );
   }
 
   /**

--- a/web/dist/assets/rows.js
+++ b/web/dist/assets/rows.js
@@ -15,6 +15,7 @@
 import { h, replace, svg } from "genba/dom.js";
 import { kindIcon, sourceColor, label, when, exact, icon, followable, copyable } from "genba/format.js";
 import { tile, cover } from "genba/content.js";
+import { badge } from "genba/verify.js";
 import { copies } from "genba/clipboard.js";
 import * as urlState from "genba/state.js";
 
@@ -188,6 +189,10 @@ export class RowList {
         { class: "cell__meta" },
         h("span", { class: "source__dot", style: { background: sourceColor(hit.source) } }),
         h("span", { class: "cell__where", title: hit.container || label(hit.source) }, hit.container || label(hit.source)),
+        // The mark and not the sentence. A cell is a picture with one line
+        // under it, and that line is already the folder truncated on the
+        // right, so the words go where a screen reader still reads them.
+        badge(hit.verified, { compact: true }),
       ),
     );
   }
@@ -273,6 +278,13 @@ export class RowList {
             { class: "crumbs", title: exact(hit.at), datetime: hit.at },
             `you opened this ${when(hit.at)}`,
           ),
+        // Last on the line and not first, because it is the one thing here that
+        // most rows do not have, and a badge in the middle of the provenance
+        // would move the folder and the date around from row to row. It is on
+        // the row at all because the whole value of the signal is that it is
+        // visible while somebody is choosing which of ten results to open.
+        hit.verified && h("span", { class: "crumbs__sep" }, "·"),
+        badge(hit.verified),
       ),
       // A row with nothing to quote does not reserve the space for a quote. An
       // image has no text in it, so every image row used to end in two empty

--- a/web/dist/assets/verify.js
+++ b/web/dist/assets/verify.js
@@ -1,0 +1,169 @@
+// Who put their name to a document, and when that stops counting.
+//
+// The badge is a claim by a named person with a date on it rather than a tick,
+// because a tick nobody ever unsets is noise within a year. So there are three
+// states and all three are drawn: current, running out, and run out. A document
+// somebody verified in 2023 and not since keeps its badge and the badge says
+// so, which is more useful than a document nobody ever looked at and reads as
+// the warning it is.
+//
+// Which state a claim is in is decided by the server and sent down with it.
+// Working it out here from the date would put the cadence and the warning
+// window in two places, and the browser's copy would be the one drawing an
+// amber badge a fortnight after the server thinks it should be red.
+
+import { h, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { icon, when, exact } from "genba/format.js";
+
+// The three states the server sends. Anything else is read as expired, which is
+// the safe way to be wrong: a badge that overstates how current a document is
+// costs somebody an hour, and one that understates it costs them a click.
+const STATES = new Set(["fresh", "expiring", "expired"]);
+
+function stateOf(v) {
+  return STATES.has(v.state) ? v.state : "expired";
+}
+
+/**
+ * badge is the mark on a document that somebody vouched for it.
+ *
+ * It takes the name only where there is room for it, which is a preview or a
+ * page rather than a result row. On a row the name is in the tooltip: the row
+ * already carries a source, a kind, a folder, an author and a date, and a sixth
+ * name on that line is the line nobody reads.
+ *
+ * compact is the grid, where the label under a picture is one line that already
+ * truncates. The words are still there and still read out, they are just not
+ * drawn, because the alternative is a mark with no name on it at all and a
+ * picture nobody can tell is stale.
+ */
+export function badge(v, opts = {}) {
+  if (!v || !v.at) return null;
+  const state = stateOf(v);
+  const said = words(v, state, opts.by);
+  return h(
+    "span",
+    { class: `verified verified--${state}`, title: sentence(v, state) },
+    svg(icon(state === "expired" ? "alert" : "check"), 14),
+    opts.compact ? h("span", { class: "visually-hidden" }, said) : said,
+  );
+}
+
+/** words is the badge itself, which is short by the time it reaches a row. */
+function words(v, state, withName) {
+  const named = withName && v.by ? `Verified by ${v.by}` : "Verified";
+  switch (state) {
+    case "fresh":
+      return named;
+    case "expiring":
+      return `${named}, expires ${when(v.until)}`;
+    default:
+      return withName && v.by
+        ? `${named}, expired ${when(v.until)}`
+        : `Verification expired ${when(v.until)}`;
+  }
+}
+
+/**
+ * sentence is the whole claim, for the tooltip.
+ *
+ * The address is in it because the point of a signal that is a person rather
+ * than a flag is that a reader who disagrees with the claim has somebody to ask.
+ */
+function sentence(v, state) {
+  const who = v.email ? `${v.by} (${v.email})` : v.by;
+  const parts = [
+    `Verified by ${who || "somebody"} on ${exact(v.at)}`,
+    state === "expired" ? `Expired ${exact(v.until)}` : `Current until ${exact(v.until)}`,
+  ];
+  if (v.note) parts.push(v.note);
+  return parts.join(". ");
+}
+
+/**
+ * note is the verifier's own sentence, where they left one.
+ *
+ * It is the case a badge cannot express: verified except for the section about
+ * the old cluster, which is the line that saves the next reader an hour. It is
+ * shown on a preview and a page and not on a row, because a row has a snippet
+ * from the document itself and this would compete with it.
+ */
+export function note(v) {
+  return v && v.note ? h("p", { class: "verified__note" }, v.note) : null;
+}
+
+/**
+ * control is the button offered to somebody who may vouch for this document.
+ *
+ * Whether they may is the server's answer, sent with the document, so a reader
+ * who is not the owner is never shown a button that would be refused. It is a
+ * button rather than a form: the note and the expiry are both worth having and
+ * neither is worth a dialog in front of the one action anybody takes, so the
+ * common case is one click and the endpoint takes the rest.
+ */
+export function control(d, opts = {}) {
+  if (!d || !d.can_verify) return null;
+  const claimed = Boolean(d.verified && d.verified.at);
+  return [
+    h(
+      "button",
+      {
+        class: "button button--verify",
+        type: "button",
+        title: claimed
+          ? "Say this document is still current, from today"
+          : "Put your name to this document as current",
+        onClick: (e) => act(e.currentTarget, () => api.verify(d.id), opts),
+      },
+      svg(icon("check"), 16),
+      claimed ? "Verify again" : "Verify",
+    ),
+    claimed &&
+      h(
+        "button",
+        {
+          class: "button button--ghost",
+          type: "button",
+          title: "Take your name off this document",
+          onClick: (e) => act(e.currentTarget, () => api.unverify(d.id), opts),
+        },
+        "Withdraw",
+      ),
+  ];
+}
+
+/**
+ * act runs one of the two writes and tells the screen what came back.
+ *
+ * The button is disabled for the round trip rather than the whole screen, and
+ * it is not enabled again on success because the screen that redraws replaces
+ * it. A failure says why and gives the button back, because the most likely
+ * reason is a network that was not there and the next likely thing is another
+ * click.
+ *
+ * Focus follows the replacement. Withdrawing a claim removes the button that
+ * did it and puts the one that undoes it in the same place, and without this
+ * the focus a keyboard was holding would land on the body, which inside a modal
+ * preview is a way out of the dialog that nobody asked for.
+ */
+async function act(button, run, { onSay = () => {}, onChange = () => {} } = {}) {
+  const foot = button.parentNode;
+  button.disabled = true;
+  try {
+    const next = await run();
+    // Every list that carries a badge now carries the wrong one. Marking them
+    // stale rather than dropping them keeps them paintable and keeps their
+    // tags, so what this costs is a revalidation rather than a skeleton.
+    cache.invalidate(cache.key("search", {}));
+    cache.invalidate(cache.key("recent", {}));
+    onChange(next);
+    const moved = foot && foot.querySelector(".button--verify");
+    if (moved) moved.focus();
+    onSay(next ? "Verified" : "Verification withdrawn");
+  } catch (err) {
+    onSay(err.message);
+    button.disabled = false;
+  }
+}

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -55,6 +55,7 @@
           "genba/state.js": "/assets/state.js",
           "genba/states.js": "/assets/states.js",
           "genba/table.js": "/assets/table.js",
+          "genba/verify.js": "/assets/verify.js",
           "genba/": "/assets/"
         }
       }
@@ -97,6 +98,7 @@
     <link rel="modulepreload" href="/assets/state.js" />
     <link rel="modulepreload" href="/assets/states.js" />
     <link rel="modulepreload" href="/assets/table.js" />
+    <link rel="modulepreload" href="/assets/verify.js" />
     <script>
       // The theme and the density are read before the first paint. Doing it in
       // the module would put a white frame in front of somebody who chose a


### PR DESCRIPTION
Part of #41, which is the knowledge management half of the interface milestone. This is the verification part of it. Curated answers, ownership correction and reporting a stale document are the other three and are not in here.

## What this adds

A verification is a named claim with a date on it rather than a flag. Somebody puts their name to a document, it counts for six months unless they say otherwise, and the badge on the row says which of three states the claim is in: current, running out, or run out. The expired one is drawn rather than dropped. A document verified two years ago and not since is a more useful thing to know about than a document nobody ever looked at, and it is the case a tick can never express.

Only the owner or the author of a document can make a claim. A badge anybody can apply is a badge that means somebody read the title.

Which state a claim is in is decided by the server and sent down with it. Working it out in the browser from the date would put the cadence and the warning window in two places, and the browser copy would be the one drawing an amber badge a fortnight after the server thinks it should be red.

## Storage

The claim is an optional capability rather than a field on the document, so a driver that cannot record one leaves the badge off and the search behind it still answers. Memory, SQLite and Postgres all record it, and the conformance suite covers the nine cases that matter, including the two that are easy to get wrong: a claim about a document the caller may not read inserts nothing, and a claim on a document that is later deleted goes with it.

The permission predicate is inside each driver own statement rather than applied afterwards in Go, which is the rule everywhere else in the storage layer, so missing and forbidden stay indistinguishable. Verifying is one statement rather than a read, a decision, and a write, which is also the only form of it that cannot race.

## The endpoints and the budget

`POST /api/v1/documents/{id}/verify` records the claim and answers with the state that resulted. `DELETE` on the same address withdraws it and answers 204. The document endpoint carries the claim and whether this reader is one of the people who could make one, both from the same request, because a second round trip to find out whether to draw a button is a panel that paints twice.

Search and the home screen ask one question for the whole page rather than one per row. That is one extra statement on a primary key per search, and the badges are left off rather than the search failing when it cannot be answered.

The ranking effect is deliberately not in here. Boosting a verified document and pushing an expired one below an unverified one means joining the claim inside candidate selection, which has a ten millisecond budget to defend, and that is worth its own change with its own numbers. Opened as #157.

## What the gate checks

The gate now verifies a document of its own before it audits anything, because nothing in a file corpus is verified by itself and a state nobody produces is a state nobody checks. That is how an expired badge ships in a colour that fails contrast and reads out as nothing at all.

The walk asserts the badge on a result row, the name of the person in the preview, the note on the document page, and both writes from the document page. The two writes are checked for what they leave alone as much as for what they change: the body underneath them has to be the same body afterwards, because a page opened at line four hundred that jumps back to the top because somebody put their name to it is a page nobody verifies twice. The expiring and expired states are asked of the module directly, since a corpus indexed a minute ago holds neither.

Green on the gate machine: keyboard walk, rendering check, states check and budgets all pass, axe reports 0 violations on all twelve screens, and the transfer budgets are 110208 bytes of script of 184320 and 38 requests of 40 with the new module in the graph.
