### PR TITLE
Answer the question people keep asking, once

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ Everything the interface does is an HTTP call, and there is nothing it can reach
 | `GET /api/v1/stats` | how much is indexed and how much is quarantined |
 | `GET /api/v1/admin/operations` | what the connectors are doing, and what is being held back and why |
 | `GET /api/v1/admin/access` | whether one named person can read one document, and why |
+| `GET /api/v1/admin/answers` | the questions this tenant has written an answer to, most recently written first |
+| `PUT /api/v1/admin/answers/{id}` | writes an answer to a question, or replaces the one that is there |
+| `DELETE /api/v1/admin/answers/{id}` | takes an answer down |
 | `POST /api/v1/admin/connectors` | adds a connector, or replaces one, and starts it |
 | `DELETE /api/v1/admin/connectors/{source}` | stops a connector and forgets how it was configured |
 | `POST /api/v1/admin/connectors/{source}/start` | switches one back on |
@@ -155,6 +158,11 @@ The snippet comes back as marked passages rather than as offsets, so a client hi
 A verification is a named claim with a date on it rather than a flag, so search results and the document itself carry who vouched for it, when, and when that stops counting.
 It lasts six months unless the verifier says otherwise, and only the owner or the author of a document can make one, because a badge anybody can apply is a badge that means somebody read the title.
 A driver that cannot record one leaves the badge off rather than failing the search behind it.
+
+A question people ask often enough is worth answering once, so an administrator can write the answer down and it stands above the results for everybody in the tenant.
+It carries the name of whoever wrote it, the date they last stood behind it and the documents they drew it from, and it takes the place of the quoted passages rather than sitting beside them, because that region is the answer to the question in the box and two answers to one question is a reader deciding which of ours to believe.
+The question is matched whole, over the phrasing it was filed under and any others its author listed, so a search that is close but not the same gets the ordinary results page it would have got before this existed.
+Its sources are resolved through the reader asking, so an answer written by somebody who can read everything never becomes a list of documents the reader in front of it cannot open.
 
 Ownership is derived from the source, and what a source derives is very often the account that ran the import, so it can be corrected.
 The correction carries the name of the person who made it and the date, it survives every crawl after it, and clearing it puts back whatever the connector reports today rather than what it reported the day somebody disagreed.

--- a/api/api.go
+++ b/api/api.go
@@ -236,6 +236,9 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("POST /api/v1/recent", s.authenticated(s.handleRecordOpen))
 	mux.Handle("GET /api/v1/stats", s.authenticated(s.handleStats))
 	mux.Handle("GET /api/v1/events", s.authenticated(s.handleEvents))
+	mux.Handle("GET /api/v1/admin/answers", s.admin(s.handleAnswers))
+	mux.Handle("PUT /api/v1/admin/answers/{id}", s.admin(s.handleCurate))
+	mux.Handle("DELETE /api/v1/admin/answers/{id}", s.admin(s.handleRetract))
 	mux.Handle("GET /api/v1/admin/operations", s.admin(s.handleAdmin))
 	mux.Handle("GET /api/v1/admin/access", s.admin(s.handleAccess))
 	mux.Handle("POST /api/v1/admin/connectors", s.admin(s.handleAddConnector))
