### PR TITLE
Give written answers a screen instead of a terminal

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -222,6 +222,7 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("GET /api/v1/me", s.authenticated(s.handleMe))
 	mux.Handle("GET /api/v1/search", s.authenticated(s.handleSearch))
 	mux.Handle("GET /api/v1/suggest", s.authenticated(s.handleSuggest))
+	mux.Handle("GET /api/v1/documents", s.authenticated(s.handleDocuments))
 	mux.Handle("GET /api/v1/documents/{id}", s.authenticated(s.handleDocument))
 	mux.Handle("POST /api/v1/documents/{id}/verify", s.authenticated(s.handleVerify))
 	mux.Handle("DELETE /api/v1/documents/{id}/verify", s.authenticated(s.handleUnverify))

--- a/api/curate.go
+++ b/api/curate.go
@@ -121,7 +121,19 @@ type answerRequest struct {
 
 type answersResponse struct {
 	Answers []curatedRecord `json:"answers"`
-	At      time.Time       `json:"at"`
+
+	// Writable says this deployment can remember an answer at all.
+	//
+	// It is here because an empty list means two very different things and the
+	// screen that draws one has to say which. A tenant that has not written an
+	// answer yet is offered the form. A deployment whose storage driver cannot
+	// keep one is told so, rather than offered a form whose answers disappear at
+	// the next restart. The caller's own permission is not on here: this list is
+	// behind the administrator guard already, and everybody who can read it can
+	// write one.
+	Writable bool `json:"writable"`
+
+	At time.Time `json:"at"`
 }
 
 // identity is the response without the timestamp, so that a list nobody has
@@ -254,7 +266,7 @@ func (s *Server) handleAnswers(w http.ResponseWriter, r *http.Request, p *acl.Pr
 	}
 
 	now := s.now()
-	out := answersResponse{Answers: make([]curatedRecord, 0, len(all)), At: now}
+	out := answersResponse{Answers: make([]curatedRecord, 0, len(all)), Writable: true, At: now}
 	for _, a := range all {
 		out.Answers = append(out.Answers, curatedRecord{
 			ID:       a.ID,

--- a/api/curate_test.go
+++ b/api/curate_test.go
@@ -64,6 +64,7 @@ type answerList struct {
 		By       string   `json:"by"`
 		State    string   `json:"state"`
 	} `json:"answers"`
+	Writable bool `json:"writable"`
 }
 
 // newAnswerServer holds two documents the engineer can read and one they cannot,
@@ -312,6 +313,46 @@ func TestTheAnswerListIsWhatAnEditorNeeds(t *testing.T) {
 		t.Fatalf("the sources came back as %v, want all three ids including the one this reader cannot open", a.Sources)
 	case a.State != string(store.Fresh):
 		t.Fatalf("the state came back as %q", a.State)
+	}
+}
+
+// forgetful is a deployment whose storage driver cannot keep a written answer.
+//
+// Embedding the plain interface is the whole trick: the driver underneath can
+// curate perfectly well, and wrapping it hides the capability the way a driver
+// that never had it would. That is a real deployment rather than a made up one,
+// because curating is optional and a driver without it still serves search.
+type forgetful struct{ store.Store }
+
+// An empty list means two very different things and the screen that draws one
+// has to say which, so the list carries whether an answer can be kept at all. A
+// tenant that has not written one yet is offered the form. A deployment that
+// cannot keep one is told so, rather than offered a form whose answers vanish
+// at the next restart.
+func TestTheAnswerListSaysWhetherAnAnswerCanBeKept(t *testing.T) {
+	h := newAnswerServer(t)
+
+	w := request(t, h, http.MethodGet, "/api/v1/admin/answers", curator())
+	got := decode[answerList](t, w)
+	if len(got.Answers) != 0 {
+		t.Fatalf("the list holds %d answers before anything was written", len(got.Answers))
+	}
+	if !got.Writable {
+		t.Fatal("a driver that is about to accept an answer says it cannot keep one")
+	}
+
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	plain := forgetful{st}
+	s := api.New(plain, index.New(plain), api.HeaderAuth{Tenant: "acme"}, api.WithClock(clock))
+	blank := s.Handler()
+
+	w = request(t, blank, http.MethodGet, "/api/v1/admin/answers", curator())
+	if w.Code != http.StatusOK {
+		t.Fatalf("listing on a driver that cannot curate: %d %s", w.Code, w.Body.String())
+	}
+	if got := decode[answerList](t, w); got.Writable {
+		t.Fatal("a driver with nowhere to put an answer offers the form anyway")
 	}
 }
 

--- a/api/documents.go
+++ b/api/documents.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// DocumentsMax is how many documents one lookup may name.
+//
+// Fifty, which is more than any screen in this product cites at once and few
+// enough that the driver reads them in one statement. It is a bound on the
+// request rather than a page size: there is no cursor here and there is not
+// meant to be, because this endpoint answers a question about a list somebody
+// already holds rather than about the corpus.
+const DocumentsMax = 50
+
+// documentsResponse is a handful of documents named by id.
+//
+// The rows are the same shape a result row is, which is what makes this useful:
+// a screen that has ids and wants titles draws them with the code it already
+// has for drawing a result.
+type documentsResponse struct {
+	Documents []searchHit `json:"documents"`
+}
+
+// handleDocuments resolves a handful of ids into rows.
+//
+// The screen that needs this is the answers editor. An answer's sources are
+// stored as ids, deliberately, so that an answer written by somebody with
+// broad access does not become a list of documents a reader may not open, and
+// the price of that is that anything editing one has ids where it needs
+// titles. Nobody knows the id of a document, so an editor that printed them
+// would be asking somebody to proofread a list of paths.
+//
+// It resolves through the caller like everything else, so an id this person
+// cannot read is simply not in the answer, and the caller is never told the
+// difference between a document that was taken down and one they may not see.
+// That is also why what comes back is display only: the editor keeps the ids it
+// was given and saves those, because saving what came back would quietly drop
+// every source the editor happens not to have access to.
+func (s *Server) handleDocuments(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	// Deduplicated, keeping the order they were asked for in. A screen that
+	// cites the same document twice is a screen with a bug in it, and answering
+	// it with the document twice makes that bug somebody else's to find.
+	var ids []string
+	for _, id := range r.URL.Query()["id"] {
+		if id != "" && !slices.Contains(ids, id) {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) > DocumentsMax {
+		writeError(w, http.StatusBadRequest, "bad_request",
+			fmt.Sprintf("name at most %d documents in one request", DocumentsMax))
+		return
+	}
+
+	out := documentsResponse{Documents: []searchHit{}}
+	for _, d := range s.documents(r, p, ids) {
+		out.Documents = append(out.Documents, hitOf(d))
+	}
+	writeConditional(w, r, http.StatusOK, out, nil)
+}

--- a/api/documents_test.go
+++ b/api/documents_test.go
@@ -1,0 +1,159 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/api"
+)
+
+// Resolving a handful of ids into titles.
+//
+// The one screen that needs this is the answers editor, which holds source ids
+// and has to print something a person recognises. Everything worth pinning here
+// is about what it refuses to do: it never answers with a document the caller
+// may not read, it never answers with the corpus, and it never answers with
+// more than was asked for.
+
+type resolved struct {
+	Documents []struct {
+		ID     string `json:"id"`
+		Title  string `json:"title"`
+		Source string `json:"source"`
+		Kind   string `json:"kind"`
+	} `json:"documents"`
+}
+
+func resolve(t *testing.T, h http.Handler, who map[string]string, ids ...string) resolved {
+	t.Helper()
+	w := request(t, h, http.MethodGet, "/api/v1/documents?"+query(ids), who)
+	if w.Code != http.StatusOK {
+		t.Fatalf("resolving %v: %d %s", ids, w.Code, w.Body.String())
+	}
+	return decode[resolved](t, w)
+}
+
+func query(ids []string) string {
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, "id="+id)
+	}
+	return strings.Join(parts, "&")
+}
+
+func namesOf(got resolved) []string {
+	out := make([]string, 0, len(got.Documents))
+	for _, d := range got.Documents {
+		out = append(out, d.ID)
+	}
+	return out
+}
+
+// The order is the caller's, because on the screen that asks it is the order
+// somebody cited them in and a driver has no reason to keep it.
+func TestDocumentsComeBackInTheOrderTheyWereAskedFor(t *testing.T) {
+	h := newAnswerServer(t)
+
+	got := resolve(t, h, engineer(), "oncall", "freeze")
+	if names := namesOf(got); len(names) != 2 || names[0] != "oncall" || names[1] != "freeze" {
+		t.Fatalf("resolved %v, want oncall then freeze", names)
+	}
+	if got.Documents[0].Title != "Holiday oncall" {
+		t.Errorf("the first row is titled %q, and the title is the whole point of this endpoint", got.Documents[0].Title)
+	}
+	if got.Documents[0].Source != "gdrive" || got.Documents[0].Kind != "page" {
+		t.Errorf("the row is %+v, want the same fields a result row carries", got.Documents[0])
+	}
+}
+
+// The rule the whole surface runs on, applied here as well: a document this
+// caller may not read is not in the answer, and is not an error either.
+func TestDocumentsLeavesOutWhatTheCallerCannotRead(t *testing.T) {
+	h := newAnswerServer(t)
+
+	got := resolve(t, h, engineer(), "freeze", "budget", "oncall")
+	if names := namesOf(got); len(names) != 2 || names[0] != "freeze" || names[1] != "oncall" {
+		t.Fatalf("the engineer resolved %v, want the two they may read in the order asked", names)
+	}
+	// And the finance reader gets the other one, which is what says the line
+	// above is a permission rule rather than a document that is missing.
+	finance := map[string]string{
+		api.HeaderSubject: "u_fin",
+		api.HeaderGroups:  "gdrive:finance@acme.com",
+	}
+	if names := namesOf(resolve(t, h, finance, "freeze", "budget")); len(names) != 1 || names[0] != "budget" {
+		t.Fatalf("finance resolved %v, want the cost model alone", names)
+	}
+}
+
+// No ids is nothing, rather than everything. An endpoint that answered a bare
+// path with the corpus would be a way of listing documents that never had to
+// name one.
+func TestDocumentsWithNoIdsIsEmpty(t *testing.T) {
+	h := newAnswerServer(t)
+
+	w := request(t, h, http.MethodGet, "/api/v1/documents", engineer())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want an empty answer rather than a refusal", w.Code)
+	}
+	if got := decode[resolved](t, w); len(got.Documents) != 0 {
+		t.Fatalf("a request naming nothing came back with %v", namesOf(got))
+	}
+	if got := resolve(t, h, engineer(), ""); len(got.Documents) != 0 {
+		t.Fatalf("an empty id came back with %v", namesOf(got))
+	}
+}
+
+// A screen that cites the same document twice has a bug in it, and answering
+// with the document twice would make that bug somebody else's to find.
+func TestDocumentsAreNotRepeated(t *testing.T) {
+	h := newAnswerServer(t)
+
+	got := resolve(t, h, engineer(), "freeze", "freeze", "oncall", "freeze")
+	if names := namesOf(got); len(names) != 2 || names[0] != "freeze" || names[1] != "oncall" {
+		t.Fatalf("resolved %v, want each named document once", names)
+	}
+}
+
+// The bound is on the request rather than on the answer, so somebody who asks
+// for too much is told, instead of being given a page of it and left to think
+// the rest do not exist.
+func TestDocumentsRefusesMoreThanItWillRead(t *testing.T) {
+	h := newAnswerServer(t)
+
+	ids := make([]string, 0, api.DocumentsMax+1)
+	for i := range api.DocumentsMax + 1 {
+		ids = append(ids, fmt.Sprintf("d%d", i))
+	}
+	w := request(t, h, http.MethodGet, "/api/v1/documents?"+query(ids), engineer())
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for more ids than one statement reads", w.Code)
+	}
+
+	// And exactly the bound is fine, so the refusal is a ceiling rather than an
+	// off by one nobody would find until a screen grew.
+	w = request(t, h, http.MethodGet, "/api/v1/documents?"+query(ids[:api.DocumentsMax]), engineer())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d for exactly the bound, want 200", w.Code)
+	}
+}
+
+// It is revalidated like every other read here, because the editor asks the
+// same question every time somebody opens the same answer.
+func TestDocumentsRevalidate(t *testing.T) {
+	h := newAnswerServer(t)
+
+	w := request(t, h, http.MethodGet, "/api/v1/documents?id=freeze", engineer())
+	tag := w.Header().Get("ETag")
+	if tag == "" {
+		t.Fatal("no entity tag, so the editor refetches every title every time it opens")
+	}
+
+	who := engineer()
+	who["If-None-Match"] = tag
+	if again := request(t, h, http.MethodGet, "/api/v1/documents?id=freeze", who); again.Code != http.StatusNotModified {
+		t.Fatalf("status = %d with the tag it was just given, want 304", again.Code)
+	}
+}

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -2,12 +2,12 @@
 # The browser half of the performance gate.
 #
 # It starts the real binary over a real corpus, which is this repository, and
