### PR TITLE
Correct who owns a document when the connector got it wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ It is also the one screen that writes: a connector is added, switched off, asked
 A connector that was named on the command line is on that screen because it is running, and says where it is configured rather than offering a button that cannot work.
 
 The whole interface is hand written HTML, CSS and ES modules, committed exactly as they are served, so a clone builds a working interface with the Go toolchain and nothing else.
-There is no bundler and there is not going to be one, since the graph is thirty two modules of our own with no third party dependency anywhere in it.
+There is no bundler and there is not going to be one, since the graph is thirty four modules of our own with no third party dependency anywhere in it.
 What a bundler would have bought is done by the server instead.
 Every file is hashed as it is read and served under a second name that says what is in it, cacheable for a year, and the document is rewritten on the way out so that its import map and its preload list point at those names.
 Bodies are compressed with brotli and gzip once at startup rather than once per request.
@@ -133,6 +133,8 @@ Everything the interface does is an HTTP call, and there is nothing it can reach
 | `GET /api/v1/documents/{id}` | one document, or the same error as one that does not exist |
 | `POST /api/v1/documents/{id}/verify` | records that the caller vouches for a document, with an optional note and expiry |
 | `DELETE /api/v1/documents/{id}/verify` | withdraws the claim |
+| `PUT /api/v1/documents/{id}/owner` | corrects who owns a document, when the connector named the account that imported it |
+| `DELETE /api/v1/documents/{id}/owner` | puts back the owner the source reports |
 | `GET /api/v1/me` | the caller, and the sources and kinds that caller can actually see |
 | `GET /api/v1/stats` | how much is indexed and how much is quarantined |
 | `GET /api/v1/admin/operations` | what the connectors are doing, and what is being held back and why |
@@ -150,6 +152,10 @@ The snippet comes back as marked passages rather than as offsets, so a client hi
 A verification is a named claim with a date on it rather than a flag, so search results and the document itself carry who vouched for it, when, and when that stops counting.
 It lasts six months unless the verifier says otherwise, and only the owner or the author of a document can make one, because a badge anybody can apply is a badge that means somebody read the title.
 A driver that cannot record one leaves the badge off rather than failing the search behind it.
+
+Ownership is derived from the source, and what a source derives is very often the account that ran the import, so it can be corrected.
+The correction carries the name of the person who made it and the date, it survives every crawl after it, and clearing it puts back whatever the connector reports today rather than what it reported the day somebody disagreed.
+It is the same rule as a verification and deliberately so, because being the owner is what makes somebody able to vouch for a document.
 
 Every `admin` endpoint needs the `admin` role, which comes from `X-Genba-Roles` or from `GENBA_ADMINS`, and the default is that nobody has it.
 The role grants nothing over documents and it must not start to.

--- a/api/api.go
+++ b/api/api.go
@@ -225,6 +225,8 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("GET /api/v1/documents/{id}", s.authenticated(s.handleDocument))
 	mux.Handle("POST /api/v1/documents/{id}/verify", s.authenticated(s.handleVerify))
 	mux.Handle("DELETE /api/v1/documents/{id}/verify", s.authenticated(s.handleUnverify))
+	mux.Handle("PUT /api/v1/documents/{id}/owner", s.authenticated(s.handleSetOwner))
+	mux.Handle("DELETE /api/v1/documents/{id}/owner", s.authenticated(s.handleClearOwner))
 	mux.Handle("GET /api/v1/documents/{id}/content", s.authenticated(s.handleContent))
 	mux.Handle("GET /api/v1/documents/{id}/thumbnail", s.authenticated(s.handleThumbnail))
 	mux.Handle("GET /api/v1/recent", s.authenticated(s.handleRecent))
@@ -803,6 +805,14 @@ func (s *Server) handleDocument(w http.ResponseWriter, r *http.Request, p *acl.P
 			body.Verified = verifiedOf(got[d.ID], s.now())
 		}
 	}
+	// The owner is on the panel whether or not the driver can remember a
+	// correction, because the document carries one either way. What the
+	// capability adds is where the answer came from and the control to change
+	// it.
+	body.Owner = ownerOf(d, s.correction(r, p, d.ID))
+	if _, ok := s.ownership(); ok {
+		body.CanReassign = store.MayReassign(p, d)
+	}
 	writeConditional(w, r, http.StatusOK, body, nil)
 }
 
@@ -830,6 +840,15 @@ type documentBody struct {
 	// than offer a button that fails.
 	Verified  *verification `json:"verified,omitempty"`
 	CanVerify bool          `json:"can_verify,omitempty"`
+
+	// Owner is who is accountable for the document, with the provenance on it
+	// when somebody has corrected what the source said, and CanReassign says
+	// whether this reader is one of the people who could. It is on the preview
+	// rather than on every result because the owner is not what somebody is
+	// choosing between ten results on, and it is the first thing they want when
+	// the document turns out to be wrong.
+	Owner       *owner `json:"owner,omitempty"`
+	CanReassign bool   `json:"can_reassign,omitempty"`
 }
 
 // documentResponse is where the wire shape is decided. Permissions are not part

--- a/api/own.go
+++ b/api/own.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// ownerBodyLimit is how large a request to change an owner may be.
+//
+// Four kilobytes, which is a name and an address. There is nothing else in it,
+// and a body larger than this is a client that has misunderstood the endpoint.
+const ownerBodyLimit = 4 << 10
+
+// owner is the wire shape of who is accountable for a document.
+//
+// The name and the address are always the owner as it stands, corrected or not,
+// because that is what the interface prints and it should not have to work out
+// which of two fields to read. By and At are the provenance and are absent until
+// somebody has disagreed with the source, which is what lets the interface say
+// where this answer came from rather than presenting a person's judgement as a
+// fact from the connector.
+type owner struct {
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+
+	By string    `json:"by,omitempty"`
+	At time.Time `json:"at,omitzero"`
+}
+
+// handover is what both writes answer with.
+//
+// The three fields are the three the preview carries under the same names, so
+// the interface merges them into the document it is already holding and paints.
+// The owner alone would not be enough: being the owner is what makes somebody
+// able to vouch for a document, so a person who has just claimed one has earned
+// a button that was not there a moment ago, and a panel that only learned the
+// new name would go on hiding it until the next load.
+type handover struct {
+	Owner       *owner `json:"owner"`
+	CanVerify   bool   `json:"can_verify"`
+	CanReassign bool   `json:"can_reassign"`
+}
+
+// answer is the document as it stands after one of the two writes.
+func (s *Server) answer(p *acl.Principal, d doc.Document, c store.Correction) handover {
+	out := handover{Owner: ownerOf(d, c), CanReassign: store.MayReassign(p, d)}
+	if _, ok := s.verifier(); ok {
+		out.CanVerify = store.MayVerify(p, d)
+	}
+	return out
+}
+
+// ownerRequest is a correction as it arrives from the interface.
+//
+// It carries no corrector and no date, for the same reason a verification does
+// not: both are facts the server records rather than claims the caller gets to
+// make, and a request that could set them would be a request that could put
+// somebody else's name against a change they did not make.
+type ownerRequest struct {
+	// Email is who owns the document now. It is an address rather than a subject
+	// id because the person choosing knows the address, and because a document
+	// whose owner is an unresolved identity is exactly what happens when a
+	// connector cannot map one either.
+	Email string `json:"email"`
+
+	// Name is what to call them, and is the address when it is absent.
+	Name string `json:"name,omitempty"`
+}
+
+// ownerOf turns the document and any correction on it into what the wire
+// carries.
+func ownerOf(d doc.Document, c store.Correction) *owner {
+	out := owner{Name: d.Owner.Display(), Email: d.Owner.Email}
+	if !c.Zero() {
+		out.By, out.At = c.By.Display(), c.At
+	}
+	if out.Name == "" && out.Email == "" {
+		// A document nobody owns says so by leaving the block out, rather than by
+		// carrying an empty name the interface would have to test for.
+		return nil
+	}
+	return &out
+}
+
+// ownership returns the driver's ownership capability, and reports whether this
+// deployment has one at all.
+func (s *Server) ownership() (store.Ownership, bool) {
+	o, ok := s.store.(store.Ownership)
+	return o, ok
+}
+
+// correction reads the standing correction on one document.
+//
+// Best effort, like the verification beside it: a driver that cannot answer
+// leaves the provenance off rather than failing the panel it decorates. The
+// owner shown is right either way, because the correction was written into the
+// document when it was made.
+func (s *Server) correction(r *http.Request, p *acl.Principal, id string) store.Correction {
+	o, ok := s.ownership()
+	if !ok {
+		return store.Correction{}
+	}
+	got, err := o.Corrections(r.Context(), p, []string{id})
+	if err != nil {
+		s.log.Error("corrections could not be read", "error", err, "document", id)
+		return store.Correction{}
+	}
+	return got[id]
+}
+
+// handleSetOwner records that the source named the wrong owner.
+//
+// The three refusals are told apart here exactly as they are for a
+// verification, and for the same reasons: a caller who may not see the document
+// gets the not found the document itself would give them, and a caller who can
+// see it but may not hand it over gets a forbidden, because they already know
+// the document is there and the useful answer is why they cannot do this.
+func (s *Server) handleSetOwner(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	o, ok := s.ownership()
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "unsupported", "this deployment cannot record a change of owner")
+		return
+	}
+
+	var body ownerRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, ownerBodyLimit)).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "the body must be a JSON object with an email address and an optional name")
+		return
+	}
+	next, ok := personOf(p, body)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "bad_request", "the new owner needs an email address, so that somebody reading the document knows who to ask")
+		return
+	}
+
+	d, ok := s.reassignable(w, r, p)
+	if !ok {
+		return
+	}
+
+	now := s.now()
+	// The corrector is named the same way a verifier is, from the document
+	// first and the principal's own identity after it.
+	c := store.Correction{Doc: d.ID, Owner: next, By: who(p, d), At: now}
+	s.log.Info("document reassigned", "subject", p.Subject, "tenant", p.Tenant, "document", d.ID, "owner", next.Email)
+	if err := o.SetOwner(r.Context(), p, c); err != nil {
+		s.log.Error("set owner failed", "error", err, "document", d.ID)
+		writeError(w, http.StatusInternalServerError, "internal", "the change of owner could not be recorded")
+		return
+	}
+	d.Owner = next
+	writeJSON(w, http.StatusOK, s.answer(p, d, c))
+}
+
+// handleClearOwner puts back the owner the source reported.
+//
+// It answers with the owner rather than with no content, which is where it
+// parts company with withdrawing a verification. Withdrawing one leaves
+// nothing, so the interface can paint the result without being told. Clearing a
+// correction leaves whatever the connector says, which only the server knows,
+// and the alternative is a second request to find out what just happened.
+func (s *Server) handleClearOwner(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	o, ok := s.ownership()
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "unsupported", "this deployment cannot record a change of owner")
+		return
+	}
+	d, ok := s.reassignable(w, r, p)
+	if !ok {
+		return
+	}
+	// Read before the write, because the source's answer is in the correction
+	// that is about to be deleted. Reading the document again afterwards would
+	// be a second round trip to learn something this request already had.
+	c := s.correction(r, p, d.ID)
+	s.log.Info("owner correction cleared", "subject", p.Subject, "tenant", p.Tenant, "document", d.ID)
+	if err := o.ClearOwner(r.Context(), p, d.ID); err != nil {
+		s.log.Error("clear owner failed", "error", err, "document", d.ID)
+		writeError(w, http.StatusInternalServerError, "internal", "the change of owner could not be undone")
+		return
+	}
+	if !c.Zero() {
+		d.Owner = c.Was
+	}
+	writeJSON(w, http.StatusOK, s.answer(p, d, store.Correction{}))
+}
+
+// reassignable reads the document named in the path and checks that this caller
+// may change who owns it, writing the refusal itself when they may not.
+func (s *Server) reassignable(w http.ResponseWriter, r *http.Request, p *acl.Principal) (doc.Document, bool) {
+	return s.mayCurate(w, r, p, store.MayReassign,
+		"only the owner or the author of a document can hand it over, and an administrator can do it for them")
+}
+
+// personOf is the new owner as the request describes them.
+//
+// The subject is filled in when the address is one of the caller's own, which is
+// the common case: somebody claiming a document a connector attributed to the
+// account that imported it. Without it the claim would rest on the address
+// alone, and the person would keep their new document until the day their
+// address changed.
+func personOf(p *acl.Principal, body ownerRequest) (doc.Person, bool) {
+	next := doc.Person{
+		Name:  strings.TrimSpace(body.Name),
+		Email: strings.TrimSpace(body.Email),
+	}
+	if !strings.Contains(next.Email, "@") || strings.ContainsAny(next.Email, " \t\r\n") {
+		return doc.Person{}, false
+	}
+	if next.Name == "" {
+		next.Name = next.Email
+	}
+	if store.IsPerson(p, next) {
+		next.Subject = p.Subject
+	}
+	return next, true
+}

