### PR TITLE
Take what readers report to the person who can fix it

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Everything the interface does is an HTTP call, and there is nothing it can reach
 | `DELETE /api/v1/documents/{id}/owner` | puts back the owner the source reports |
 | `POST /api/v1/documents/{id}/stale` | records that the caller says a document is out of date, with an optional note |
 | `DELETE /api/v1/documents/{id}/stale` | clears the reports, which the owner or the author may do |
+| `GET /api/v1/reported` | the documents the caller owns or wrote that somebody has reported, most recent first |
 | `GET /api/v1/me` | the caller, and the sources and kinds that caller can actually see |
 | `GET /api/v1/stats` | how much is indexed and how much is quarantined |
 | `GET /api/v1/admin/operations` | what the connectors are doing, and what is being held back and why |

--- a/api/api.go
+++ b/api/api.go
@@ -231,6 +231,7 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("DELETE /api/v1/documents/{id}/stale", s.authenticated(s.handleResolve))
 	mux.Handle("GET /api/v1/documents/{id}/content", s.authenticated(s.handleContent))
 	mux.Handle("GET /api/v1/documents/{id}/thumbnail", s.authenticated(s.handleThumbnail))
+	mux.Handle("GET /api/v1/reported", s.authenticated(s.handleReported))
 	mux.Handle("GET /api/v1/recent", s.authenticated(s.handleRecent))
 	mux.Handle("POST /api/v1/recent", s.authenticated(s.handleRecordOpen))
 	mux.Handle("GET /api/v1/stats", s.authenticated(s.handleStats))

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/api"
 	"github.com/tamnd/genba/benchcorpus"
+	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/index"
 )
 
@@ -174,6 +176,78 @@ func BenchmarkAPIRecent(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		get(b, h, "/api/v1/recent", hdr)
+	}
+}
+
+// BenchmarkAPIReported is the other panel on the home screen: the documents
+// this person owns or wrote that somebody has said are out of date. It is
+// measured for the same reason the recent lists are, which is that the front
+// page reads it on every visit, and a panel that is usually empty still costs a
+// query every time.
+//
+// The corpus draws its owners from its own generated people and the reader
+// every other benchmark runs as owns none of it, so the reports are made by
+// that reader and read back by one carrying the owners' addresses. That is also
+// the shape the endpoint answers in a deployment: the person who complained and
+// the person who has to fix it are not the same person.
+func BenchmarkAPIReported(b *testing.B) {
+	// A screenful, which is what the panel draws and so what it asks for.
+	const rows = 6
+
+	st, spec := benchcorpus.Fixture(b)
+	s := api.New(st, index.New(st, index.WithClock(func() time.Time { return benchcorpus.Epoch })),
+		api.HeaderAuth{Tenant: benchcorpus.Tenant}, api.WithLogger(slog.New(slog.DiscardHandler)))
+	h := s.Handler()
+	reader := headers(spec.Principal())
+
+	owners := make([]string, 0, rows)
+	if err := st.Scan(b.Context(), spec.Principal(), func(d doc.Document) bool {
+		if d.Owner.Email == "" {
+			return true
+		}
+		r := httptest.NewRequestWithContext(b.Context(), http.MethodPost,
+			"/api/v1/documents/"+url.PathEscape(d.ID)+"/stale",
+			strings.NewReader(`{"note":"this names a cluster that was turned off"}`))
+		for k, v := range reader {
+			r.Header.Set(k, v)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, r)
+		if rec.Code != http.StatusOK {
+			b.Fatalf("POST /api/v1/documents/%s/stale = %d, %s", d.ID, rec.Code, rec.Body)
+		}
+		owners = append(owners, "gdrive:"+d.Owner.Email)
+		return len(owners) < rows
+	}); err != nil {
+		b.Fatalf("reading the corpus: %v", err)
+	}
+
+	// The same reader, carrying the addresses those six documents are owned at.
+	// The groups do not move, so what is being measured is the ownership match
+	// on top of the permission predicate rather than a different corpus.
+	owner := headers(spec.Principal())
+	owner[api.HeaderIdentities] = strings.Join(owners, ",")
+
+	target := "/api/v1/reported?limit=" + strconv.Itoa(rows)
+	var inbox struct {
+		Documents []struct {
+			ID string `json:"id"`
+		} `json:"documents"`
+	}
+	if err := json.Unmarshal(get(b, h, target, owner).Body.Bytes(), &inbox); err != nil {
+		b.Fatalf("decoding the inbox: %v", err)
+	}
+	// An empty list is a read of nothing, and a benchmark of it would report a
+	// number that says the panel is free right up until somebody's readers use
+	// the feature.
+	if len(inbox.Documents) != rows {
+		b.Fatalf("the inbox holds %d documents and %d were reported", len(inbox.Documents), rows)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		get(b, h, target, owner)
 	}
 }
 