-# audits thirteen screens: the home page, the home page over an index holding
+# audits fourteen screens: the home page, the home page over an index holding
 # nothing, a results page, a results page with an answer quoted above it, a
 # results page with a written answer above it, a results page with the document
 # drawer open, a search that matched nothing, a filter that matched nothing, a
 # grid of pictures, a document on a page of its own, the recent screen, the
-# settings screen and administration. They are
+# settings screen, administration and the answers screen. They are
 # states rather than layouts, because a layout is looked at every day and a
 # state is looked at once. Auditing a static fixture would audit the fixture,
 # and every accessibility bug this is meant to catch lives in the markup the
@@ -294,6 +294,10 @@ fi
 # looks perfect to everybody else. It is also the only screen that repaints
 # itself on a timer, so it is the one place a focus ring can be quietly taken
 # away from somebody five seconds after they put it there.
+#
+# The answers screen is the one place in the product where somebody writes
+# rather than reads, so it is the one screen where a field with no label costs
+# more than a sentence nobody hears.
 for url in \
 	"$BASE/" \
 	"$EMPTY/" \
@@ -307,7 +311,8 @@ for url in \
 	"$BASE/d/$ID" \
 	"$BASE/recent" \
 	"$BASE/settings" \
-	"$BASE/admin"; do
+	"$BASE/admin" \
+	"$BASE/answers"; do
 	echo "ui-gate: axe $url"
 	# The interface renders after a fetch, so the audit waits for the first
 	# paint to have happened. Auditing an empty document passes and proves