--- a/api/own_test.go
+++ b/api/own_test.go
@@ -1,0 +1,262 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// Correcting who owns a document.
+//
+// Ownership is derived, and what a connector derives is often the account that
+// ran the import. The rules the endpoint enforces are the same two the
+// verification endpoint enforces, and deliberately so: only somebody who owns or
+// wrote the document may hand it over, because being the owner is what makes
+// somebody able to vouch for it and a corpus where any reader can name
+// themselves the owner is a corpus where any reader can vouch for anything. And
+// a person who cannot see the document is told nothing at all.
+
+// ownerBody is the block the interface reads to print who is accountable.
+type ownerBody struct {
+	Name  string    `json:"name"`
+	Email string    `json:"email"`
+	By    string    `json:"by"`
+	At    time.Time `json:"at"`
+}
+
+// documentOwner is the preview as far as this file is concerned.
+type documentOwner struct {
+	Owner       *ownerBody `json:"owner"`
+	CanReassign bool       `json:"can_reassign"`
+	CanVerify   bool       `json:"can_verify"`
+}
+
+// newOwnerServer holds one document the engineer wrote and a service account
+// owns, and one that is somebody else's from end to end.
+//
+// The first is the case the whole feature is for: a real document, with a real
+// author, owned by whatever ran the sync. The second is what tells reading a
+// document apart from being able to hand it over.
+func newOwnerServer(t *testing.T) (http.Handler, *memstore.Store) {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	if err := st.Put(t.Context(), ownedDocs()...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}, api.WithClock(clock))
+	return s.Handler(), st
+}
+
+func ownedDocs() []doc.Document {
+	perm := acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "gdrive",
+		AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}},
+		Version:     1,
+	}
+	return []doc.Document{
+		{
+			ID: "mine", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Payments failover runbook", Body: "Fail the payments queue over to the replica.",
+			Author:      doc.Person{Name: "Mei Tanaka", Email: "mei@acme.com"},
+			Owner:       doc.Person{Name: "Drive Sync", Email: "drive-sync@acme.com"},
+			Permissions: perm,
+		},
+		{
+			// Somebody else wrote this one and Mei ended up owning it, which is
+			// what a document handed over once looks like from then on.
+			ID: "hers", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Payments oncall rota", Body: "Who carries the payments pager this week.",
+			Author:      doc.Person{Name: "Kenji Sato", Email: "kenji@acme.com"},
+			Owner:       doc.Person{Name: "Mei Tanaka", Email: "mei@acme.com"},
+			Permissions: perm,
+		},
+		{
+			ID: "theirs", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Payments retention policy", Body: "Payments records are kept for seven years.",
+			Author:      doc.Person{Name: "Kenji Sato", Email: "kenji@acme.com"},
+			Owner:       doc.Person{Name: "Kenji Sato", Email: "kenji@acme.com"},
+			Permissions: perm,
+		},
+	}
+}
+
+// curator is an administrator who can also read the documents, which is what an
+// operator fixing a connector's mistakes on somebody else's behalf looks like.
+func curator() map[string]string {
+	return map[string]string{
+		api.HeaderSubject: "u_ops",
+		api.HeaderRoles:   acl.RoleAdmin,
+		api.HeaderGroups:  "gdrive:eng@acme.com",
+	}
+}
+
+func previewOf(t *testing.T, h http.Handler, id string, headers map[string]string) documentOwner {
+	t.Helper()
+	w := request(t, h, http.MethodGet, "/api/v1/documents/"+id, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reading %s: %d %s", id, w.Code, w.Body.String())
+	}
+	return decode[documentOwner](t, w)
+}
+
+func TestCorrectingAnOwnerPutsTheirNameOnTheDocument(t *testing.T) {
+	h, _ := newOwnerServer(t)
+
+	w := post(t, h, http.MethodPut, "/api/v1/documents/mine/owner", `{"email":"mei@acme.com"}`, owner())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	made := decode[documentOwner](t, w).Owner
+	if made == nil || made.Email != "mei@acme.com" {
+		t.Errorf("the document was handed to %q", made.Email)
+	}
+	// The name of the person who said so, and when. A change of ownership with
+	// nobody against it is a change nobody can query.
+	if made.By != "Mei Tanaka" || !made.At.Equal(clock()) {
+		t.Errorf("the correction is recorded against %q at %v", made.By, made.At)
+	}
+
+	// And the document itself says so, which is the part that matters: the owner
+	// on the preview is the corrected one, not a second field beside the
+	// connector's answer.
+	got := previewOf(t, h, "mine", owner())
+	if got.Owner == nil || got.Owner.Email != "mei@acme.com" {
+		t.Fatalf("the preview says the owner is %+v", got.Owner)
+	}
+	if got.Owner.By != "Mei Tanaka" {
+		t.Errorf("the preview does not say who corrected it: %+v", got.Owner)
+	}
+}
+
+// Reading a document is not the same as being able to hand it over, and the
+// difference has to be a refusal rather than a quietly ignored write.
+func TestOnlyTheOwnerOrTheAuthorCanReassign(t *testing.T) {
+	h, _ := newOwnerServer(t)
+
+	w := post(t, h, http.MethodPut, "/api/v1/documents/theirs/owner", `{"email":"mei@acme.com"}`, owner())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+	if got := previewOf(t, h, "theirs", owner()); got.CanReassign {
+		t.Errorf("a reader who is not the owner is offered a control that would be refused")
+	}
+}
+
+// A person who cannot see the document is told the same thing they would be told
+// if it were not there. Anything else is a way to ask whether an id is real.
+func TestReassigningSomethingYouCannotSeeIsANotFound(t *testing.T) {
+	h, _ := newOwnerServer(t)
+
+	seen := post(t, h, http.MethodPut, "/api/v1/documents/mine/owner", `{"email":"sam@acme.com"}`, salesperson())
+	missing := post(t, h, http.MethodPut, "/api/v1/documents/nothing/owner", `{"email":"sam@acme.com"}`, salesperson())
+	if seen.Code != http.StatusNotFound || missing.Code != http.StatusNotFound {
+		t.Fatalf("a hidden document answered %d and a missing one answered %d, and both should be 404",
+			seen.Code, missing.Code)
+	}
+	if seen.Body.String() != missing.Body.String() {
+		t.Errorf("the two answers differ, which is enough to tell that mine exists:\n%s\n%s",
+			seen.Body.String(), missing.Body.String())
+	}
+}
+
+func TestClearingACorrectionPutsTheSourcesAnswerBack(t *testing.T) {
+	h, _ := newOwnerServer(t)
+	if w := post(t, h, http.MethodPut, "/api/v1/documents/mine/owner", `{"email":"mei@acme.com"}`, owner()); w.Code != http.StatusOK {
+		t.Fatalf("set owner: %d %s", w.Code, w.Body.String())
+	}
+
+	w := post(t, h, http.MethodDelete, "/api/v1/documents/mine/owner", "", owner())
+	if w.Code != http.StatusOK {
+		t.Fatalf("clear owner: %d %s", w.Code, w.Body.String())
+	}
+	// The answer carries the owner that was put back, because it is the
+	// connector's and the interface has no way to know it otherwise.
+	if back := decode[documentOwner](t, w).Owner; back == nil || back.Email != "drive-sync@acme.com" || back.By != "" {
+		t.Errorf("clearing answered with %+v", back)
+	}
+
+	got := previewOf(t, h, "mine", owner())
+	if got.Owner == nil || got.Owner.Email != "drive-sync@acme.com" {
+		t.Fatalf("clearing the correction left the owner as %+v", got.Owner)
+	}
+	if got.Owner.By != "" {
+		t.Errorf("the document is back to what the source says and still claims %q corrected it", got.Owner.By)
+	}
+}
+
+// The crawl comes round every night and reports the account that ran the import
+// every time. A correction that does not survive one is not a correction.
+func TestACrawlDoesNotUndoACorrection(t *testing.T) {
+	h, st := newOwnerServer(t)
+	if w := post(t, h, http.MethodPut, "/api/v1/documents/mine/owner", `{"email":"mei@acme.com"}`, owner()); w.Code != http.StatusOK {
+		t.Fatalf("set owner: %d %s", w.Code, w.Body.String())
+	}
+
+	if err := st.Put(t.Context(), ownedDocs()...); err != nil {
+		t.Fatalf("re-crawl: %v", err)
+	}
+	got := previewOf(t, h, "mine", owner())
+	if got.Owner == nil || got.Owner.Email != "mei@acme.com" {
+		t.Fatalf("a crawl handed the document back to %+v", got.Owner)
+	}
+}
+
+// The two policies are the same policy on purpose. Handing a document to
+// somebody is what makes them able to vouch for it, which is why handing one
+// over is not something any reader may do.
+func TestBeingGivenADocumentIsWhatMakesYouAbleToVouchForIt(t *testing.T) {
+	h, _ := newOwnerServer(t)
+	if got := previewOf(t, h, "theirs", owner()); got.CanVerify {
+		t.Fatalf("a reader who neither owns nor wrote the document is offered the verify button")
+	}
+
+	if w := post(t, h, http.MethodPut, "/api/v1/documents/theirs/owner", `{"email":"mei@acme.com","name":"Mei Tanaka"}`, curator()); w.Code != http.StatusOK {
+		t.Fatalf("an administrator could not correct the owner: %d %s", w.Code, w.Body.String())
+	}
+	if got := previewOf(t, h, "theirs", owner()); !got.CanVerify {
+		t.Errorf("the new owner cannot vouch for the document they were just given")
+	}
+}
+
+// Handing over a document you did not write hands over the controls with it.
+//
+// This is the answer earning its keep. The write says what the person who made
+// it may do afterwards, and after this one they may do nothing, so the panel
+// takes both buttons away without asking the server a second question.
+func TestGivingAwayADocumentYouDidNotWriteTakesTheControlsWithIt(t *testing.T) {
+	h, _ := newOwnerServer(t)
+
+	w := post(t, h, http.MethodPut, "/api/v1/documents/hers/owner", `{"email":"kenji@acme.com","name":"Kenji Sato"}`, owner())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	got := decode[documentOwner](t, w)
+	if got.Owner == nil || got.Owner.Email != "kenji@acme.com" {
+		t.Fatalf("the document went to %+v", got.Owner)
+	}
+	if got.CanReassign || got.CanVerify {
+		t.Errorf("the person who gave it away is still offered the controls: %+v", got)
+	}
+}
+
+// The address is the whole point of the correction. A name with nobody behind it
+// leaves the next reader with somebody to blame and no way to ask.
+func TestANewOwnerNeedsAnAddress(t *testing.T) {
+	h, _ := newOwnerServer(t)
+
+	for _, body := range []string{`{"name":"Mei Tanaka"}`, `{"email":"mei at acme"}`, `{"email":""}`} {
+		w := post(t, h, http.MethodPut, "/api/v1/documents/mine/owner", body, owner())
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s answered %d, want 400: %s", body, w.Code, w.Body.String())
+		}
+	}
+}