@@ -362,6 +365,16 @@ type searchResponse struct {
 	// no content under it is the most common way an answer surface makes a page
 	// worse than it was.
 	Answer *answer `json:"answer,omitempty"`
+
+	// Curated is an answer a person wrote to exactly this question, and it takes
+	// the place of the quoted one above when there is one.
+	//
+	// Takes the place rather than sits beside, because the region above the
+	// results holds one answer. Two of them is a reader deciding which of the
+	// product's two answers to believe, which is a worse page than either alone,
+	// and it is also the sense in which a written answer outranks the documents
+	// it summarises: it is not scored against them, it stands in front of them.
+	Curated *curatedAnswer `json:"curated,omitempty"`
 
 	// Correction is a spelling of the query that would have found something. It
 	// is only ever present on a search that found nothing, and it has already
@@ -490,6 +503,14 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 		Hits:       []searchHit{},
 		Answer:     answerOf(res.Answer),
 		Correction: res.Correction,
+	}
+	// The written answer is asked for by the words that were typed rather than
+	// by the parsed text, because a person writing one writes a question and not
+	// a query, and app:slack what is the deploy freeze is a search rather than a
+	// question. If somebody has answered it, it stands in front of the quotes
+	// rather than beside them.
+	if out.Curated = s.curatedFor(r, p, out.Query); out.Curated != nil {
+		out.Answer = nil
 	}
 	ids := make([]string, 0, len(res.Hits))
 	for _, h := range res.Hits {

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"encoding/json"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -126,6 +127,74 @@ func BenchmarkAPIDocument(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; b.Loop(); i++ {
 		get(b, h, "/api/v1/documents/"+page.Hits[i%len(page.Hits)].ID, hdr)
+	}
+}
+
+// BenchmarkAPISearchCurated is a search that somebody has written the answer to.
+//
+// The miss is already measured, because every search asks whether this question
+// has been answered and almost none of them have, so the cost of asking is in
+// BenchmarkAPISearch above. This is the other half: the probe finds something,
+// and the answer's sources are then read through the reader asking, which is one
+// more query and a permission check per citation.
+//
+// The question is deliberately not one of the checked in queries. Answering one
+// of those would put a card on a page the benchmark beside this one measures,
+// and the two numbers would stop being comparable.
+func BenchmarkAPISearchCurated(b *testing.B) {
+	const question = "how does the benchmark corpus answer this particular question"
+	h, hdr := handler(b, api.WithLogger(slog.New(slog.DiscardHandler)))
+
+	var page struct {
+		Hits []struct {
+			ID string `json:"id"`
+		} `json:"hits"`
+	}
+	queries := benchcorpus.ByClass(benchcorpus.Queries())[benchcorpus.ClassCommon]
+	w := get(b, h, "/api/v1/search?q="+urlQuery(queries[0].Text), hdr)
+	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil {
+		b.Fatalf("decoding the search page: %v", err)
+	}
+	if len(page.Hits) < api.AnswerSources {
+		b.Fatalf("the corpus returned %d documents, and an answer is measured with %d sources under it",
+			len(page.Hits), api.AnswerSources)
+	}
+
+	sources := make([]string, 0, api.AnswerSources)
+	for _, hit := range page.Hits[:api.AnswerSources] {
+		sources = append(sources, hit.ID)
+	}
+	body, err := json.Marshal(map[string]any{
+		"question": question,
+		"body":     "The corpus is generated from a seed, so every run reads the same documents in the same order.",
+		"sources":  sources,
+	})
+	if err != nil {
+		b.Fatalf("encoding the answer: %v", err)
+	}
+
+	admin := maps.Clone(hdr)
+	admin[api.HeaderRoles] = acl.RoleAdmin
+	r := httptest.NewRequestWithContext(b.Context(), http.MethodPut, "/api/v1/admin/answers/bench", strings.NewReader(string(body)))
+	for k, v := range admin {
+		r.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+	if rec.Code != http.StatusOK {
+		b.Fatalf("writing the answer: %d %s", rec.Code, rec.Body)
+	}
+
+	target := "/api/v1/search?q=" + urlQuery(question)
+	got := get(b, h, target, hdr)
+	if !strings.Contains(got.Body.String(), `"curated"`) {
+		b.Fatal("the question that was just answered came back with no answer on it")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		get(b, h, target, hdr)
 	}
 }
 

--- a/api/curate.go
+++ b/api/curate.go
@@ -1,0 +1,365 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// answerBodyLimit is how large a written answer may be.
+//
+// Sixty four kilobytes, which is far more prose than anybody should put above a
+// list of results and is the point at which what is being written is a document
+// rather than an answer. It is a limit on the request rather than a rule about
+// good answers, and the reader who has to scroll past a long one is what
+// actually enforces the second.
+const answerBodyLimit = 64 << 10
+
+// AnswerSources is how many of an answer's sources are drawn under it.
+//
+// Six, which is a row of citations rather than a second list of results. An
+// answer that needs more than six documents to stand up is not an answer, it is
+// a reading list, and the reader is better served by the search underneath.
+const AnswerSources = 6
+
+// AnswersLimit and AnswersMax bound the maintenance list.
+const (
+	AnswersLimit = 50
+	AnswersMax   = 500
+)
+
+// curatedAnswer is the card above the results.
+//
+// Its sources are whole rows rather than ids, unlike the quotes in an
+// extractive answer, and the difference is not an inconsistency. A quote is
+// always taken from a document that is already on the page below it, so the
+// title is on the wire once. An answer's sources are whatever the person who
+// wrote it cited, which has nothing to do with what this query happened to
+// rank, so there is nothing on the page for a bare id to point at.
+//
+// They are the same shape a result row is, so the interface draws a citation
+// with the code it already has, and a reader recognises a citation as the same
+// kind of thing as a result.
+type curatedAnswer struct {
+	ID       string `json:"id"`
+	Question string `json:"question"`
+
+	// Body is markdown, unrendered, exactly as it was typed. Rendering it is the
+	// interface's job for the reason every other body on the wire is: the
+	// renderer that draws a document has to be the renderer that draws this, or
+	// an answer and the document it cites format the same list two ways.
+	Body string `json:"body"`
+
+	// By and Email are who wrote it, and At is when they last did.
+	//
+	// This is the field the whole card rests on. A reader believes an answer
+	// over the four documents underneath it because a person they can go and ask
+	// put their name to it, so an unsigned card would be worse than no card.
+	By    string    `json:"by"`
+	Email string    `json:"email,omitempty"`
+	At    time.Time `json:"at"`
+
+	// Until is when it stops counting as current, and State is where that puts
+	// it now, in the same three words a verification badge uses.
+	//
+	// An expired answer still renders and says so. It is a more useful thing for
+	// a reader to know about than the silence they would get if it disappeared,
+	// and it is the only way the person who wrote it finds out it needs looking
+	// at.
+	Until time.Time `json:"until"`
+	State string    `json:"state"`
+
+	// Sources are the documents it was drawn from, resolved through the reader
+	// asking, so an answer written by somebody with broader access does not
+	// become a list of the documents this reader may not open.
+	Sources []searchHit `json:"sources,omitempty"`
+}
+
+// curatedRecord is the same answer as the person maintaining it sees it.
+//
+// The difference is the sources, which are ids here and rows on the card. This
+// is the shape that goes back out to whoever is going to edit it, and an id
+// they cannot read has to survive the round trip: resolving the sources for
+// this list and then saving what came back would quietly drop every source the
+// editor happens not to have access to.
+type curatedRecord struct {
+	ID       string    `json:"id"`
+	Question string    `json:"question"`
+	Variants []string  `json:"variants,omitempty"`
+	Body     string    `json:"body"`
+	Sources  []string  `json:"sources,omitempty"`
+	By       string    `json:"by"`
+	Email    string    `json:"email,omitempty"`
+	At       time.Time `json:"at"`
+	Until    time.Time `json:"until"`
+	State    string    `json:"state"`
+}
+
+// answerRequest is an answer as it arrives from whoever wrote it.
+//
+// It carries no author and no date, for the same reason a verification does
+// not: both are facts the server records rather than claims the caller makes. It
+// carries no id either, because the id is in the path.
+type answerRequest struct {
+	Question string   `json:"question"`
+	Variants []string `json:"variants,omitempty"`
+	Body     string   `json:"body"`
+	Sources  []string `json:"sources,omitempty"`
+
+	// Until is optional and is almost always left out. When it is, the answer
+	// gets the standing cadence, which is the right default for prose somebody
+	// wrote in a hurry, and an author who knows their answer goes stale sooner
+	// says so.
+	Until time.Time `json:"until,omitzero"`
+}
+
+type answersResponse struct {
+	Answers []curatedRecord `json:"answers"`
+	At      time.Time       `json:"at"`
+}
+
+// identity is the response without the timestamp, so that a list nobody has
+// touched revalidates rather than being sent again.
+func (a answersResponse) identity() any {
+	a.At = time.Time{}
+	return a
+}
+
+// curator returns the driver's curation capability, and reports whether this
+// deployment has one at all.
+func (s *Server) curator() (store.Curator, bool) {
+	c, ok := s.store.(store.Curator)
+	return c, ok
+}
+
+// curatedFor is the answer to a query, drawn ready for the wire.
+//
+// Best effort, like the verifications beside it in a search response. A driver
+// that cannot answer, or a query nobody has written an answer to, leaves the
+// card off rather than failing the search it sits above, because a page of
+// twenty results with no card is the page this feature was added to, and a page
+// with no results at all is not.
+func (s *Server) curatedFor(r *http.Request, p *acl.Principal, query string) *curatedAnswer {
+	c, ok := s.curator()
+	if !ok || query == "" {
+		return nil
+	}
+	a, err := c.Curated(r.Context(), p, query)
+	switch {
+	case errors.Is(err, genba.ErrNotFound):
+		return nil
+	case err != nil:
+		s.log.Error("the curated answer could not be read", "error", err, "tenant", p.Tenant)
+		return nil
+	}
+
+	out := &curatedAnswer{
+		ID:       a.ID,
+		Question: a.Question,
+		Body:     a.Body,
+		By:       a.By.Display(),
+		Email:    a.By.Email,
+		At:       a.At,
+		Until:    a.Until,
+		State:    string(a.State(s.now())),
+	}
+	ids := a.Sources
+	if len(ids) > AnswerSources {
+		ids = ids[:AnswerSources]
+	}
+	for _, d := range s.documents(r, p, ids) {
+		out.Sources = append(out.Sources, hitOf(d))
+	}
+	return out
+}
+
+// documents resolves a handful of ids through the principal, keeping the order
+// they were given in and dropping the ones that come back not found.
+//
+// Dropping rather than failing is the rule the whole surface runs on: a citation
+// to something this reader may not open is not an error, it is a citation that
+// is not drawn, and the reader is never told the difference between a document
+// they cannot see and one that was deleted.
+func (s *Server) documents(r *http.Request, p *acl.Principal, ids []string) []doc.Document {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]doc.Document, 0, len(ids))
+	if f, ok := s.store.(store.Fetcher); ok {
+		found, err := f.Fetch(r.Context(), p, ids)
+		if err != nil {
+			s.log.Error("the sources of an answer could not be read", "error", err, "tenant", p.Tenant)
+			return nil
+		}
+		// One statement for the page, and then back into the order they were
+		// cited in, because the order is the author's and a driver has no reason
+		// to preserve it.
+		by := make(map[string]doc.Document, len(found))
+		for _, d := range found {
+			by[d.ID] = d
+		}
+		for _, id := range ids {
+			if d, ok := by[id]; ok {
+				out = append(out, d)
+			}
+		}
+		return out
+	}
+	for _, id := range ids {
+		d, err := s.store.Get(r.Context(), p, id)
+		if err != nil {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+// handleAnswers lists the answers this tenant has written down.
+//
+// It is the maintenance view rather than anything a reader sees, which is why
+// it sits behind the administrator guard with the connectors: the reader's view
+// of an answer is the card above their results, and it arrives with the search.
+func (s *Server) handleAnswers(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	c, ok := s.curator()
+	if !ok {
+		// An empty list rather than a refusal, for the reason the inbox answers
+		// with one: the screen that reads this draws nothing, instead of drawing
+		// an error about a capability nobody asked for.
+		writeConditional(w, r, http.StatusOK, answersResponse{Answers: []curatedRecord{}}, nil)
+		return
+	}
+
+	limit, err := intParam(r.URL.Query().Get("limit"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "limit must be a number")
+		return
+	}
+	if limit <= 0 {
+		limit = AnswersLimit
+	}
+	limit = min(limit, AnswersMax)
+
+	all, err := c.Answers(r.Context(), p, limit)
+	if err != nil {
+		s.log.Error("the answers could not be listed", "error", err, "tenant", p.Tenant)
+		writeError(w, http.StatusInternalServerError, "internal", "the answers could not be read")
+		return
+	}
+
+	now := s.now()
+	out := answersResponse{Answers: make([]curatedRecord, 0, len(all)), At: now}
+	for _, a := range all {
+		out.Answers = append(out.Answers, curatedRecord{
+			ID:       a.ID,
+			Question: a.Question,
+			Variants: a.Variants,
+			Body:     a.Body,
+			Sources:  a.Sources,
+			By:       a.By.Display(),
+			Email:    a.By.Email,
+			At:       a.At,
+			Until:    a.Until,
+			State:    string(a.State(now)),
+		})
+	}
+	writeConditional(w, r, http.StatusOK, out, out.identity())
+}
+
+// handleCurate writes an answer, or replaces the one that was there.
+//
+// Writing one is the same call as editing one, and both are also how an answer
+// is re-verified: the date on the card is the date somebody last stood behind
+// the words, and there is no separate act that produces it.
+func (s *Server) handleCurate(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	c, ok := s.curator()
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "unsupported", "this deployment cannot remember a written answer")
+		return
+	}
+	if !store.MayCurate(p) {
+		writeError(w, http.StatusForbidden, "forbidden", "only an administrator can write an answer")
+		return
+	}
+
+	var body answerRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, answerBodyLimit)).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "the body must be a JSON object with a question and an answer in it")
+		return
+	}
+
+	now := s.now()
+	until := body.Until
+	if until.IsZero() {
+		until = now.Add(store.Cadence)
+	}
+	a := store.Answer{
+		ID:       r.PathValue("id"),
+		Question: body.Question,
+		Variants: body.Variants,
+		Body:     body.Body,
+		Sources:  body.Sources,
+		By:       whoever(p),
+		At:       now,
+		Until:    until,
+	}
+	// Checked here as well as in the driver, because the difference between a
+	// request that was wrong and a deployment that broke is the difference
+	// between a 400 and a 500, and a driver returning one error for both would
+	// have the interface tell somebody to try again with the same words.
+	if err := a.Check(); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	s.log.Info("answer written", "subject", p.Subject, "tenant", p.Tenant, "answer", a.ID)
+	if err := c.Curate(r.Context(), p, a); err != nil {
+		s.log.Error("the answer could not be written", "error", err, "answer", a.ID)
+		writeError(w, http.StatusInternalServerError, "internal", "the answer could not be written")
+		return
+	}
+	writeJSON(w, http.StatusOK, curatedRecord{
+		ID:       a.ID,
+		Question: a.Question,
+		Variants: a.Variants,
+		Body:     a.Body,
+		Sources:  a.Sources,
+		By:       a.By.Display(),
+		Email:    a.By.Email,
+		At:       a.At,
+		Until:    a.Until,
+		State:    string(a.State(now)),
+	})
+}
+
+// handleRetract takes an answer down.
+//
+// Taking down one that is not there is not an error, so that a mistake can be
+// undone twice and so that two administrators clearing the same bad answer do
+// not race each other into a failure.
+func (s *Server) handleRetract(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	c, ok := s.curator()
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "unsupported", "this deployment cannot remember a written answer")
+		return
+	}
+	if !store.MayCurate(p) {
+		writeError(w, http.StatusForbidden, "forbidden", "only an administrator can take an answer down")
+		return
+	}
+
+	id := r.PathValue("id")
+	s.log.Info("answer retracted", "subject", p.Subject, "tenant", p.Tenant, "answer", id)
+	if err := c.Retract(r.Context(), p, id); err != nil {
+		s.log.Error("the answer could not be retracted", "error", err, "answer", id)
+		writeError(w, http.StatusInternalServerError, "internal", "the answer could not be taken down")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/api/curate_test.go
+++ b/api/curate_test.go
@@ -1,0 +1,368 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// The answer somebody wrote down.
+//
+// Everything else on this surface improves the corpus by marking it. This is the
+// one endpoint that adds to it, and the two things worth pinning are what it
+// takes the place of and what it is allowed to show. It takes the place of the
+// quoted answer above the results, because that region holds one answer and two
+// of them is a reader choosing which of the product's two answers to believe.
+// What it may show is bounded by the reader rather than by whoever wrote it: an
+// answer written by an administrator who can read everything must not turn into
+// a list of the documents the reader in front of it cannot open.
+
+// card is the answer above the results as this file reads it.
+type card struct {
+	ID       string    `json:"id"`
+	Question string    `json:"question"`
+	Body     string    `json:"body"`
+	By       string    `json:"by"`
+	Email    string    `json:"email"`
+	At       time.Time `json:"at"`
+	Until    time.Time `json:"until"`
+	State    string    `json:"state"`
+	Sources  []struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	} `json:"sources"`
+}
+
+// answered is the search response as far as this file is concerned. The quoted
+// answer is here only so that a test can watch it step aside.
+type answered struct {
+	Curated *card `json:"curated"`
+	Answer  *struct {
+		Quotes []struct {
+			ID string `json:"id"`
+		} `json:"quotes"`
+	} `json:"answer"`
+	Hits []struct {
+		ID string `json:"id"`
+	} `json:"hits"`
+}
+
+type answerList struct {
+	Answers []struct {
+		ID       string   `json:"id"`
+		Question string   `json:"question"`
+		Variants []string `json:"variants"`
+		Body     string   `json:"body"`
+		Sources  []string `json:"sources"`
+		By       string   `json:"by"`
+		State    string   `json:"state"`
+	} `json:"answers"`
+}
+
+// newAnswerServer holds two documents the engineer can read and one they cannot,
+// which is the shape the citation rule needs: an answer that cites all three.
+func newAnswerServer(t *testing.T) http.Handler {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	eng := acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "gdrive",
+		AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}},
+		Version:     1,
+	}
+	finance := acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "gdrive",
+		AllowGroups: []acl.Ref{{Source: "gdrive", Value: "finance@acme.com"}},
+		Version:     1,
+	}
+	docs := []doc.Document{
+		{
+			ID: "freeze", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Release calendar", Body: "The deploy freeze runs over the end of the year.",
+			Permissions: eng,
+		},
+		{
+			ID: "oncall", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Holiday oncall", Body: "Who carries the pager over the freeze.",
+			Permissions: eng,
+		},
+		{
+			ID: "budget", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Deploy freeze cost model", Body: "What the freeze costs in deferred revenue.",
+			Permissions: finance,
+		},
+	}
+	if err := st.Put(t.Context(), docs...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}, api.WithClock(clock))
+	return s.Handler()
+}
+
+// write puts an answer up as the administrator, which is the only person who
+// may, and returns the response so a test can look at what came back.
+func write(t *testing.T, h http.Handler, id, body string) {
+	t.Helper()
+	w := post(t, h, http.MethodPut, "/api/v1/admin/answers/"+id, body, curator())
+	if w.Code != http.StatusOK {
+		t.Fatalf("writing the answer: %d %s", w.Code, w.Body.String())
+	}
+}
+
+// theFreeze is the answer these tests write, citing one document the reader can
+// open, one they cannot, and one they can.
+const theFreeze = `{
+	"question": "What is the deploy freeze?",
+	"variants": ["when is the code freeze"],
+	"body": "No production deploys from the 20th of December to the 2nd of January, except for incidents.",
+	"sources": ["freeze", "budget", "oncall"]
+}`
+
+func searchAs(t *testing.T, h http.Handler, query string, who map[string]string) answered {
+	t.Helper()
+	w := request(t, h, http.MethodGet, "/api/v1/search?q="+query, who)
+	if w.Code != http.StatusOK {
+		t.Fatalf("searching for %q: %d %s", query, w.Code, w.Body.String())
+	}
+	return decode[answered](t, w)
+}
+
+func TestAWrittenAnswerStandsInFrontOfTheResults(t *testing.T) {
+	h := newAnswerServer(t)
+
+	// The same question before anybody wrote it down, so that the quoted answer
+	// stepping aside below is something that happened rather than something that
+	// was never there.
+	before := searchAs(t, h, "What+is+the+deploy+freeze%3F", engineer())
+	if before.Curated != nil {
+		t.Fatal("a card came back for a question nobody has answered")
+	}
+	if before.Answer == nil {
+		t.Fatal("the query does not produce a quoted answer, so this test is not watching one step aside")
+	}
+
+	write(t, h, "a_freeze", theFreeze)
+
+	got := searchAs(t, h, "What+is+the+deploy+freeze%3F", engineer())
+	if got.Curated == nil {
+		t.Fatal("the question somebody answered came back with no answer on it")
+	}
+	if got.Answer != nil {
+		t.Fatal("the quoted answer is still there, so the page offers two answers to one question")
+	}
+	if len(got.Hits) == 0 {
+		t.Fatal("the results went away, and the card is meant to stand in front of them rather than instead of them")
+	}
+	if got.Curated.Question != "What is the deploy freeze?" {
+		t.Fatalf("the card is titled %q", got.Curated.Question)
+	}
+	if got.Curated.Body == "" {
+		t.Fatal("the card has no body, which is the only part of it that answers anything")
+	}
+}
+
+// The name and the date are the reason a reader believes a card over the four
+// documents underneath it.
+func TestTheCardSaysWhoWroteItAndWhenItWasVerified(t *testing.T) {
+	h := newAnswerServer(t)
+	write(t, h, "a_freeze", theFreeze)
+
+	got := searchAs(t, h, "when+is+the+code+freeze", engineer()).Curated
+	if got == nil {
+		t.Fatal("the variant found nothing, so an answer is only ever found by the person who wrote it")
+	}
+	if got.By != "u_ops" {
+		t.Fatalf("the card is signed %q, and an unsigned card is worse than no card", got.By)
+	}
+	if !got.At.Equal(clock()) {
+		t.Fatalf("it was written at %v, want the request clock at %v", got.At, clock())
+	}
+	if want := clock().Add(store.Cadence); !got.Until.Equal(want) {
+		t.Fatalf("it runs out at %v, want the standing cadence at %v", got.Until, want)
+	}
+	if got.State != string(store.Fresh) {
+		t.Fatalf("an answer written a moment ago is %q", got.State)
+	}
+}
+
+// An answer cites what its author cited, and shows what its reader may open.
+func TestACardNeverCitesADocumentTheReaderCannotOpen(t *testing.T) {
+	h := newAnswerServer(t)
+	write(t, h, "a_freeze", theFreeze)
+
+	got := searchAs(t, h, "What+is+the+deploy+freeze%3F", engineer()).Curated
+	if got == nil {
+		t.Fatal("no card came back")
+	}
+	ids := make([]string, 0, len(got.Sources))
+	for _, src := range got.Sources {
+		ids = append(ids, src.ID)
+		if src.ID == "budget" {
+			t.Fatal("the card cites a document this reader has no access to, which is an existence oracle with a title on it")
+		}
+	}
+	if len(ids) != 2 || ids[0] != "freeze" || ids[1] != "oncall" {
+		t.Fatalf("the card cites %v, want the two readable ones in the order they were cited", ids)
+	}
+	if got.Sources[0].Title != "Release calendar" {
+		t.Fatalf("the citation reads %q, and an id is not something a reader can decide to click", got.Sources[0].Title)
+	}
+}
+
+// The match is the whole question, because the cost of getting this wrong is
+// not a bad result, it is a reader believing a confident answer to a question
+// they did not ask.
+func TestANearMissGetsTheOrdinaryPage(t *testing.T) {
+	h := newAnswerServer(t)
+	write(t, h, "a_freeze", theFreeze)
+
+	for _, query := range []string{"deploy+freeze", "what+is+the+deploy+freeze+in+december", "pager"} {
+		if got := searchAs(t, h, query, engineer()); got.Curated != nil {
+			t.Fatalf("searching for %q drew a card titled %q", query, got.Curated.Question)
+		}
+	}
+}
+
+func TestRetractingAnAnswerTakesTheCardDown(t *testing.T) {
+	h := newAnswerServer(t)
+	write(t, h, "a_freeze", theFreeze)
+
+	w := request(t, h, http.MethodDelete, "/api/v1/admin/answers/a_freeze", curator())
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("retracting: %d %s", w.Code, w.Body.String())
+	}
+	if got := searchAs(t, h, "What+is+the+deploy+freeze%3F", engineer()); got.Curated != nil {
+		t.Fatal("the retracted answer is still above the results")
+	}
+	// Twice, so that a mistake can be undone twice and two administrators
+	// clearing the same bad answer do not race each other into a failure.
+	if w := request(t, h, http.MethodDelete, "/api/v1/admin/answers/a_freeze", curator()); w.Code != http.StatusNoContent {
+		t.Fatalf("retracting again: %d %s", w.Code, w.Body.String())
+	}
+}
+
+// An answer stands in front of the results for everybody in the tenant, so the
+// blast radius of a bad one is the whole deployment.
+func TestOnlyAnAdministratorCanWriteAnAnswer(t *testing.T) {
+	h := newAnswerServer(t)
+
+	w := post(t, h, http.MethodPut, "/api/v1/admin/answers/a_freeze", theFreeze, engineer())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("an ordinary reader writing an answer got %d, want 403", w.Code)
+	}
+	w = request(t, h, http.MethodDelete, "/api/v1/admin/answers/a_freeze", engineer())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("an ordinary reader retracting an answer got %d, want 403", w.Code)
+	}
+	w = request(t, h, http.MethodGet, "/api/v1/admin/answers", engineer())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("an ordinary reader listing the answers got %d, want 403", w.Code)
+	}
+}
+
+// The three fields a card is unreadable without are refused with a 400 rather
+// than a 500, because the difference is whether the interface should tell
+// somebody to try again with the same words.
+func TestAnIncompleteAnswerIsRefusedAsABadRequest(t *testing.T) {
+	h := newAnswerServer(t)
+	for name, body := range map[string]string{
+		"no question": `{"body":"words"}`,
+		"no body":     `{"question":"what is the deploy freeze"}`,
+		"not json":    `{`,
+	} {
+		w := post(t, h, http.MethodPut, "/api/v1/admin/answers/a_freeze", body, curator())
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("an answer with %s got %d, want 400", name, w.Code)
+		}
+	}
+}
+
+// The maintenance list carries the sources as ids rather than as rows, because
+// resolving them here and saving back what came out would quietly drop every
+// source the editor happens not to have access to.
+func TestTheAnswerListIsWhatAnEditorNeeds(t *testing.T) {
+	h := newAnswerServer(t)
+	write(t, h, "a_freeze", theFreeze)
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/answers", curator())
+	if w.Code != http.StatusOK {
+		t.Fatalf("listing: %d %s", w.Code, w.Body.String())
+	}
+	got := decode[answerList](t, w)
+	if len(got.Answers) != 1 {
+		t.Fatalf("the list holds %d answers, want the one that was written", len(got.Answers))
+	}
+	a := got.Answers[0]
+	switch {
+	case a.ID != "a_freeze":
+		t.Fatalf("the answer came back as %q", a.ID)
+	case len(a.Variants) != 1 || a.Variants[0] != "when is the code freeze":
+		t.Fatalf("the variants came back as %v, and they are what an editor edits", a.Variants)
+	case len(a.Sources) != 3:
+		t.Fatalf("the sources came back as %v, want all three ids including the one this reader cannot open", a.Sources)
+	case a.State != string(store.Fresh):
+		t.Fatalf("the state came back as %q", a.State)
+	}
+}
+
+// Editing is the same call as writing, and it is also how an answer is
+// re-verified.
+func TestWritingAnAnswerAgainEditsItRatherThanAddingOne(t *testing.T) {
+	h := newAnswerServer(t)
+	write(t, h, "a_freeze", theFreeze)
+	write(t, h, "a_freeze", `{
+		"question": "What is the deploy freeze?",
+		"body": "The freeze now runs to the 6th of January.",
+		"sources": ["freeze"]
+	}`)
+
+	got := searchAs(t, h, "What+is+the+deploy+freeze%3F", engineer()).Curated
+	if got == nil {
+		t.Fatal("no card came back")
+	}
+	if got.Body != "The freeze now runs to the 6th of January." {
+		t.Fatalf("the card still reads %q, so the edit did not land", got.Body)
+	}
+	// The variant went with the edit, because an answer has to be able to lose a
+	// question it turned out not to answer.
+	if second := searchAs(t, h, "when+is+the+code+freeze", engineer()); second.Curated != nil {
+		t.Fatal("the dropped variant still finds the answer")
+	}
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/answers", curator())
+	if got := decode[answerList](t, w); len(got.Answers) != 1 {
+		t.Fatalf("the tenant holds %d answers, and an edit is not a second answer", len(got.Answers))
+	}
+}
+
+// The list is read on a screen that polls, so an unchanged one revalidates
+// rather than being sent again.
+func TestAnUnchangedAnswerListIsNotSentTwice(t *testing.T) {
+	h := newAnswerServer(t)
+	write(t, h, "a_freeze", theFreeze)
+
+	first := request(t, h, http.MethodGet, "/api/v1/admin/answers", curator())
+	tag := first.Header().Get("ETag")
+	if tag == "" {
+		t.Fatal("the list carries no entity tag, so there is nothing to revalidate against")
+	}
+	who := curator()
+	who["If-None-Match"] = tag
+	second := request(t, h, http.MethodGet, "/api/v1/admin/answers", who)
+	if second.Code != http.StatusNotModified {
+		t.Fatalf("asking again with the tag returned %d, want 304", second.Code)
+	}
+	if second.Body.Len() != 0 {
+		t.Fatalf("a 304 carried %d bytes of body", second.Body.Len())
+	}
+}