--- a/web/dist/assets/answers.js
+++ b/web/dist/assets/answers.js
@@ -1,0 +1,866 @@
+// The answers screen.
+//
+// One screen for the prose somebody here wrote and signed, which is the only
+// thing in this product that is added to the corpus rather than found in it.
+// The three endpoints behind it have existed for a while and the only way to
+// reach them was curl, which made the feature available to whoever was willing
+// to write JSON by hand.
+//
+// Three things about it are worth writing down, and they are all consequences
+// of decisions taken further down the stack.
+//
+// The sources are ids and they stay ids. An answer's sources are stored that
+// way so that an answer written by somebody who can read everything does not
+// become a list of documents the reader in front of it cannot open, and the
+// price of that is a screen holding ids where it wants titles. It resolves them
+// for display through an endpoint of their own and saves back the ids it was
+// given, because saving what came back would quietly drop every source the
+// editor happens not to have access to.
+//
+// Saving is also confirming. There is no separate act that re-verifies an
+// answer: the date under it is the date somebody last stood behind the words,
+// and pressing Save is somebody standing behind them. The form says so rather
+// than leaving it to be found out.
+//
+// It does not poll. The administration screen next to this one does, because it
+// is watching a process that changes on its own. This one is watching a form,
+// and a five second timer running through a half typed answer is a screen
+// nobody can write in.
+
+import { h, replace, svg } from "genba/dom.js";
+import { api } from "genba/api.js";
+import { cache } from "genba/cache.js";
+import { exact, icon, label, sourceColor, when } from "genba/format.js";
+import { render as markdown } from "genba/markdown.js";
+import { failed as failedState } from "genba/states.js";
+
+// The three words the server sends with an answer, which are the three a
+// verification badge uses, because a reader who has learnt what an amber mark
+// on a document means has learnt what it means here.
+const STATES = new Set(["fresh", "expiring", "expired"]);
+
+// SOURCES is how many documents one answer may cite.
+//
+// Six, because six is what the card under an answer draws. A seventh would be
+// stored, would never be seen, and would leave whoever added it believing they
+// had cited it. The server is the one that truncates, so this is the screen
+// declining to write something it knows will not be shown.
+const SOURCES = 6;
+
+// FOUND is how many results the source picker offers, and TYPING is how long it
+// waits before asking. Five results is a short list somebody reads rather than
+// scans, and a sixth of a second is long enough that a typed word is one
+// request rather than six.
+const FOUND = 5;
+const TYPING = 160;
+
+// EXCERPT is how much of an answer the list shows under its question. Enough to
+// recognise which answer it is, and not so much that a list of ten is a page of
+// prose nobody scrolls past.
+const EXCERPT = 180;
+
+export class Answers {
+  constructor({ onBack, onSay }) {
+    this.onBack = onBack;
+    this.onSay = onSay || (() => {});
+
+    this.data = null;
+    // Two errors rather than one, because they mean different things and are
+    // printed in different places. broken is a list that could not be read, and
+    // it takes over the screen. error is a write that was refused, and it goes
+    // on the status line above the form.
+    this.broken = null;
+    this.error = null;
+    this.busy = "";
+    this.said = "";
+    // The answer whose removal has been asked for once. Taking one down cannot
+    // be undone from here, so it is asked twice, and the confirmation replaces
+    // the button that opened it so a keyboard lands on it without going looking.
+    this.confirming = "";
+
+    // The answer being written, or null when this screen is only a list. It
+    // holds the id and nothing else. The words live in the fields below, which
+    // are the same nodes for the life of the screen, so that repainting the list
+    // underneath somebody never empties what they are typing.
+    this.editing = null;
+    this.sources = [];
+    // Titles for the ids above, filled in behind the screen. What is saved is
+    // the ids, never this.
+    this.titles = new Map();
+    this.finding = 0;
+    this.looking = "";
+
+    this.title = h("h1", { class: "answers__title", tabindex: "-1" }, "Answers");
+    this.output = h("p", {
+      class: "answers__output",
+      role: "status",
+      "aria-live": "polite",
+      tabindex: "-1",
+    });
+    this.back = h("div", { class: "page__back" });
+    this.editorEl = h("section", { class: "panel answers__editor", hidden: true });
+    this.listEl = h("section", { class: "panel" });
+    this.el = h("div", { class: "answers" });
+    this.build();
+  }
+
+  /** key is the entry this screen paints from, which the offline banner names. */
+  key() {
+    return cache.key("answers", {});
+  }
+
+  /**
+   * build makes the screen once.
+   *
+   * Once rather than on every paint, because half of it is a form. The list
+   * repaints on its own into a node that outlives it, and the fields never
+   * repaint at all: their values are set when an answer is opened and read back
+   * when it is saved.
+   */
+  build() {
+    this.editorTitle = h("h2", { class: "panel__title" }, "Write an answer");
+    this.question = field({
+      id: "answer-question",
+      name: "Question",
+      hint: "The question in the words somebody would type into the box",
+    });
+    this.variants = area({
+      id: "answer-variants",
+      name: "Other phrasings",
+      hint: "One a line. Each one finds this answer too, so a question that gets asked three ways is answered once",
+      rows: 3,
+    });
+    this.body = area({
+      id: "answer-body",
+      name: "Answer",
+      hint: "Markdown, drawn by the same renderer that draws a document",
+      rows: 12,
+    });
+    this.body.input.addEventListener("input", () => this.repreview());
+    this.preview = h("div", { class: "answers__preview prose" });
+
+    this.find = field({
+      id: "answer-source",
+      name: "Add a source",
+      hint: "Search the corpus for it. A document is cited by id, so a reader who cannot open it simply does not see the citation",
+    });
+    this.find.input.addEventListener("input", () => this.look());
+    this.found = h("div", { class: "answers__found" });
+    this.chosen = h("ul", { class: "answers__chosen" });
+
+    const form = h(
+      "form",
+      {
+        class: "answers__form",
+        onSubmit: (e) => {
+          e.preventDefault();
+          this.save();
+        },
+      },
+      this.question.el,
+      this.variants.el,
+      h(
+        "div",
+        { class: "answers__writing" },
+        this.body.el,
+        h(
+          "div",
+          { class: "answers__side" },
+          h("span", { class: "answers__label" }, "Preview"),
+          this.preview,
+        ),
+      ),
+      h(
+        "div",
+        { class: "answers__block" },
+        h("span", { class: "answers__label" }, "Sources"),
+        this.chosen,
+        this.find.el,
+        this.found,
+      ),
+      // Said on the form rather than left to be discovered, because it is the
+      // part of this screen that is not obvious: there is no button anywhere
+      // that re-verifies an answer, and this is why there does not need to be.
+      h(
+        "p",
+        { class: "answers__rule" },
+        "Saving is also confirming. The date under the answer becomes today, and the review date moves out again.",
+      ),
+      h(
+        "div",
+        { class: "answers__actions" },
+        h("button", { class: "button button--primary", type: "submit" }, "Save answer"),
+        h(
+          "button",
+          { class: "button", type: "button", onClick: () => this.close() },
+          "Cancel",
+        ),
+      ),
+    );
+    replace(this.editorEl, h("div", { class: "panel__head" }, this.editorTitle), form);
+    replace(
+      this.el,
+      this.back,
+      h(
+        "header",
+        { class: "answers__head" },
+        this.title,
+        h(
+          "p",
+          { class: "answers__lead" },
+          "Answers written here stand above the results for the questions they answer, signed by whoever wrote them.",
+        ),
+      ),
+      // Above both panels rather than inside the form, because the form is not
+      // on the screen when an answer is taken down and a sentence nobody can
+      // see is a write that reports nothing.
+      this.output,
+      this.editorEl,
+      this.listEl,
+    );
+    this.repreview();
+    this.say();
+  }
+
+  /**
+   * render paints what was held and then what the server says.
+   *
+   * The held copy goes up first for the reason every other screen does it: the
+   * layout is on the page while the request is in flight, so the rows land in
+   * place rather than after a blank.
+   *
+   * This runs again every time the tab comes back to the front, which is what
+   * makes the focus check matter. Arriving here from the rail has to land
+   * somewhere, and the heading is where, but the same call while somebody is
+   * halfway through an answer must leave the cursor where their hands are.
+   */
+  async render() {
+    const working = this.el.contains(document.activeElement) && document.activeElement !== this.title;
+    replace(this.back, this.backLink());
+    const held = cache.read(this.key()).data;
+    if (held) this.data = held;
+    this.paintList();
+    if (!working) this.title.focus();
+    await this.refresh();
+  }
+
+  /** refresh reads the list again and repaints only if it moved. */
+  async refresh() {
+    try {
+      await cache.swr(
+        this.key(),
+        (opts) => api.answers(opts),
+        (data) => {
+          this.data = data;
+          this.paintList();
+        },
+      );
+      if (this.broken) {
+        this.broken = null;
+        this.paintList();
+      }
+    } catch (err) {
+      if (err.name === "AbortError") return;
+      // A check that failed behind a list already on screen keeps the list.
+      // What is on it was true when it was painted, and somebody halfway
+      // through writing an answer should not lose the screen because a poll
+      // arrived during a restart.
+      this.broken = err;
+      this.paintList();
+    }
+  }
+
+  backLink() {
+    const to = this.onBack();
+    return h(
+      "a",
+      {
+        class: "page__back-link",
+        href: to.href,
+        onClick: (e) => {
+          if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+          e.preventDefault();
+          to.go();
+        },
+      },
+      svg(icon("arrow-left"), 16),
+      to.title,
+    );
+  }
+
+  /**
+   * open puts an answer in the form, or empties it for a new one.
+   *
+   * The fields are set here and nowhere else. Nothing repaints them afterwards,
+   * which is what makes it safe for the list below to redraw itself while
+   * somebody is typing.
+   */
+  open(record) {
+    this.editing = { id: (record && record.id) || "" };
+    this.question.input.value = (record && record.question) || "";
+    this.variants.input.value = ((record && record.variants) || []).join("\n");
+    this.body.input.value = (record && record.body) || "";
+    this.sources = [...((record && record.sources) || [])];
+    this.find.input.value = "";
+    this.error = null;
+    this.said = "";
+    this.confirming = "";
+
+    replace(this.editorTitle, record ? "Edit this answer" : "Write an answer");
+    replace(this.found);
+    this.editorEl.hidden = false;
+    this.repreview();
+    this.paintChosen();
+    this.say();
+    this.paintList();
+    this.resolve();
+    this.question.input.focus();
+  }
+
+  /** close takes the form off the screen and empties it. */
+  close() {
+    this.editing = null;
+    this.sources = [];
+    this.question.input.value = "";
+    this.variants.input.value = "";
+    this.body.input.value = "";
+    this.find.input.value = "";
+    replace(this.found);
+    this.editorEl.hidden = true;
+    this.paintList();
+    const back = this.listEl.querySelector('[data-focus-key="new"]');
+    if (back) back.focus();
+  }
+
+  /** repreview draws the answer as it is being typed. */
+  repreview() {
+    const text = this.body.input.value;
+    replace(
+      this.preview,
+      text.trim()
+        ? markdown(text)
+        : h("p", { class: "answers__blank" }, "What is typed on the left is drawn here."),
+    );
+  }
+
+  /**
+   * look asks for documents matching what has been typed into the picker.
+   *
+   * Debounced, because this fires on every keystroke and the server is being
+   * asked a real search each time. The answer is thrown away if the box has
+   * moved on, so a slow request for three letters cannot overwrite the list for
+   * six.
+   */
+  look() {
+    clearTimeout(this.finding);
+    const q = this.find.input.value.trim();
+    this.looking = q;
+    if (!q) {
+      replace(this.found);
+      return;
+    }
+    this.finding = setTimeout(() => this.search(q), TYPING);
+  }
+
+  async search(q) {
+    let hits = [];
+    try {
+      const res = await cache.swr(
+        cache.key("search", { q, limit: FOUND }),
+        (opts) => api.search({ q, limit: FOUND }, opts),
+        () => {},
+      );
+      hits = (res && res.hits) || [];
+    } catch (err) {
+      if (err.name === "AbortError") return;
+      if (this.looking !== q) return;
+      replace(this.found, h("p", { class: "answers__blank" }, err.message));
+      return;
+    }
+    if (this.looking !== q) return;
+    if (!hits.length) {
+      replace(this.found, h("p", { class: "answers__blank" }, `Nothing here matches ${q}.`));
+      return;
+    }
+    replace(this.found, hits.map((hit) => this.result(hit)));
+  }
+
+  /** result is one document the picker is offering. */
+  result(hit) {
+    const already = this.sources.includes(hit.id);
+    return h(
+      "button",
+      {
+        class: "answers__result",
+        type: "button",
+        disabled: already || this.sources.length >= SOURCES,
+        onClick: () => this.add(hit),
+      },
+      h("span", { class: "source__dot", style: { background: sourceColor(hit.source) } }),
+      h("span", { class: "answers__result-title" }, hit.title || hit.id),
+      h("span", { class: "answers__result-where" }, label(hit.source)),
+      already ? h("span", { class: "answers__result-note" }, "Already cited") : null,
+    );
+  }
+
+  add(hit) {
+    if (this.sources.includes(hit.id) || this.sources.length >= SOURCES) return;
+    this.sources.push(hit.id);
+    this.titles.set(hit.id, hit);
+    this.find.input.value = "";
+    this.looking = "";
+    replace(this.found);
+    this.paintChosen();
+    this.find.input.focus();
+  }
+
+  drop(id) {
+    this.sources = this.sources.filter((one) => one !== id);
+    this.paintChosen();
+    this.find.input.focus();
+  }
+
+  /**
+   * resolve fills in the titles of the sources this answer already carries.
+   *
+   * Behind the screen, because the ids are what makes the form correct and the
+   * titles are only what makes it readable. An id that does not come back is
+   * either a document this editor may not open or one that has gone, and the
+   * two are deliberately not distinguished. Either way it stays on the answer.
+   */
+  async resolve() {
+    const want = this.sources.filter((id) => !this.titles.has(id));
+    if (!want.length) return;
+    try {
+      const res = await cache.swr(
+        cache.key("documents", { id: want }),
+        (opts) => api.documents(want, opts),
+        () => {},
+      );
+      for (const hit of (res && res.documents) || []) this.titles.set(hit.id, hit);
+    } catch {
+      // A lookup that failed costs a nicer label and nothing else.
+    }
+    this.paintChosen();
+  }
+
+  /** paintChosen draws the sources on the answer being written. */
+  paintChosen() {
+    const rows = this.sources.map((id) => {
+      const hit = this.titles.get(id);
+      return h(
+        "li",
+        { class: "answers__source" },
+        h("span", {
+          class: "source__dot",
+          style: { background: sourceColor(hit ? hit.source : "") },
+        }),
+        h("span", { class: "answers__source-title" }, hit ? hit.title || hit.id : id),
+        hit
+          ? h("span", { class: "answers__source-where" }, label(hit.source))
+          : h(
+              "span",
+              { class: "answers__source-where" },
+              "Did not resolve for you, and stays on the answer",
+            ),
+        h(
+          "button",
+          {
+            class: "button button--small",
+            type: "button",
+            onClick: () => this.drop(id),
+          },
+          "Remove",
+        ),
+      );
+    });
+    if (this.sources.length >= SOURCES) {
+      rows.push(
+        h(
+          "li",
+          { class: "answers__full" },
+          `Six is what a reader sees under an answer, so this one is full.`,
+        ),
+      );
+    }
+    replace(this.chosen, rows.length ? rows : h("li", { class: "answers__blank" }, "None yet."));
+  }
+
+  /** save writes the answer, which is the same call whether it is new or not. */
+  async save() {
+    const question = this.question.input.value.trim();
+    if (!question) {
+      this.complain("Write the question this answers.", this.question.input);
+      return;
+    }
+    const body = this.body.input.value.trim();
+    if (!body) {
+      this.complain("Write the answer.", this.body.input);
+      return;
+    }
+    // A new answer is named here rather than by the server, because the id is
+    // in the path of the write. It is derived from the question so that
+    // anybody reading a log can tell which answer it is, and it carries a
+    // suffix so that two differently worded questions about the same subject
+    // cannot silently replace one another.
+    const id = this.editing.id || idFor(question);
+    const record = { question, variants: lines(this.variants.input.value), body, sources: this.sources };
+    const ok = await this.write("save", () => api.curate(id, record), "Saved.");
+    if (ok) this.close();
+  }
+
+  /** ask opens or closes the confirmation on one answer's removal. */
+  ask(id) {
+    this.confirming = id;
+    this.error = null;
+    this.said = "";
+    this.say();
+    this.paintList();
+  }
+
+  async remove(id) {
+    const editing = this.editing && this.editing.id === id;
+    const ok = await this.write(`remove:${id}`, () => api.retract(id), "Taken down.");
+    if (ok && editing) this.close();
+  }
+
+  /**
+   * write does one change and repaints from what is true afterwards.
+   *
+   * Nothing is retried and a second press while one is in flight is dropped
+   * here rather than by disabling the button, because a disabled button loses
+   * focus and a keyboard that pressed Save would be thrown to the top of the
+   * page for it.
+   */
+  async write(about, run, said) {
+    if (this.busy) return false;
+    this.busy = about;
+    this.error = null;
+    this.said = "";
+    this.confirming = "";
+    this.say();
+    this.paintList();
+
+    try {
+      await run();
+      this.said = said;
+    } catch (err) {
+      this.error = err;
+    }
+    this.busy = "";
+    this.say();
+    if (this.error) {
+      this.paintList();
+      return false;
+    }
+    // Every search this tab is holding may have a card on it that this write
+    // just changed, and the search screen has no way of knowing that. Marking
+    // them stale rather than dropping them means the next visit revalidates in
+    // a few hundred bytes instead of painting a skeleton.
+    cache.invalidate();
+    this.onSay(said);
+    await this.refresh();
+    return true;
+  }
+
+  /** complain refuses a form that is not finished, and says which field. */
+  complain(message, where) {
+    this.error = new Error(message);
+    this.said = "";
+    this.say();
+    if (where) where.focus();
+  }
+
+  /**
+   * say prints the outcome of the last write.
+   *
+   * One line above the form for all of them, rather than a message beside each
+   * button, because it is the one node on this screen that does not move when
+   * an answer is saved or taken down.
+   */
+  say() {
+    if (this.error) {
+      replace(this.output, svg(icon("alert"), 16), this.error.message);
+      this.output.className = "answers__output answers__output--bad";
+      return;
+    }
+    if (this.busy) {
+      replace(this.output, this.busy === "save" ? "Saving it." : "Taking it down.");
+      this.output.className = "answers__output answers__output--busy";
+      return;
+    }
+    if (this.said) {
+      replace(this.output, svg(icon("check"), 16), this.said);
+      this.output.className = "answers__output answers__output--good";
+      return;
+    }
+    replace(this.output);
+    this.output.className = "answers__output";
+  }
+
+  paintList() {
+    // Nothing arrived and nothing was held, so there is nothing to draw. The
+    // empty list this would otherwise print is the state of this browser rather
+    // than the state of the tenant, and it is also what somebody who typed this
+    // address without the role sees, where the server's own refusal is a better
+    // sentence than anything written here.
+    if (!this.data && this.broken) {
+      this.editorEl.hidden = true;
+      replace(this.listEl, failedState(this.broken, () => this.refresh()));
+      return;
+    }
+
+    const data = this.data || {};
+    const rows = data.answers || [];
+    replace(
+      this.listEl,
+      h(
+        "div",
+        { class: "panel__head" },
+        h("h2", { class: "panel__title" }, "Written answers"),
+        rows.length
+          ? h("span", { class: "panel__note" }, rows.length === 1 ? "One answer" : `${rows.length} answers`)
+          : null,
+        data.writable && !this.editing
+          ? h(
+              "button",
+              {
+                class: "button button--primary answers__new",
+                type: "button",
+                dataset: { focusKey: "new" },
+                onClick: () => this.open(null),
+              },
+              "Write an answer",
+            )
+          : null,
+      ),
+      this.broken
+        ? h(
+            "p",
+            { class: "answers__stale", role: "status" },
+            svg(icon("clock"), 16),
+            `This is the last list that arrived. The server said: ${this.broken.message}`,
+          )
+        : null,
+      // A deployment whose storage driver cannot keep an answer gets the
+      // sentence rather than the form, because a form whose answers disappear
+      // at the next restart is worse than no form at all.
+      data.writable
+        ? null
+        : note(
+            "This deployment cannot keep a written answer.",
+            "The storage driver it is running on has nowhere to put one, so there is nothing here that could write one. Sqlite and Postgres both can.",
+          ),
+      rows.length ? rows.map((a) => this.row(a)) : null,
+      rows.length || !data.writable
+        ? null
+        : note(
+            "Nothing has been answered yet.",
+            "An answer is worth writing when the same question keeps being asked and the documents that answer it are spread across four places.",
+          ),
+    );
+  }
+
+  /** row is one answer as the person who maintains it sees it. */
+  row(a) {
+    const state = STATES.has(a.state) ? a.state : "expired";
+    const editing = Boolean(this.editing && this.editing.id === a.id);
+    const confirming = this.confirming === a.id;
+    const variants = (a.variants || []).length;
+    const sources = (a.sources || []).length;
+    return h(
+      "article",
+      { class: editing ? "answer-row answer-row--editing" : "answer-row" },
+      h(
+        "div",
+        { class: "answer-row__head" },
+        h("h3", { class: "answer-row__question" }, a.question || a.id),
+        pill(state, a.until),
+      ),
+      h("p", { class: "answer-row__excerpt" }, excerpt(a.body || "")),
+      h(
+        "p",
+        { class: "answer-row__meta" },
+        h(
+          "span",
+          { title: exact(a.at) },
+          `${a.by || "somebody"} wrote this ${when(a.at)}`,
+        ),
+        variants ? h("span", {}, variants === 1 ? "One other phrasing" : `${variants} other phrasings`) : null,
+        sources ? h("span", {}, sources === 1 ? "One source" : `${sources} sources`) : null,
+      ),
+      h(
+        "div",
+        { class: "answer-row__controls" },
+        action(editing ? "Editing it" : "Edit", `edit:${a.id}`, () => this.open(a)),
+        confirming
+          ? action("Take it down", `remove:${a.id}`, () => this.remove(a.id), "button--danger")
+          : action("Take down", `remove:${a.id}`, () => this.ask(a.id)),
+        confirming ? action("Keep it", `keep:${a.id}`, () => this.ask("")) : null,
+        confirming
+          ? h(
+              "p",
+              { class: "answer-row__warn" },
+              "This cannot be undone from here. The documents it cited stay where they are.",
+            )
+          : null,
+      ),
+    );
+  }
+}
+
+/**
+ * pill is where the answer stands today, in the words a verification uses.
+ *
+ * An expired answer is still on the screen and still says so, because taking it
+ * off the list on the day it runs out would leave the person who wrote it with
+ * no way to find out it needs looking at.
+ *
+ * A current one carries no date, the same way a verification badge does not. Six
+ * months away is not a date anybody acts on, and the two states that do want
+ * acting on are the ones that print how long is left.
+ */
+function pill(state, until) {
+  if (state === "fresh") {
+    return h(
+      "span",
+      { class: "verified", title: `Due to be confirmed again ${exact(until)}` },
+      svg(icon("check"), 14),
+      "Current",
+    );
+  }
+  return h(
+    "span",
+    {
+      class: `verified verified--${state}`,
+      title:
+        state === "expired"
+          ? `Nobody has confirmed this since ${exact(until)}`
+          : `Due to be confirmed again ${exact(until)}`,
+    },
+    svg(icon("alert"), 14),
+    state === "expired" ? "Not confirmed recently" : `Due for review ${when(until)}`,
+  );
+}
+
+/**
+ * excerpt is enough of an answer to recognise which one it is.
+ *
+ * The markdown is not rendered, because this is a line in a list of answers and
+ * a rendered heading in it would be a heading in the middle of somebody else's
+ * list. It is not printed as typed either. The markers that carry no meaning
+ * once the structure is gone read as typing mistakes to whoever is scanning the
+ * list for the answer they came to fix, so the inline ones come off and what is
+ * left is the sentence underneath.
+ */
+function excerpt(body) {
+  const flat = body
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/^\s*[>#]+\s*/gm, "")
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/(\*\*|__|[*_`])/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return flat.length > EXCERPT ? `${flat.slice(0, EXCERPT).trimEnd()}...` : flat;
+}
+
+/** lines splits a textarea into the list of phrasings it holds. */
+function lines(value) {
+  return value
+    .split("\n")
+    .map((one) => one.trim())
+    .filter(Boolean);
+}
+
+/**
+ * idFor names a new answer.
+ *
+ * The question, so that a log line or a stored row says which answer it is,
+ * with a short suffix on the end. Without the suffix two questions that reduce
+ * to the same words would be the same id, and writing the second would replace
+ * the first with no warning anywhere. Nobody reads this: an answer is addressed
+ * by the question a reader typed, never by its id.
+ */
+function idFor(question) {
+  const slug = question
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  const random = crypto.getRandomValues(new Uint8Array(4));
+  const suffix = Array.from(random, (b) => b.toString(36).padStart(2, "0")).join("").slice(0, 6);
+  return slug ? `${slug}-${suffix}` : `answer-${suffix}`;
+}
+
+/**
+ * field and area are one labelled control each, returned with the control so it
+ * can be read back.
+ *
+ * The label, the hint and the identifier that ties them together are the same in
+ * both, which is why they are two shapes of one function rather than two
+ * functions: a hint that is a label's sibling in one and something else in the
+ * other is two things to get right in the accessibility tree instead of one.
+ */
+function field(spec) {
+  const hint = `${spec.id}-hint`;
+  const input = h("input", {
+    class: "answers__input",
+    id: spec.id,
+    type: "text",
+    autocomplete: "off",
+    spellcheck: "false",
+    "aria-describedby": hint,
+  });
+  return { input, el: labelled(spec, hint, input) };
+}
+
+function area(spec) {
+  const hint = `${spec.id}-hint`;
+  const input = h("textarea", {
+    class: "answers__area",
+    id: spec.id,
+    rows: String(spec.rows || 4),
+    "aria-describedby": hint,
+  });
+  return { input, el: labelled(spec, hint, input) };
+}
+
+function labelled(spec, hint, input) {
+  return h(
+    "div",
+    { class: "answers__field" },
+    h("label", { class: "answers__label", for: spec.id }, spec.name),
+    input,
+    h("span", { class: "answers__hint", id: hint }, spec.hint),
+  );
+}
+
+/**
+ * action is one button on one answer.
+ *
+ * The key names the answer as well as the verb, because every row has a Take
+ * down button and focus belongs on the one it was on.
+ */
+function action(name, key, onClick, extra = "") {
+  return h(
+    "button",
+    {
+      class: extra ? `button button--small ${extra}` : "button button--small",
+      type: "button",
+      dataset: { focusKey: key },
+      onClick,
+    },
+    name,
+  );
+}
+
+/** note is an empty state, which on this screen is usually just news. */
+function note(title, body) {
+  return h(
+    "div",
+    { class: "answers__note" },
+    h("p", { class: "answers__note-title" }, title),
+    h("p", { class: "answers__note-body" }, body),
+  );
+}

--- a/web/dist/assets/api.js
+++ b/web/dist/assets/api.js
@@ -152,6 +152,11 @@ function stalePath(id) {
   return `/documents/${encodeURIComponent(id)}/stale`;
 }
 
+/** answerPath is one written answer, which is saved and taken down. */
+function answerPath(id) {
+  return `/admin/answers/${encodeURIComponent(id)}`;
+}
+
 /** connector is one source's path under the administration endpoints. */
 function connector(source, action = "") {
   return `/admin/connectors/${encodeURIComponent(source)}${action}`;
@@ -264,6 +269,19 @@ export const api = {
   startConnector: (source) => send("POST", connector(source, "/start")),
   stopConnector: (source) => send("POST", connector(source, "/stop")),
   syncConnector: (source) => send("POST", connector(source, "/sync")),
+  // The written answers, and the two writes that maintain them. Saving one is
+  // the same call whether it is new or not, and it is also how an answer is
+  // confirmed: the date under it is the date somebody last stood behind the
+  // words, and there is no separate act that produces one.
+  answers: (opts) => get("/admin/answers", {}, opts),
+  curate: (id, answer) => send("PUT", answerPath(id), answer),
+  retract: (id) => send("DELETE", answerPath(id)),
+  // Titles for a handful of ids, for the one screen that holds ids and has to
+  // print something a person recognises. It resolves through the caller, so an
+  // id this person cannot read is simply not in the answer, and what comes back
+  // is for display only: the editor saves the ids it was given, because saving
+  // what came back would drop every source it happens not to have access to.
+  documents: (ids, opts) => get("/documents", { id: ids }, opts),
   search: (query, opts) => get("/search", query, opts),
   // One request for both halves of the recent screen, because the screen asks
   // both questions at once and a screen that paints in two stages paints twice.

--- a/web/dist/assets/app.css
+++ b/web/dist/assets/app.css
@@ -3714,6 +3714,369 @@ ol.prose__list {
   color: var(--text-inverse);
 }
 
+/* Answers ---------------------------------------------------------------- */
+
+/* The screen for the prose somebody here wrote. Same page shape as settings and
+   administration, because a third shape for a third screen of this kind is a
+   third thing to keep in step. */
+.answers {
+  max-width: var(--page-max);
+  margin: 0 auto;
+  padding: var(--space-16) var(--gutter) var(--space-24);
+}
+
+.answers__head {
+  margin-bottom: var(--space-12);
+}
+
+.answers__title {
+  font-size: var(--text-display);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-display);
+  letter-spacing: var(--display-tracking);
+}
+
+/* The heading takes focus when the screen opens so that a screen reader starts
+   at the top of it. It is not a control, so it does not draw a ring. */
+.answers__title:focus {
+  outline: none;
+}
+
+.answers__lead {
+  max-width: var(--measure);
+  margin-top: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-lead);
+  line-height: var(--leading-lead);
+}
+
+.answers .panel {
+  margin-bottom: var(--space-16);
+}
+
+/* The button that opens the form sits at the end of the heading rather than
+   above the list, so that the list starts where every other list on this screen
+   starts. */
+.answers__new {
+  margin-left: auto;
+}
+
+.answers__stale {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-8);
+  color: var(--warning-700);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+/* What the last write did, above both panels. It is the one node on this screen
+   that does not move when an answer is saved or taken down, which is what makes
+   it the place to say that one was. */
+.answers__output {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-8);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.answers__output:empty {
+  display: none;
+}
+
+.answers__output:focus {
+  outline: none;
+}
+
+.answers__output--good {
+  color: var(--success-700);
+}
+
+.answers__output--bad {
+  color: var(--danger-700);
+}
+
+.answers__output--busy {
+  color: var(--text-muted);
+}
+
+.answers__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.answers__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.answers__label {
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-small);
+}
+
+.answers__input {
+  height: 40px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-control);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  font-size: var(--text-body);
+}
+
+.answers__input:hover {
+  border-color: var(--border-strong);
+}
+
+/* The answer itself is written in a monospaced field, because it is markdown
+   and the two characters that matter most in markdown are the ones that line
+   up: a list marker and an indent. */
+.answers__area {
+  padding: var(--space-3);
+  border: 1px solid var(--border-control);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--text-small);
+  line-height: var(--leading-body);
+  resize: vertical;
+}
+
+.answers__area:hover {
+  border-color: var(--border-strong);
+}
+
+.answers__hint {
+  color: var(--text-muted);
+  font-size: var(--text-caption);
+  line-height: var(--leading-small);
+  overflow-wrap: anywhere;
+}
+
+/* The words and what they will look like, side by side, because the whole point
+   of a preview is that the eye moves between the two without scrolling. They
+   stack on a narrow screen, where side by side would be two columns too thin to
+   read either. */
+.answers__writing {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: var(--space-6) var(--space-8);
+  align-items: start;
+}
+
+.answers__side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.answers__preview {
+  min-height: 120px;
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--bg-subtle);
+}
+
+.answers__block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.answers__chosen {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  list-style: none;
+}
+
+/* A cited document reads as a row rather than as a chip, because it is the same
+   thing a result is and a reader recognises it from the search. */
+.answers__source {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border);
+  font-size: var(--text-body);
+}
+
+.answers__source-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.answers__source-where {
+  margin-right: auto;
+  color: var(--text-muted);
+  font-size: var(--text-small);
+}
+
+.answers__full,
+.answers__blank {
+  color: var(--text-muted);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.answers__found {
+  display: flex;
+  flex-direction: column;
+}
+
+/* One result of the picker. Borderless and full width, so that the list reads
+   as a set of choices rather than as a row of controls. */
+.answers__result {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: none;
+  border-radius: var(--radius-md);
+  background: none;
+  color: var(--text);
+  font-size: var(--text-body);
+  text-align: left;
+}
+
+.answers__result:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.answers__result:disabled {
+  color: var(--text-muted);
+}
+
+.answers__result-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.answers__result-where,
+.answers__result-note {
+  color: var(--text-muted);
+  font-size: var(--text-small);
+}
+
+.answers__result-note {
+  margin-left: auto;
+}
+
+/* The sentence that says saving is also confirming. It sits above the buttons
+   rather than beside one of them, because it is true of the whole form. */
+.answers__rule {
+  max-width: var(--measure);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.answers__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.answers__note {
+  max-width: var(--measure);
+}
+
+.answers__note-title {
+  font-size: var(--text-body);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-body);
+}
+
+.answers__note-body {
+  margin-top: var(--space-1);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+/* One answer in the list. The rule goes between rows rather than around each of
+   them, which is the same argument every other list on this screen makes. */
+.answer-row {
+  padding: var(--space-8) 0;
+  border-top: 1px solid var(--border);
+}
+
+.answer-row:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+
+/* The row whose answer is in the form above, marked so that somebody who
+   scrolled down to the list can see which one they are editing. */
+.answer-row--editing .answer-row__question {
+  color: var(--text-link);
+}
+
+.answer-row__head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  margin-bottom: var(--space-2);
+}
+
+.answer-row__question {
+  font-size: var(--text-title);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-title);
+}
+
+.answer-row__excerpt {
+  max-width: var(--measure);
+  color: var(--text-secondary);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+}
+
+/* Who wrote it and what it carries, as one line of small print. The separator
+   is drawn rather than typed, so a row with nothing to say after the byline
+   does not end in a stray bullet. */
+.answer-row__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+  color: var(--text-muted);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
+.answer-row__meta > span + span::before {
+  content: "\00b7";
+  margin-right: var(--space-3);
+}
+
+.answer-row__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
+}
+
+.answer-row__warn {
+  flex-basis: 100%;
+  max-width: var(--measure);
+  color: var(--text-secondary);
+  font-size: var(--text-small);
+  line-height: var(--leading-small);
+}
+
 /* Responsive ------------------------------------------------------------- */
 
 /*

--- a/web/dist/assets/app.js
+++ b/web/dist/assets/app.js
@@ -21,6 +21,7 @@ import { Page } from "genba/page.js";
 import { Home } from "genba/home.js";
 import { Recent } from "genba/recent.js";
 import { Admin } from "genba/admin.js";
+import { Answers } from "genba/answers.js";
 import { Settings } from "genba/settings.js";
 import { forget, remember } from "genba/queries.js";
 import { failed } from "genba/states.js";
@@ -133,6 +134,10 @@ class App {
       onSay: (text) => this.say(text),
     });
     this.admin = new Admin({ onBack: () => this.backFromAdmin() });
+    this.answers = new Answers({
+      onBack: () => this.backFromSettings(),
+      onSay: (text) => this.say(text),
+    });
 
     this.main = h("main", {
       class: "main",
@@ -384,8 +389,9 @@ class App {
     // Where the settings screen was opened from, taken before the address
     // moves. No other screen needs this: the rest either carry their own state
     // in the address or have a list behind them to go back to.
-    const aside = path === urlState.SETTINGS || path === urlState.ADMIN;
-    if (aside && !["settings", "admin"].includes(urlState.route().name)) {
+    const aside =
+      path === urlState.SETTINGS || path === urlState.ADMIN || path === urlState.ANSWERS;
+    if (aside && !["settings", "admin", "answers"].includes(urlState.route().name)) {
       this.lastScreen = location.pathname + location.search;
     }
     if (location.pathname !== path || location.search) history.pushState(null, "", path);
@@ -435,8 +441,8 @@ class App {
   }
 
   /**
-   * renderAdmin puts the administration entry on the rail, for the people who
-   * can reach it.
+   * renderAdmin puts the two administrator entries on the rail, for the people
+   * who can reach them.
    *
    * The role is the server's answer rather than this browser's, because it is
    * the server that decides and a client that guessed would either hide a
@@ -462,6 +468,18 @@ class App {
         },
         svg(icon("slider"), 20),
         h("span", { class: "rail__label" }, "Admin"),
+      ),
+      h(
+        "a",
+        {
+          class: "rail__link",
+          href: urlState.ANSWERS,
+          title: "Answers written for this company",
+          dataset: { route: "answers" },
+          onClick: (e) => this.follow(e, urlState.ANSWERS),
+        },
+        svg(icon("star"), 20),
+        h("span", { class: "rail__label" }, "Answers"),
       ),
     );
   }
@@ -592,6 +610,10 @@ class App {
       this.showAdmin();
       return;
     }
+    if (route.name === "answers") {
+      this.showAnswers();
+      return;
+    }
 
     document.title = "genba";
     this.omnibox.value = this.query.q;
@@ -691,6 +713,24 @@ class App {
     await this.admin.render();
   }
 
+  /**
+   * showAnswers renders the answers this company has written down.
+   *
+   * It does not poll, unlike the screen beside it on the rail, because half of
+   * it is a form and the other half changes only when somebody on this screen
+   * changes it. The endpoint refuses anybody without the role, so somebody who
+   * typed the address rather than following the rail entry lands on the error
+   * the server gave rather than on a screen that pretends.
+   */
+  async showAnswers() {
+    this.currentKey = this.answers.key();
+    this.drawer.currentId = null;
+    if (this.drawer.open) this.drawer.close({ notify: false, focus: false });
+    document.title = "Answers · genba";
+    if (this.main.firstChild !== this.answers.el) replace(this.main, this.answers.el);
+    await this.answers.render();
+  }
+
   /** backFromAdmin is the way out, which is the same one settings offers. */
   backFromAdmin() {
     const back = this.backFromSettings();
@@ -756,7 +796,7 @@ class App {
     const searching = Boolean(this.query.q) || urlState.count(this.query) > 0 || Boolean(this.query.sort);
     const route = urlState.route();
     const here =
-      route.name === "recent" || route.name === "settings" || route.name === "admin"
+      ["recent", "settings", "admin", "answers"].includes(route.name)
         ? route.name
         : route.name === "search" && !searching
           ? "home"

--- a/web/dist/assets/state.js
+++ b/web/dist/assets/state.js
@@ -7,7 +7,7 @@
 
 const LIST_KEYS = ["source", "kind", "container", "author", "owner"];
 
-// The four screens that are a path rather than a query string.
+// The five screens that are a path rather than a query string.
 //
 // A document is the thing somebody pastes into a message, so it gets an address
 // that survives being read out loud and does not carry the state of whoever
@@ -25,6 +25,11 @@ export const RECENT = "/recent";
 export const SETTINGS = "/settings";
 export const ADMIN = "/admin";
 
+// The answers screen is a path for the same two reasons administration is, and
+// it is a path of its own rather than a tab on that screen because what it
+// maintains is part of the corpus rather than part of the process.
+export const ANSWERS = "/answers";
+
 /**
  * route says which screen the path names.
  *
@@ -35,6 +40,7 @@ export function route(pathname = location.pathname) {
   if (pathname === RECENT) return { name: "recent", id: "" };
   if (pathname === SETTINGS) return { name: "settings", id: "" };
   if (pathname === ADMIN) return { name: "admin", id: "" };
+  if (pathname === ANSWERS) return { name: "answers", id: "" };
   if (!pathname.startsWith(DOCUMENT)) return { name: "search", id: "" };
   const id = decode(pathname.slice(DOCUMENT.length));
   return id ? { name: "document", id } : { name: "search", id: "" };

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -26,6 +26,7 @@
           "genba/access.js": "/assets/access.js",
           "genba/admin.js": "/assets/admin.js",
           "genba/answer.js": "/assets/answer.js",
+          "genba/answers.js": "/assets/answers.js",
           "genba/api.js": "/assets/api.js",
           "genba/app.js": "/assets/app.js",
           "genba/cache.js": "/assets/cache.js",
@@ -71,6 +72,7 @@
     <link rel="modulepreload" href="/assets/access.js" />
     <link rel="modulepreload" href="/assets/admin.js" />
     <link rel="modulepreload" href="/assets/answer.js" />
+    <link rel="modulepreload" href="/assets/answers.js" />
     <link rel="modulepreload" href="/assets/api.js" />
     <link rel="modulepreload" href="/assets/app.js" />
     <link rel="modulepreload" href="/assets/cache.js" />


### PR DESCRIPTION
Closes #166.

#165 landed three endpoints for written answers and no way to reach them.
The person who knows the deploy freeze dates is not the person who knows how to send a PUT with a JSON body, so correcting a typo in a paragraph that stands above the results for the whole tenant meant finding somebody who could open a terminal.

This adds the screen.

## What is on it

The second entry in the administrator rail, listing what this tenant has answered with the newest first.
Every row says who wrote it, when they last stood behind it, and whether it has run out.
That last part is on the row rather than inside the answer, because the reason to open this list is to find the ones that need attention, and a list that makes you open six answers to find the stale one is not helping.

The editor holds the question, the other phrasings the answer is filed under, the body as markdown with a live preview drawn by the same renderer that draws a document, and the documents it draws from.
Saving is also re-verifying and the form says so under the button, rather than leaving somebody looking for a control that does not exist.
Taking one down asks twice, because it is invisible to the person who does it and visible to everybody else.

## Sources stay ids

`GET /api/v1/admin/answers` returns sources unresolved and that is deliberate.
An answer written by somebody who can read everything must not turn into a list of documents narrowed to what the editor can read and then saved back, because that silently drops every source the editor cannot see.

So the screen resolves titles for display through a new `GET /api/v1/documents`.
It takes up to fifty ids, resolves them through the caller like every other read, and is ETagged like every other read.
What it returns is a label. What is saved is what came in.
An id that does not resolve is drawn as the bare id with a sentence saying it stays on the answer, so nobody removes a source because it looked broken.

Picking a source is a search, since nobody knows the id of a document.
The picker is the ordinary search endpoint debounced at a sixth of a second, five results, and a result already cited is disabled rather than missing so it reads as already chosen rather than as not found.
It stops at six, because `curatedFor` truncates to six when it draws the card and a seventh source would be stored, never shown, and believed by whoever added it.

## Nothing written yet is not the same as nowhere to put it

An empty list means two different things and the screen has to say which.
A tenant that has not written an answer yet is offered the form.
A deployment whose storage driver cannot keep one is told so.
The list response carries `writable` for that, the same way the connectors response carries `manageable`.
The test wraps a memstore in a struct that embeds the plain interface, which hides the capability exactly the way a driver that never had it would.

## The form is built once

Only the list, the picker results and the chosen sources redraw.
This screen is refreshed by the same tab focus handler as every other one, so somebody could be four sentences into a paragraph when a revalidation lands.
Not repainting the fields removes the whole class of bug rather than compensating for it the way the administration screen does with its save and restore of the caret.
For the same reason the heading only takes focus when focus is not already somewhere on this screen.

A new answer needs an id, since the id is in the path of the write, and it is a slug of the question with six random characters after it.
The slug alone would let two differently worded questions collide and quietly replace each other.
Nobody reads it, because a reader addresses an answer by typing the question.

Every write drops the whole client cache.
A saved answer changes the card above an unknown number of held searches, and working out which of them costs more than fetching them again.

## Checks

`go build ./...`, `go vet ./api/... ./web/...` and `go test -count=1 ./api/... ./web/...` all pass on server3.
The full UI gate passes on server2: keyboard walk, rendering check, states check, budgets, and axe over fourteen URLs with zero violations, the fourteenth being the new screen.
Asset budget is 126807 bytes of script of 184320 and 22999 bytes of style of 40960.
Lighthouse reports accessibility 99 and best practices 100.

Latency is over the advisory budget on that box as it has been since the gate started printing it, which is #55.