--- a/api/verify.go
+++ b/api/verify.go
@@ -172,6 +172,24 @@ func (s *Server) handleUnverify(w http.ResponseWriter, r *http.Request, p *acl.P
 // allowed to make a claim about it, writing the refusal itself when they are
 // not.
 func (s *Server) verifiable(w http.ResponseWriter, r *http.Request, p *acl.Principal) (doc.Document, bool) {
+	return s.mayCurate(w, r, p, store.MayVerify,
+		"only the owner or the author of a document can say it is current, and an administrator can do it for them")
+}
+
+// mayCurate is the shape every curation endpoint has: read the document named in
+// the path, refuse the caller who may not see it the way the document itself
+// would, and refuse the caller who may see it but not do this with a reason.
+//
+// The policy is passed in rather than named here so that the two endpoints
+// cannot answer the permission question in two places and eventually differ
+// about which of them is stricter.
+func (s *Server) mayCurate(
+	w http.ResponseWriter,
+	r *http.Request,
+	p *acl.Principal,
+	allow func(*acl.Principal, doc.Document) bool,
+	refusal string,
+) (doc.Document, bool) {
 	d, err := s.store.Get(r.Context(), p, r.PathValue("id"))
 	switch {
 	case errors.Is(err, genba.ErrNotFound):
@@ -181,9 +199,8 @@ func (s *Server) verifiable(w http.ResponseWriter, r *http.Request, p *acl.Princ
 		s.log.Error("document lookup failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal", "the document could not be read")
 		return doc.Document{}, false
-	case !store.MayVerify(p, d):
-		writeError(w, http.StatusForbidden, "forbidden",
-			"only the owner or the author of a document can say it is current, and an administrator can do it for them")
+	case !allow(p, d):
+		writeError(w, http.StatusForbidden, "forbidden", refusal)
 		return doc.Document{}, false
 	}
 	return d, true

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -410,6 +410,68 @@ async function walk(session) {
     })()`,
   );
 
+  // Correcting the owner, from the same screen and on the same document. The
+  // file connector finds no owner for anything, which is the state this exists
+  // for: a corpus where the owner line is empty or wrong is a corpus where a
+  // stale document has nobody to go to.
+  await check(
+    session,
+    "a document with no owner still offers the person who may name one a way to",
+    `!document.querySelector('.page__meta .owner') && Boolean(${foot("Change owner")})`,
+  );
+
+  await evaluate(session, foot("Change owner") + ".click()");
+  await check(
+    session,
+    "changing the owner opens a field and puts the cursor in it",
+    `document.activeElement.classList.contains('own__field')`,
+  );
+
+  // Escape closes the field it is typed in rather than the screen around it,
+  // and gives the focus back to the button that opened it. On a phone that
+  // screen is a modal drawer, so an Escape that went past the field would take
+  // the document with it.
+  await press(session, "Escape", "Escape", 27);
+  await check(
+    session,
+    "escape closes the field and leaves the focus where the hand was",
+    `!document.querySelector('.own__field') &&
+      document.activeElement.classList.contains('button--reassign')`,
+  );
+
+  await evaluate(
+    session,
+    `(() => {
+      document.querySelector('.button--reassign').click();
+      const field = document.querySelector('.own__field');
+      field.value = 'dev@example.com';
+      field.form.requestSubmit();
+      return true;
+    })()`,
+  );
+  await check(
+    session,
+    "the corrected owner is on the page, from this screen, with the document untouched",
+    `(() => {
+      const line = document.querySelector('.page__meta .owner');
+      return Boolean(line) && line.textContent.includes('Owned by dev@example.com') &&
+        Boolean(document.querySelector('.page__body [data-walk="kept"]'));
+    })()`,
+  );
+  await check(
+    session,
+    "a corrected owner offers the way back to what the source says",
+    `Boolean(${foot("Undo correction")})`,
+  );
+
+  await evaluate(session, foot("Undo correction") + ".click()");
+  await check(
+    session,
+    "undoing the correction puts the source's answer back and leaves the document alone",
+    `!document.querySelector('.page__meta .owner') && !${foot("Undo correction")} &&
+      Boolean(document.querySelector('.page__body [data-walk="kept"]'))`,
+  );
+
   // The keyboard on its own. Everything above uses it in passing; this is the
   // part an audit finds and the part somebody using it all day notices.
   await visit(session, `${BASE}/?q=cache`, "document.querySelectorAll('.result').length > 0");

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -47,6 +47,12 @@ type Store struct {
 	// permission to see what it is about.
 	verified map[string]store.Verification
 
+	// owners is who somebody said really owns what, keyed by document id. The
+	// correction is kept beside the document rather than only inside it because
+	// the document holds one owner and the interface has to be able to say which
+	// of the two answers it is and who chose it.
+	owners map[string]store.Correction
+
 	// feeds is how the connectors were configured, keyed by tenant and source.
 	// It is in memory like everything else here, so a restart forgets it, which
 	// is the documented behaviour of this driver rather than an oversight.
@@ -63,6 +69,7 @@ func New() *Store {
 		opens:    make(map[[2]string]*opened),
 		feeds:    make(map[[2]string]store.Feed),
 		verified: make(map[string]store.Verification),
+		owners:   make(map[string]store.Correction),
 	}
 }
 
@@ -75,6 +82,7 @@ var (
 	_ store.Access       = (*Store)(nil)
 	_ store.Feeds        = (*Store)(nil)
 	_ store.Verifier     = (*Store)(nil)
+	_ store.Ownership    = (*Store)(nil)
 )
 
 // Put inserts or replaces documents.
@@ -110,7 +118,7 @@ func (s *Store) put(docs []doc.Document) (map[string][]string, error) {
 			delete(s.content, d.ID)
 		}
 		d.Content = nil
-		s.docs[d.ID] = d
+		s.docs[d.ID] = s.correct(d)
 		written[d.Tenant] = append(written[d.Tenant], d.ID)
 	}
 	return written, nil
@@ -146,6 +154,7 @@ func (s *Store) remove(ids []string) (map[string][]string, error) {
 		delete(s.docs, id)
 		delete(s.content, id)
 		delete(s.verified, id)
+		delete(s.owners, id)
 	}
 	return removed, nil
 }

--- a/store/memstore/own.go
+++ b/store/memstore/own.go
@@ -1,0 +1,126 @@
+package memstore
+
+import (
+	"context"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Ownership = (*Store)(nil)
+
+// SetOwner records a correction and writes the new owner into the document.
+func (s *Store) SetOwner(ctx context.Context, p *acl.Principal, c store.Correction) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	if err := c.Check(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return genba.ErrClosed
+	}
+	// Same rule as recording an open: a document this principal cannot see is a
+	// write that does not happen rather than an error naming the id.
+	d, ok := s.docs[c.Doc]
+	if !ok || !visible(p, d) {
+		return nil
+	}
+	// The source's answer is whatever the document said before the first
+	// correction, not before this one. Correcting a correction must still leave
+	// the connector's answer to go back to.
+	if old, ok := s.owners[c.Doc]; ok {
+		c.Was = old.Was
+	} else {
+		c.Was = d.Owner
+	}
+	s.owners[c.Doc] = c
+	d.Owner = c.Owner
+	s.docs[c.Doc] = d
+	return nil
+}
+
+// ClearOwner drops the correction and puts the source's answer back.
+func (s *Store) ClearOwner(ctx context.Context, p *acl.Principal, id string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return genba.ErrClosed
+	}
+	d, ok := s.docs[id]
+	if !ok || !visible(p, d) {
+		return nil
+	}
+	c, ok := s.owners[id]
+	if !ok {
+		return nil
+	}
+	delete(s.owners, id)
+	d.Owner = c.Was
+	s.docs[id] = d
+	return nil
+}
+
+// Corrections returns the corrections on the documents the principal may read.
+func (s *Store) Corrections(ctx context.Context, p *acl.Principal, ids []string) (map[string]store.Correction, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, genba.ErrClosed
+	}
+
+	var out map[string]store.Correction
+	for _, id := range ids {
+		c, ok := s.owners[id]
+		if !ok {
+			continue
+		}
+		d, ok := s.docs[id]
+		if !ok || !visible(p, d) {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]store.Correction, len(ids))
+		}
+		out[id] = c
+	}
+	return out, nil
+}
+
+// correct applies a standing correction to a document on its way in, and
+// refreshes the source's answer from what the crawl just reported.
+//
+// It runs under the write lock, from put, which is the contract [store.Ownership]
+// states: the correction outlives the crawl that would otherwise undo it.
+func (s *Store) correct(d doc.Document) doc.Document {
+	c, ok := s.owners[d.ID]
+	if !ok {
+		return d
+	}
+	c.Was = d.Owner
+	s.owners[d.ID] = c
+	d.Owner = c.Owner
+	return d
+}

--- a/store/own.go
+++ b/store/own.go
@@ -1,0 +1,156 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+)
+
+// Correction is a person saying that the owner a source reported is wrong.
+//
+// Ownership is derived, and derived ownership is wrong often enough that a
+// corpus which cannot be corrected slowly stops being trusted. A connector
+// reports whoever the source calls the owner, which is the account that ran the
+// import, the person who created the folder in 2019, or the service that syncs
+// the drive. None of them can answer a question about the document and none of
+// them will re-verify it, so the badge, the nudge and the report all go
+// nowhere.
+//
+// A correction is one row per document and it replaces the derived answer
+// rather than sitting beside it. That is the whole design. An overlay applied
+// while reading would be invisible to the owner: filter, to the facet counts
+// and to every ranking signal that reads the owner, which means the interface
+// would show one owner and the search would sort by another. So the driver
+// writes the corrected owner into the document itself, and keeps applying it
+// every time the crawl reports the source's answer again.
+//
+// Correcting who owns a document does not change who may read it. Ownership
+// here is the person accountable for the content and permissions are
+// [acl.Permissions], a different field with a different meaning that no part of
+// this touches. It is worth saying plainly because the two words are the same
+// word, and a curation feature that quietly widened an ACL would be the worst
+// bug this repository could ship.
+type Correction struct {
+	// Doc is the document this is about.
+	Doc string
+
+	// Owner is who owns it, and Was is what the source said before anybody
+	// corrected it.
+	//
+	// Was is kept because a correction has to be undoable, and undoing one means
+	// putting back the answer the connector gave rather than leaving the
+	// document owned by nobody until the next crawl comes round. It is refreshed
+	// on every write, so a source that fixes its own metadata is what a reader
+	// gets back when the correction is cleared.
+	Owner doc.Person
+	Was   doc.Person
+
+	// By is who said so and At is when, carried whole for the same reason a
+	// verification carries its verifier whole: the interface says a name, and a
+	// change of ownership with no name against it is a change nobody can query.
+	By doc.Person
+	At time.Time
+}
+
+// Zero reports whether there is no correction here at all.
+func (c Correction) Zero() bool { return c.At.IsZero() }
+
+// ErrNoOwner and ErrNoCorrector are what [Correction.Check] stands behind.
+var (
+	ErrNoOwner     = errors.New("correction has no owner")
+	ErrNoCorrector = errors.New("correction has nobody making it")
+)
+
+// Check rejects a correction that cannot be stored.
+//
+// Both refusals are here rather than in each driver, so that three drivers
+// cannot disagree about what a correction is. A correction to nobody is a
+// deletion written the wrong way and there is a call for that, and one with
+// nobody making it is an audit trail with a hole in it exactly where the
+// question gets asked.
+func (c Correction) Check() error {
+	switch {
+	case c.Owner.Name == "" && c.Owner.Email == "" && c.Owner.Subject == "":
+		return ErrNoOwner
+	case c.By.Name == "" && c.By.Subject == "":
+		return ErrNoCorrector
+	default:
+		return nil
+	}
+}
+
+// MayReassign reports whether the principal is allowed to correct who owns the
+// document.
+//
+// It is deliberately the same rule as [MayVerify], and it delegates rather than
+// restating it so that the two cannot drift apart. They have to be the same
+// rule, because being the owner is what makes somebody allowed to verify: if
+// any reader could name themselves the owner, then any reader could vouch for
+// any document they can read, and the accountability that makes a verification
+// worth reading would be gone. Reassignment is a handover between people who
+// were already accountable, or an administrator fixing what a connector got
+// wrong.
+//
+// The cost of that is real and worth naming. A document whose derived owner is
+// a service account, with no author, cannot be claimed by the person who
+// actually owns it: they have to ask an administrator. That is the right way
+// round. The alternative hands the strongest signal in the corpus to whoever
+// clicks first.
+func MayReassign(p *acl.Principal, d doc.Document) bool { return MayVerify(p, d) }
+
+// Ownership is the optional capability of a driver that can remember a
+// corrected owner.
+//
+// It is optional like every capability outside [Store], and a deployment whose
+// driver does not implement it is not broken: it shows the owner the connector
+// reported, exactly as it did before this existed, and the interface offers no
+// way to change it rather than one that fails.
+//
+// A driver that implements this applies corrections on [Store.Put]. That is the
+// contract and it is the only part of this that is subtle: a crawl which reports
+// the source's answer again must not undo a correction, and the place that can
+// promise it is the write, because the write is the one path every document
+// takes into a driver. Doing it there is also what keeps reading free. The
+// stored document already names the corrected owner, so a search result, an
+// owner: filter and a facet count all agree with the interface without joining
+// to anything, and the whole cost of the feature sits on a write that happens
+// once a year per document.
+//
+// The permission rule does not move. Corrections are written and read through
+// the principal, so a caller who may not see a document cannot correct it,
+// cannot learn that somebody else did, and gets the same silence the document
+// itself would give them. Correcting a document that is not there, or that the
+// principal may not read, writes nothing and is not an error, for the same
+// reason recording an open is not: an error that says the id was wrong is a way
+// to find out that an id is right.
+type Ownership interface {
+	Store
+
+	// SetOwner records the correction, replacing any earlier one for the same
+	// document, and writes the new owner into the document itself.
+	//
+	// Replacing rather than appending is what makes correcting a correction the
+	// same call as making one. The source's own answer survives the replacement:
+	// a document corrected twice still remembers what the connector said, so
+	// clearing it once puts the derived owner back rather than the previous
+	// person's guess.
+	SetOwner(ctx context.Context, p *acl.Principal, c Correction) error
+
+	// ClearOwner drops the correction and puts back the owner the source
+	// reported. Clearing one that is not there is not an error, so that a
+	// mistake can be undone twice.
+	ClearOwner(ctx context.Context, p *acl.Principal, id string) error
+
+	// Corrections returns the correction for each of the given documents that
+	// has one and that the principal may read. A document with no correction is
+	// absent from the map rather than present with a zero value.
+	//
+	// It takes a page of ids rather than one for the same reason [Verifier] does,
+	// though the caller today is a single document: the owner shown in a result
+	// is already the corrected one, and this is what is asked for when somebody
+	// opens the document and wants to know who changed it and when.
+	Corrections(ctx context.Context, p *acl.Principal, ids []string) (map[string]Correction, error)
+}

--- a/store/pgstore/migrations/0007_document_own.down.sql
+++ b/store/pgstore/migrations/0007_document_own.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE document_own;

--- a/store/pgstore/migrations/0007_document_own.up.sql
+++ b/store/pgstore/migrations/0007_document_own.up.sql
@@ -1,0 +1,48 @@
+-- document_own is a person saying the owner the source reported is wrong.
+--
+-- Ownership is derived, and derived ownership is wrong often enough that a
+-- corpus which cannot be corrected slowly stops being trusted. The connector
+-- reports whoever the source calls the owner, which is the account that ran the
+-- import or the person who created the folder in 2019, and neither of them will
+-- answer a question about the document or re-verify it.
+--
+-- The corrected owner is written into the document as well as into this table,
+-- and that is deliberate. The columns on document are what an owner: filter and
+-- a facet count are computed from, so a correction that lived only here would
+-- leave the interface showing one person and the search matching another. No
+-- query path reads this table. What it is for is making the correction outlive
+-- the next crawl and making it possible to undo.
+--
+-- The three people are stored as JSON rather than as nine columns, because they
+-- go back into the document when the correction is cleared and a person
+-- flattened into a subject, a name and an address comes back missing the source
+-- identity that an owner: filter matches on. It is text rather than jsonb for
+-- the same reason document_data is: nothing queries into it, and jsonb would
+-- parse it on the way in and rebuild it on the way out to store the same bytes.
+--
+-- The cascade is what keeps it honest, exactly as it is for document_verify. A
+-- document that leaves the corpus takes its correction with it, so re-crawling
+-- a document that was deleted brings back the document without handing it to
+-- somebody named in a correction about the old one.
+CREATE TABLE document_own (
+    doc_id       text   PRIMARY KEY REFERENCES document(id) ON DELETE CASCADE,
+
+    -- Who owns it, and what the source said before anybody disagreed.
+    --
+    -- was is refreshed on every write of the document, so clearing a correction
+    -- puts back the answer the connector gives today rather than the one it
+    -- gave the day somebody first corrected it. A source that fixes its own
+    -- metadata is a source whose answer is worth going back to.
+    owner        text   NOT NULL,
+    was          text   NOT NULL,
+
+    -- Who said so and when. A change of ownership with no name against it is a
+    -- change nobody can query, and the person shown in the interface is the
+    -- person who has to be asked when the correction is itself wrong.
+    --
+    -- Unix nanoseconds, for the same reason document_verify.verified_at is: a
+    -- timestamptz keeps microseconds, and a time read back out of one does not
+    -- compare equal to the time that went in.
+    corrected_by text   NOT NULL,
+    corrected_at bigint NOT NULL
+);

--- a/store/pgstore/own.go
+++ b/store/pgstore/own.go
@@ -1,0 +1,316 @@
+package pgstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Ownership = (*Store)(nil)
+
+// SetOwner records a correction and writes the new owner into the document.
+//
+// Unlike Verify it does take the write lock, because it writes the document row
+// rather than a row beside it. A crawl landing between the read of what the
+// document says now and the write of who owns it would leave the correction
+// recorded and the document still owned by the account that ran the import,
+// which is the one outcome this feature exists to prevent.
+func (s *Store) SetOwner(ctx context.Context, p *acl.Principal, c store.Correction) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	if err := c.Check(); err != nil {
+		return fmt.Errorf("pgstore: set owner: %w", err)
+	}
+
+	v := visible(p)
+	args := append([]any{c.Doc}, v.args...)
+	err := s.retry(ctx, func(ctx context.Context) error {
+		return s.transact(ctx, func(tx pgx.Tx) error {
+			// The document is read through the visibility predicate, exactly as
+			// recording an open is, so a correction to something this principal
+			// may not read reads no rows and writes nothing.
+			//
+			// The source's answer comes from the standing correction when there
+			// is one and from the document otherwise. Reading it from the
+			// document in both cases would remember the previous person's guess
+			// as what the connector said, and clearing the correction would then
+			// hand the document to somebody who was themselves a correction.
+			var data, was string
+			s.counters.statements.Add(1)
+			row := tx.QueryRow(ctx, rebind(`
+				SELECT dd.data, coalesce(o.was, '')
+				FROM document d
+				JOIN document_data dd ON dd.doc_id = d.id
+				LEFT JOIN document_own o ON o.doc_id = d.id
+				WHERE d.id = ? AND `+v.where()), args...)
+			if err := row.Scan(&data, &was); errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			} else if err != nil {
+				return err
+			}
+
+			d, err := decode(data)
+			if err != nil {
+				return err
+			}
+			if was == "" {
+				if was, err = marshalPerson(d.Owner); err != nil {
+					return err
+				}
+			}
+			owner, err := marshalPerson(c.Owner)
+			if err != nil {
+				return err
+			}
+			by, err := marshalPerson(c.By)
+			if err != nil {
+				return err
+			}
+
+			b := &pgx.Batch{}
+			b.Queue(`
+				INSERT INTO document_own (doc_id, owner, was, corrected_by, corrected_at)
+				VALUES ($1, $2, $3, $4, $5)
+				ON CONFLICT (doc_id) DO UPDATE SET
+					owner        = excluded.owner,
+					was          = excluded.was,
+					corrected_by = excluded.corrected_by,
+					corrected_at = excluded.corrected_at`,
+				c.Doc, owner, was, by, c.At.UnixNano())
+			if err := writeOwner(b, d, c.Owner); err != nil {
+				return err
+			}
+			return tx.SendBatch(ctx, b).Close()
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("pgstore: set owner: %w", err)
+	}
+	return nil
+}
+
+// ClearOwner drops the correction and puts the source's answer back.
+func (s *Store) ClearOwner(ctx context.Context, p *acl.Principal, id string) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+
+	v := visible(p)
+	args := append([]any{id}, v.args...)
+	err := s.retry(ctx, func(ctx context.Context) error {
+		return s.transact(ctx, func(tx pgx.Tx) error {
+			var data, was string
+			s.counters.statements.Add(1)
+			row := tx.QueryRow(ctx, rebind(`
+				SELECT dd.data, o.was
+				FROM document_own o
+				JOIN document d ON d.id = o.doc_id
+				JOIN document_data dd ON dd.doc_id = o.doc_id
+				WHERE o.doc_id = ? AND `+v.where()), args...)
+			if err := row.Scan(&data, &was); errors.Is(err, pgx.ErrNoRows) {
+				// Nothing to clear, or nothing this principal may see. Both are
+				// quiet, which is what makes undoing a mistake safe to do twice.
+				return nil
+			} else if err != nil {
+				return err
+			}
+
+			d, err := decode(data)
+			if err != nil {
+				return err
+			}
+			source, err := unmarshalPerson(was)
+			if err != nil {
+				return err
+			}
+
+			b := &pgx.Batch{}
+			b.Queue(`DELETE FROM document_own WHERE doc_id = $1`, id)
+			if err := writeOwner(b, d, source); err != nil {
+				return err
+			}
+			return tx.SendBatch(ctx, b).Close()
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("pgstore: clear owner: %w", err)
+	}
+	return nil
+}
+
+// Corrections returns the corrections on the documents the principal may read.
+//
+// One statement for the whole page, with the ids bound as a text array, exactly
+// as Verifications does it.
+func (s *Store) Corrections(ctx context.Context, p *acl.Principal, ids []string) (map[string]store.Correction, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	v := visible(p)
+	args := append([]any{ids}, v.args...)
+
+	var out map[string]store.Correction
+	err := s.retry(ctx, func(ctx context.Context) error {
+		out = nil
+		rows, err := s.query(ctx, `
+			SELECT o.doc_id, o.owner, o.was, o.corrected_by, o.corrected_at
+			FROM document_own o
+			JOIN document d ON d.id = o.doc_id
+			WHERE o.doc_id = ANY(?) AND `+v.where(), args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var (
+				c              store.Correction
+				owner, was, by string
+				corrected      int64
+			)
+			if err := rows.Scan(&c.Doc, &owner, &was, &by, &corrected); err != nil {
+				return err
+			}
+			s.counters.rows.Add(1)
+			people := [3]doc.Person{}
+			var bad error
+			for i, stored := range [3]string{owner, was, by} {
+				who, err := unmarshalPerson(stored)
+				people[i], bad = who, errors.Join(bad, err)
+			}
+			if bad != nil {
+				return bad
+			}
+			c.Owner, c.Was, c.By = people[0], people[1], people[2]
+			c.At = unixNano(corrected)
+			if out == nil {
+				out = make(map[string]store.Correction, len(ids))
+			}
+			out[c.Doc] = c
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: corrections: %w", err)
+	}
+	return out, nil
+}
+
+// writeOwner queues the two writes that put a person on a document: the stored
+// document a reader is shown, and the column an owner: filter and a facet count
+// are computed from.
+//
+// Both, always. A change that touches one of them leaves the interface and the
+// search disagreeing about who owns the same document.
+//
+// The document is decoded, changed and encoded again rather than edited in
+// place with jsonb_set, because the column is text on purpose and converting it
+// to jsonb to change one field would rewrite every document that went through a
+// correction into Postgres's normal form. The SQLite driver can edit its copy
+// where it lies, and this one reads a few kilobytes on a write that happens
+// about once a year per document.
+func writeOwner(b *pgx.Batch, d doc.Document, who doc.Person) error {
+	d.Owner = who
+	data, err := json.Marshal(d)
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", d.ID, err)
+	}
+	b.Queue(`UPDATE document_data SET data = $1 WHERE doc_id = $2`, string(data), d.ID)
+	b.Queue(`UPDATE document SET owner_keys = $1 WHERE id = $2`, nonEmpty(store.PersonKeys(who)), d.ID)
+	return nil
+}
+
+// keepOwners applies the standing corrections to a batch on its way in.
+//
+// This is the contract in [store.Ownership] that says a crawl does not undo a
+// correction, and it is one statement for the batch rather than one per
+// document. The source's answer is written back as it goes past, so a connector
+// that fixes its own metadata is what clearing the correction restores.
+func keepOwners(ctx context.Context, tx pgx.Tx, docs []doc.Document) (map[string]doc.Person, error) {
+	ids := make([]string, len(docs))
+	for i, d := range docs {
+		ids[i] = d.ID
+	}
+	rows, err := tx.Query(ctx, `SELECT doc_id, owner FROM document_own WHERE doc_id = ANY($1::text[])`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("read the standing corrections: %w", err)
+	}
+	defer rows.Close()
+
+	var out map[string]doc.Person
+	for rows.Next() {
+		var id, owner string
+		if err := rows.Scan(&id, &owner); err != nil {
+			return nil, err
+		}
+		who, err := unmarshalPerson(owner)
+		if err != nil {
+			return nil, err
+		}
+		if out == nil {
+			out = make(map[string]doc.Person, len(docs))
+		}
+		out[id] = who
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+
+	b := &pgx.Batch{}
+	for _, d := range docs {
+		if _, ok := out[d.ID]; !ok {
+			continue
+		}
+		was, err := marshalPerson(d.Owner)
+		if err != nil {
+			return nil, err
+		}
+		b.Queue(`UPDATE document_own SET was = $1 WHERE doc_id = $2`, was, d.ID)
+	}
+	if err := tx.SendBatch(ctx, b).Close(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func marshalPerson(p doc.Person) (string, error) {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("encode a person: %w", err)
+	}
+	return string(b), nil
+}
+
+func unmarshalPerson(s string) (doc.Person, error) {
+	var p doc.Person
+	if err := json.Unmarshal([]byte(s), &p); err != nil {
+		return doc.Person{}, fmt.Errorf("decode a person: %w", err)
+	}
+	return p, nil
+}

--- a/store/pgstore/write.go
+++ b/store/pgstore/write.go
@@ -54,6 +54,13 @@ func write(ctx context.Context, tx pgx.Tx, docs []doc.Document) error {
 	if err != nil {
 		return err
 	}
+	// Standing ownership corrections, read once for the batch. A crawl reports
+	// the owner the source believes in every night, and this is what stops it
+	// from undoing a person who said the source is wrong.
+	own, err := keepOwners(ctx, tx, docs)
+	if err != nil {
+		return err
+	}
 
 	b := &pgx.Batch{}
 	retire(b, priors, ids)
@@ -68,6 +75,9 @@ func write(ctx context.Context, tx pgx.Tx, docs []doc.Document) error {
 	written := map[string][]string{}
 	tokens := map[string][2]int64{}
 	for _, d := range docs {
+		if who, ok := own[d.ID]; ok {
+			d.Owner = who
+		}
 		a := d.Analyze()
 		if err := replace(b, d, a); err != nil {
 			return err

--- a/store/sqlitestore/own.go
+++ b/store/sqlitestore/own.go
@@ -1,0 +1,309 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Ownership = (*Store)(nil)
+
+// SetOwner records a correction and writes the new owner into the document.
+//
+// It takes the write lock and does its work in one transaction, because it is a
+// read of what the document says now followed by two writes that depend on it,
+// and the whole point of the feature is that the answer does not change under
+// somebody.
+func (s *Store) SetOwner(ctx context.Context, p *acl.Principal, c store.Correction) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	if err := c.Check(); err != nil {
+		return fmt.Errorf("sqlitestore: set owner: %w", err)
+	}
+
+	s.write.Lock()
+	defer s.write.Unlock()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: set owner: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// The document is read through the visibility predicate, exactly as
+	// recording an open is, so a correction to something this principal may not
+	// read reads no rows and writes nothing.
+	//
+	// The source's answer comes from the standing correction when there is one
+	// and from the document otherwise. Reading it from the document in both
+	// cases would remember the previous person's guess as what the connector
+	// said, and clearing the correction would then hand the document to somebody
+	// who was themselves a correction.
+	v := visible(p)
+	args := append([]any{c.Doc}, v.args...)
+	var (
+		current string
+		was     sql.NullString
+	)
+	s.counters.statements.Add(1)
+	err = tx.QueryRowContext(ctx, `
+		SELECT json_extract(dd.data, '$.Owner'), o.was
+		FROM document d
+		JOIN document_data dd ON dd.doc_id = d.id
+		LEFT JOIN document_own o ON o.doc_id = d.id
+		WHERE d.id = ? AND `+v.where(), args...).Scan(&current, &was)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("sqlitestore: set owner: %w", err)
+	}
+	if !was.Valid {
+		was = sql.NullString{String: current, Valid: true}
+	}
+
+	owner, err := marshalPerson(c.Owner)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: set owner: %w", err)
+	}
+	by, err := marshalPerson(c.By)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: set owner: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO document_own (doc_id, owner, was, corrected_by, corrected_at) VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (doc_id) DO UPDATE SET
+			owner        = excluded.owner,
+			was          = excluded.was,
+			corrected_by = excluded.corrected_by,
+			corrected_at = excluded.corrected_at`,
+		c.Doc, owner, was.String, by, c.At.UnixNano()); err != nil {
+		return fmt.Errorf("sqlitestore: set owner: %w", err)
+	}
+	if err := writeOwner(ctx, tx, c.Doc, owner, c.Owner); err != nil {
+		return fmt.Errorf("sqlitestore: set owner: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sqlitestore: set owner: %w", err)
+	}
+	return nil
+}
+
+// ClearOwner drops the correction and puts the source's answer back.
+func (s *Store) ClearOwner(ctx context.Context, p *acl.Principal, id string) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+
+	s.write.Lock()
+	defer s.write.Unlock()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: clear owner: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	v := visible(p)
+	args := append([]any{id}, v.args...)
+	var was string
+	s.counters.statements.Add(1)
+	err = tx.QueryRowContext(ctx, `
+		SELECT o.was FROM document_own o
+		JOIN document d ON d.id = o.doc_id
+		WHERE o.doc_id = ? AND `+v.where(), args...).Scan(&was)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Nothing to clear, or nothing this principal may see. Both are quiet,
+		// which is what makes undoing a mistake safe to do twice.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("sqlitestore: clear owner: %w", err)
+	}
+
+	source, err := unmarshalPerson(was)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: clear owner: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM document_own WHERE doc_id = ?`, id); err != nil {
+		return fmt.Errorf("sqlitestore: clear owner: %w", err)
+	}
+	if err := writeOwner(ctx, tx, id, was, source); err != nil {
+		return fmt.Errorf("sqlitestore: clear owner: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sqlitestore: clear owner: %w", err)
+	}
+	return nil
+}
+
+// Corrections returns the corrections on the documents the principal may read.
+//
+// The join order is pinned for the same reason it is in Verifications, and the
+// measurement quoted there applies here unchanged: the visibility clause carries
+// correlated subqueries, this table has no statistics saying it is nearly empty,
+// and letting the planner drive the join from document turns a handful of
+// primary key probes into a walk of the corpus.
+func (s *Store) Corrections(ctx context.Context, p *acl.Principal, ids []string) (map[string]store.Correction, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	v := visible(p)
+	args := append([]any{jsonList(ids)}, v.args...)
+	rows, err := s.query(ctx, `
+		SELECT o.doc_id, o.owner, o.was, o.corrected_by, o.corrected_at
+		FROM json_each(?) j
+		CROSS JOIN document_own o ON o.doc_id = j.value
+		CROSS JOIN document d ON d.id = o.doc_id
+		WHERE `+v.where(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlitestore: corrections: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out map[string]store.Correction
+	for rows.Next() {
+		var (
+			c              store.Correction
+			owner, was, by string
+			corrected      int64
+			people         [3]doc.Person
+			bad            error
+		)
+		if err := rows.Scan(&c.Doc, &owner, &was, &by, &corrected); err != nil {
+			return nil, fmt.Errorf("sqlitestore: corrections: %w", err)
+		}
+		s.counters.rows.Add(1)
+		for i, stored := range [3]string{owner, was, by} {
+			who, err := unmarshalPerson(stored)
+			people[i], bad = who, errors.Join(bad, err)
+		}
+		if bad != nil {
+			return nil, fmt.Errorf("sqlitestore: corrections: %w", bad)
+		}
+		c.Owner, c.Was, c.By = people[0], people[1], people[2]
+		c.At = unixNano(corrected)
+		if out == nil {
+			out = make(map[string]store.Correction, len(ids))
+		}
+		out[c.Doc] = c
+	}
+	return out, rows.Err()
+}
+
+// writeOwner puts a person into the stored document and into the column the
+// index reads.
+//
+// Both, always. The document is what a reader is shown and the column is what an
+// owner: filter and a facet count are computed from, and a change that touches
+// one of them leaves the interface and the search disagreeing about who owns the
+// same document.
+//
+// The document is edited in place with json_set rather than decoded, changed and
+// encoded again, so a body of any size is the database's business rather than
+// something this driver reads into memory to change one field.
+func writeOwner(ctx context.Context, tx *sql.Tx, id, person string, who doc.Person) error {
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE document_data SET data = json_set(data, '$.Owner', json(?)) WHERE doc_id = ?`,
+		person, id); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE document SET owner_keys = ? WHERE id = ?`,
+		jsonKeys(store.PersonKeys(who)), id); err != nil {
+		return err
+	}
+	return nil
+}
+
+// keepOwners applies the standing corrections to a batch on its way in.
+//
+// This is the contract in [store.Ownership] that says a crawl does not undo a
+// correction, and it is one statement per batch rather than one per document.
+// The source's answer is written back as it goes past, so a connector that fixes
+// its own metadata is what clearing the correction restores.
+func keepOwners(ctx context.Context, tx *sql.Tx, docs []doc.Document) (map[string]doc.Person, error) {
+	ids := make([]string, len(docs))
+	for i, d := range docs {
+		ids[i] = d.ID
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT o.doc_id, o.owner FROM json_each(?) j
+		CROSS JOIN document_own o ON o.doc_id = j.value`, jsonList(ids))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out map[string]doc.Person
+	for rows.Next() {
+		var id, owner string
+		if err := rows.Scan(&id, &owner); err != nil {
+			return nil, err
+		}
+		who, err := unmarshalPerson(owner)
+		if err != nil {
+			return nil, err
+		}
+		if out == nil {
+			out = make(map[string]doc.Person, len(docs))
+		}
+		out[id] = who
+	}
+	if err := errors.Join(rows.Err(), rows.Close()); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	for _, d := range docs {
+		if _, ok := out[d.ID]; !ok {
+			continue
+		}
+		was, err := marshalPerson(d.Owner)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE document_own SET was = ? WHERE doc_id = ?`, was, d.ID); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func marshalPerson(p doc.Person) (string, error) {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("encode a person: %w", err)
+	}
+	return string(b), nil
+}
+
+func unmarshalPerson(s string) (doc.Person, error) {
+	var p doc.Person
+	if err := json.Unmarshal([]byte(s), &p); err != nil {
+		return doc.Person{}, fmt.Errorf("decode a person: %w", err)
+	}
+	return p, nil
+}

--- a/store/sqlitestore/schema.go
+++ b/store/sqlitestore/schema.go
@@ -290,6 +290,32 @@ var migrations = []step{
 		note        TEXT    NOT NULL
 	) WITHOUT ROWID`),
 	ddl(`CREATE INDEX document_verify_expiry ON document_verify (expires_at)`),