--- a/api/reported.go
+++ b/api/reported.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// Reported is the other half of saying a document is out of date: what somebody
+// said has to reach the person who can do something about it.
+//
+// A report that lands in a table nobody reads is a report that was never made,
+// and the reader who took the trouble to write the sentence learns that taking
+// the trouble does nothing. So this endpoint exists for the owner rather than
+// for the reporter, and it answers with the documents this caller owns or wrote
+// that somebody has complained about, most recently complained about first.
+const (
+	// ReportedLimit is how many the caller gets when they do not say. It is the
+	// home screen panel, which holds six rows and is a summary rather than a
+	// queue.
+	ReportedLimit = 10
+
+	// ReportedMax is the most a caller can ask for, for the reason RecentMax
+	// exists: this is read at a glance, and a URL should not be able to turn a
+	// fast endpoint into a slow one.
+	ReportedMax = 50
+)
+
+// reportedResponse is the inbox.
+type reportedResponse struct {
+	// Documents is what has been reported, and is an empty list rather than a
+	// null when there is nothing, so the interface can count it without
+	// checking whether it is there.
+	Documents []reportedHit `json:"documents"`
+
+	// At is when the server answered, which is what the interface shows beside a
+	// list it is holding from a minute ago.
+	At time.Time `json:"at"`
+}
+
+// reportedHit is one document with what was said about it.
+//
+// The document fields are embedded rather than nested, exactly as they are in
+// the recent lists, so a row of this list and a row of a result list are the
+// same shape to a client and are drawn by the same code.
+type reportedHit struct {
+	searchHit
+	Stale *staleness `json:"stale"`
+}
+
+// identity is the response without the fields that move on their own, so that
+// two answers a minute apart share a tag. When the server answered is one of
+// them; when somebody reported a document is not, because that is a fact about
+// the past.
+func (r reportedResponse) identity() any {
+	r.At = time.Time{}
+	docs := make([]reportedHit, len(r.Documents))
+	copy(docs, r.Documents)
+	for i := range docs {
+		docs[i].Score = 0
+	}
+	r.Documents = docs
+	return r
+}
+
+// handleReported answers with what this caller's readers have said about this
+// caller's own documents.
+//
+// A deployment whose driver cannot remember a report gets an empty list rather
+// than a refusal, the way the recent screen gets one list instead of two when
+// there is no history to read. The panel this feeds simply does not draw, and a
+// home screen with one section missing is a better answer than a home screen
+// with an error on it.
+func (s *Server) handleReported(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	limit, err := intParam(r.URL.Query().Get("limit"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "limit must be a number")
+		return
+	}
+	if limit <= 0 {
+		limit = ReportedLimit
+	}
+	limit = min(limit, ReportedMax)
+
+	out := reportedResponse{Documents: []reportedHit{}, At: s.now().UTC()}
+	rep, ok := s.reporter()
+	if !ok {
+		writeConditional(w, r, http.StatusOK, out, out.identity())
+		return
+	}
+
+	flagged, err := rep.Reported(r.Context(), p, limit)
+	if err != nil {
+		s.log.Error("the reported list could not be read", "error", err, "tenant", p.Tenant)
+		writeError(w, http.StatusInternalServerError, "internal", "the reported list could not be read")
+		return
+	}
+	for _, f := range flagged {
+		out.Documents = append(out.Documents, reportedHit{
+			searchHit: hitOf(f.Document),
+			Stale:     staleOf(f.Stale),
+		})
+	}
+	writeConditional(w, r, http.StatusOK, out, out.identity())
+}