--- a/api/verify.go
+++ b/api/verify.go
@@ -227,6 +227,19 @@ func who(p *acl.Principal, d doc.Document) doc.Person {
 			return known
 		}
 	}
+	return whoever(p)
+}
+
+// whoever is the same question with no document to ask.
+//
+// It is the first identity, and failing that the subject. A badge that says
+// u-4181 vouched for this is a poor badge and it is still one somebody can
+// chase down, which is more than an empty one gives them.
+//
+// An answer signs itself with this and nothing else, because there is no
+// document for it to borrow a name from: it is the one thing on this surface
+// that is not about a file.
+func whoever(p *acl.Principal) doc.Person {
 	person := doc.Person{Subject: p.Subject, Name: p.Subject}
 	for _, id := range p.Identities {
 		if id.Value == "" {

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -1174,6 +1174,43 @@ async function walk(session) {
     "!location.search.includes('at=') && !location.search.includes('open=')",
   );
 
+  // The answer somebody wrote down, which the gate put there before this ran.
+  //
+  // It is the same region as the quotes and the region holds one of them, so the
+  // assertion worth making is not that the card is on the page. It is that the
+  // quotes are gone: two answers to one question is a reader deciding which of
+  // the product's own answers to believe.
+  await visit(
+    session,
+    `${BASE}/?q=what+is+the+cache`,
+    "document.querySelector('.answer__panel--written') !== null",
+  );
+  await check(
+    session,
+    "a written answer takes the place of the quotes rather than sitting beside them",
+    `(() => {
+      const main = document.querySelector('.results__main');
+      const card = document.querySelector('.answer__panel--written');
+      return document.querySelectorAll('.answer__quote').length === 0 &&
+        main.firstElementChild.contains(card) &&
+        document.querySelector('.answer__question').textContent.trim().length > 0 &&
+        document.querySelector('.answer__body').textContent.trim().length > 0 &&
+        document.querySelector('.answer__author').textContent.trim().length > 0;
+    })()`,
+  );
+
+  // A source of a written answer is a document its author cited rather than a
+  // sentence they pointed at, so it opens the document and highlights nothing.
+  await evaluate(session, "document.querySelector('.answer__source .quote__cite').click()");
+  await settle(session, "!document.querySelector('.drawer').hidden");
+  await check(
+    session,
+    "one click on a source opens that document without inventing a passage to jump to",
+    `location.search.includes('open=') && !location.search.includes('at=') &&
+      document.querySelectorAll('.drawer__body mark.hit--passage').length === 0`,
+  );
+  await press(session, "Escape", "Escape", 27);
+
   // The grid. The pictures behind this query are written into the corpus by the
   // gate before the server starts, because the repository itself holds none.
   await visit(session, `${BASE}/?q=gatepix`, "document.querySelectorAll('.cell').length > 0");

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -2,11 +2,12 @@
 # The browser half of the performance gate.
 #
 # It starts the real binary over a real corpus, which is this repository, and
-# audits eleven screens: the home page, the home page over an index holding
+# audits thirteen screens: the home page, the home page over an index holding
 # nothing, a results page, a results page with an answer quoted above it, a
-# results page with the document drawer open, a search that matched nothing, a
-# filter that matched nothing, a grid of pictures, a document on a page of its
-# own, the recent screen and the settings screen. They are
+# results page with a written answer above it, a results page with the document
+# drawer open, a search that matched nothing, a filter that matched nothing, a
+# grid of pictures, a document on a page of its own, the recent screen, the
+# settings screen and administration. They are
 # states rather than layouts, because a layout is looked at every day and a
 # state is looked at once. Auditing a static fixture would audit the fixture,
 # and every accessibility bug this is meant to catch lives in the markup the
@@ -175,7 +176,9 @@ if [ -z "$ID" ]; then
 fi
 
 # A document id carries a source prefix and a path, so it goes through the URL
-# encoder rather than into the string.
+# encoder rather than into the string. The id itself is kept as it is, because a
+# citation inside a JSON body is the id and not an address.
+RAW_ID=$ID
 ID=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$ID")
 
 # One verified document, so that the badge is on a screen the audit looks at.
@@ -192,6 +195,20 @@ curl -fsS -o /dev/null -X POST "$BASE/api/v1/documents/$ID/verify" \
 	-H "Content-Type: application/json" \
 	-d '{"note":"checked against the current deployment"}' || {
 	echo "ui-gate: the document could not be verified, so the badge would be on no screen this audits" >&2
+	exit 1
+}
+
+# One written answer, for the same reason. Nothing in a file corpus answers a
+# question in prose, and the card that holds one is a heading, a paragraph of
+# rendered markdown, a signature and a row of citations, none of which any other
+# screen builds. The question is matched whole, so the query that reaches it is
+# the words below and no others.
+curl -fsS -o /dev/null -X PUT "$BASE/api/v1/admin/answers/gate" \
+	-H "X-Genba-Tenant: $TENANT" \
+	-H "X-Genba-Subject: dev" \
+	-H "Content-Type: application/json" \
+	-d '{"question":"what is the cache","variants":["how does caching work here"],"body":"The response cache holds whole answers, keyed by the query and the person asking.\n\n- A repeated search is answered without touching the index.\n- An entry is dropped when the documents behind it change.\n\nCall `cache.clear()` to empty it during a migration.","sources":["'"$RAW_ID"'"]}' || {
+	echo "ui-gate: the answer could not be written, so the card would be on no screen this audits" >&2
 	exit 1
 }
 
@@ -252,30 +269,37 @@ if [ -n "${CHROMEDRIVER:-}" ]; then
 	DRIVER="--chromedriver-path $CHROMEDRIVER"
 fi
 
-# Twelve screens, and they are states rather than layouts. Three of them, the
+# Thirteen screens, and they are states rather than layouts. Three of them, the
 # empty index, the query that matched nothing and the filter that matched
 # nothing, produce markup no other screen produces, and that markup is where an
 # accessibility bug survives longest: nobody looks at an empty page twice.
 #
-# The eleventh is a search that has an answer above it. The region is a heading,
-# a list and a link per quote, none of which the results page below it has, and
-# it appears on some searches and not others, so it is a screen the other ten
-# never reach.
+# One of them is a search that has quotes above it. The region is a heading, a
+# list and a link per quote, none of which the results page below it has, and it
+# appears on some searches and not others, so it is a screen no other one reaches.
 #
-# The settings screen is the tenth. It is the only screen in the product built
-# out of form controls, and a radio group that has lost its label is the kind of
-# thing that reads perfectly to whoever wrote it and not at all to anybody else.
+# Another is a search that has a written answer above it instead. It is the same
+# region and it is different markup: a rendered paragraph of somebody's markdown,
+# a signature with an address in it and a row of citations. It is also the only
+# place in the product where prose nobody indexed is drawn above a list of
+# results, which makes it the one screen where a heading level or a link with no
+# name would go unnoticed.
 #
-# The twelfth is administration. It is the only screen in the product built out
-# of tables, and a table whose headers are not headers is unreadable to anybody
-# using a screen reader and looks perfect to everybody else. It is also the only
-# screen that repaints itself on a timer, so it is the one place a focus ring
-# can be quietly taken away from somebody five seconds after they put it there.
+# The settings screen is the only one built out of form controls, and a radio
+# group that has lost its label is the kind of thing that reads perfectly to
+# whoever wrote it and not at all to anybody else.
+#
+# Administration is the only screen built out of tables, and a table whose
+# headers are not headers is unreadable to anybody using a screen reader and
+# looks perfect to everybody else. It is also the only screen that repaints
+# itself on a timer, so it is the one place a focus ring can be quietly taken
+# away from somebody five seconds after they put it there.
 for url in \
 	"$BASE/" \
 	"$EMPTY/" \
 	"$BASE/?q=cache" \
 	"$BASE/?q=drawer" \
+	"$BASE/?q=what+is+the+cache" \
 	"$BASE/?q=cache&open=$ID" \
 	"$BASE/?q=zzqxzzqx" \
 	"$BASE/?q=cache&kind=image" \

--- a/store/curate.go
+++ b/store/curate.go
@@ -1,0 +1,242 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+)
+
+// Answer is a question somebody answered once so that nobody has to answer it
+// again.
+//
+// Everything else in this package improves the corpus by ranking it, marking it
+// or complaining about it. This is the one object that adds to it. It exists
+// because a search engine is only ever as good as what was written down, and
+// the questions people actually ask are the ones nobody wrote down: what the
+// deploy freeze dates are, which of the four onboarding documents is current,
+// who to ask about billing. The answer is in somebody's head and in a chat
+// thread from March, and no amount of ranking finds it.
+//
+// It is written by a person and quoted verbatim. Nothing here is generated, and
+// the body is stored as the markdown somebody typed rather than as anything
+// derived from the documents it cites, which is what makes it worth outranking
+// them: it is not a better summary of the corpus, it is a claim the corpus does
+// not contain.
+//
+// The whole design rests on one rule taken from every curation system that has
+// ever failed: curation has to be cheap to write and immediately visible, or
+// the curator does the work, sees nothing change, and never does it again. So
+// an answer is a question, a body, and a name, it takes effect on the next
+// search, and everything else about it is optional.
+type Answer struct {
+	// ID is the answer, chosen by whoever wrote it. It is a caller's id for the
+	// same reason a document's is: the thing that owns the name is the thing
+	// that has to reference it later.
+	ID string
+
+	// Question is the canonical phrasing, as written, and is what a reader sees
+	// at the top of the card. Variants are the other ways people ask it.
+	//
+	// Both are matched by [AnswerKey], so the punctuation and the capitals in
+	// them are for the reader rather than for the lookup, and "What's the deploy
+	// freeze?" is found by somebody who typed it without the question mark.
+	Question string
+	Variants []string
+
+	// Body is the answer itself, in markdown. It is the only free text here and
+	// it is deliberately not bounded by this package: an answer long enough to
+	// be a problem is a document, and the person writing it will find that out
+	// from the reader who has to scroll past it.
+	Body string
+
+	// Sources are the documents the answer is drawn from, by id.
+	//
+	// They are ids and not documents because the reader they are shown to is not
+	// necessarily the person who wrote them down. Whoever renders an answer
+	// resolves these through the principal asking, and the ones that come back
+	// not found are simply not drawn, so an answer written by somebody with
+	// broader access does not become a list of the documents a reader may not
+	// open. That is why nothing on this type carries a title.
+	Sources []string
+
+	// By is who wrote it, carried whole so that the card has a name on it
+	// without a second lookup, and At is when they last wrote it.
+	By doc.Person
+	At time.Time
+
+	// Until is when it stops counting as current.
+	//
+	// An answer is a verification of itself. Editing one is the same act as
+	// saying it is still true, made by the same person, so there is no separate
+	// verifier here and no second date: At is both when it was written and when
+	// somebody last stood behind it, and Until is how long that lasts. A
+	// deployment that wanted those to be different people would be asking a
+	// reviewer to vouch for prose they cannot edit, which is a workflow rather
+	// than a fact about an answer.
+	//
+	// It is stored rather than derived from At plus [Cadence] for the reason a
+	// verification's is: the cadence is policy and it will change, and an answer
+	// written under the old one keeps the deadline it was given.
+	Until time.Time
+}
+
+// State reports where the answer is in its life at the given time, using the
+// same three words and the same window a verification uses.
+//
+// An expired answer is still an answer and still renders. It says how long it
+// has been since anybody stood behind it, which is a more useful thing for a
+// reader to know than the silence they would get if it disappeared, and it is
+// the only way the person who wrote it ever finds out it needs looking at.
+func (a Answer) State(now time.Time) State { return stateAt(a.Until, now) }
+
+// Zero reports whether there is no answer here at all.
+func (a Answer) Zero() bool { return a.ID == "" }
+
+// What [Answer.Check] stands behind.
+var (
+	ErrNoQuestion = errors.New("answer has no question")
+	ErrNoBody     = errors.New("answer has no body")
+	ErrNoAuthor   = errors.New("answer has no author")
+	ErrNoAnswerID = errors.New("answer has no id")
+)
+
+// Check rejects an answer that cannot be stored.
+//
+// The three required fields are the three a card is unreadable without. An
+// answer with no question is unfindable, one with no body is a heading, and one
+// with nobody's name on it is the anonymous wiki page this type exists to
+// replace: the entire reason a reader believes an answer over the four
+// documents under it is that a person they can go and ask put their name to it.
+//
+// An answer with no expiry is refused for the reason a verification with none
+// is. A claim that never runs out is a boolean that nothing ever unsets, and a
+// corpus full of those is the state this whole area of the product is trying to
+// get out of.
+func (a Answer) Check() error {
+	switch {
+	case a.ID == "":
+		return ErrNoAnswerID
+	case AnswerKey(a.Question) == "":
+		return ErrNoQuestion
+	case strings.TrimSpace(a.Body) == "":
+		return ErrNoBody
+	case a.By.Name == "" && a.By.Subject == "" && a.By.Email == "":
+		return ErrNoAuthor
+	case a.Until.IsZero():
+		return ErrNoExpiry
+	}
+	return nil
+}
+
+// Keys is every phrasing this answer is found by, folded and deduplicated.
+//
+// It is a method rather than something each driver works out, because the set
+// of rows a driver writes has to be the set of keys a lookup asks for, and two
+// spellings of that would give an answer that can be written and never found.
+func (a Answer) Keys() []string {
+	out := make([]string, 0, len(a.Variants)+1)
+	for _, phrasing := range append([]string{a.Question}, a.Variants...) {
+		k := AnswerKey(phrasing)
+		if k == "" {
+			continue
+		}
+		if !slices.Contains(out, k) {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// AnswerKey folds a phrasing into the string a query is matched against.
+//
+// It is the index's own analyzer with the terms joined back up, so a question
+// and a query that produce the same terms produce the same key. Using anything
+// else here means an answer that matches a query the search does not, which is
+// a card above a list of results that has nothing to do with it.
+//
+// The match is the whole key and not part of it. That is a deliberately strict
+// rule and it is the important decision in this file. A card above the results
+// claims authority, and the cost of getting it wrong is not a bad result, it is
+// a reader believing a confident answer to a question they did not ask. Until
+// there is a model that can score a query against a question and be held to a
+// confidence floor, the phrasings an answer is found by are the ones a person
+// wrote down, and a near miss gets the ordinary list of results it would have
+// got before this existed.
+func AnswerKey(s string) string { return strings.Join(doc.Tokenize(s), " ") }
+
+// MayCurate reports whether the principal may write answers.
+//
+// Administrators, which is narrower than the product wants and is the right
+// place to start. An answer outranks the documents it cites for every reader in
+// the tenant, so the blast radius of a bad one is the whole deployment, and a
+// permission that starts narrow can be widened once there is a role to widen it
+// to. The role model this eventually wants is a content manager grant rather
+// than an administrator, and that is a decision about roles rather than about
+// answers.
+//
+// It lives here beside [MayVerify] rather than inside a driver for the same
+// reason that one does: it is a curation policy, made once, above the storage
+// layer, and what a driver enforces is the tenant.
+func MayCurate(p *acl.Principal) bool { return p.HasRole(acl.RoleAdmin) }
+
+// Curator is the optional capability of a driver that can remember an answer
+// somebody wrote.
+//
+// It is optional like every capability outside [Store]. A deployment whose
+// driver does not implement it searches exactly as it did before this existed,
+// with no card above the results and no way to write one, rather than with a
+// button that fails.
+//
+// The permission rule is not the document rule and this is the one place in the
+// package where that is true. An answer belongs to the tenant rather than to a
+// principal: everybody who can search can read every answer, because an answer
+// is the product's own text and the whole point of writing one is that the next
+// person finds it. What does not follow is the documents it cites, which stay
+// behind the permission they always had, and [Answer.Sources] carries ids
+// precisely so that resolving them applies it.
+//
+// Anything genuinely sensitive belongs in a permissioned document rather than
+// in an answer, and that is a rule for whoever writes one rather than something
+// a driver can enforce. It is written down here because a curation object with
+// an audience field would look like it enforces it, which is how a system ends
+// up with salary bands on the front page.
+type Curator interface {
+	Store
+
+	// Curate writes an answer, replacing any earlier one with the same id.
+	//
+	// Replacing rather than appending is what makes editing an answer the same
+	// call as writing one, and it is why re-writing an answer is also how it is
+	// re-verified. The phrasings it is found by are replaced with it: a variant
+	// dropped from the answer stops matching, or an answer could never lose a
+	// question it turned out not to answer.
+	//
+	// A phrasing that already belongs to another answer moves to this one. Two
+	// answers claiming the same question is a curation conflict rather than a
+	// storage problem, and the resolution that does not need a screen is that
+	// the most recent writer wins.
+	Curate(ctx context.Context, p *acl.Principal, a Answer) error
+
+	// Retract removes an answer. Retracting one that is not there is not an
+	// error, so that a mistake can be undone twice.
+	Retract(ctx context.Context, p *acl.Principal, id string) error
+
+	// Curated returns the answer to a question, or [genba.ErrNotFound].
+	//
+	// The question is a phrasing rather than a key: folding it is this method's
+	// job, so that a caller cannot fold it differently.
+	Curated(ctx context.Context, p *acl.Principal, question string) (Answer, error)
+
+	// Answers lists the answers in the tenant, most recently written first, at
+	// most limit of them. A limit of zero or less returns nothing.
+	//
+	// Most recent first because the list is read by whoever maintains it, and
+	// what they are looking for is either the one they just wrote or the ones
+	// nobody has touched since the reorganisation.
+	Answers(ctx context.Context, p *acl.Principal, limit int) ([]Answer, error)
+}

--- a/store/memstore/curate.go
+++ b/store/memstore/curate.go
@@ -1,0 +1,139 @@
+package memstore
+
+import (
+	"cmp"
+	"context"
+	"slices"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+// An answer is the one thing this driver keeps that is not about a document, so
+// it is the one thing here keyed by tenant rather than reached through one. The
+// tenant comes off the principal on every path below, and it is the whole of
+// the permission rule: everybody who can search a tenant can read its answers,
+// and the documents an answer cites are resolved by whoever draws it.
+
+// Curate writes an answer, replacing any earlier one with the same id.
+func (s *Store) Curate(ctx context.Context, p *acl.Principal, a store.Answer) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	if err := a.Check(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return genba.ErrClosed
+	}
+
+	// The phrasings this answer used to claim go before the ones it claims now
+	// are written, or an edit that drops a variant leaves the old variant
+	// pointing at an answer that no longer says it.
+	s.forget(p.Tenant, a.ID)
+	s.answers[[2]string{p.Tenant, a.ID}] = a
+	for _, key := range a.Keys() {
+		s.phrasings[[2]string{p.Tenant, key}] = a.ID
+	}
+	return nil
+}
+
+// Retract removes an answer.
+func (s *Store) Retract(ctx context.Context, p *acl.Principal, id string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return genba.ErrClosed
+	}
+	s.forget(p.Tenant, id)
+	delete(s.answers, [2]string{p.Tenant, id})
+	return nil
+}
+
+// forget drops every phrasing pointing at an answer. The caller holds the lock.
+//
+// It walks the phrasings rather than reading the answer's own keys, because the
+// keys that have to go are the ones that were written, and an answer edited by
+// a build that folded a question differently would leave one behind.
+func (s *Store) forget(tenant, id string) {
+	for key, at := range s.phrasings {
+		if key[0] == tenant && at == id {
+			delete(s.phrasings, key)
+		}
+	}
+}
+
+// Curated returns the answer to a question.
+func (s *Store) Curated(ctx context.Context, p *acl.Principal, question string) (store.Answer, error) {
+	if err := ctx.Err(); err != nil {
+		return store.Answer{}, err
+	}
+	if p == nil {
+		return store.Answer{}, genba.ErrNoPrincipal
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return store.Answer{}, genba.ErrClosed
+	}
+
+	id, ok := s.phrasings[[2]string{p.Tenant, store.AnswerKey(question)}]
+	if !ok {
+		return store.Answer{}, genba.ErrNotFound
+	}
+	a, ok := s.answers[[2]string{p.Tenant, id}]
+	if !ok {
+		return store.Answer{}, genba.ErrNotFound
+	}
+	return a, nil
+}
+
+// Answers lists the answers in the tenant, most recently written first.
+func (s *Store) Answers(ctx context.Context, p *acl.Principal, limit int) ([]store.Answer, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, genba.ErrClosed
+	}
+
+	var out []store.Answer
+	for key, a := range s.answers {
+		if key[0] == p.Tenant {
+			out = append(out, a)
+		}
+	}
+	// The id breaks the tie, because two answers written in the same nanosecond
+	// are possible on a test clock and a list that puts them in a different
+	// order on every call is a screen that changes when nothing did.
+	slices.SortFunc(out, func(x, y store.Answer) int {
+		if !x.At.Equal(y.At) {
+			return y.At.Compare(x.At)
+		}
+		return cmp.Compare(x.ID, y.ID)
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -59,6 +59,14 @@ type Store struct {
 	// has to land on the first.
 	reports map[string]map[string]store.Report
 
+	// answers is what somebody wrote down, keyed by tenant and answer id, and
+	// phrasings is the folded question and every variant of it pointing back at
+	// the id it belongs to. Two maps because a lookup is one phrasing and has to
+	// be a single probe, and an edit has to be able to take away a phrasing the
+	// answer no longer claims.
+	answers   map[[2]string]store.Answer
+	phrasings map[[2]string]string
+
 	// feeds is how the connectors were configured, keyed by tenant and source.
 	// It is in memory like everything else here, so a restart forgets it, which
 	// is the documented behaviour of this driver rather than an oversight.
@@ -77,6 +85,9 @@ func New() *Store {
 		verified: make(map[string]store.Verification),
 		owners:   make(map[string]store.Correction),
 		reports:  make(map[string]map[string]store.Report),
+
+		answers:   make(map[[2]string]store.Answer),
+		phrasings: make(map[[2]string]string),
 	}
 }
 
@@ -90,6 +101,7 @@ var (
 	_ store.Feeds        = (*Store)(nil)
 	_ store.Verifier     = (*Store)(nil)
 	_ store.Ownership    = (*Store)(nil)
+	_ store.Curator      = (*Store)(nil)
 )
 
 // Put inserts or replaces documents.

--- a/store/pgstore/curate.go
+++ b/store/pgstore/curate.go
@@ -1,0 +1,248 @@
+package pgstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Curator = (*Store)(nil)
+
+// answerColumns is the row every read below selects, in one place so that the
+// three of them cannot select it in three orders.
+const answerColumns = `a.id, a.question, a.variants, a.body, a.sources, a.author, a.written_at, a.until`
+
+// Curate writes an answer, replacing any earlier one with the same id.
+//
+// It runs in a transaction because it is three statements that have to land
+// together: the answer, the phrasings it no longer claims going away, and the
+// ones it claims now arriving. A reader who caught the middle of that would find
+// a question with no answer behind it.
+//
+// It does not take the write lock the ingestion path holds, for the reason
+// Verify does not: writing an answer is not corpus bookkeeping and nobody doing
+// it should be waiting for a crawl.
+func (s *Store) Curate(ctx context.Context, p *acl.Principal, a store.Answer) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	if err := a.Check(); err != nil {
+		return fmt.Errorf("pgstore: curate: %w", err)
+	}
+	author, err := marshalPerson(a.By)
+	if err != nil {
+		return fmt.Errorf("pgstore: curate: %w", err)
+	}
+
+	err = s.retry(ctx, func(ctx context.Context) error {
+		return s.transact(ctx, func(tx pgx.Tx) error {
+			s.counters.statements.Add(1)
+			if _, err := tx.Exec(ctx, rebind(`
+				INSERT INTO answer (id, tenant, question, variants, body, sources, author, written_at, until)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT (tenant, id) DO UPDATE SET
+					question   = excluded.question,
+					variants   = excluded.variants,
+					body       = excluded.body,
+					sources    = excluded.sources,
+					author     = excluded.author,
+					written_at = excluded.written_at,
+					until      = excluded.until`),
+				a.ID, p.Tenant, a.Question, jsonStrings(a.Variants), a.Body, jsonStrings(a.Sources),
+				author, a.At.UnixNano(), a.Until.UnixNano()); err != nil {
+				return err
+			}
+
+			// Every phrasing this answer used to claim goes before the ones it
+			// claims now arrive, or an edit that drops a variant leaves the old
+			// variant pointing at an answer that no longer says it.
+			s.counters.statements.Add(1)
+			if _, err := tx.Exec(ctx, rebind(
+				`DELETE FROM answer_phrasing WHERE tenant = ? AND id = ?`), p.Tenant, a.ID); err != nil {
+				return err
+			}
+			for _, key := range a.Keys() {
+				// The conflict is a phrasing another answer already claims, and
+				// it moves to this one, because the writer who wrote it most
+				// recently has the better idea of what the question means today.
+				s.counters.statements.Add(1)
+				if _, err := tx.Exec(ctx, rebind(`
+					INSERT INTO answer_phrasing (tenant, key, id) VALUES (?, ?, ?)
+					ON CONFLICT (tenant, key) DO UPDATE SET id = excluded.id`),
+					p.Tenant, key, a.ID); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("pgstore: curate: %w", err)
+	}
+	return nil
+}
+
+// Retract removes an answer, and the phrasings that found it with it.
+//
+// The phrasings go explicitly rather than by the cascade, so that this driver
+// and the SQLite one delete the same rows in the same order. The cascade is
+// still there for what a person does at a psql prompt.
+func (s *Store) Retract(ctx context.Context, p *acl.Principal, id string) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+
+	err := s.retry(ctx, func(ctx context.Context) error {
+		return s.transact(ctx, func(tx pgx.Tx) error {
+			for _, stmt := range []string{
+				`DELETE FROM answer_phrasing WHERE tenant = ? AND id = ?`,
+				`DELETE FROM answer WHERE tenant = ? AND id = ?`,
+			} {
+				s.counters.statements.Add(1)
+				if _, err := tx.Exec(ctx, rebind(stmt), p.Tenant, id); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("pgstore: retract: %w", err)
+	}
+	return nil
+}
+
+// Curated returns the answer to a question.
+//
+// It is one primary key probe on the phrasing and one on the answer, which is
+// the reason the phrasings are a table. This runs on every search, beside the
+// ranking, so it has to cost about nothing whether or not anybody has ever
+// written an answer down.
+func (s *Store) Curated(ctx context.Context, p *acl.Principal, question string) (store.Answer, error) {
+	if err := s.ready(ctx); err != nil {
+		return store.Answer{}, err
+	}
+	if p == nil {
+		return store.Answer{}, genba.ErrNoPrincipal
+	}
+	key := store.AnswerKey(question)
+	if key == "" {
+		return store.Answer{}, genba.ErrNotFound
+	}
+
+	var a store.Answer
+	err := s.retry(ctx, func(ctx context.Context) error {
+		row := s.queryRow(ctx, `
+			SELECT `+answerColumns+`
+			FROM answer_phrasing k
+			JOIN answer a ON a.tenant = k.tenant AND a.id = k.id
+			WHERE k.tenant = ? AND k.key = ?`, p.Tenant, key)
+		var err error
+		a, err = scanAnswer(row)
+		return err
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return store.Answer{}, genba.ErrNotFound
+	case err != nil:
+		return store.Answer{}, fmt.Errorf("pgstore: curated: %w", err)
+	}
+	s.counters.rows.Add(1)
+	return a, nil
+}
+
+// Answers lists the answers in the tenant, most recently written first.
+func (s *Store) Answers(ctx context.Context, p *acl.Principal, limit int) ([]store.Answer, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	var out []store.Answer
+	err := s.retry(ctx, func(ctx context.Context) error {
+		out = nil
+		// The id breaks the tie for the reason the report query breaks its own:
+		// two answers written in the same nanosecond are possible on a test
+		// clock, and a list that orders them differently on every call is a
+		// screen that changes when nothing did.
+		rows, err := s.query(ctx, `
+			SELECT `+answerColumns+`
+			FROM answer a
+			WHERE a.tenant = ?
+			ORDER BY a.written_at DESC, a.id
+			LIMIT ?`, p.Tenant, limit)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			a, err := scanAnswer(rows)
+			if err != nil {
+				return err
+			}
+			s.counters.rows.Add(1)
+			out = append(out, a)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pgstore: answers: %w", err)
+	}
+	return out, nil
+}
+
+// jsonStrings encodes a list for a text column, with nil going in as an empty
+// array rather than as the four characters "null", so that reading it back is
+// one path rather than two.
+func jsonStrings(values []string) string {
+	if values == nil {
+		values = []string{}
+	}
+	b, _ := json.Marshal(values)
+	return string(b)
+}
+
+func scanAnswer(row scanner) (store.Answer, error) {
+	var (
+		a        store.Answer
+		variants string
+		sources  string
+		author   string
+		written  int64
+		until    int64
+	)
+	if err := row.Scan(&a.ID, &a.Question, &variants, &a.Body, &sources, &author, &written, &until); err != nil {
+		return store.Answer{}, err
+	}
+	if err := json.Unmarshal([]byte(variants), &a.Variants); err != nil {
+		return store.Answer{}, fmt.Errorf("decode the variants: %w", err)
+	}
+	if err := json.Unmarshal([]byte(sources), &a.Sources); err != nil {
+		return store.Answer{}, fmt.Errorf("decode the sources: %w", err)
+	}
+	who, err := unmarshalPerson(author)
+	if err != nil {
+		return store.Answer{}, err
+	}
+	a.By, a.At, a.Until = who, unixNano(written), unixNano(until)
+	return a, nil
+}

--- a/store/pgstore/migrations/0009_answer.down.sql
+++ b/store/pgstore/migrations/0009_answer.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE answer_phrasing;
+DROP TABLE answer;

--- a/store/pgstore/migrations/0009_answer.up.sql
+++ b/store/pgstore/migrations/0009_answer.up.sql
@@ -1,0 +1,73 @@
+-- answer is a question somebody answered, and it is the first table here that
+-- is not about a document.
+--
+-- So it is the first one keyed by tenant. Everything else reaches its tenant
+-- through the document it hangs off, and an answer hangs off nothing: it is the
+-- product's own text rather than a fact about a file, which is also why it has
+-- no cascade to be deleted by.
+CREATE TABLE answer (
+    id         text   NOT NULL,
+    tenant     text   NOT NULL,
+
+    -- The canonical phrasing and the other ways people ask it, both kept
+    -- verbatim because they are read by a person maintaining the answer. What a
+    -- lookup matches against lives in answer_phrasing below.
+    question   text   NOT NULL,
+    variants   text   NOT NULL,
+
+    -- The answer itself, as the markdown somebody typed. Not bounded here: an
+    -- answer long enough to be a problem is a document, and whoever wrote it
+    -- finds that out from the reader who has to scroll past it.
+    body       text   NOT NULL,
+
+    -- Document ids as JSON rather than a join table, because nothing queries
+    -- into them. They are resolved one page at a time through whoever is
+    -- reading, which is what stops an answer from listing the documents a reader
+    -- may not open. Text rather than jsonb for the same reason document_own
+    -- stores its people as text.
+    sources    text   NOT NULL,
+
+    -- Who wrote it, carried whole, so the card has a name on it without a
+    -- second lookup.
+    author     text   NOT NULL,
+
+    -- Unix nanoseconds, like every other time in this schema, because a
+    -- timestamptz keeps microseconds and a time read back out of one does not
+    -- compare equal to the time that went in. until is stored rather than
+    -- derived from the cadence, so an answer written under an older policy keeps
+    -- the deadline it was given.
+    written_at bigint NOT NULL,
+    until      bigint NOT NULL,
+
+    PRIMARY KEY (tenant, id)
+);
+
+-- The list of answers is read most recently written first by whoever maintains
+-- them, and it is the only query over this table that is not a point lookup.
+CREATE INDEX answer_recent ON answer (tenant, written_at DESC);
+
+-- answer_phrasing is every way an answer can be asked for, folded by
+-- store.AnswerKey, one row per phrasing.
+--
+-- A table rather than a JSON column on the answer, because this is the one
+-- thing about an answer that is on the search path: every search asks whether
+-- anybody has written this question down, and that question has to be a single
+-- primary key probe or the card costs more than the results it sits above.
+--
+-- The key is unique within the tenant, so a phrasing claimed by a second answer
+-- moves to it. Two answers claiming the same question is a curation conflict
+-- rather than a storage problem, and the resolution that needs no screen is that
+-- the most recent writer wins.
+CREATE TABLE answer_phrasing (
+    tenant text NOT NULL,
+    key    text NOT NULL,
+    id     text NOT NULL,
+
+    PRIMARY KEY (tenant, key),
+    FOREIGN KEY (tenant, id) REFERENCES answer (tenant, id) ON DELETE CASCADE
+);
+
+-- Retracting an answer and editing one both have to find the rows pointing at
+-- it, and without this that is a scan of every phrasing in the tenant. It is
+-- also what the foreign key above needs to check without one.
+CREATE INDEX answer_phrasing_answer ON answer_phrasing (tenant, id);

--- a/store/sqlitestore/curate.go
+++ b/store/sqlitestore/curate.go
@@ -1,0 +1,225 @@
+package sqlitestore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/store"
+)
+
+var _ store.Curator = (*Store)(nil)
+
+// answerColumns is the row every read below selects, in one place so that the
+// three of them cannot select it in three orders.
+const answerColumns = `a.id, a.question, a.variants, a.body, a.sources, a.author, a.written_at, a.until`
+
+// Curate writes an answer, replacing any earlier one with the same id.
+//
+// It takes the write lock and does its work in one transaction, because it is
+// three statements that have to land together: the answer, the phrasings it no
+// longer claims going away, and the ones it claims now arriving. A reader who
+// caught the middle of that would find a question with no answer behind it.
+func (s *Store) Curate(ctx context.Context, p *acl.Principal, a store.Answer) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+	if err := a.Check(); err != nil {
+		return fmt.Errorf("sqlitestore: curate: %w", err)
+	}
+	author, err := marshalPerson(a.By)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: curate: %w", err)
+	}
+
+	s.write.Lock()
+	defer s.write.Unlock()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: curate: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	s.counters.statements.Add(1)
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO answer (id, tenant, question, variants, body, sources, author, written_at, until)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (tenant, id) DO UPDATE SET
+			question   = excluded.question,
+			variants   = excluded.variants,
+			body       = excluded.body,
+			sources    = excluded.sources,
+			author     = excluded.author,
+			written_at = excluded.written_at,
+			until      = excluded.until`,
+		a.ID, p.Tenant, a.Question, jsonKeys(a.Variants), a.Body, jsonKeys(a.Sources),
+		author, a.At.UnixNano(), a.Until.UnixNano()); err != nil {
+		return fmt.Errorf("sqlitestore: curate: %w", err)
+	}
+
+	// Every phrasing this answer used to claim goes before the ones it claims
+	// now arrive, or an edit that drops a variant leaves the old variant
+	// pointing at an answer that no longer says it.
+	s.counters.statements.Add(1)
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM answer_phrasing WHERE tenant = ? AND id = ?`, p.Tenant, a.ID); err != nil {
+		return fmt.Errorf("sqlitestore: curate: %w", err)
+	}
+	for _, key := range a.Keys() {
+		// The conflict is a phrasing another answer already claims, and it moves
+		// to this one, because the writer who wrote it most recently is the one
+		// with the better idea of what the question means today.
+		s.counters.statements.Add(1)
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO answer_phrasing (tenant, key, id) VALUES (?, ?, ?)
+			ON CONFLICT (tenant, key) DO UPDATE SET id = excluded.id`,
+			p.Tenant, key, a.ID); err != nil {
+			return fmt.Errorf("sqlitestore: curate: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// Retract removes an answer, and the phrasings that found it with it.
+func (s *Store) Retract(ctx context.Context, p *acl.Principal, id string) error {
+	if err := s.ready(ctx); err != nil {
+		return err
+	}
+	if p == nil {
+		return genba.ErrNoPrincipal
+	}
+
+	s.write.Lock()
+	defer s.write.Unlock()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlitestore: retract: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, stmt := range []string{
+		`DELETE FROM answer_phrasing WHERE tenant = ? AND id = ?`,
+		`DELETE FROM answer WHERE tenant = ? AND id = ?`,
+	} {
+		s.counters.statements.Add(1)
+		if _, err := tx.ExecContext(ctx, stmt, p.Tenant, id); err != nil {
+			return fmt.Errorf("sqlitestore: retract: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// Curated returns the answer to a question.
+//
+// It is one primary key probe on the phrasing and one on the answer, which is
+// the reason the phrasings are a table. This runs on every search, beside the
+// ranking, so it has to cost about nothing whether or not anybody has ever
+// written an answer down.
+func (s *Store) Curated(ctx context.Context, p *acl.Principal, question string) (store.Answer, error) {
+	if err := s.ready(ctx); err != nil {
+		return store.Answer{}, err
+	}
+	if p == nil {
+		return store.Answer{}, genba.ErrNoPrincipal
+	}
+	key := store.AnswerKey(question)
+	if key == "" {
+		return store.Answer{}, genba.ErrNotFound
+	}
+
+	row := s.queryRow(ctx, `
+		SELECT `+answerColumns+`
+		FROM answer_phrasing k
+		CROSS JOIN answer a ON a.tenant = k.tenant AND a.id = k.id
+		WHERE k.tenant = ? AND k.key = ?`, p.Tenant, key)
+	a, err := scanAnswer(row)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return store.Answer{}, genba.ErrNotFound
+	case err != nil:
+		return store.Answer{}, fmt.Errorf("sqlitestore: curated: %w", err)
+	}
+	s.counters.rows.Add(1)
+	return a, nil
+}
+
+// Answers lists the answers in the tenant, most recently written first.
+func (s *Store) Answers(ctx context.Context, p *acl.Principal, limit int) ([]store.Answer, error) {
+	if err := s.ready(ctx); err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, genba.ErrNoPrincipal
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	// The id breaks the tie for the reason the report query breaks its own: two
+	// answers written in the same nanosecond are possible on a test clock, and a
+	// list that orders them differently on every call is a screen that changes
+	// when nothing did.
+	rows, err := s.query(ctx, `
+		SELECT `+answerColumns+`
+		FROM answer a
+		WHERE a.tenant = ?
+		ORDER BY a.written_at DESC, a.id
+		LIMIT ?`, p.Tenant, limit)
+	if err != nil {
+		return nil, fmt.Errorf("sqlitestore: answers: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]store.Answer, 0, limit)
+	for rows.Next() {
+		a, err := scanAnswer(rows)
+		if err != nil {
+			return nil, fmt.Errorf("sqlitestore: answers: %w", err)
+		}
+		s.counters.rows.Add(1)
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func scanAnswer(row scanner) (store.Answer, error) {
+	var (
+		a          store.Answer
+		variants   string
+		sources    string
+		author     string
+		written    int64
+		until      int64
+		unmarshals = func(s string, into *[]string) error { return json.Unmarshal([]byte(s), into) }
+	)
+	if err := row.Scan(&a.ID, &a.Question, &variants, &a.Body, &sources, &author, &written, &until); err != nil {
+		return store.Answer{}, err
+	}
+	if err := unmarshals(variants, &a.Variants); err != nil {
+		return store.Answer{}, fmt.Errorf("decode the variants: %w", err)
+	}
+	if err := unmarshals(sources, &a.Sources); err != nil {
+		return store.Answer{}, fmt.Errorf("decode the sources: %w", err)
+	}
+	who, err := unmarshalPerson(author)
+	if err != nil {
+		return store.Answer{}, err
+	}
+	a.By, a.At, a.Until = who, unixNano(written), unixNano(until)
+	return a, nil
+}

--- a/store/sqlitestore/schema.go
+++ b/store/sqlitestore/schema.go
@@ -349,6 +349,72 @@ var migrations = []step{
 	// The primary key above answers the other question, what has been said about
 	// these twenty ids, from a range scan per id.
 	ddl(`CREATE INDEX document_report_recent ON document_report (reported_at DESC)`),
+
+	// answer is a question somebody answered, and it is the first table here
+	// that is not about a document.
+	//
+	// So it is the first one keyed by tenant. Everything else reaches its tenant
+	// through the document it hangs off, and an answer hangs off nothing: it is
+	// the product's own text rather than a fact about a file, which is also why
+	// it has no cascade to be deleted by.
+	//
+	// question is the canonical phrasing as it was typed, and variants are the
+	// other ways people ask it, both kept verbatim because they are read by a
+	// person maintaining the answer. What a lookup matches against lives in
+	// answer_phrasing below.
+	//
+	// sources are document ids as JSON and not a join table, because nothing
+	// queries into them: they are resolved one page at a time through whoever is
+	// reading, which is what stops an answer from listing the documents a reader
+	// may not open. author is JSON in one column for the reason document_own
+	// stores its people that way.
+	//
+	// written_at and until are unix nanoseconds, like every other time in this
+	// schema. until is stored rather than derived from the cadence, so an answer
+	// written under an older policy keeps the deadline it was given.
+	ddl(`CREATE TABLE answer (
+		id         TEXT    NOT NULL,
+		tenant     TEXT    NOT NULL,
+		question   TEXT    NOT NULL,
+		variants   TEXT    NOT NULL,
+		body       TEXT    NOT NULL,
+		sources    TEXT    NOT NULL,
+		author     TEXT    NOT NULL,
+		written_at INTEGER NOT NULL,
+		until      INTEGER NOT NULL,
+		PRIMARY KEY (tenant, id)
+	) WITHOUT ROWID`),
+
+	// The list of answers is read most recently written first by whoever
+	// maintains them, and it is the only query over this table that is not a
+	// point lookup.
+	ddl(`CREATE INDEX answer_recent ON answer (tenant, written_at DESC)`),
+
+	// answer_phrasing is every way an answer can be asked for, folded by
+	// store.AnswerKey, one row per phrasing.
+	//
+	// A table rather than a JSON column on the answer, because this is the one
+	// thing about an answer that is on the search path: every search asks
+	// whether anybody has written this question down, and that question has to
+	// be a single primary key probe or the card costs more than the results it
+	// sits above.
+	//
+	// The key is unique within the tenant, so a phrasing claimed by a second
+	// answer moves to it. Two answers claiming the same question is a curation
+	// conflict rather than a storage problem, and the resolution that needs no
+	// screen is that the most recent writer wins.
+	ddl(`CREATE TABLE answer_phrasing (
+		tenant TEXT NOT NULL,
+		key    TEXT NOT NULL,
+		id     TEXT NOT NULL,
+		PRIMARY KEY (tenant, key),
+		FOREIGN KEY (tenant, id) REFERENCES answer (tenant, id) ON DELETE CASCADE
+	) WITHOUT ROWID`),
+
+	// Retracting an answer and editing one both have to find the rows pointing
+	// at it, and without this that is a scan of every phrasing in the tenant. It
+	// is also what the foreign key above needs to check without one.
+	ddl(`CREATE INDEX answer_phrasing_answer ON answer_phrasing (tenant, id)`),
 }
 
 // backfill recomputes the ranking statistics for every document already stored.

--- a/store/storetest/curate.go
+++ b/store/storetest/curate.go
@@ -1,0 +1,317 @@
+package storetest
+
+import (
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba"
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/store"
+)
+
+// An answer is the only object in this interface that is not about a document,
+// and that is what these cases are about. Everything else here reaches its
+// tenant through a document and inherits a permission rule from it. An answer
+// has neither, so a driver has to apply the tenant itself, and the way to get
+// that wrong is to key an answer by its id alone and hand one deployment's
+// handbook to another.
+//
+// The other half is what a lookup finds. An answer is found by the phrasings
+// somebody wrote down, folded, and a driver that writes a different set of keys
+// from the set it later probes gives an answer that can be written and never
+// read. So these cases write one, edit it, take a phrasing away, and ask for it
+// by each of the ways it was said.
+
+// curator skips a case for a driver that cannot remember an answer.
+func curator(t *testing.T, s store.Store) store.Curator {
+	t.Helper()
+	c, ok := s.(store.Curator)
+	if !ok {
+		t.Skip("driver does not implement store.Curator")
+	}
+	return c
+}
+
+// written is an answer made at a fixed time, so that a test asserts on the
+// dates it asked for rather than on whatever the machine managed between two
+// calls.
+func written(id string) store.Answer {
+	return store.Answer{
+		ID:       id,
+		Question: "What is the deploy freeze?",
+		Variants: []string{"when is the code freeze"},
+		Body:     "No production deploys from the 20th of December to the 2nd of January, except for incidents.",
+		Sources:  []string{"d1"},
+		By:       doc.Person{Subject: "u_mei", Name: "Mei Tanaka", Email: "mei@acme.com"},
+		At:       at(0),
+		Until:    at(0).Add(store.Cadence),
+	}
+}
+
+func curate(t *testing.T, c store.Curator, p *acl.Principal, a store.Answer) {
+	t.Helper()
+	if err := c.Curate(t.Context(), p, a); err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+}
+
+func curated(t *testing.T, c store.Curator, p *acl.Principal, question string) (store.Answer, error) {
+	t.Helper()
+	return c.Curated(t.Context(), p, question)
+}
+
+func answers(t *testing.T, c store.Curator, p *acl.Principal, limit int) []string {
+	t.Helper()
+	got, err := c.Answers(t.Context(), p, limit)
+	if err != nil {
+		t.Fatalf("Answers: %v", err)
+	}
+	ids := make([]string, 0, len(got))
+	for _, a := range got {
+		ids = append(ids, a.ID)
+	}
+	return ids
+}
+
+func testCurateRoundTrip(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	in := written("a1")
+	curate(t, c, reader(), in)
+
+	got, err := curated(t, c, reader(), in.Question)
+	if err != nil {
+		t.Fatalf("Curated: %v", err)
+	}
+	switch {
+	case got.ID != in.ID:
+		t.Fatalf("the answer came back as %q", got.ID)
+	case got.Question != in.Question:
+		t.Fatalf("the question came back as %q, and it is what the card is titled with", got.Question)
+	case got.Body != in.Body:
+		t.Fatalf("the body came back as %q", got.Body)
+	case !slices.Equal(got.Variants, in.Variants):
+		t.Fatalf("the variants came back as %v, so a phrasing was lost on the way in", got.Variants)
+	case !slices.Equal(got.Sources, in.Sources):
+		t.Fatalf("the sources came back as %v, so the card would cite nothing", got.Sources)
+	case got.By.Name != in.By.Name || got.By.Email != in.By.Email:
+		t.Fatalf("the author came back as %+v, and the name is why a reader believes the answer", got.By)
+	case !got.At.Equal(in.At):
+		t.Fatalf("it was written at %v, want %v", got.At, in.At)
+	case !got.Until.Equal(in.Until):
+		t.Fatalf("it runs out at %v, want %v", got.Until, in.Until)
+	}
+}
+
+// A question is matched by what it means rather than by how it was typed, or
+// the answer is only ever found by the person who wrote it.
+func testCuratedIgnoresPunctuationAndCase(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	curate(t, c, reader(), written("a1"))
+
+	for _, asked := range []string{
+		"What is the deploy freeze?",
+		"what is the deploy freeze",
+		"  WHAT IS THE DEPLOY FREEZE!!  ",
+		"when is the code freeze",
+	} {
+		if _, err := curated(t, c, reader(), asked); err != nil {
+			t.Fatalf("asking %q found nothing: %v", asked, err)
+		}
+	}
+}
+
+// A near miss gets the ordinary list of results rather than a confident card
+// above them, which is the whole reason the match is the whole key.
+func testCuratedIsNotFuzzy(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	curate(t, c, reader(), written("a1"))
+
+	for _, asked := range []string{"deploy freeze", "what is the deploy freeze in december", ""} {
+		if _, err := curated(t, c, reader(), asked); !errors.Is(err, genba.ErrNotFound) {
+			t.Fatalf("asking %q returned %v, want ErrNotFound", asked, err)
+		}
+	}
+}
+
+// Editing an answer is the same call as writing one, and it is also how an
+// answer is re-verified.
+func testCurateReplaces(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	curate(t, c, reader(), written("a1"))
+
+	again := written("a1")
+	again.Body = "No production deploys for the last two weeks of December."
+	again.At = at(5)
+	again.Until = at(5).Add(store.Cadence)
+	curate(t, c, reader(), again)
+
+	got, err := curated(t, c, reader(), again.Question)
+	if err != nil {
+		t.Fatalf("Curated: %v", err)
+	}
+	if got.Body != again.Body {
+		t.Fatalf("the body is still %q, so the edit did not land", got.Body)
+	}
+	if !got.Until.Equal(again.Until) {
+		t.Fatalf("it runs out at %v, want %v, because writing an answer is standing behind it", got.Until, again.Until)
+	}
+	if ids := answers(t, c, reader(), 10); len(ids) != 1 {
+		t.Fatalf("the tenant holds %v, and an edit is not a second answer", ids)
+	}
+}
+
+// A variant taken out of an answer stops finding it, or an answer could never
+// lose a question it turned out not to answer.
+func testCurateDropsAPhrasing(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	curate(t, c, reader(), written("a1"))
+	if _, err := curated(t, c, reader(), "when is the code freeze"); err != nil {
+		t.Fatalf("the variant did not find the answer to begin with: %v", err)
+	}
+
+	fewer := written("a1")
+	fewer.Variants = nil
+	curate(t, c, reader(), fewer)
+
+	if _, err := curated(t, c, reader(), "when is the code freeze"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("the dropped variant returned %v, want ErrNotFound", err)
+	}
+	if _, err := curated(t, c, reader(), fewer.Question); err != nil {
+		t.Fatalf("the question it still claims found nothing: %v", err)
+	}
+}
+
+// Two answers claiming the same question is a curation conflict, and the
+// resolution that needs no screen is that the most recent writer wins.
+func testCurateMovesAPhrasing(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	curate(t, c, reader(), written("a1"))
+
+	second := written("a2")
+	second.Body = "The freeze now runs to the 6th of January."
+	second.At = at(5)
+	curate(t, c, reader(), second)
+
+	got, err := curated(t, c, reader(), second.Question)
+	if err != nil {
+		t.Fatalf("Curated: %v", err)
+	}
+	if got.ID != "a2" {
+		t.Fatalf("the question still answers to %q, so the later writer did not win", got.ID)
+	}
+	if ids := answers(t, c, reader(), 10); len(ids) != 2 {
+		t.Fatalf("the tenant holds %v, and taking a question away is not deleting an answer", ids)
+	}
+}
+
+func testRetract(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	curate(t, c, reader(), written("a1"))
+
+	if err := c.Retract(t.Context(), reader(), "a1"); err != nil {
+		t.Fatalf("Retract: %v", err)
+	}
+	if _, err := curated(t, c, reader(), written("a1").Question); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("the retracted answer returned %v, want ErrNotFound", err)
+	}
+	// Twice, so that a mistake can be undone twice.
+	if err := c.Retract(t.Context(), reader(), "a1"); err != nil {
+		t.Fatalf("retracting again: %v", err)
+	}
+	if ids := answers(t, c, reader(), 10); len(ids) != 0 {
+		t.Fatalf("the tenant still holds %v", ids)
+	}
+}
+
+// An answer belongs to a tenant and to nothing else, which is the one rule a
+// driver has to apply here by itself.
+func testCurateTenants(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	globex := &acl.Principal{Tenant: "globex", Subject: "u_pat"}
+	curate(t, c, reader(), written("a1"))
+
+	if _, err := curated(t, c, globex, written("a1").Question); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("another tenant asking the same question got %v, want ErrNotFound", err)
+	}
+	if ids := answers(t, c, globex, 10); len(ids) != 0 {
+		t.Fatalf("another tenant listed %v", ids)
+	}
+
+	// The same id in two tenants is two answers, and neither of them is the
+	// other, which is what a driver keying on the id alone gets wrong.
+	theirs := written("a1")
+	theirs.Question = "What is the deploy freeze?"
+	theirs.Body = "Globex does not freeze deploys."
+	curate(t, c, globex, theirs)
+
+	ours, err := curated(t, c, reader(), theirs.Question)
+	if err != nil {
+		t.Fatalf("Curated: %v", err)
+	}
+	if ours.Body == theirs.Body {
+		t.Fatal("one tenant's answer replaced another's, which is the whole of the isolation rule here")
+	}
+}
+
+// The list is what whoever maintains the answers reads, so it is most recently
+// written first and it stops where it was told to.
+func testAnswersOrder(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	for i, id := range []string{"a1", "a2", "a3"} {
+		a := written(id)
+		a.Question = "question " + id
+		a.Variants = nil
+		a.At = at(i)
+		curate(t, c, reader(), a)
+	}
+
+	if ids := answers(t, c, reader(), 10); !slices.Equal(ids, []string{"a3", "a2", "a1"}) {
+		t.Fatalf("the list came back as %v, want the most recently written first", ids)
+	}
+	if ids := answers(t, c, reader(), 2); !slices.Equal(ids, []string{"a3", "a2"}) {
+		t.Fatalf("a limit of two gave %v", ids)
+	}
+	if ids := answers(t, c, reader(), 0); len(ids) != 0 {
+		t.Fatalf("a limit of zero gave %v", ids)
+	}
+}
+
+// The three fields a card is unreadable without, refused above the drivers so
+// that two of them cannot disagree about what an answer is.
+func testCurateRejectsIncomplete(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	for name, a := range map[string]func(store.Answer) store.Answer{
+		"no id":       func(a store.Answer) store.Answer { a.ID = ""; return a },
+		"no question": func(a store.Answer) store.Answer { a.Question = "  ?  "; return a },
+		"no body":     func(a store.Answer) store.Answer { a.Body = "   "; return a },
+		"no author":   func(a store.Answer) store.Answer { a.By = doc.Person{}; return a },
+		"no expiry":   func(a store.Answer) store.Answer { a.Until = time.Time{}; return a },
+	} {
+		if err := c.Curate(t.Context(), reader(), a(written("a1"))); err == nil {
+			t.Fatalf("an answer with %s was accepted", name)
+		}
+	}
+}
+
+// A nil principal has no tenant, so it has no answers, and it says so rather
+// than reading somebody else's.
+func testCurateNilPrincipal(t *testing.T, s store.Store) {
+	c := curator(t, s)
+	curate(t, c, reader(), written("a1"))
+
+	if err := c.Curate(t.Context(), nil, written("a2")); !errors.Is(err, genba.ErrNoPrincipal) {
+		t.Fatalf("Curate with no principal returned %v, want ErrNoPrincipal", err)
+	}
+	if _, err := c.Curated(t.Context(), nil, "What is the deploy freeze?"); !errors.Is(err, genba.ErrNoPrincipal) {
+		t.Fatalf("Curated with no principal returned %v, want ErrNoPrincipal", err)
+	}
+	if _, err := c.Answers(t.Context(), nil, 10); !errors.Is(err, genba.ErrNoPrincipal) {
+		t.Fatalf("Answers with no principal returned %v, want ErrNoPrincipal", err)
+	}
+	if err := c.Retract(t.Context(), nil, "a1"); !errors.Is(err, genba.ErrNoPrincipal) {
+		t.Fatalf("Retract with no principal returned %v, want ErrNoPrincipal", err)
+	}
+}

--- a/store/storetest/storetest.go
+++ b/store/storetest/storetest.go
@@ -95,6 +95,18 @@ var cases = []testCase{
 	{"the inbox is most recently reported first and honours a limit", testReportedOrder},
 	{"a report by nobody is refused", testReportRejectsAnonymous},
 	{"a page of ids is one question about reports", testReportBatch},
+
+	{"an answer comes back as it was written", testCurateRoundTrip},
+	{"a question is found however it was typed", testCuratedIgnoresPunctuationAndCase},
+	{"a question nobody wrote down has no answer", testCuratedIsNotFuzzy},
+	{"writing an answer again is editing it", testCurateReplaces},
+	{"a phrasing an answer drops stops finding it", testCurateDropsAPhrasing},
+	{"a phrasing a second answer claims moves to it", testCurateMovesAPhrasing},
+	{"an answer can be retracted, twice", testRetract},
+	{"an answer belongs to one tenant", testCurateTenants},
+	{"the answers come back most recently written first", testAnswersOrder},
+	{"an answer with no question, body, author or expiry is refused", testCurateRejectsIncomplete},
+	{"a nil principal writes and reads no answers", testCurateNilPrincipal},
 }
 
 // contentStore skips a case for a driver that does not hold bytes.

--- a/store/verify.go
+++ b/store/verify.go
@@ -95,11 +95,19 @@ const ExpiringWindow = 14 * 24 * time.Hour
 
 // State reports where the verification is at the given time. The zero
 // [Verification] is expired, which is the safe reading of no claim at all.
-func (v Verification) State(now time.Time) State {
+func (v Verification) State(now time.Time) State { return stateAt(v.Until, now) }
+
+// stateAt is the rule itself, shared with [Answer.State].
+//
+// A verification and an answer are the same claim about two different things,
+// and a reader who learns what the amber badge on a document means has learned
+// what it means on a card. Two copies of these three comparisons would let one
+// of them start expiring a day earlier than the other.
+func stateAt(until, now time.Time) State {
 	switch {
-	case !now.Before(v.Until):
+	case !now.Before(until):
 		return Expired
-	case now.Add(ExpiringWindow).After(v.Until):
+	case now.Add(ExpiringWindow).After(until):
 		return Expiring
 	default:
 		return Fresh

--- a/web/dist/assets/answer.js
+++ b/web/dist/assets/answer.js
@@ -1,10 +1,18 @@
 // The answer above the results.
 //
-// It holds passages taken out of the documents on the page below it, word for
-// word, each one with the document it came from underneath it. Nothing in here
-// is written by the product and nothing is paraphrased, which is a smaller claim
+// There are two kinds and the region holds one of them at a time. Usually it
+// holds passages taken out of the documents on the page below it, word for word,
+// each one with the document it came from underneath it. Nothing in that kind is
+// written by the product and nothing is paraphrased, which is a smaller claim
 // than the one an assistant makes and the only one this build can keep: there is
 // no model behind it yet.
+//
+// The other kind is prose a person in this company wrote and signed, for a
+// question somebody asked often enough to be worth answering once. It takes the
+// place of the quotes rather than sitting above them, because this region is the
+// answer to the question in the box and two answers to one question is a reader
+// deciding which of the product's own answers to believe. The server decides
+// which arrives, and it never sends both.
 //
 // That is deliberate rather than a placeholder. The part of an answer surface
 // that a model does not fix is where it sits, what a citation does when somebody
@@ -25,7 +33,13 @@
 // amount of usefulness that pays for that.
 
 import { h, replace, svg } from "genba/dom.js";
-import { icon, label, sourceColor } from "genba/format.js";
+import { icon, label, sourceColor, when, exact } from "genba/format.js";
+import { render as markdown } from "genba/markdown.js";
+
+// The three states the server sends with a written answer, in the words the
+// verification badge uses, since a reader who has learnt what an amber mark on a
+// document means has learnt what it means here.
+const STATES = new Set(["fresh", "expiring", "expired"]);
 
 export class Answer {
   constructor({ onCite }) {
@@ -42,6 +56,10 @@ export class Answer {
    * second copy to disagree with the first.
    */
   render(res) {
+    if (res && res.curated) {
+      this.written(res.curated);
+      return;
+    }
     const answer = res && res.answer;
     const quotes = (answer && answer.quotes) || [];
     const hits = new Map((res.hits || []).map((hit) => [hit.id, hit]));
@@ -79,6 +97,134 @@ export class Answer {
           { class: "answer__list" },
           cited.map(({ quote, hit }) => this.renderQuote(quote, hit)),
         ),
+      ),
+    );
+  }
+
+  /**
+   * written draws the answer somebody in this company wrote down.
+   *
+   * The three things it has to carry are the words, the name and the date. The
+   * words are why a reader stops here instead of opening four documents, and the
+   * name and the date are the whole reason they are allowed to. An unsigned
+   * paragraph above a list of results is the product asserting something, and
+   * this product does not assert things about a corpus it did not write.
+   *
+   * The body is markdown, rendered by the same renderer that draws a document,
+   * so a list in an answer looks like a list in the document it came from. The
+   * source of it never came from a source outside this deployment: somebody with
+   * the administrator role typed it into this product.
+   */
+  written(a) {
+    this.el.hidden = false;
+    const state = STATES.has(a.state) ? a.state : "expired";
+    const sources = a.sources || [];
+    replace(
+      this.el,
+      h(
+        "section",
+        { class: "answer__panel answer__panel--written", "aria-labelledby": "answer-title" },
+        h(
+          "div",
+          { class: "answer__head" },
+          h("h2", { class: "answer__title", id: "answer-title" }, "Answer"),
+          // The question as it was written down, which is not always the words
+          // that were typed into the box. A reader who searched for a phrasing
+          // somebody thought of as the same question deserves to see which
+          // question they have been given the answer to.
+          h("p", { class: "answer__question" }, a.question || ""),
+        ),
+        h("div", { class: "answer__body prose" }, markdown(a.body || "")),
+        this.byline(a, state),
+        sources.length
+          ? h(
+              "div",
+              { class: "answer__sources" },
+              h("h3", { class: "answer__sources-title" }, "Sources"),
+              h(
+                "ul",
+                { class: "answer__source-list" },
+                sources.map((hit) => this.renderSource(hit)),
+              ),
+            )
+          : null,
+      ),
+    );
+  }
+
+  /**
+   * byline is who wrote it and when they last stood behind it.
+   *
+   * An answer that has run out still says so and is still drawn. Taking it down
+   * on the day it expires would leave the reader with silence, which tells them
+   * nothing, and would leave the person who wrote it with no way to find out it
+   * needs looking at.
+   */
+  byline(a, state) {
+    const stale = state !== "fresh";
+    return h(
+      "p",
+      { class: `answer__by${stale ? " answer__by--stale" : ""}` },
+      // The name and the date are one sentence, so they are one element. Two
+      // elements in the flex row below would be two things with a gap between
+      // them, and the gap is meant to separate the sentence from the mark
+      // beside it rather than a person from the day they wrote something.
+      h(
+        "span",
+        { class: "answer__wrote", title: exact(a.at) },
+        a.email
+          ? h("a", { class: "answer__author", href: `mailto:${a.email}` }, a.by || a.email)
+          : h("span", { class: "answer__author" }, a.by || "somebody"),
+        ` wrote this ${when(a.at)}`,
+      ),
+      stale
+        ? h(
+            "span",
+            {
+              class: `verified verified--${state}`,
+              title:
+                state === "expired"
+                  ? `Nobody has confirmed this since ${exact(a.until)}`
+                  : `Due to be confirmed again ${exact(a.until)}`,
+            },
+            svg(icon("alert"), 14),
+            state === "expired" ? "Not confirmed recently" : `Due for review ${when(a.until)}`,
+          )
+        : null,
+    );
+  }
+
+  /**
+   * renderSource is one of the documents the answer was drawn from.
+   *
+   * They arrive resolved through the reader asking, so a source this person
+   * cannot open is simply not in the list. It is the same link a citation under
+   * a quote is, opening the same preview, because there is one document viewer
+   * in this product.
+   */
+  renderSource(hit) {
+    return h(
+      "li",
+      { class: "answer__source" },
+      h(
+        "a",
+        {
+          class: "quote__cite",
+          href: sourceHref(hit.id),
+          "aria-label": `Open ${hit.title || hit.id}`,
+          onClick: (e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey) return;
+            e.preventDefault();
+            this.onCite(hit.id, "");
+          },
+        },
+        h("span", {
+          class: "source__dot",
+          style: { background: sourceColor(hit.source) },
+        }),
+        h("span", { class: "quote__title" }, hit.title || hit.id),
+        h("span", { class: "quote__where" }, label(hit.source)),
+        svg(icon("arrow-right"), 16),
       ),
     );
   }
@@ -159,5 +305,20 @@ function citeHref(quote) {
   const params = new URLSearchParams(location.search);
   params.set("open", quote.id);
   params.set("at", quote.text);
+  return `/?${params.toString()}`;
+}
+
+/**
+ * sourceHref is the address a source of a written answer leads to.
+ *
+ * The same address without a passage, because the person who wrote the answer
+ * cited a document rather than a sentence, and jumping the reader to a
+ * highlighted line the author never pointed at would be the product inventing
+ * the part of a citation that matters most.
+ */
+function sourceHref(id) {
+  const params = new URLSearchParams(location.search);
+  params.set("open", id);
+  params.delete("at");
   return `/?${params.toString()}`;
 }

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -968,6 +968,91 @@ time {
 }
 
 /*
+ * The answer a person in this company wrote down.
+ *
+ * It is the same region as the quotes and it is set larger, because it is prose
+ * somebody wrote to be read rather than a passage lifted out of a document to be
+ * checked. Still no card, no border and no fill: the thing that says this is
+ * worth reading before the ten results underneath it is its size and the name at
+ * the bottom of it, not a box drawn around it.
+ */
+.answer__panel--written {
+  padding-bottom: var(--space-4);
+}
+
+.answer__question {
+  max-width: var(--measure);
+  margin: var(--space-1) 0 0;
+  color: var(--text);
+  font-size: var(--text-title);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-title);
+}
+
+.answer__body {
+  max-width: var(--measure);
+  margin-top: var(--space-4);
+  font-size: var(--text-lead);
+  line-height: var(--leading-prose);
+}
+
+/* Who wrote it, under the words rather than over them. The words are what the
+   reader came for and the name is how they decide whether to trust them, which
+   is the order somebody reads a signed note in anyway. */
+.answer__by {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-4) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.answer__author {
+  color: var(--text);
+  font-weight: var(--weight-semibold);
+  text-decoration: none;
+}
+
+.answer__author:hover {
+  color: var(--text-link);
+  text-decoration: underline;
+}
+
+/* The name and the date are one sentence and wrap as one. */
+.answer__wrote {
+  min-width: 0;
+}
+
+.answer__sources {
+  margin-top: var(--space-5);
+}
+
+.answer__sources-title {
+  margin: 0 0 var(--space-1);
+  color: var(--text-muted);
+  font-size: var(--text-caption);
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.answer__source-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* The citations line up with the words above them rather than with the quote
+   rule, which is not on this kind of answer. */
+.answer__source .quote__cite {
+  margin-top: 0;
+  margin-left: 0;
+}
+
+/*
  * The passage a citation sent somebody to, inside the document it is in.
  *
  * A wash over the whole sentence rather than the two pixel rule the matched
@@ -2101,13 +2186,27 @@ h6.prose__h {
   color: var(--text-muted);
 }
 
+/* The markers are put back, because the reset above takes them off every list
+   in the product and this is the one place a list is prose rather than a
+   layout. A numbered list with no numbers has lost what the author was saying
+   with it, and a bulleted one reads as three sentences somebody indented for no
+   reason. */
 .prose__list {
   margin: 0 0 var(--space-4);
   padding-left: var(--space-6);
+  list-style: disc;
 }
 
+ol.prose__list {
+  list-style: decimal;
+}
+
+/* A nested list takes a different mark, so a reader can see which level a line
+   is on without counting the indent. A task keeps its own box and no mark,
+   which the rule below it already says. */
 .prose__list .prose__list {
   margin: var(--space-2) 0 0;
+  list-style: circle;
 }
 
 .prose__item {


### PR DESCRIPTION
Some questions are asked every week and the answer is not in any document.
It is in somebody's head, or spread over four pages that each hold a third of it.
Ten people search, ten people open four documents, and the tenth of them still gets it wrong because one of those pages is from 2023.

So an administrator can write the answer down and it stands above the results for everybody in the tenant.
It carries the name of whoever wrote it, the date they last stood behind it, and the documents they drew it from.
It takes the place of the quoted passages rather than sitting beside them, because that region is the answer to the question in the box, and two answers to one question is a reader deciding which of ours to believe.

This is the last box on #41.

## How a question is matched

Whole, and deliberately not fuzzy.
The phrasings an answer is filed under, its own and any others its author listed, are folded through the same analyzer the index uses and looked up as a unit.
A search that is close but not the same gets the ordinary results page it would have got before this existed.
Near matching waits for the ranking work in #24, and until then a confident card answering a question nobody asked is worse than no card at all.

The lookup is on the search path, so every search asks whether this question has been answered and almost none of them have.
The phrasings are their own table keyed by tenant and folded key, which makes the miss one primary key probe and the hit one more.

## What a card may show

The sources are read through the reader asking rather than resolved when the answer was written.
An answer written by somebody who can read everything never becomes a list of documents the reader in front of it cannot open, and a citation to something they may not see is simply not drawn.
The maintenance list keeps the sources as ids for the opposite reason: resolving them there and saving back what came out would quietly drop every source the editor happens not to have access to.

Writing one is administrators only.
That is narrower than the product wants and the right place to start, because an answer outranks documents for every reader in the tenant, and a content manager grant is a decision about the role model rather than about answers.

## Writing, editing and expiry

Writing an answer again is editing it, and editing it is also how it is re-verified.
The date on the card is the date somebody last stood behind the words and there is no separate act that produces it.
An expired one still renders and says so, since that is more useful to a reader than silence and is the only way the person who wrote it finds out it needs looking at.

## The store

A Curator capability with four methods.
memstore, sqlitestore and pgstore all implement it and all three pass the eleven new conformance cases.
It is the first thing in the store that is not about a document, so it is keyed by tenant explicitly rather than reaching a tenant through the document it hangs off, and there is a case for the same id in two tenants being two answers.
The sqlite tables are appended migrations and the postgres one is 0009.

## On screen

The same region the quotes use and the same renderer a document body uses, so a list in an answer looks like a list in the page it came from.
That renderer had lost its list markers to the global reset, which nobody had noticed because a bulleted list still reads as three indented lines.
A numbered one does not, and this feature puts prose above the results where it will be read closely, so the markers are back.

## Endpoints

| Endpoint | What it does |
| --- | --- |
| `GET /api/v1/admin/answers` | the questions this tenant has written an answer to, most recently written first |
| `PUT /api/v1/admin/answers/{id}` | writes an answer, or replaces the one that is there |
| `DELETE /api/v1/admin/answers/{id}` | takes an answer down, and does not mind if it was already down |

A search now carries `curated` when somebody has answered that exact question, and drops `answer` when it does.

## Checks

Eleven conformance cases on three drivers, ten API tests, `go test ./...` and golangci-lint clean.
The gate audits the card as a thirteenth screen with axe and it reports no violations.
The walk asserts the two things that matter: the quotes are gone when a written answer is there, and a source opens the document without inventing a passage to jump to.
BenchmarkAPISearchCurated measures the hit path with six sources under it, and the miss path is already in BenchmarkAPISearch because every search pays for the probe.