+
+	// document_own is a person saying the owner the source reported is wrong.
+	//
+	// The corrected owner is written into the document as well as here, and that
+	// is deliberate: the row the index reads has to name the same person the
+	// reader sees, or an owner: filter and a facet count would answer with the
+	// connector's guess while the interface showed somebody else. This table is
+	// what makes the correction outlive the next crawl and what lets it be
+	// undone, and no query path reads it.
+	//
+	// The three people are stored as JSON rather than as nine columns because
+	// they go back into the document when the correction is cleared, and a
+	// person flattened into a subject, a name and an address comes back missing
+	// the source identity that an owner: filter matches on. The document itself
+	// is stored as JSON in this database for the same reason.
+	//
+	// was is the source's own answer, refreshed on every write, so clearing a
+	// correction puts back what the connector says today rather than what it
+	// said the day somebody first disagreed with it.
+	ddl(`CREATE TABLE document_own (
+		doc_id       TEXT PRIMARY KEY REFERENCES document(id) ON DELETE CASCADE,
+		owner        TEXT    NOT NULL,
+		was          TEXT    NOT NULL,
+		corrected_by TEXT    NOT NULL,
+		corrected_at INTEGER NOT NULL
+	) WITHOUT ROWID`),
 }
 
 // backfill recomputes the ranking statistics for every document already stored.

