### PR TITLE
Count the filter rail instead of sampling it

### DIFF
--- a/api/access.go
+++ b/api/access.go
@@ -165,7 +165,12 @@ func (s *Server) handleAccess(w http.ResponseWriter, r *http.Request, p *acl.Pri
 			writeError(w, http.StatusInternalServerError, "internal", "the counts are not available")
 			return
 		}
-		res.Sources = sourcesOf(reach)
+		// The kinds come back with the sources and this screen does not draw
+		// them. It asks whether somebody's access is the shape it should be,
+		// which is a question about which connectors they can see into, and a
+		// second breakdown of the same documents by document type answers a
+		// question nobody opened this screen with.
+		res.Sources = sourcesOf(reach.Sources)
 		for _, one := range res.Sources {
 			res.Documents += one.Documents
 		}
@@ -226,10 +231,10 @@ func matchedKey(d acl.Decision) string {
 // sourcesOf puts the counts on the wire, largest first so that the connector
 // somebody has most of is the one they read first, and by name within a tie so
 // that two readings of an unchanged corpus are the same list.
-func sourcesOf(in []store.Reach) []source {
+func sourcesOf(in []store.Facet) []source {
 	out := make([]source, len(in))
-	for i, r := range in {
-		out[i] = source{Source: r.Source, Documents: r.Documents}
+	for i, f := range in {
+		out[i] = source{Source: f.Value, Documents: f.Count}
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Documents != out[j].Documents {

--- a/api/bench_test.go
+++ b/api/bench_test.go
@@ -201,6 +201,11 @@ func BenchmarkAPISearchCurated(b *testing.B) {
 // BenchmarkAPIMe and BenchmarkAPIStats are the two calls the interface makes
 // before it can draw anything, so they are on the path to first paint even
 // though neither of them searches for anything.
+//
+// This measures the second session of the morning rather than the first. The
+// filter rail is counted over every document the reader may open and held for a
+// minute, so what is on this path almost always is the cache lookup, and the
+// count behind it is measured where it happens, in BenchmarkReachable.
 func BenchmarkAPIMe(b *testing.B) {
 	h, hdr := handler(b)
 	get(b, h, "/api/v1/me", hdr)

--- a/index/cache.go
+++ b/index/cache.go
@@ -62,6 +62,18 @@ const (
 	// DefaultDocumentEntries is how many documents are held. It is the layer
 	// that turns paging back and forth through a result set into no work at all.
 	DefaultDocumentEntries = 20_000
+
+	// DefaultShapeExpiry is how long the shape of the corpus is reused.
+	//
+	// A minute, and a write does not shorten it, which makes this the one layer
+	// here whose key does not carry the tenant's generation. The reasoning is in
+	// [Cache.shapeOf] and it comes down to the rail not being a search result.
+	DefaultShapeExpiry = time.Minute
+
+	// DefaultShapeEntries is how many corpus shapes are held. One per distinct
+	// visibility rather than one per person, so a company where everybody is in
+	// the same handful of groups needs a handful of entries.
+	DefaultShapeEntries = 1_000
 )
 
 // Cache is the derived state a searcher reuses between requests.
@@ -73,6 +85,7 @@ type Cache struct {
 	results *cache.Cache[store.Ranked]
 	corpus  *cache.Cache[store.Corpus]
 	docs    *cache.Cache[doc.Document]
+	shape   *cache.Cache[store.Reach]
 
 	// blind is set when the driver does not report its writes, which turns off
 	// the two layers that have no other way to learn that they are wrong.
@@ -167,6 +180,8 @@ func NewCache(opts ...CacheOption) *Cache {
 		corpus: cache.New(cfg.corpus, cache.Forever, cache.WithClock[store.Corpus](cfg.clock)),
 		docs:   cache.New(cfg.docs, cache.Forever, cache.WithClock[doc.Document](cfg.clock)),
 
+		shape: cache.New(DefaultShapeEntries, DefaultShapeExpiry, cache.WithClock[store.Reach](cfg.clock)),
+
 		gen: make(map[string]uint64),
 	}
 }
@@ -209,6 +224,7 @@ func (c *Cache) Clear() {
 	c.results.Clear()
 	c.corpus.Clear()
 	c.docs.Clear()
+	c.shape.Clear()
 }
 
 // Stats reports each layer separately, because a hit rate averaged over three
@@ -218,6 +234,7 @@ func (c *Cache) Stats() map[string]cache.Stats {
 		"results":   c.results.Stats(),
 		"corpus":    c.corpus.Stats(),
 		"documents": c.docs.Stats(),
+		"shape":     c.shape.Stats(),
 	}
 }
 
@@ -244,6 +261,45 @@ func (c *Cache) ranked(p *acl.Principal, r store.Request, sel store.Selection, f
 	key.WriteByte('|')
 	writeRequest(&key, r, sel)
 	return c.results.Do(key.String(), fn)
+}
+
+// shapeOf returns the corpus as one principal sees it, counted by the driver.
+//
+// This is the layer that lets the filter rail print the counts of the corpus
+// rather than a sample of them. Counting them exactly is an aggregate over
+// every document the asker may read, which is tens of milliseconds on a corpus
+// of twenty thousand and more than that on a real one, and the rail is the
+// first thing every session asks for. Reading it out of a cache is what turns
+// that into an answer inside the budget.
+//
+// The key is the tenant and the asker's visibility fingerprint, and it is the
+// one key in this file that does not carry the tenant's generation. That is the
+// whole design and it deserves its own paragraph rather than a clause.
+//
+// A write drops a cached ordering because somebody who saves a document and
+// then searches for it must find it, and being told for thirty seconds that it
+// does not exist is the complaint that makes people stop trusting a search box.
+// The rail is not a search result. It is the shape of the corpus, it is read as
+// proportions rather than as numbers, and nobody has ever noticed that a
+// vertical said four hundred and ten when it had just become four hundred and
+// eleven. Keying it by the generation would mean any write anywhere in the
+// tenant makes the next session bootstrap pay the exact count again, which on a
+// corpus being ingested is every bootstrap, which is the cost this layer exists
+// to remove.
+//
+// So the bound is the clock, at [DefaultShapeExpiry]. What that admits is a
+// count up to a minute out of date. What it does not admit is a leak: the
+// fingerprint changes when somebody's groups change, so a principal never reads
+// an entry counted for a different visibility, and the entry holds counts
+// rather than ids or titles either way. A document whose permissions changed
+// without any group changing moves a number by one for up to a minute, and that
+// is the honest cost of the layer.
+func (c *Cache) shapeOf(p *acl.Principal, fn func() (store.Reach, error)) (store.Reach, error) {
+	fp := acl.Fingerprint(p)
+	if fp == "" {
+		return fn()
+	}
+	return c.shape.Do(fp, fn)
 }
 
 // corpusStats returns the cached corpus numbers for a set of terms.

--- a/index/cache_test.go
+++ b/index/cache_test.go
@@ -33,6 +33,7 @@ type counting struct {
 	ranks   int
 	stats   int
 	fetches int
+	reaches int
 	fetched []string
 
 	// hold blocks every rank until it is closed, which is how the single flight
@@ -122,10 +123,35 @@ func (s *counting) Fetch(ctx context.Context, p *acl.Principal, ids []string) ([
 	return out, nil
 }
 
+func (s *counting) Reachable(ctx context.Context, p *acl.Principal) (store.Reach, error) {
+	s.mu.Lock()
+	s.reaches++
+	s.mu.Unlock()
+	return s.Store.Reachable(ctx, p)
+}
+
 func (s *counting) counts() (ranks, stats, fetches int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.ranks, s.stats, s.fetches
+}
+
+// reached is the aggregate the filter rail is drawn from, counted separately
+// because it is the one call here whose cost follows the corpus rather than the
+// page and the only one a write is allowed not to invalidate.
+func (s *counting) reached() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.reaches
+}
+
+func filters(t *testing.T, s *index.Searcher, p *acl.Principal) map[string][]index.Facet {
+	t.Helper()
+	got, err := s.Filters(t.Context(), p)
+	if err != nil {
+		t.Fatalf("Filters: %v", err)
+	}
+	return got
 }
 
 // documents turns the shared fixtures into documents. It is the body of
@@ -453,6 +479,107 @@ func TestResultCacheExpires(t *testing.T) {
 	}
 }
 
+// The filter rail is counted once per visibility rather than once per session.
+//
+// It is the first request every browser makes and the answer is the same for
+// everybody in the same groups, so counting it per person is counting the
+// corpus once per person who opens the product in the morning.
+func TestTheRailIsCountedOncePerVisibility(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+	p := principal("gdrive:eng@acme.com")
+
+	first := filters(t, s, p)
+	second := filters(t, s, p)
+	if !slices.Equal(first["source"], second["source"]) {
+		t.Fatalf("the rail changed between two reads: %v then %v", first["source"], second["source"])
+	}
+	if got := st.reached(); got != 1 {
+		t.Errorf("the driver counted the corpus %d times for two reads of the rail, want 1", got)
+	}
+}
+
+// A write does not recount the rail, and that is the one place in this file
+// where a write leaves an entry standing.
+//
+// A search must never be answered from before a write, because somebody who
+// saves a document and cannot then find it stops trusting the search box. The
+// rail is not that. It is the shape of the corpus, it is read as proportions,
+// and it is the aggregate over every document the reader may open. Recounting
+// it on every write means recounting it on every document a connector ingests,
+// which during an ingestion is continuously.
+func TestAWriteDoesNotRecountTheRail(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+	p := principal("gdrive:eng@acme.com")
+
+	filters(t, s, p)
+	if err := st.Put(t.Context(), documents([]fixture{
+		{id: "d4", title: "Another runbook", body: "How to fail over the other queue.", perm: openTo("eng@acme.com")},
+	})...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	filters(t, s, p)
+
+	if got := st.reached(); got != 1 {
+		t.Errorf("the driver counted the corpus %d times across a write, want 1", got)
+	}
+	// The same write does sweep the orderings, which is what makes the line
+	// above a decision about the rail rather than a cache that ignores writes.
+	res := search(t, s, p, index.Query{Text: "runbook"})
+	if !slices.Contains(ids(res), "d4") {
+		t.Errorf("a search after the write found %v, want the document that was just written", ids(res))
+	}
+}
+
+// What bounds the staleness the test above admits is the clock.
+func TestTheRailExpiresOnTheClock(t *testing.T) {
+	st := newCounting(t, corpus)
+	var now atomic.Int64
+	now.Store(epoch.UnixNano())
+	c := index.NewCache(index.WithCacheClock(func() time.Time { return time.Unix(0, now.Load()) }))
+	s := index.New(st, index.WithClock(clock), index.WithCache(c))
+	t.Cleanup(func() { _ = s.Close() })
+	p := principal("gdrive:eng@acme.com")
+
+	filters(t, s, p)
+	now.Add(int64(index.DefaultShapeExpiry) + 1)
+	filters(t, s, p)
+
+	if got := st.reached(); got != 2 {
+		t.Errorf("the driver counted the corpus %d times either side of the expiry, want 2", got)
+	}
+}
+
+// The rail says how many documents there are of each source, so an entry that
+// crossed between two people would tell one of them how much of a corpus the
+// other can read.
+func TestTheRailNeverCrossesVisibility(t *testing.T) {
+	st := newCounting(t, corpus)
+	s, _ := cachedSearcher(t, st)
+
+	engineer := filters(t, s, principal("gdrive:eng@acme.com"))
+	seller := filters(t, s, principal("gdrive:sales@acme.com"))
+
+	if got := sources(engineer); !slices.Equal(got, []string{"gdrive"}) {
+		t.Errorf("the engineer's rail draws %v, want gdrive alone", got)
+	}
+	if got := sources(seller); !slices.Equal(got, []string{"salesforce"}) {
+		t.Errorf("the seller's rail draws %v, want salesforce alone", got)
+	}
+	if got := st.reached(); got != 2 {
+		t.Errorf("two visibilities cost %d counts, want one each", got)
+	}
+}
+
+func sources(facets map[string][]index.Facet) []string {
+	out := make([]string, 0, len(facets["source"]))
+	for _, f := range facets["source"] {
+		out = append(out, f.Value)
+	}
+	return out
+}
+
 // TestSixteenReadersProduceOneQuery is the case a cache exists for: a popular
 // key goes cold and everybody misses it at once.
 func TestSixteenReadersProduceOneQuery(t *testing.T) {
@@ -510,9 +637,13 @@ func TestCacheStatsAreReportedPerLayer(t *testing.T) {
 
 	search(t, s, p, index.Query{Text: "payments"})
 	search(t, s, p, index.Query{Text: "payments"})
+	// The rail is its own layer with its own expiry, so it is read twice here
+	// like the rest of them rather than left to a search to populate.
+	filters(t, s, p)
+	filters(t, s, p)
 
 	stats := s.CacheStats()
-	for _, layer := range []string{"results", "corpus", "documents"} {
+	for _, layer := range []string{"results", "corpus", "documents", "shape"} {
 		got, ok := stats[layer]
 		if !ok {
 			t.Fatalf("the stats do not report the %s layer", layer)

--- a/index/counters_test.go
+++ b/index/counters_test.go
@@ -274,6 +274,71 @@ func TestFacetCounters(t *testing.T) {
 	}
 }
 
+// The filter rail counts the corpus and a search samples it, and the difference
+// is the whole of #142.
+//
+// A sidebar is drawn beside a match set, where the bound is the right trade: a
+// query that matched fifty thousand documents is described well enough by the
+// first thousand of them, and reading four columns of the other forty nine to
+// improve the second digit of a number nobody reads that far is not worth a
+// second of anybody's time. A rail is drawn beside no match set at all. It says
+// how much of each source and each kind there is, it is read as proportions,
+// and a rail whose every row reports the same bound has no proportions in it.
+//
+// So this asserts the two behaviours side by side on one corpus, because either
+// one alone reads like an accident.
+func TestTheRailCountsPastTheBoundASearchStopsAt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("generating the corpus takes a few seconds the first time")
+	}
+	s, p, st := counters(t)
+
+	// A search with nothing in it, which is the most documents any query here
+	// can match and therefore the case the bound bites hardest.
+	res, err := s.Search(t.Context(), p, index.Query{Limit: 1})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if res.Total <= index.FacetPool {
+		t.Fatalf("the corpus holds %d readable documents and the facet pool is %d, so the bound is never reached",
+			res.Total, index.FacetPool)
+	}
+	if !res.Approximate {
+		t.Errorf("a search over %d documents counted its facets over %d and did not say so",
+			res.Total, index.FacetPool)
+	}
+	if got := sum(res.Facets["source"]); got != index.FacetPool {
+		t.Errorf("the search sidebar adds up to %d, want the bound of %d", got, index.FacetPool)
+	}
+
+	st.ResetCounters()
+	rail, err := s.Filters(t.Context(), p)
+	if err != nil {
+		t.Fatalf("Filters: %v", err)
+	}
+	for _, field := range []string{"source", "kind"} {
+		if got := sum(rail[field]); got != res.Total {
+			t.Errorf("the rail adds up to %d by %s, want the %d documents this reader can open",
+				got, field, res.Total)
+		}
+	}
+
+	// One statement for both groupings. Counting the corpus twice to describe it
+	// two ways would double the one part of this that is proportional to the
+	// corpus, and it is the part that put the rail behind a cache.
+	if c := st.Counters(); c.Statements != 1 {
+		t.Errorf("the rail cost %d statements, want one", c.Statements)
+	}
+}
+
+func sum(facets []index.Facet) int {
+	var n int
+	for _, f := range facets {
+		n += f.Count
+	}
+	return n
+}
+
 // A filtered search counts more documents than it matched, on purpose. A field
 // somebody has ticked is counted a second time with its own filter lifted, so
 // that the values nobody ticked still carry the number of results choosing them

--- a/index/driver_test.go
+++ b/index/driver_test.go
@@ -155,10 +155,15 @@ func TestDriversAgree(t *testing.T) {
 // rail a search would have drawn.
 //
 // It used to be drawn from a search with a limit of one, which is where the
-// counts came from and is why they were right. Now it is drawn from a selection
-// that asks for the counts and no candidates, so the thing worth asserting is
-// that nothing moved: the values, the counts and the order are what the search
-// reports, on the driver that counts in SQL and on the one that counts in Go.
+// counts came from and is why they were right. Now it is counted by the driver
+// under the same permission rule, so the thing worth asserting is that nothing
+// moved: the values, the counts and the order are what the search reports, on
+// the driver that counts in SQL and on the one that counts in Go.
+//
+// Over a corpus this size the two are the same numbers arrived at two ways. The
+// case where they differ is a corpus larger than the facet bound, where the
+// search reports a sample and the rail reports the count, and that one is
+// TestTheRailCountsPastTheBoundASearchStopsAt.
 func TestFiltersMatchWhatASearchWouldHaveCounted(t *testing.T) {
 	scanning, retrieving := searchers(t)
 
@@ -175,10 +180,20 @@ func TestFiltersMatchWhatASearchWouldHaveCounted(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s Filters: %v", name, err)
 			}
-			for _, field := range []string{"source", "kind", "container", "author"} {
+			// The two the rail draws. The container and author counts a search
+			// reports are counted over a match set, where narrowing to one of
+			// them is a question somebody might have; over a whole corpus the
+			// answer is every author in the company and the rail does not ask.
+			for _, field := range []string{"source", "kind"} {
 				if !slices.Equal(got[field], res.Facets[field]) {
 					t.Errorf("%s %s filters for %s = %v, a search counted %v",
 						name, field, who.Subject, got[field], res.Facets[field])
+				}
+			}
+			for _, field := range []string{"container", "author"} {
+				if len(got[field]) != 0 {
+					t.Errorf("%s counted %s for the rail: %v, and the rail does not draw it",
+						name, field, got[field])
 				}
 			}
 		}

--- a/index/index.go
+++ b/index/index.go
@@ -481,8 +481,8 @@ func (s *Searcher) Recent(ctx context.Context, p *acl.Principal, limit int) ([]d
 	return out, nil
 }
 
-// Filters is what a filter rail is drawn from: every facet value the principal
-// can see, and how many documents carry each.
+// Filters is what a filter rail is drawn from: the sources and the kinds the
+// principal can see something in, and how many documents they can see of each.
 //
 // It is a separate method rather than a search with a tiny limit because the
 // candidate pool has a floor. Asking for one result asks the driver for five
@@ -497,15 +497,46 @@ func (s *Searcher) Recent(ctx context.Context, p *acl.Principal, limit int) ([]d
 // two together is how a limit of zero comes to mean whichever of them the reader
 // guesses.
 //
-// The counts are bounded by [FacetPool], which is the same bound a search puts
-// on its sidebar and the same one this endpoint was already getting when it went
-// through Search. Counting them exactly is a read of four columns of every
-// document the principal can see, and it was measured: on twenty thousand
-// documents the exact count costs more than the five hundred candidates removing
-// it saved, so a change made to take work off this path would have put more
-// back. What the bound costs is that the rail's numbers are lower bounds on a
-// corpus larger than the pool, which is #142.
+// The counts are exact on a driver that can count what somebody may read, which
+// is [store.Access], and the search path is the fallback for one that cannot.
+// The fallback is what this used to do on every driver, and it bounds the
+// counting at [FacetPool], so on a corpus larger than the pool it drew a rail
+// that added up to a thousand. That is #142 and the difference is worth being
+// blunt about: a rail is read as proportions, and proportions taken from a
+// sample of the first thousand documents the planner happened to reach are not
+// proportions of anything.
+//
+// The exact count is an aggregate over every document the principal may read,
+// which is more than an interactive request can afford to spend, so it is read
+// through the one cache layer here that a write does not drop. That is where
+// the staleness this endpoint admits is written down: see [Cache.shapeOf].
+//
+// Two fields rather than four. The rail draws the sources and the kinds, and
+// the container and author counts a search reports are counted over a match
+// set, where the question is which of the things this query found are worth
+// narrowing to. Over a whole corpus there is no such question: the answer is
+// every author in the company, in a list of fifty, which is not a filter.
 func (s *Searcher) Filters(ctx context.Context, p *acl.Principal) (map[string][]Facet, error) {
+	if a, ok := s.store.(store.Access); ok {
+		call := func() (store.Reach, error) { return a.Reachable(ctx, p) }
+		var (
+			reach store.Reach
+			err   error
+		)
+		if s.cache != nil {
+			reach, err = s.cache.shapeOf(p, call)
+		} else {
+			reach, err = call()
+		}
+		if err != nil {
+			return nil, err
+		}
+		return facetsFrom(map[string][]store.Facet{
+			"source": reach.Sources,
+			"kind":   reach.Kinds,
+		}), nil
+	}
+
 	found, err := s.collect(ctx, p, store.Request{}, store.Selection{Counts: true, Facets: FacetPool})
 	if err != nil {
 		return nil, err

--- a/store/access.go
+++ b/store/access.go
@@ -6,24 +6,33 @@ import (
 	"github.com/tamnd/genba/acl"
 )
 
-// Reach is how much of one source a principal can read.
+// Reach is how much of the corpus a principal can read, by source and by kind.
 //
-// It is a count and nothing else on purpose. The question an operator opens
-// this for is whether somebody's access is roughly the shape it should be, and
-// a list of titles would answer that question by handing the operator the
-// documents themselves, which is the one thing the administrator role does not
-// grant. Counts answer it without becoming a way to read a corpus through
-// somebody else's eyes.
+// It is counts and nothing else on purpose. One of the questions it answers is
+// whether somebody's access is roughly the shape it should be, and a list of
+// titles would answer that question by handing an operator the documents
+// themselves, which is the one thing the administrator role does not grant.
+// Counts answer it without becoming a way to read a corpus through somebody
+// else's eyes.
+//
+// The other question it answers is the filter rail, which is the same question
+// asked by a different screen: how many documents are there of each source and
+// of each kind, for the person looking. That used to be a search with no query
+// in it, whose facet counts stop at a bound, so a rail over a corpus of twenty
+// thousand documents added up to a thousand. See #142.
+//
+// Both fields are counted exactly rather than sampled. A number that says "at
+// least four hundred" cannot be compared with the same number taken last week,
+// and comparing it with last week is the whole use of it on one screen, while
+// on the other a rail whose every row says the same bound has no proportions in
+// it and proportions are what a rail is for.
 type Reach struct {
-	// Source is the connector the documents came from, which is the same name a
-	// search filters on.
-	Source string
+	// Sources is how many documents of each connector this principal may read.
+	// The value is the same name a search filters on.
+	Sources []Facet
 
-	// Documents is how many of that source's documents this principal may read,
-	// counted exactly rather than sampled. A number that says "at least four
-	// hundred" cannot be compared with the same number taken last week, and
-	// comparing it with last week is the whole use of it.
-	Documents int
+	// Kinds is the same count over the document type.
+	Kinds []Facet
 }
 
 // Access is the capability that answers what one principal can reach.
@@ -42,25 +51,29 @@ type Reach struct {
 // Be plain about what it still costs. The aggregate is over every document in
 // the tenant, and on the twenty thousand document benchmark corpus it takes
 // tens of milliseconds, which is outside what an interactive request is allowed
-// to spend here. That is why the interface asks for it rather than showing it
-// with everything else, and #149 is what would have to change for it not to
-// have to.
+// to spend. Two things follow from that and both are deliberate. The screen an
+// operator opens asks for it rather than getting it with everything else, and
+// the filter rail reads it through a cache with an expiry of its own rather
+// than through the one a search uses. See [index.Cache] for why the rail may be
+// a minute out of date and a search may not. #149 is what would have to change
+// for neither to be necessary.
 type Access interface {
 	Store
 
-	// Reachable reports, per source, how many documents the principal may read.
+	// Reachable reports how many documents the principal may read, of each
+	// source and of each kind.
 	//
 	// The permission rule is the same one every other read path applies and it
 	// is applied the same way, inside the driver's own query. A driver that
 	// counts everything and filters afterwards is not conformant, and the
 	// suite in store/storetest will say so.
 	//
-	// Sources the principal can reach nothing in are left out rather than
+	// Values the principal can reach nothing under are left out rather than
 	// returned as zero, because a source that has nothing in it for somebody
 	// and a source that does not exist are the same answer to the person
 	// looking at the screen.
 	//
-	// The order is unspecified. A caller drawing a list sorts it into whatever
-	// order that list is read in.
-	Reachable(ctx context.Context, p *acl.Principal) ([]Reach, error)
+	// The order of each list is unspecified. A caller drawing a list sorts it
+	// into whatever order that list is read in.
+	Reachable(ctx context.Context, p *acl.Principal) (Reach, error)
 }

--- a/store/memstore/memstore.go
+++ b/store/memstore/memstore.go
@@ -406,35 +406,44 @@ func (s *Store) Quarantined(ctx context.Context, tenant string, limit int) ([]st
 	return out, nil
 }
 
-// Reachable counts what one principal may read, by source.
+// Reachable counts what one principal may read, by source and by kind.
 //
 // It is the same decision Scan makes, taken over the same map, and it is a
 // separate method because the counting is the point: Scan hands back documents
-// and this hands back four numbers, and on a driver whose documents are already
-// in memory that difference is the whole cost of the answer.
-func (s *Store) Reachable(ctx context.Context, p *acl.Principal) ([]store.Reach, error) {
+// and this hands back a handful of numbers, and on a driver whose documents are
+// already in memory that difference is the whole cost of the answer.
+func (s *Store) Reachable(ctx context.Context, p *acl.Principal) (store.Reach, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return store.Reach{}, err
 	}
 	if p == nil {
-		return nil, genba.ErrNoPrincipal
+		return store.Reach{}, genba.ErrNoPrincipal
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.closed {
-		return nil, genba.ErrClosed
+		return store.Reach{}, genba.ErrClosed
 	}
-	counts := make(map[string]int)
+	sources, kinds := map[string]int{}, map[string]int{}
 	for _, d := range s.docs {
 		if visible(p, d) {
-			counts[d.Source]++
+			sources[d.Source]++
+			kinds[string(d.Kind)]++
 		}
 	}
-	out := make([]store.Reach, 0, len(counts))
-	for source, n := range counts {
-		out = append(out, store.Reach{Source: source, Documents: n})
+	return store.Reach{Sources: facetsOf(sources), Kinds: facetsOf(kinds)}, nil
+}
+
+// facetsOf turns a tally into the counts a caller reads. The order is
+// unspecified, so it is whatever ranging over a map gave, which is the honest
+// way to say so: a caller that started depending on an order would find out
+// here rather than on the driver that changed one.
+func facetsOf(counts map[string]int) []store.Facet {
+	out := make([]store.Facet, 0, len(counts))
+	for value, n := range counts {
+		out = append(out, store.Facet{Value: value, Count: n})
 	}
-	return out, nil
+	return out
 }
 
 // Close releases the store.

--- a/store/pgstore/access.go
+++ b/store/pgstore/access.go
@@ -11,7 +11,7 @@ import (
 
 var _ store.Access = (*Store)(nil)
 
-// Reachable counts what one principal may read, by source.
+// Reachable counts what one principal may read, by source and by kind.
 //
 // The permission rule is the same clause every read path here builds, so there
 // is one definition of who may see what and this is not a second one that can
@@ -19,21 +19,30 @@ var _ store.Access = (*Store)(nil)
 // answer to "how much of this corpus can this person reach" is a handful of
 // numbers, and reading a million documents to arrive at a handful of numbers is
 // how a screen that has to answer in ten milliseconds ends up taking a second.
-func (s *Store) Reachable(ctx context.Context, p *acl.Principal) ([]store.Reach, error) {
+//
+// The documents the rule admits are materialised once and grouped twice, rather
+// than the clause being run once per grouping. The pass over the corpus is all
+// of the cost and there is no reason to pay for it twice to count the same rows
+// two ways.
+func (s *Store) Reachable(ctx context.Context, p *acl.Principal) (store.Reach, error) {
 	if err := s.ready(ctx); err != nil {
-		return nil, err
+		return store.Reach{}, err
 	}
 	if p == nil {
-		return nil, genba.ErrNoPrincipal
+		return store.Reach{}, genba.ErrNoPrincipal
 	}
 
-	var out []store.Reach
+	var out store.Reach
 	err := s.retry(ctx, func(ctx context.Context) error {
 		c := visible(p)
 		rows, err := s.query(ctx, `
-			SELECT d.source, count(*) FROM document d
-			WHERE `+c.where()+`
-			GROUP BY d.source`, c.args...)
+			WITH mine AS MATERIALIZED (
+				SELECT d.source AS source, d.kind AS kind FROM document d
+				WHERE `+c.where()+`
+			)
+			SELECT 'source' AS field, source AS value, count(*) AS n FROM mine GROUP BY source
+			UNION ALL
+			SELECT 'kind', kind, count(*) FROM mine GROUP BY kind`, c.args...)
 		if err != nil {
 			return err
 		}
@@ -42,19 +51,27 @@ func (s *Store) Reachable(ctx context.Context, p *acl.Principal) ([]store.Reach,
 		// Cleared on every attempt, for the same reason the quarantine listing
 		// clears its own: a retry that appended to what the failed attempt had
 		// already read would count half the corpus twice.
-		out = nil
+		out = store.Reach{}
 		for rows.Next() {
-			var r store.Reach
-			if err := rows.Scan(&r.Source, &r.Documents); err != nil {
+			var (
+				field string
+				f     store.Facet
+			)
+			if err := rows.Scan(&field, &f.Value, &f.Count); err != nil {
 				return err
 			}
 			s.counters.rows.Add(1)
-			out = append(out, r)
+			switch field {
+			case "source":
+				out.Sources = append(out.Sources, f)
+			case "kind":
+				out.Kinds = append(out.Kinds, f)
+			}
 		}
 		return rows.Err()
 	})
 	if err != nil {
-		return nil, fmt.Errorf("pgstore: reachable: %w", err)
+		return store.Reach{}, fmt.Errorf("pgstore: reachable: %w", err)
 	}
 	return out, nil
 }

--- a/store/sqlitestore/access.go
+++ b/store/sqlitestore/access.go
@@ -11,7 +11,7 @@ import (
 
 var _ store.Access = (*Store)(nil)
 
-// Reachable counts what one principal may read, by source.
+// Reachable counts what one principal may read, by source and by kind.
 //
 // The counting is an aggregate rather than a walk: the answer to "how much of
 // this corpus can this person reach" is a handful of numbers, and reading a
@@ -19,35 +19,47 @@ var _ store.Access = (*Store)(nil)
 // that has to answer in ten milliseconds ends up taking a second. The rule it
 // aggregates over is [reachable], which is the rule [visible] applies in the
 // order it applies it.
-func (s *Store) Reachable(ctx context.Context, p *acl.Principal) ([]store.Reach, error) {
+//
+// Both groupings come back from one statement, labelled by the field they
+// grouped on. Two statements would apply the permission rule to the whole
+// corpus twice to answer two questions about the same rows.
+func (s *Store) Reachable(ctx context.Context, p *acl.Principal) (store.Reach, error) {
 	if err := s.ready(ctx); err != nil {
-		return nil, err
+		return store.Reach{}, err
 	}
 	if p == nil {
-		return nil, genba.ErrNoPrincipal
+		return store.Reach{}, genba.ErrNoPrincipal
 	}
 
 	q, args := reachable(p)
 	rows, err := s.query(ctx, q, args...)
 	if err != nil {
-		return nil, fmt.Errorf("sqlitestore: reachable: %w", err)
+		return store.Reach{}, fmt.Errorf("sqlitestore: reachable: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	var out []store.Reach
+	var out store.Reach
 	for rows.Next() {
-		var r store.Reach
-		if err := rows.Scan(&r.Source, &r.Documents); err != nil {
-			return nil, fmt.Errorf("sqlitestore: reachable: %w", err)
+		var (
+			field string
+			f     store.Facet
+		)
+		if err := rows.Scan(&field, &f.Value, &f.Count); err != nil {
+			return store.Reach{}, fmt.Errorf("sqlitestore: reachable: %w", err)
 		}
-		// One per source rather than one per document, which is the difference
+		// One per value rather than one per document, which is the difference
 		// this method exists for and is worth counting honestly: a change that
 		// turned this back into a walk would show up here first.
 		s.counters.rows.Add(1)
-		out = append(out, r)
+		switch field {
+		case "source":
+			out.Sources = append(out.Sources, f)
+		case "kind":
+			out.Kinds = append(out.Kinds, f)
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("sqlitestore: reachable: %w", err)
+		return store.Reach{}, fmt.Errorf("sqlitestore: reachable: %w", err)
 	}
 	return out, nil
 }

--- a/store/sqlitestore/bench_test.go
+++ b/store/sqlitestore/bench_test.go
@@ -70,6 +70,31 @@ func BenchmarkRankFilterOnly(b *testing.B) {
 	}
 }
 
+// BenchmarkReachable is the filter rail, counted rather than sampled.
+//
+// It is the one read here whose cost follows the corpus rather than the page,
+// deliberately: a rail that reports the first thousand documents the planner
+// happened to reach reports proportions of nothing, which was #142. So the
+// number this prints is meant to be looked at rather than assumed, and it is
+// why the layer above reads it through a cache with an expiry of its own
+// instead of on every session bootstrap. Making it cheap enough not to need
+// that cache is #149.
+func BenchmarkReachable(b *testing.B) {
+	st, spec := benchcorpus.Fixture(b)
+	p := spec.Principal()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		got, err := st.Reachable(b.Context(), p)
+		if err != nil {
+			b.Fatalf("Reachable: %v", err)
+		}
+		if len(got.Sources) == 0 || len(got.Kinds) == 0 {
+			b.Fatalf("the corpus counted %d sources and %d kinds", len(got.Sources), len(got.Kinds))
+		}
+	}
+}
+
 // BenchmarkStatistics is the second query of every search. It is separate
 // because it is the one that would quietly become a scan over every document
 // carrying a common term.

--- a/store/sqlitestore/query.go
+++ b/store/sqlitestore/query.go
@@ -87,6 +87,11 @@ func visible(p *acl.Principal) *clause {
 // unresolved is already excluded by queryable, then a deny denies, then the
 // owner is allowed, then the mode decides.
 //
+// The documents that survive the rule are materialised as two columns and
+// grouped twice, rather than the rule being run once per grouping. Two counts
+// of the same rows is one pass over the corpus and two passes over a temporary
+// table of two short strings, and the pass over the corpus is all of the cost.
+//
 // It is a second expression of the rule and that is the thing to be careful
 // about, so it is held to the first by storetest.RunReachable, which walks the
 // order clause by clause against every driver.
@@ -106,17 +111,21 @@ func reachable(p *acl.Principal) (query string, args []any) {
 			UNION
 			SELECT doc_id, effect FROM document_ref
 			WHERE scope = 1 AND key IN (SELECT value FROM json_each(?))
+		),
+		mine(source, kind) AS MATERIALIZED (
+			SELECT d.source, d.kind FROM document d
+			WHERE d.queryable = 1
+			  AND d.tenant = ?
+			  AND d.id NOT IN (SELECT doc_id FROM named WHERE effect = 1)
+			  AND (
+			    (d.owner_key <> '' AND d.owner_key IN (SELECT value FROM json_each(?)))
+			    OR d.mode = ?
+			    OR (d.mode = ? AND d.id IN (SELECT doc_id FROM named WHERE effect = 0))
+			  )
 		)
-		SELECT d.source, count(*) FROM document d
-		WHERE d.queryable = 1
-		  AND d.tenant = ?
-		  AND d.id NOT IN (SELECT doc_id FROM named WHERE effect = 1)
-		  AND (
-		    (d.owner_key <> '' AND d.owner_key IN (SELECT value FROM json_each(?)))
-		    OR d.mode = ?
-		    OR (d.mode = ? AND d.id IN (SELECT doc_id FROM named WHERE effect = 0))
-		  )
-		GROUP BY d.source`
+		SELECT 'source' AS field, source AS value, count(*) AS n FROM mine GROUP BY source
+		UNION ALL
+		SELECT 'kind', kind, count(*) FROM mine GROUP BY kind`
 
 	return q, []any{
 		string(users), string(groups),

--- a/store/storetest/access.go
+++ b/store/storetest/access.go
@@ -10,14 +10,16 @@ import (
 	"github.com/tamnd/genba/store"
 )
 
-// RunReachable checks a driver's [store.Access] against what the screen that
-// answers "what can this person see" relies on.
+// RunReachable checks a driver's [store.Access] against what the two screens
+// built on it rely on: the one that answers "what can this person see", and the
+// filter rail, which asks the same question of the person looking at it.
 //
 // Every case here is a way of counting the wrong documents while looking
 // correct, and all of them matter more than an ordinary miscount because of
-// what the number is used for: an operator compares it against what they expect
-// somebody's access to be, and a count that is too high sends them looking for
-// a leak that is not there while a count that is too low hides one that is.
+// what the numbers are used for: an operator compares one against what they
+// expect somebody's access to be, and a count that is too high sends them
+// looking for a leak that is not there while a count that is too low hides one
+// that is.
 //
 // The case that is easy to skip is the quarantine. A held document is invisible
 // to every principal, and a driver that counts with an aggregate rather than
@@ -49,24 +51,41 @@ var reachableCases = []reachableCase{
 	{"another tenant's documents are not counted", testReachableTenant},
 	{"a principal who may see nothing gets nothing", testReachableEmpty},
 	{"the counts are per source", testReachableSources},
+	{"the counts are per kind as well", testReachableKinds},
 	{"the whole rule is applied in order", testReachableRuleOrder},
 	{"the count is the read path's own answer", testReachableAgreesWithScan},
 }
 
-// reach collects the counts as a map, because the order is unspecified and a
-// test that depended on it would pass on one driver and fail on the next.
+// reach collects the counts by source as a map, because the order is
+// unspecified and a test that depended on it would pass on one driver and fail
+// on the next.
 func reach(t *testing.T, a store.Access, p *acl.Principal) map[string]int {
 	t.Helper()
-	list, err := a.Reachable(t.Context(), p)
+	got, err := a.Reachable(t.Context(), p)
 	if err != nil {
 		t.Fatalf("Reachable: %v", err)
 	}
-	out := make(map[string]int, len(list))
-	for _, r := range list {
-		if _, seen := out[r.Source]; seen {
-			t.Fatalf("source %q is counted twice, so the driver is grouping by something else", r.Source)
+	return tally(t, "source", got.Sources)
+}
+
+// reachKinds is [reach] over the other grouping.
+func reachKinds(t *testing.T, a store.Access, p *acl.Principal) map[string]int {
+	t.Helper()
+	got, err := a.Reachable(t.Context(), p)
+	if err != nil {
+		t.Fatalf("Reachable: %v", err)
+	}
+	return tally(t, "kind", got.Kinds)
+}
+
+func tally(t *testing.T, field string, in []store.Facet) map[string]int {
+	t.Helper()
+	out := make(map[string]int, len(in))
+	for _, f := range in {
+		if _, seen := out[f.Value]; seen {
+			t.Fatalf("%s %q is counted twice, so the driver is grouping by something else", field, f.Value)
 		}
-		out[r.Source] = r.Documents
+		out[f.Value] = f.Count
 	}
 	return out
 }
@@ -75,6 +94,14 @@ func reach(t *testing.T, a store.Access, p *acl.Principal) map[string]int {
 func sourced(id, source string, perm acl.Permissions) doc.Document {
 	d := document(id, perm)
 	d.Source = source
+	return d
+}
+
+// kinded is a document of a stated type, in a source of its own so that a
+// miscount cannot be hidden by the source grouping agreeing.
+func kinded(id string, kind doc.Kind, perm acl.Permissions) doc.Document {
+	d := document(id, perm)
+	d.Kind = kind
 	return d
 }
 
@@ -208,17 +235,52 @@ func testReachableAgreesWithScan(t *testing.T, s store.Store, a store.Access) {
 	mustPut(t, s, corpus...)
 
 	for _, p := range []*acl.Principal{reader(), stranger()} {
-		counted := reach(t, a, p)
-		walked := map[string]int{}
+		sources, kinds := map[string]int{}, map[string]int{}
 		if err := s.Scan(t.Context(), p, func(d doc.Document) bool {
-			walked[d.Source]++
+			sources[d.Source]++
+			kinds[string(d.Kind)]++
 			return true
 		}); err != nil {
 			t.Fatalf("Scan: %v", err)
 		}
-		if !maps.Equal(counted, walked) {
-			t.Errorf("%s is counted %v and reads %v, so the two rules disagree", p.Subject, counted, walked)
+		if counted := reach(t, a, p); !maps.Equal(counted, sources) {
+			t.Errorf("%s is counted %v by source and reads %v, so the two rules disagree", p.Subject, counted, sources)
 		}
+		// Both groupings, because a driver that counts one of them from the
+		// rule and the other from something else would pass on the first alone.
+		if counted := reachKinds(t, a, p); !maps.Equal(counted, kinds) {
+			t.Errorf("%s is counted %v by kind and reads %v, so the two rules disagree", p.Subject, counted, kinds)
+		}
+	}
+}
+
+// testReachableKinds is the grouping the filter rail draws its verticals from.
+//
+// The corpus is deliberately lopsided against the source grouping: every
+// document is in the same source, so a driver that counted by source and
+// labelled the answer kind gets one row of three here instead of three rows.
+func testReachableKinds(t *testing.T, s store.Store, a store.Access) {
+	mustPut(t, s,
+		kinded("d1", doc.KindPage, readable()),
+		kinded("d2", doc.KindMessage, readable()),
+		kinded("d3", doc.KindMessage, readable()),
+		// Not readable by the engineer, so a kind nobody else carries has to be
+		// missing rather than present at zero.
+		kinded("d4", doc.KindTicket, acl.Permissions{
+			Mode:        acl.ModeACL,
+			Source:      "gdrive",
+			AllowGroups: []acl.Ref{{Source: "gdrive", Value: "sales@acme.com"}},
+			Version:     1,
+		}),
+	)
+
+	got := reachKinds(t, a, reader())
+	kinds := slices.Sorted(maps.Keys(got))
+	if !slices.Equal(kinds, []string{"message", "page"}) {
+		t.Fatalf("the kinds are %v, want message and page", kinds)
+	}
+	if got["page"] != 1 || got["message"] != 2 {
+		t.Fatalf("the counts are %v, want one page and two messages", got)
 	}
 }
 


### PR DESCRIPTION
Closes #142.

The numbers beside the sources in the filter rail were never counts.
They came from a search with no query in it, and a search stops counting facets once it has seen `index.FacetPool` candidates, which is a thousand.
On any corpus worth having, the rail was reporting the proportions of whichever thousand documents the planner reached first.
The interface printed them plainly, with no lower bound marker, because they look like counts.

## Where the count came from

The exact count already existed and was reachable from one screen only.
`store/sqlitestore/query.go` grew a `reachable` query for the admin access screen, and that screen asks the same question the rail asks: how much of the corpus can this principal read.
It was written that way because counting what somebody can reach has no match set to stop at.

So this widens `store.Reach` to carry both groupings and routes the rail through `store.Access`, rather than inventing a third path that counts the same documents under the same permission rule.
One permission aggregate per driver, one conformance suite over it.

## One statement, two groupings

The documents that survive the rule are materialised once and grouped twice off that temporary table, instead of the rule being run once per grouping.
Two counts of the same rows is one pass over the corpus and two passes over a temporary table of two short strings, and the pass over the corpus is all of the cost.

`TestTheRailCountsPastTheBoundASearchStopsAt` builds a corpus larger than the facet bound, checks that a search does report an approximate total capped at the bound, then checks the rail sums to the real total and that the driver spent exactly one statement doing it.
A change back to two statements fails there rather than showing up as a slow bootstrap later.

## Two fields rather than four

Container and author facets are counted over a match set, where narrowing to one of them is a question somebody might have.
Over a whole corpus the author facet is every author in the company truncated to fifty names, which is not a filter.
The rail no longer asks for them, so two of the four columns stop being counted at all.

## The one cache layer a write does not drop

A search must never be answered from before a write.
Somebody who saves a document, searches for it and does not find it stops trusting the search box, and no cache is worth that.

The rail is not that.
It is proportions over a whole corpus, and keying it by the tenant generation would mean any write anywhere makes the next session bootstrap pay the full aggregate again, which during an ingestion is every bootstrap.
It is bounded by a one minute clock instead.
What that admits is a count up to a minute stale.
What it does not admit is a leak: the key is `acl.Fingerprint(p)`, which already folds in the tenant, the groups version, the user keys and the group keys, and the entry holds counts rather than ids or titles.
The reasoning is written down in `Cache.shapeOf` next to the code it explains.

A driver that does not implement `store.Access` keeps the old path, so there the rail is still a lower bound, which is the honest answer for a driver that cannot count.

## The frontend

Nothing to change.
`renderSources` in `app.js` and the home screen both print `number(s.count)` with no lower bound marker, so the interface was already written as if these were counts.

## Tests

- `TestFiltersMatchWhatASearchWouldHaveCounted` now asserts source and kind agree with what a search counts, on the driver that counts in SQL and the one that counts in Go, and that container and author are absent.
- `TestTheRailCountsPastTheBoundASearchStopsAt` is the case where the two must differ, past the bound.
- `TestTheRailIsCountedOncePerVisibility`, `TestAWriteDoesNotRecountTheRail`, `TestTheRailExpiresOnTheClock` and `TestTheRailNeverCrossesVisibility` cover the new cache layer. The write test also checks that a search after the write does find the new document, which is what makes the line above it a decision about the rail rather than a cache that ignores writes.
- `store/storetest` gained a kinds case, and the agreement test now walks the corpus once and compares both groupings, because a driver that counted one of them from the rule and the other from something else would pass on the first alone.
- `BenchmarkReachable` measures the new read on the bench corpus, since it is the one read in the driver whose cost follows the corpus rather than the page.

`go build`, `go vet`, `golangci-lint run` and a full `go test -count=1 ./...` with postgres configured are all clean on server3.

#149 is what would make the count cheap enough that the cache layer could go.