--- a/api/reported_test.go
+++ b/api/reported_test.go
@@ -1,0 +1,202 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// The owner's side of a report.
+//
+// A report that lands in a table nobody reads is a report that was never made.
+// What is being checked here is that it reaches the person who can act on it and
+// reaches nobody else: this endpoint is the one place in the product that hands
+// somebody a list of documents on the grounds that they are accountable for
+// them, and the rule for that is the same owns or wrote it rule the rest of
+// curation uses.
+
+// inbox is the reported list as this file reads it.
+type inbox struct {
+	Documents []struct {
+		ID    string     `json:"id"`
+		Title string     `json:"title"`
+		Stale *staleBody `json:"stale"`
+	} `json:"documents"`
+	At time.Time `json:"at"`
+}
+
+// stepping is a clock that moves a minute every time it is read, so that three
+// reports made in one test are three different instants and the order the
+// endpoint promises is an order this test can see.
+func stepping(from time.Time) func() time.Time {
+	at := from
+	return func() time.Time {
+		at = at.Add(time.Minute)
+		return at
+	}
+}
+
+func newInboxServer(t *testing.T, now func() time.Time) http.Handler {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	if err := st.Put(t.Context(), ownedDocs()...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}, api.WithClock(now))
+	return s.Handler()
+}
+
+// reportOne says a document is out of date and fails the test if it could not.
+func reportOne(t *testing.T, h http.Handler, id, note string, headers map[string]string) {
+	t.Helper()
+	w := post(t, h, http.MethodPost, "/api/v1/documents/"+id+"/stale", `{"note":"`+note+`"}`, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reporting %s: %d %s", id, w.Code, w.Body.String())
+	}
+}
+
+func inboxOf(t *testing.T, h http.Handler, query string, headers map[string]string) inbox {
+	t.Helper()
+	w := request(t, h, http.MethodGet, "/api/v1/reported"+query, headers)
+	if w.Code != http.StatusOK {
+		t.Fatalf("reading the inbox: %d %s", w.Code, w.Body.String())
+	}
+	return decode[inbox](t, w)
+}
+
+func ids(got inbox) []string {
+	out := make([]string, 0, len(got.Documents))
+	for _, d := range got.Documents {
+		out = append(out, d.ID)
+	}
+	return out
+}
+
+// Owning it or having written it is what puts a document in this list, and
+// neither of those is being able to read it.
+func TestTheInboxHoldsOnlyYourOwnDocuments(t *testing.T) {
+	h := newInboxServer(t, clock)
+
+	for _, id := range []string{"mine", "hers", "theirs"} {
+		reportOne(t, h, id, "out of date", colleague())
+	}
+
+	// Mei wrote mine and owns hers. Kenji's document is reported and is not her
+	// problem.
+	got := ids(inboxOf(t, h, "", owner()))
+	if len(got) != 2 || got[0] != "hers" || got[1] != "mine" {
+		t.Fatalf("the owner's inbox holds %v, and should hold hers and mine", got)
+	}
+
+	// The person who reported all three owns none of them, so they are told
+	// about none of them. A report is not a subscription.
+	if said := ids(inboxOf(t, h, "", colleague())); len(said) != 0 {
+		t.Errorf("the reader who made the reports was handed %v", said)
+	}
+}
+
+// The list is worth reading because of what is on each row, not because of how
+// long it is.
+func TestTheInboxCarriesTheCountAndTheSentence(t *testing.T) {
+	// A moving clock, because the row carries the most recent of the two reports
+	// and two reports made in the same instant leave which one that is up to the
+	// driver.
+	h := newInboxServer(t, stepping(clock()))
+	reportOne(t, h, "hers", "the pager numbers are last year's", curator())
+	reportOne(t, h, "hers", "and it still names a rota we stopped running", colleague())
+
+	got := inboxOf(t, h, "", owner())
+	if len(got.Documents) != 1 {
+		t.Fatalf("the inbox holds %d rows, and two people reported one document", len(got.Documents))
+	}
+	row := got.Documents[0]
+	if row.Title != "Payments oncall rota" {
+		t.Errorf("the row says %q rather than naming the document", row.Title)
+	}
+	if row.Stale == nil || row.Stale.Count != 2 {
+		t.Fatalf("two people reported it and the row says %+v", row.Stale)
+	}
+	// The last thing said and the person who said it, so the owner has a sentence
+	// to act on and somebody to go back to rather than a number to argue with.
+	if row.Stale.Note != "and it still names a rota we stopped running" {
+		t.Errorf("the row carries the note %q", row.Stale.Note)
+	}
+	if row.Stale.By != "ren@acme.com" {
+		t.Errorf("the row says %q reported it", row.Stale.By)
+	}
+}
+
+// An empty inbox is the common case and has to be cheap to draw.
+func TestAnEmptyInboxIsAListRatherThanANull(t *testing.T) {
+	h := newInboxServer(t, clock)
+
+	w := request(t, h, http.MethodGet, "/api/v1/reported", owner())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if got := decode[inbox](t, w); got.Documents == nil || len(got.Documents) != 0 {
+		t.Errorf("an empty inbox came back as %+v", got.Documents)
+	}
+}
+
+// Most recently reported first, because the report somebody made this morning is
+// the one that is still being lived with.
+func TestTheInboxIsMostRecentFirstAndHonoursALimit(t *testing.T) {
+	h := newInboxServer(t, stepping(clock()))
+
+	reportOne(t, h, "mine", "the first thing anybody said", colleague())
+	reportOne(t, h, "hers", "and the second", colleague())
+
+	if got := ids(inboxOf(t, h, "", owner())); len(got) != 2 || got[0] != "hers" {
+		t.Fatalf("the inbox reads %v, and hers was reported last", got)
+	}
+	if got := ids(inboxOf(t, h, "?limit=1", owner())); len(got) != 1 || got[0] != "hers" {
+		t.Errorf("asking for one gave %v", got)
+	}
+	if w := request(t, h, http.MethodGet, "/api/v1/reported?limit=nine", owner()); w.Code != http.StatusBadRequest {
+		t.Errorf("a limit that is not a number answered %d", w.Code)
+	}
+}
+
+// Dealing with a report takes the document off the list, which is what makes the
+// list a thing somebody can get to the bottom of.
+func TestClearingAReportEmptiesTheInbox(t *testing.T) {
+	h := newInboxServer(t, clock)
+	reportOne(t, h, "hers", "out of date", colleague())
+
+	if w := post(t, h, http.MethodDelete, "/api/v1/documents/hers/stale", "", owner()); w.Code != http.StatusNoContent {
+		t.Fatalf("clearing the report: %d %s", w.Code, w.Body.String())
+	}
+	if got := ids(inboxOf(t, h, "", owner())); len(got) != 0 {
+		t.Errorf("the report was dealt with and the inbox still holds %v", got)
+	}
+}
+
+// The home screen reads this on every visit, so an answer that has not changed
+// has to cost a tag rather than a body.
+func TestAnUnchangedInboxIsNotSentTwice(t *testing.T) {
+	h := newInboxServer(t, clock)
+	reportOne(t, h, "hers", "out of date", colleague())
+
+	first := request(t, h, http.MethodGet, "/api/v1/reported", owner())
+	tag := first.Header().Get("ETag")
+	if first.Code != http.StatusOK || tag == "" {
+		t.Fatalf("the first read answered %d with tag %q", first.Code, tag)
+	}
+
+	headers := owner()
+	headers["If-None-Match"] = tag
+	second := request(t, h, http.MethodGet, "/api/v1/reported", headers)
+	if second.Code != http.StatusNotModified {
+		t.Fatalf("status = %d, want 304: %s", second.Code, second.Body.String())
+	}
+	if second.Body.Len() != 0 {
+		t.Errorf("a not modified answer carried %d bytes", second.Body.Len())
+	}
+}

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -526,9 +526,58 @@ async function walk(session) {
       'the section about the old cluster is wrong'`,
   );
 
-  // And clearing it, which is the half of the pair a reader is not offered. The
-  // walk runs as the administrator this server was started with, so both halves
-  // are on the screen here and the refusal is the API test's business.
+  // The owner's side of the same report, which is the half that decides whether
+  // any of this was worth typing. Nothing a file connector indexes has an owner,
+  // so one is named first: the panel exists for the person accountable for a
+  // document, and until somebody says who that is a report has nowhere to go.
+  await evaluate(
+    session,
+    `(() => {
+      document.querySelector('.button--reassign').click();
+      const field = document.querySelector('.own__field');
+      field.value = 'dev@example.com';
+      field.form.requestSubmit();
+      return true;
+    })()`,
+  );
+  await check(
+    session,
+    "naming an owner is what gives a report somewhere to go",
+    `Boolean(document.querySelector('.page__meta .owner'))`,
+  );
+
+  await visit(session, `${BASE}/`, "document.querySelectorAll('.home .panel').length > 0");
+  await check(
+    session,
+    "what a reader reported is on the home screen of the person who owns the document",
+    `(() => {
+      const panel = [...document.querySelectorAll('.home .panel')].find(
+        (p) => (p.querySelector('.panel__title') || {}).textContent === 'Reported as out of date',
+      );
+      if (!panel) return false;
+      const row = panel.querySelector('.panel__row');
+      return Boolean(row) && (row.querySelector('.panel__row-meta') || {}).textContent === '1 report';
+    })()`,
+  );
+
+  // Back to the document to put both of those away. The marker has to go on
+  // again because this is a fresh load of the page, which costs the claim below
+  // nothing: what it rules out is the clear reloading the document, and the
+  // element it watches was put there before the clear rather than by it.
+  await visit(session, BASE + id, "Boolean(document.querySelector('.page__meta .stale'))");
+  await evaluate(session, "document.querySelector('.page__body > *').dataset.walk = 'kept'");
+  await evaluate(session, foot("Undo correction") + ".click()");
+  await check(
+    session,
+    "putting the source's answer back about who owns it leaves the report standing",
+    `!document.querySelector('.page__meta .owner') &&
+      Boolean(document.querySelector('.page__meta .stale'))`,
+  );
+
+  // And clearing the report, which is the half of the pair a reader is not
+  // offered. The walk runs as the administrator this server was started with, so
+  // both halves are on the screen here and the refusal is the API test's
+  // business.
   await evaluate(session, foot("Mark as dealt with") + ".click()");
   await check(
     session,

--- a/store/sqlitestore/report.go
+++ b/store/sqlitestore/report.go
@@ -163,6 +163,17 @@ func (s *Store) Reports(ctx context.Context, p *acl.Principal, ids []string) (ma
 // Owns or wrote is the same membership test an owner: filter is, against the
 // folded key columns the index already keeps, so the question is answered while
 // SQLite walks its own rows rather than by reading documents and deciding in Go.
+//
+// The join order is pinned for the reason written out over Verifications and
+// Reports, and this is the query that proves the point rather than restating it.
+// Left to itself the planner drives from document, because it has no statistics
+// saying the report table holds six rows against the corpus's twenty thousand,
+// and then evaluates the ownership test and the visibility predicate over every
+// document in the tenant. Measured on the benchmark corpus that was 900
+// milliseconds for a panel on the front page. Driven from the reports, which is
+// what the CROSS JOIN forces, the same answer is a few hundred microseconds:
+// the work is proportional to what has been reported, which is the only thing
+// this endpoint is about.
 func (s *Store) Reported(ctx context.Context, p *acl.Principal, limit int) ([]store.Flagged, error) {
 	if err := s.ready(ctx); err != nil {
 		return nil, err
@@ -181,8 +192,8 @@ func (s *Store) Reported(ctx context.Context, p *acl.Principal, limit int) ([]st
 	rows, err := s.query(ctx, `
 		SELECT r.doc_id, r.reporter, r.reported_at, r.note, r.n, x.data
 		FROM (`+latest+`) r
-		JOIN document d ON d.id = r.doc_id
-		JOIN document_data x ON x.doc_id = d.id
+		CROSS JOIN document d ON d.id = r.doc_id
+		CROSS JOIN document_data x ON x.doc_id = d.id
 		WHERE r.rn = 1
 		  AND (
 			EXISTS (SELECT 1 FROM json_each(d.owner_keys) k WHERE k.value IN (SELECT value FROM json_each(?)))

--- a/web/dist/assets/api.js
+++ b/web/dist/assets/api.js
@@ -291,6 +291,11 @@ export const api = {
   // many other people had already said the same thing is on the server.
   report: (id, said) => send("POST", stalePath(id), said),
   resolve: (id) => send("DELETE", stalePath(id)),
+  // The owner's side of the same feature: the documents this person owns or
+  // wrote that somebody has complained about. A deployment whose driver cannot
+  // remember a report answers with an empty list rather than a refusal, so the
+  // panel this feeds simply does not draw.
+  reported: (limit, opts) => get("/reported", { limit }, opts),
   content: (id, opts) => bytes(`/documents/${encodeURIComponent(id)}/content`, opts),
   // The version goes in the URL rather than in a header, because it is what
   // makes the address of a thumbnail stand for one picture forever. The server

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -1710,6 +1710,18 @@ mark.hit--current::after {
 }
 
 /*
+ * How many people have reported a document, on the owner's panel. It takes the
+ * warning colour the mark on a document takes rather than the secondary one
+ * every other row meta carries, because that panel is a job list and the number
+ * is the job. It has to be written here rather than by putting .stale on the
+ * span, because .panel__row-meta is further down this file and would win.
+ */
+.panel__row-meta--flag {
+  color: var(--danger-700);
+  font-weight: var(--weight-semibold);
+}
+
+/*
  * A row that is a link says so on hover rather than by being blue while it
  * sits there. The tip rows on the home page are not links, so they carry
  * .panel__row--static and their titles stay in the text colour in every

--- a/web/dist/assets/home.js
+++ b/web/dist/assets/home.js
@@ -1,17 +1,19 @@
 // The home screen.
 //
-// It answers three questions and nothing else. What is in here, from the session
+// It answers four questions and nothing else. What is in here, from the session
 // and the index statistics. What was I doing, from the recent endpoint and from
 // the searches this browser remembers. What is going on, which is what changed
-// in the corpus. Everything on it is a real read against the same API the search
-// page uses, so nothing here can show a document the person could not have found
-// by searching for it.
+// in the corpus. And what is waiting for me, which is the documents this person
+// owns or wrote that a reader has said are out of date. Everything on it is a
+// real read against the same API the search page uses, so nothing here can show
+// a document the person could not have found by searching for it.
 
 import { h, replace } from "genba/dom.js";
 import { api } from "genba/api.js";
 import { cache } from "genba/cache.js";
 import { queries } from "genba/queries.js";
 import { LIMIT as RECENT_LIMIT } from "genba/recent.js";
+import { brief, sentence } from "genba/stale.js";
 import { label, sourceColor, when, number, initials } from "genba/format.js";
 import { firstRun } from "genba/states.js";
 
@@ -39,9 +41,11 @@ export class Home {
   async render(session) {
     const recentKey = cache.key("recent", { limit: RECENT_LIMIT });
     const statsKey = cache.key("stats", {});
+    const reportedKey = cache.key("reported", { limit: PANEL_ROWS });
     let recent = cache.read(recentKey).data || null;
     let stats = cache.read(statsKey).data || null;
-    this.paint(session, recent, stats);
+    let reported = cache.read(reportedKey).data || null;
+    this.paint(session, recent, stats, reported);
 
     let changed = false;
     // The paint callbacks fire once with what was already on screen, which is
@@ -61,12 +65,22 @@ export class Home {
           changed = true;
         })
         .catch(() => {}),
+      // Only as many as the panel draws, so the request the screen makes and
+      // the list it paints are the same list. The other two reads feed screens
+      // with a see all link and ask for more than they show.
+      cache
+        .swr(reportedKey, (opts) => api.reported(PANEL_ROWS, opts), (d) => {
+          if (d === reported) return;
+          reported = d;
+          changed = true;
+        })
+        .catch(() => {}),
     ]);
-    if (changed) this.paint(session, recent, stats);
+    if (changed) this.paint(session, recent, stats, reported);
   }
 
   /** paint draws the screen, with skeletons standing in for what is not here. */
-  paint(session, recent, stats) {
+  paint(session, recent, stats, reported) {
     // An index with nothing in it gets the screen about that and not this one.
     // A first install currently sees a dashboard reading zero in three places,
     // which is the only first impression this program will ever get and is
@@ -88,6 +102,7 @@ export class Home {
         ? h(
             "div",
             { class: "home__grid" },
+            this.reportedPanel(reported),
             this.openedPanel(recent),
             this.changedPanel(recent),
             this.searchesPanel(),
@@ -107,6 +122,48 @@ export class Home {
         h("div", { class: "skeleton", style: { width: "40%", height: "24px", marginBottom: "24px" } }),
         ...Array.from({ length: 4 }, () =>
           h("div", { class: "skeleton", style: { width: "100%", height: "16px", marginBottom: "24px" } }),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * reportedPanel is what this person's readers have said about this person's
+   * own documents.
+   *
+   * It comes first on the screen and it is the one panel that is not drawn at
+   * all when it is empty, which is the opposite of the two beneath it. Those
+   * are histories, and a history that says it is empty is worth reading. This
+   * one is a job list, and a job list that sits on everybody's home screen
+   * reading nothing every day of the year teaches the whole company to look
+   * past the one place a report ever appears.
+   *
+   * There is no see all link because there is nothing more to see. A person
+   * with more than six reported documents has a bad week rather than a second
+   * page, and the count on each row says which one to start with.
+   */
+  reportedPanel(reported) {
+    const rows = (reported && reported.documents) || [];
+    if (!rows.length) return null;
+    return h(
+      "section",
+      { class: "panel" },
+      h("div", { class: "panel__head" }, h("h2", { class: "panel__title" }, "Reported as out of date")),
+      rows.slice(0, PANEL_ROWS).map((hit) =>
+        h(
+          "button",
+          {
+            class: "panel__row",
+            type: "button",
+            // The whole report on hover, because the sentence somebody wrote is
+            // what says whether this is ten minutes of work or an afternoon,
+            // and it does not fit on the row.
+            title: sentence(hit.stale),
+            onClick: () => this.onOpen(hit.id),
+          },
+          h("span", { class: "source__dot", style: { background: sourceColor(hit.source) } }),
+          h("span", { class: "panel__row-title" }, hit.title || hit.id),
+          h("span", { class: "panel__row-meta panel__row-meta--flag" }, brief(hit.stale)),
         ),
       ),
     );

--- a/web/dist/assets/stale.js
+++ b/web/dist/assets/stale.js
@@ -43,6 +43,18 @@ export function mark(s) {
   );
 }
 
+/**
+ * brief is the same fact as the mark, short enough for a row in a panel.
+ *
+ * The owner's list has a title on every row and no space for a sentence, so
+ * what is left is the number, and the number is the part that says which of six
+ * documents to open first.
+ */
+export function brief(s) {
+  if (!s || !s.at) return "";
+  return s.count > 1 ? `${s.count} reports` : "1 report";
+}
+
 /** words is the mark itself, which stays short enough for a crumb. */
 function words(s) {
   if (s.count > 1) return `Reported out of date by ${s.count} people`;
@@ -56,7 +68,7 @@ function words(s) {
  * somebody to ask, exactly as the reader who disagrees with a verification
  * does.
  */
-function sentence(s) {
+export function sentence(s) {
   const who = s.email ? `${s.by} (${s.email})` : s.by || "somebody";
   const parts = [`Reported out of date by ${who} on ${exact(s.at)}`];
   if (s.count > 1) parts.push(`${s.count} people have said so`);
@@ -200,6 +212,7 @@ async function act(button, d, box, run, { onSay = () => {}, onChange = () => {} 
     // what this costs is a revalidation that is usually answered with a 304.
     cache.invalidate(cache.key("search", {}));
     cache.invalidate(cache.key("recent", {}));
+    cache.invalidate(cache.key("reported", {}));
     cache.invalidate(cache.key("document", { id: d.id }));
     // Reporting answers with what stands afterwards and clearing answers with
     // nothing at all, which is the same thing said two ways.


### PR DESCRIPTION
## What this is

The other half of the report button that shipped in #159. A reader can say a document is out of date, and until now the only place that showed up was on the document itself. This takes it to the person who can do something about it.

`GET /api/v1/reported` answers with the documents the caller owns or wrote that somebody has reported, most recently reported first, with the count, the most recent reporter and what they said on each row. The home screen draws it as a panel.

Part of #41, and it ticks the fourth box.

## The permission rule

Owns or wrote, which is the rule the rest of curation uses, and it is applied while the driver walks its own rows rather than by filtering afterwards. Being able to read a document does not put it on your list, and a document you cannot read cannot appear on it, so nobody learns that a document exists by asking whether it has been reported.

Being an administrator does not put the whole corpus on your list either. An administrator may clear any report and has no reason to be handed everybody else's work as their own.

A deployment whose driver cannot remember a report gets an empty list rather than a 501. The panel simply does not draw, which is how `handleRecent` behaves when there is no history to read, and a home screen with one section missing is a better answer than a home screen with an error on it.

## The panel

It is first on the grid and it is the only panel that is not drawn at all when it is empty. The two beneath it are histories, and a history that says it is empty is worth reading. This one is a job list, and a job list that reads nothing on everybody's front page every day of the year teaches the whole company to look past the one place a report ever appears.

There is no see all link because there is nothing more to see. Somebody with more than six reported documents has a bad week rather than a second page. The count on each row is the thing that says which one to open first, so it takes the warning colour rather than the secondary one every other row meta carries, and the whole report is on the row's tooltip because the sentence somebody wrote is what says whether this is ten minutes of work or an afternoon.

## The query the planner got wrong

This is the part worth reviewing. The sqlite driver had `JOIN document` where it needed `CROSS JOIN`, and left to itself the planner drove the query from `document`. It has no statistics saying the report table holds six rows against a corpus of twenty thousand, so it walked the corpus, running the ownership test and the visibility predicate over every document in the tenant.

Measured on the benchmark corpus that was 900 ms for a panel on the front page. Pinning the join order takes it to what the other endpoints on that screen cost on the same machine in the same minute:

```
BenchmarkAPIRecent-8       142 ms/op
BenchmarkAPIReported-8      45 ms/op
BenchmarkAPIStats-8         28 ms/op
```

Those absolute numbers are a loaded shared box rather than a budget, which is what the calibrated gate is for. The comparison is the point: the endpoint went from an order of magnitude worse than everything around it to in family with it, and the work is now proportional to what has been reported rather than to the size of the corpus.

The same lesson is already written out over `Verifications` and `Reports` in that file. This is the query that proves it rather than restating it, so the comment says so and gives the number.

`BenchmarkAPIReported` reads as a reader carrying the addresses those documents are owned at, and fails if the inbox came back empty. A benchmark of an empty list reports that the panel is free right up until somebody's readers use the feature.

## Tests

`api/reported_test.go` covers the rule and the shape: mei sees the document she wrote and the one she owns and never the one that is Kenji's from end to end, the reader who made all three reports is handed none of them, two people reporting one document is one row saying two, an empty inbox is a list rather than a null, most recently reported first with a moving clock, a limit that is honoured and one that is not a number, clearing a report empties the inbox, and an unchanged inbox comes back as a 304 with no body.

The keyboard walk names an owner, reports the document as a reader, goes to the front page and finds what was said waiting there, then comes back and puts both away. That is the round trip the feature is, and none of the halves prove it on their own.

## Checks

Full suite green on sqlite, postgres 18 and the memory driver. `golangci-lint` reports 0 issues, still no `//nolint` anywhere. The browser gate is green: 158 checks, 0 axe violations, 40 requests against a ceiling of 48, 777 nodes on a results page and 2429 with a document open.