--- a/store/sqlitestore/sqlitestore.go
+++ b/store/sqlitestore/sqlitestore.go
@@ -223,8 +223,19 @@ func (s *Store) Put(ctx context.Context, docs ...doc.Document) error {
 	}
 	defer w.close()
 
+	// Standing ownership corrections, read once for the batch. A crawl reports
+	// the owner the source believes in every night, and this is what stops it
+	// from undoing a person who said the source is wrong.
+	own, err := keepOwners(ctx, tx, docs)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: put: %w", err)
+	}
+
 	written := make(map[string][]string)
 	for _, d := range docs {
+		if who, ok := own[d.ID]; ok {
+			d.Owner = who
+		}
 		if err := putOne(ctx, tx, w, d); err != nil {
 			return fmt.Errorf("sqlitestore: put %s: %w", d.ID, err)
 		}

--- a/store/storetest/own.go
+++ b/store/storetest/own.go
@@ -1,0 +1,272 @@
+package storetest
+
+import (
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// A correction is the one write in this interface that changes the document
+// itself rather than something stored beside it, and that is what these cases
+// are about. The owner a reader sees, the owner an owner: filter matches and the
+// owner the next crawl reports all have to be the same person, and a driver that
+// keeps the correction in its own table and forgets to apply it to the document
+// passes a naive round trip and fails every one of those.
+//
+// The other half is what survives what, and it is the opposite of the rule for a
+// verification. A crawl rewrites a document and the correction is applied again
+// rather than left alone, because the source will keep reporting the answer
+// somebody has already said is wrong, and a correction that lasts until the next
+// nightly crawl is not a correction. A deletion takes it with it, for the same
+// reason a deletion takes the badge: whatever gets written under that id next is
+// a different document.
+
+// ownership skips a case for a driver that cannot remember a correction.
+func ownership(t *testing.T, s store.Store) store.Ownership {
+	t.Helper()
+	o, ok := s.(store.Ownership)
+	if !ok {
+		t.Skip("driver does not implement store.Ownership")
+	}
+	return o
+}
+
+// derived is who the connector says owns these documents, which is the account
+// that ran the import rather than a person. It is the case the whole feature is
+// for.
+var derived = doc.Person{Name: "Drive Sync", Email: "drive-sync@acme.com"}
+
+// owned is a document with a derived owner on it.
+func owned(id string) doc.Document {
+	d := document(id, readable())
+	d.Owner = derived
+	return d
+}
+
+// reassign is a correction made at a fixed time, so that a test asserts on the
+// date it asked for rather than on whatever the machine managed between two
+// calls.
+func reassign(id string, owner doc.Person) store.Correction {
+	return store.Correction{
+		Doc:   id,
+		Owner: owner,
+		By:    doc.Person{Subject: "u_mei", Name: "Mei Tanaka", Email: "mei@acme.com"},
+		At:    at(0),
+	}
+}
+
+// ada is who the documents keep being handed to.
+var ada = doc.Person{Subject: "u_ada", Name: "Ada Okafor", Email: "ada@acme.com"}
+
+func corrections(t *testing.T, o store.Ownership, p *acl.Principal, ids ...string) map[string]store.Correction {
+	t.Helper()
+	got, err := o.Corrections(t.Context(), p, ids)
+	if err != nil {
+		t.Fatalf("Corrections: %v", err)
+	}
+	return got
+}
+
+// ownerOf reads back who the store says owns a document.
+func ownerOf(t *testing.T, s store.Store, id string) doc.Person {
+	t.Helper()
+	d, err := s.Get(t.Context(), reader(), id)
+	if err != nil {
+		t.Fatalf("Get %s: %v", id, err)
+	}
+	return d.Owner
+}
+
+func testOwnerRoundTrip(t *testing.T, s store.Store) {
+	o := ownership(t, s)
+	mustPut(t, s, owned("d1"))
+
+	if err := o.SetOwner(t.Context(), reader(), reassign("d1", ada)); err != nil {
+		t.Fatalf("SetOwner: %v", err)
+	}
+
+	// The document itself, because that is the contract. A correction that only
+	// a second call can see is an overlay, and an overlay is invisible to every
+	// query path.
+	if got := ownerOf(t, s, "d1"); got.Email != ada.Email {
+		t.Errorf("the document is owned by %+v, and it was handed to %+v", got, ada)
+	}
+
+	c, ok := corrections(t, o, reader(), "d1")["d1"]
+	if !ok {
+		t.Fatalf("the owner was corrected and the document came back with no correction on it")
+	}
+	if c.Owner != ada {
+		t.Errorf("the correction names %+v as the owner, and %+v went in", c.Owner, ada)
+	}
+	if c.Was != derived {
+		t.Errorf("the source said %+v and the correction remembers %+v", derived, c.Was)
+	}
+	if c.By.Subject != "u_mei" || !c.At.Equal(at(0)) {
+		t.Errorf("the correction was made by %+v at %v", c.By, c.At)
+	}
+}
+
+func testOwnerReplaces(t *testing.T, s store.Store) {
+	o := ownership(t, s)
+	mustPut(t, s, owned("d1"))
+
+	if err := o.SetOwner(t.Context(), reader(), reassign("d1", ada)); err != nil {
+		t.Fatalf("SetOwner: %v", err)
+	}
+	kenji := doc.Person{Subject: "u_kenji", Name: "Kenji Ito", Email: "kenji@acme.com"}
+	if err := o.SetOwner(t.Context(), reader(), reassign("d1", kenji)); err != nil {
+		t.Fatalf("correcting the correction: %v", err)
+	}
+
+	got := corrections(t, o, reader(), "d1")
+	if len(got) != 1 {
+		t.Fatalf("correcting twice produced %d corrections, and a document has one", len(got))
+	}
+	if got["d1"].Owner.Subject != "u_kenji" {
+		t.Errorf("the document still belongs to %q after somebody handed it on", got["d1"].Owner.Subject)
+	}
+	// The connector's answer, not the previous person's. Clearing has to put back
+	// what the source said rather than an earlier guess.
+	if got["d1"].Was != derived {
+		t.Errorf("the second correction remembers %+v as the source's answer, and the source said %+v", got["d1"].Was, derived)
+	}
+}
+
+func testOwnerPermissions(t *testing.T, s store.Store) {
+	o := ownership(t, s)
+	mustPut(t, s, owned("d1"))
+
+	// A stranger cannot make the correction, and the refusal is silence rather
+	// than an error, for the same reason a missing document and a forbidden one
+	// are the same answer.
+	if err := o.SetOwner(t.Context(), stranger(), reassign("d1", ada)); err != nil {
+		t.Fatalf("correcting something the stranger cannot see should be quiet, and it said: %v", err)
+	}
+	if got := corrections(t, o, reader(), "d1"); len(got) != 0 {
+		t.Fatalf("a reader who cannot see the document reassigned it anyway")
+	}
+	if got := ownerOf(t, s, "d1"); got != derived {
+		t.Fatalf("the document is owned by %+v after a stranger tried to hand it over", got)
+	}
+
+	// Nor can a stranger read a correction somebody else made, which is the half
+	// that would otherwise be an existence oracle.
+	if err := o.SetOwner(t.Context(), reader(), reassign("d1", ada)); err != nil {
+		t.Fatalf("SetOwner: %v", err)
+	}
+	if got := corrections(t, o, stranger(), "d1"); len(got) != 0 {
+		t.Fatalf("the stranger learned that d1 exists from a correction on it")
+	}
+}
+
+func testOwnerSurvivesRewrite(t *testing.T, s store.Store) {
+	o := ownership(t, s)
+	mustPut(t, s, owned("d1"))
+	if err := o.SetOwner(t.Context(), reader(), reassign("d1", ada)); err != nil {
+		t.Fatalf("SetOwner: %v", err)
+	}
+
+	// The crawl comes round again and reports the account that ran the import,
+	// exactly as it did last night and will again tomorrow.
+	again := owned("d1")
+	again.Body = "how to fail over the payments queue, second edition"
+	mustPut(t, s, again)
+
+	if got := ownerOf(t, s, "d1"); got.Email != ada.Email {
+		t.Fatalf("a crawl handed the document back to %+v", got)
+	}
+	if got := corrections(t, o, reader(), "d1"); len(got) != 1 {
+		t.Fatalf("rewriting the document erased the correction on it")
+	}
+
+	// The source's answer is refreshed by the crawl, so a source that fixes its
+	// own metadata is what clearing the correction puts back.
+	fixed := owned("d1")
+	fixed.Owner = doc.Person{Subject: "u_kenji", Name: "Kenji Ito", Email: "kenji@acme.com"}
+	mustPut(t, s, fixed)
+	if got := corrections(t, o, reader(), "d1")["d1"].Was.Subject; got != "u_kenji" {
+		t.Errorf("the correction remembers %q as the source's answer, and the source now says u_kenji", got)
+	}
+}
+
+func testClearOwner(t *testing.T, s store.Store) {
+	o := ownership(t, s)
+	mustPut(t, s, owned("d1"))
+	if err := o.SetOwner(t.Context(), reader(), reassign("d1", ada)); err != nil {
+		t.Fatalf("SetOwner: %v", err)
+	}
+
+	if err := o.ClearOwner(t.Context(), reader(), "d1"); err != nil {
+		t.Fatalf("ClearOwner: %v", err)
+	}
+	if got := corrections(t, o, reader(), "d1"); len(got) != 0 {
+		t.Fatalf("the correction was cleared and is still there")
+	}
+	if got := ownerOf(t, s, "d1"); got != derived {
+		t.Fatalf("clearing the correction left the document owned by %+v, and the source says %+v", got, derived)
+	}
+	// Twice, because undoing a mistake should not itself be a mistake.
+	if err := o.ClearOwner(t.Context(), reader(), "d1"); err != nil {
+		t.Fatalf("clearing a correction that is not there: %v", err)
+	}
+}
+
+func testOwnerDelete(t *testing.T, s store.Store) {
+	o := ownership(t, s)
+	mustPut(t, s, owned("d1"))
+	if err := o.SetOwner(t.Context(), reader(), reassign("d1", ada)); err != nil {
+		t.Fatalf("SetOwner: %v", err)
+	}
+	if err := s.Delete(t.Context(), "d1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// The correction goes with the document. Putting the id back is a new
+	// document that nobody has corrected yet.
+	mustPut(t, s, owned("d1"))
+	if got := corrections(t, o, reader(), "d1"); len(got) != 0 {
+		t.Fatalf("a document that was deleted and re-crawled came back carrying a correction about the old one")
+	}
+	if got := ownerOf(t, s, "d1"); got != derived {
+		t.Fatalf("a document that was deleted and re-crawled came back owned by %+v", got)
+	}
+}
+
+func testOwnerRejectsIncomplete(t *testing.T, s store.Store) {
+	o := ownership(t, s)
+	mustPut(t, s, owned("d1"))
+
+	nobody := reassign("d1", doc.Person{})
+	if err := o.SetOwner(t.Context(), reader(), nobody); err == nil {
+		t.Errorf("a document was handed to nobody, which is a deletion written the wrong way")
+	}
+
+	anonymous := reassign("d1", ada)
+	anonymous.By = doc.Person{}
+	if err := o.SetOwner(t.Context(), reader(), anonymous); err == nil {
+		t.Errorf("a correction with nobody making it was accepted")
+	}
+}
+
+func testOwnerBatch(t *testing.T, s store.Store) {
+	o := ownership(t, s)
+	mustPut(t, s, owned("d1"), owned("d2"), owned("d3"))
+	for _, id := range []string{"d1", "d3"} {
+		if err := o.SetOwner(t.Context(), reader(), reassign(id, ada)); err != nil {
+			t.Fatalf("SetOwner %s: %v", id, err)
+		}
+	}
+
+	got := corrections(t, o, reader(), "d1", "d2", "d3")
+	if len(got) != 2 {
+		t.Fatalf("asked about three documents and got %d corrections, and two of them were corrected", len(got))
+	}
+	// A document nobody corrected is absent rather than present and empty, so
+	// that a caller can range over what came back.
+	if _, ok := got["d2"]; ok {
+		t.Errorf("a document nobody corrected came back with a correction on it")
+	}
+}

--- a/store/storetest/retrieve.go
+++ b/store/storetest/retrieve.go
@@ -55,6 +55,7 @@ var retrieveCases = []retrieveCase{
 	{"retrieve stops when the callback says so", testRetrieveEarlyStop},
 	{"retrieve reflects a delete", testRetrieveDelete},
 	{"retrieve reflects a revocation", testRetrieveRevocation},
+	{"an owner filter follows a correction", testRetrieveCorrectedOwner},
 }
 
 // corpus is the fixture the retrieval cases share. The documents differ in
@@ -276,6 +277,37 @@ func testRetrieveDelete(t *testing.T, s store.Store, rt store.Retriever) {
 	got := agree(t, s, rt, reader(), store.Request{Terms: []string{"runbook"}})
 	if slices.Contains(got, "r1") {
 		t.Fatal("retrieved a deleted document, the index still holds its terms")
+	}
+}
+
+// testRetrieveCorrectedOwner is the case the whole design of a correction is
+// for. The owner shown on a result and the owner an owner: filter matches are
+// the same person, and a driver that stores the correction beside the document
+// without writing it into the row the index reads fails here and nowhere else.
+func testRetrieveCorrectedOwner(t *testing.T, s store.Store, rt store.Retriever) {
+	o, ok := s.(store.Ownership)
+	if !ok {
+		t.Skip("driver does not implement store.Ownership")
+	}
+	mustPut(t, s, corpus()...)
+
+	// r1 belongs to Mei according to the source, and somebody says it is Ada's.
+	c := store.Correction{
+		Doc:   "r1",
+		Owner: doc.Person{Subject: "u_ada", Name: "Ada Okafor", Email: "ada@acme.com"},
+		By:    doc.Person{Subject: "u_mei", Name: "Mei Tanaka", Email: "mei@acme.com"},
+		At:    at(0),
+	}
+	if err := o.SetOwner(t.Context(), reader(), c); err != nil {
+		t.Fatalf("SetOwner: %v", err)
+	}
+
+	got := agree(t, s, rt, reader(), store.Request{Owners: []string{"u_ada"}})
+	if !slices.Contains(got, "r1") {
+		t.Fatal("a filter on the corrected owner does not find the document, the index still has the source's answer")
+	}
+	if got := agree(t, s, rt, reader(), store.Request{Owners: []string{"mei@acme.com"}}); slices.Contains(got, "r1") {
+		t.Fatal("a filter on the owner the source reported still finds a document that was handed to somebody else")
 	}
 }
 

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -74,6 +74,14 @@ var cases = []testCase{
 	{"a claim can be withdrawn, twice", testUnverify},
 	{"a claim with no name or no expiry is refused", testVerifyRejectsIncomplete},
 	{"a page of ids is one question", testVerifyBatch},
+	{"a corrected owner is what the document says", testOwnerRoundTrip},
+	{"correcting again still remembers what the source said", testOwnerReplaces},
+	{"a correction is neither made nor read across a permission", testOwnerPermissions},
+	{"a rewrite by a crawl does not undo a correction", testOwnerSurvivesRewrite},
+	{"clearing a correction puts the source's answer back", testClearOwner},
+	{"a deleted document forgets who was said to own it", testOwnerDelete},
+	{"a correction to nobody, or by nobody, is refused", testOwnerRejectsIncomplete},
+	{"a page of ids is one question about owners", testOwnerBatch},
 }
 
 // contentStore skips a case for a driver that does not hold bytes.

--- a/web/dist/assets/api.js
+++ b/web/dist/assets/api.js
@@ -142,6 +142,11 @@ function verifyPath(id) {
   return `/documents/${encodeURIComponent(id)}/verify`;
 }
 
+/** ownerPath is one document's owner, which is corrected and put back. */
+function ownerPath(id) {
+  return `/documents/${encodeURIComponent(id)}/owner`;
+}
+
 /** connector is one source's path under the administration endpoints. */
 function connector(source, action = "") {
   return `/admin/connectors/${encodeURIComponent(source)}${action}`;
@@ -268,6 +273,12 @@ export const api = {
   // neither, which is what makes the common case one click.
   verify: (id, claim) => send("POST", verifyPath(id), claim),
   unverify: (id) => send("DELETE", verifyPath(id)),
+  // Correcting who owns a document, and undoing that. Both answer with the
+  // owner that stands afterwards, including the undo, because what a connector
+  // says is on the server and asking again would be a second round trip to find
+  // out what the first one just did.
+  setOwner: (id, who) => send("PUT", ownerPath(id), who),
+  clearOwner: (id) => send("DELETE", ownerPath(id)),
   content: (id, opts) => bytes(`/documents/${encodeURIComponent(id)}/content`, opts),
   // The version goes in the URL rather than in a header, because it is what
   // makes the address of a thumbnail stand for one picture forever. The server

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -682,6 +682,77 @@ time {
   line-height: var(--leading-small);
 }
 
+/* Owner ------------------------------------------------------------------ */
+
+/*
+ * Who is accountable for a document, on the same line as where it came from.
+ *
+ * It is set in the same size and colour as the rest of that line rather than
+ * being dressed up, because the owner is a fact about the document and not a
+ * status. What it does get is the icon, so the eye can find the name on a line
+ * that is otherwise words.
+ */
+.owner {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.owner svg {
+  flex: none;
+  color: var(--text-muted);
+}
+
+/*
+ * The control, which is a button until somebody presses it and a field after.
+ *
+ * The two states are one box so the row does not move when it changes: the
+ * field takes the width the button had plus what it needs, and the buttons
+ * beside it stay where the hand left them.
+ */
+.own {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.own__form {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.own__field {
+  width: 260px;
+  max-width: 100%;
+  height: 40px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-control);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--text-body);
+}
+
+.own__field:hover {
+  border-color: var(--border-strong);
+}
+
+/* On a phone the field takes the line it is on, because 260px beside two
+   buttons is a field with room for four characters. */
+@media (max-width: 560px) {
+  .own,
+  .own__form {
+    flex-wrap: wrap;
+  }
+
+  .own__field {
+    flex: 1 1 100%;
+  }
+}
+
 /* Answer ----------------------------------------------------------------- */
 
 /*

--- a/web/dist/assets/drawer.js
+++ b/web/dist/assets/drawer.js
@@ -16,6 +16,7 @@ import { icon, label, sourceColor, when, exact, followable, copyable } from "gen
 import { body as renderBody, shapeOf, detailOf } from "genba/content.js";
 import { reveal } from "genba/marks.js";
 import { badge, note, control } from "genba/verify.js";
+import { owner, reassign } from "genba/own.js";
 import { NOT_AVAILABLE, NO_ACCESS } from "genba/states.js";
 import { documentPath } from "genba/state.js";
 
@@ -213,6 +214,8 @@ export class Drawer {
       detail && h("span", {}, detail),
       d.container && h("span", { class: "crumbs__sep" }, "·"),
       d.container && h("span", {}, d.container),
+      d.owner && h("span", { class: "crumbs__sep" }, "·"),
+      owner(d.owner),
       d.verified && h("span", { class: "crumbs__sep" }, "·"),
       badge(d.verified, { by: true }),
     );
@@ -254,13 +257,23 @@ export class Drawer {
         ),
       d.modified_at &&
         h("span", { class: "meta", title: exact(d.modified_at) }, `Updated ${when(d.modified_at)}`),
-      // The two writes, offered only to somebody the server has already said
-      // may make them. Redrawing this and the header is all a claim changes,
-      // which is why they are the two things in here.
+      // The writes, offered only to somebody the server has already said may
+      // make them. Redrawing this and the header is all any of them changes,
+      // which is why they are in here.
       control(d, {
         onSay: this.onSay,
         onChange: (next) => {
           d.verified = next;
+          this.stamp(d);
+        },
+      }),
+      // Changing who owns it, on the same terms. The write answers with the
+      // owner and with what this reader may do next, under the same names the
+      // document carries them, so merging it in is the whole update.
+      reassign(d, {
+        onSay: this.onSay,
+        onChange: (next) => {
+          Object.assign(d, next);
           this.stamp(d);
         },
       }),

--- a/web/dist/assets/own.js
+++ b/web/dist/assets/own.js
@@ -1,0 +1,183 @@
+// Who owns a document, and how somebody says the connector got it wrong.
+//
+// Ownership is derived, and what a connector derives is very often the account
+// that ran the import. A corpus where half the documents are owned by Drive
+// Sync is a corpus where the owner is not worth printing, and the owner is the
+// one field on a stale document that tells a reader who to go and ask. So it is
+// printed, and anybody the server says may hand the document over is offered a
+// field to correct it in.
+//
+// The correction carries the name of the person who made it, which is what
+// keeps it honest: an owner nobody can be shown to have chosen is a fact from
+// nowhere, and the point of the whole feature is that there is somebody behind
+// the name.
+
+import { h, replace, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { icon, exact } from "genba/format.js";
+
+/**
+ * owner is the line that says who is accountable for a document.
+ *
+ * It draws the owner as it stands, corrected or not, because that is the
+ * question a reader is asking and the provenance is the answer to a different
+ * one. Where the answer came from is in the tooltip for a mouse and in a hidden
+ * sentence for a screen reader, rather than in a second visible crumb: this
+ * line already sits after a source, a kind, a folder and a date, and the reader
+ * who wants to know who chose the owner is rarer than the reader who wants to
+ * know who it is.
+ */
+export function owner(o) {
+  if (!o || (!o.name && !o.email)) return null;
+  return h(
+    "span",
+    { class: o.by ? "owner owner--corrected" : "owner", title: sentence(o) },
+    svg(icon("people"), 14),
+    `Owned by ${o.name || o.email}`,
+    o.by && h("span", { class: "visually-hidden" }, `, ${provenance(o)}`),
+  );
+}
+
+/** sentence is the whole of what is known about the owner, for the tooltip. */
+function sentence(o) {
+  const who = o.name && o.email ? `${o.name} (${o.email})` : o.name || o.email;
+  return o.by ? `${who}. ${provenance(o)}` : `${who}, as reported by the source`;
+}
+
+function provenance(o) {
+  return o.at ? `handed over by ${o.by} on ${exact(o.at)}` : `handed over by ${o.by}`;
+}
+
+/**
+ * reassign is the control offered to somebody who may change the owner.
+ *
+ * Whether they may is the server's answer, sent with the document, so a reader
+ * who neither owns nor wrote it is never shown a field that would be refused.
+ *
+ * It starts as a button and becomes a field when the button is pressed, rather
+ * than being a field that is always there. An address box sitting open under
+ * every document invites a change on a document nobody meant to change, and the
+ * action here is one somebody takes about twice a year.
+ */
+export function reassign(d, opts = {}) {
+  if (!d || !d.can_reassign) return null;
+  const box = h("div", { class: "own" });
+  return replace(box, closed(d, box, opts));
+}
+
+/** closed is the resting state: one button, and a way back when there is one. */
+function closed(d, box, opts) {
+  const corrected = Boolean(d.owner && d.owner.by);
+  return [
+    h(
+      "button",
+      {
+        class: "button button--ghost button--reassign",
+        type: "button",
+        title: "Say who really owns this document",
+        onClick: () => open(d, box, opts),
+      },
+      svg(icon("people"), 16),
+      "Change owner",
+    ),
+    corrected &&
+      h(
+        "button",
+        {
+          class: "button button--ghost",
+          type: "button",
+          title: "Put back the owner the source reports",
+          onClick: (e) => act(e.currentTarget, d.id, box, () => api.clearOwner(d.id), opts, "Owner put back"),
+        },
+        "Undo correction",
+      ),
+  ];
+}
+
+/**
+ * open swaps the button for the field, and puts the cursor in it.
+ *
+ * The field is prefilled with the address that stands and selected, so the
+ * common case is type over it and press return. Escape closes the field and
+ * stops there rather than closing the preview around it, because the innermost
+ * thing open is the thing Escape means.
+ */
+function open(d, box, opts) {
+  const field = h("input", {
+    class: "own__field",
+    type: "email",
+    required: true,
+    autocomplete: "email",
+    spellcheck: "false",
+    placeholder: "name@example.com",
+    "aria-label": "The address of the person who owns this document",
+    value: (d.owner && d.owner.email) || "",
+  });
+  const form = h(
+    "form",
+    {
+      class: "own__form",
+      onSubmit: (e) => {
+        e.preventDefault();
+        const email = field.value.trim();
+        if (!email) return field.focus();
+        const button = e.submitter || form.querySelector("[type=submit]");
+        act(button, d.id, box, () => api.setOwner(d.id, { email }), opts, `Owner changed to ${email}`);
+      },
+      onKeyDown: (e) => {
+        if (e.key !== "Escape") return;
+        e.stopPropagation();
+        cancel(d, box, opts);
+      },
+    },
+    field,
+    h("button", { class: "button button--primary", type: "submit" }, "Save"),
+    h("button", { class: "button button--ghost", type: "button", onClick: () => cancel(d, box, opts) }, "Cancel"),
+  );
+  replace(box, form);
+  field.focus();
+  field.select();
+}
+
+/** cancel puts the button back and takes the focus with it. */
+function cancel(d, box, opts) {
+  replace(box, closed(d, box, opts));
+  const back = box.querySelector(".button--reassign");
+  if (back) back.focus();
+}
+
+/**
+ * act runs one of the two writes and tells the screen what came back.
+ *
+ * The control is disabled for the round trip rather than the whole screen, and
+ * it is not enabled again on success because the screen that redraws replaces
+ * it. A failure says why and gives it back, because the most likely reason is a
+ * network that was not there and the next likely thing is another try.
+ *
+ * Focus follows the replacement, the same way it does for a verification and
+ * for the same reason: the element that had the focus is gone by the time this
+ * returns, and focus that falls to the body inside a modal preview is a way out
+ * of the dialog that nobody asked for.
+ */
+async function act(button, id, box, run, { onSay = () => {}, onChange = () => {} } = {}, said) {
+  const foot = box.parentNode;
+  if (button) button.disabled = true;
+  try {
+    const next = await run();
+    // Every list that carries an owner now carries the wrong one, and so does
+    // the held copy of this document. Marking them stale rather than dropping
+    // them keeps them paintable, so what this costs is a revalidation that is
+    // usually answered with a 304.
+    cache.invalidate(cache.key("search", {}));
+    cache.invalidate(cache.key("recent", {}));
+    cache.invalidate(cache.key("document", { id }));
+    onChange(next);
+    const moved = foot && foot.querySelector(".button--reassign");
+    if (moved) moved.focus();
+    onSay(said);
+  } catch (err) {
+    onSay(err.message);
+    if (button) button.disabled = false;
+  }
+}

--- a/web/dist/assets/page.js
+++ b/web/dist/assets/page.js
@@ -26,6 +26,7 @@ import {
 } from "genba/format.js";
 import { body as renderBody, shapeOf, detailOf } from "genba/content.js";
 import { badge, note, control } from "genba/verify.js";
+import { owner, reassign } from "genba/own.js";
 import { reveal, toLine } from "genba/marks.js";
 import { notPermitted, failedBody, failureTitle, NOT_AVAILABLE } from "genba/states.js";
 import { documentPath } from "genba/state.js";
@@ -186,6 +187,8 @@ export class Page {
       d.modified_at && h("span", { class: "crumbs__sep" }, "·"),
       d.modified_at &&
         h("time", { title: exact(d.modified_at), datetime: d.modified_at }, `Updated ${when(d.modified_at)}`),
+      d.owner && h("span", { class: "crumbs__sep" }, "·"),
+      owner(d.owner),
       d.verified && h("span", { class: "crumbs__sep" }, "·"),
       badge(d.verified, { by: true }),
     );
@@ -196,6 +199,21 @@ export class Page {
         onSay: this.onSay,
         onChange: (next) => {
           d.verified = next;
+          this.stamp(d);
+        },
+      }),
+      // Handing the document over is drawn beside vouching for it because the
+      // two are the same decision from either end: the owner is who may vouch,
+      // so the person reading this line is either the one who should put their
+      // name to it or the one who knows whose name belongs there.
+      reassign(d, {
+        onSay: this.onSay,
+        // The write answers with the owner and with what this reader may do
+        // next, under the same names the document carries them, so merging it
+        // in is the whole update. Somebody who has just given away a document
+        // they did not write loses both controls here.
+        onChange: (next) => {
+          Object.assign(d, next);
           this.stamp(d);
         },
       }),

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -45,6 +45,7 @@
           "genba/media.js": "/assets/media.js",
           "genba/notebook.js": "/assets/notebook.js",
           "genba/omnibox.js": "/assets/omnibox.js",
+          "genba/own.js": "/assets/own.js",
           "genba/page.js": "/assets/page.js",
           "genba/prefs.js": "/assets/prefs.js",
           "genba/queries.js": "/assets/queries.js",
@@ -88,6 +89,7 @@
     <link rel="modulepreload" href="/assets/media.js" />
     <link rel="modulepreload" href="/assets/notebook.js" />
     <link rel="modulepreload" href="/assets/omnibox.js" />
+    <link rel="modulepreload" href="/assets/own.js" />
     <link rel="modulepreload" href="/assets/page.js" />
     <link rel="modulepreload" href="/assets/prefs.js" />
     <link rel="modulepreload" href="/assets/queries.js" />


### PR DESCRIPTION
Second box of #41.

Ownership is derived, and what a connector derives is very often the account that ran the import.
The owner is the one field on a stale document that tells a reader who to go and ask, so it is now printed on the preview and on the document page, and anybody who may hand the document over is offered a field to correct it in.

Who may: the owner, the author, or an administrator.
That is the same rule that decides who may verify a document, and `store.MayReassign` delegates to `store.MayVerify` rather than restating it so the two cannot drift apart.
They have to be the same rule, because being the owner is what makes somebody able to vouch for a document.
If any reader could name themselves the owner, any reader could vouch for anything they can read.

### How the correction survives a crawl

The driver applies standing corrections inside `Put`.
That is the one place every writer goes through, so ingest is untouched, reads pay nothing, and an `owner:` filter and the facet counts agree with what the preview says.
The alternative was a read time overlay, which would have left the search and the panel disagreeing about the same document.

The source's own answer is kept beside the correction and refreshed on every write.
Clearing a correction therefore puts back what the connector reports today rather than what it reported the day somebody first disagreed, and correcting a correction still remembers the connector rather than the previous person's guess.

### The API

| Endpoint | What it does |
| --- | --- |
| `PUT /api/v1/documents/{id}/owner` | records that the source named the wrong owner |
| `DELETE /api/v1/documents/{id}/owner` | puts back the owner the source reports |

Both answer with the owner that stands afterwards and with `can_verify` and `can_reassign`, under the same names the document preview carries them.
The owner alone would not be enough: somebody who has just given away a document they did not write has lost both controls, and a panel that only learned the new name would go on offering them.
A caller who cannot see the document gets the same 404 the document itself would give them, and one who can see it but may not hand it over gets a 403.

### Storage

`store.Ownership` is another optional capability, with `store/storetest` cases for the round trip, replacing a correction, surviving a rewrite, clearing, deleting, a page of ids in one question, and the permission cases.
`store/storetest/retrieve.go` gains a case that runs an `owner:` filter after a correction, which is what catches a driver that records the correction and forgets to write it into the indexed row.

- memstore keeps a map beside the documents and applies it under the write lock.
- sqlitestore adds a `document_own` table in a new migration, edits the stored document with `json_set` where it lies, and rewrites `owner_keys`. `Corrections` pins the join order from `json_each` the same way `Verifications` does.
- pgstore adds migration 0007, decodes and re-encodes the document in Go rather than using `jsonb_set`, because `document_data.data` is text on purpose and a jsonb round trip would rewrite every corrected document into Postgres's normal form.

Both writes take the write lock, unlike `Verify`, because they write the document row.
A crawl landing between the read and the write would leave the correction recorded and the document still owned by the import account, which is the one outcome this exists to prevent.

### Interface

`web/dist/assets/own.js` is the owner line and the control.
The control is a button until it is pressed and a field after, because an address box open under every document invites a change nobody meant to make, and this is something somebody does about twice a year.
The field is prefilled and selected, Escape closes the field rather than the drawer around it, and focus follows the replacement when a write lands so a keyboard does not fall out of the modal preview.
Only the stamp is redrawn, so a page opened at line four hundred stays where it is.

### Checks

- `go test ./...` on server3 with `GENBA_TEST_POSTGRES` set, all packages green.
- `golangci-lint run`, 0 issues.
- The UI gate on server2, exit 0, with six new keyboard walk assertions covering the field, Escape, the correction and the undo.
