### PR TITLE
Make the gate fail instead of hanging or guessing

### DIFF
--- a/scripts/chrome.mjs
+++ b/scripts/chrome.mjs
@@ -19,6 +19,18 @@ import { join } from "node:path";
 const DEADLINE = 20_000;
 const PATIENCE = 5_000;
 
+// How long a single DevTools command may go unanswered before the gate says the
+// browser is wedged.
+//
+// Longer than DEADLINE on purpose. Every wait in this file spends its time
+// inside an await on a command, so a command with no deadline of its own turns
+// every deadline above it into a suggestion: the clock is read between polls and
+// the loop never comes back round to read it. This number is not the budget for
+// a slow page, which is what DEADLINE is. It is the point past which the answer
+// is never coming, and it is generous because the cost of guessing low is a run
+// that fails for a reason that is not the reason it exists.
+const WEDGED = 45_000;
+
 const CHROMES = [
   process.env.CHROME_PATH,
   process.env.CHROME_BIN,
@@ -168,16 +180,59 @@ async function endpoint(port, exited, said) {
  */
 async function attach(url) {
   const socket = new WebSocket(url);
-  const pending = new Map();
-  const listeners = new Map();
-  let next = 0;
 
   await new Promise((resolve, reject) => {
     socket.addEventListener("open", resolve, { once: true });
     socket.addEventListener("error", () => reject(new Error("could not open a DevTools connection")), {
       once: true,
     });
+    socket.addEventListener("close", () => reject(new Error("the DevTools connection closed before it opened")), {
+      once: true,
+    });
   });
+
+  const { send, on } = wire(socket);
+
+  const { targetId } = await send("Target.createTarget", { url: "about:blank" });
+  const { sessionId } = await send("Target.attachToTarget", { targetId, flatten: true });
+  await send("Page.bringToFront", {}, sessionId);
+  const session = (method, params) => send(method, params, sessionId);
+  session.on = on;
+  return session;
+}
+
+/**
+ * wire is the message pump over an open socket.
+ *
+ * It is its own function rather than four closures inside attach so that the
+ * part with the failure modes in it can be driven by a test without a browser.
+ * What it owns is the bookkeeping: which command each reply belongs to, which
+ * events go to which handler, and what happens to a command that is never
+ * answered.
+ *
+ * Every promise it hands out settles. A command that goes unanswered for WEDGED
+ * is rejected with the method in the message, because a hung gate today prints
+ * the line before the one that hung and leaves whoever reads it guessing. A
+ * connection that closes or errors takes every outstanding command with it, for
+ * the same reason a Chrome that has exited is never going to answer, and a
+ * command sent after that is refused rather than queued into a socket nobody is
+ * reading.
+ */
+export function wire(socket, deadline = WEDGED) {
+  const pending = new Map();
+  const listeners = new Map();
+  let next = 0;
+  let gone = "";
+
+  const abandon = (why) => {
+    if (gone) return;
+    gone = why;
+    for (const waiting of pending.values()) {
+      clearTimeout(waiting.timer);
+      waiting.reject(new Error(`${waiting.method} was outstanding when ${why}`));
+    }
+    pending.clear();
+  };
 
   socket.addEventListener("message", (event) => {
     const message = JSON.parse(event.data);
@@ -189,25 +244,40 @@ async function attach(url) {
     const waiting = pending.get(message.id);
     if (!waiting) return;
     pending.delete(message.id);
+    clearTimeout(waiting.timer);
     if (message.error) waiting.reject(new Error(message.error.message));
     else waiting.resolve(message.result);
   });
 
+  socket.addEventListener("close", () => abandon("the DevTools connection closed"));
+  socket.addEventListener("error", () => abandon("the DevTools connection failed"));
+
   const send = (method, params, sessionId) =>
     new Promise((resolve, reject) => {
+      if (gone) {
+        reject(new Error(`${method} was not sent because ${gone}`));
+        return;
+      }
       const id = ++next;
-      pending.set(id, { resolve, reject });
+      const where = sessionId ? ` on session ${sessionId}` : "";
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`${method}${where} went unanswered for ${deadline}ms, so the browser is wedged`));
+      }, deadline);
+      // Deliberately not unref'd. An unreferenced timer lets node decide the
+      // loop has nothing left to do and shut down with this promise still
+      // pending, which is the silent version of the hang being fixed here. Every
+      // script that uses this exits explicitly when it is done, so a timer that
+      // holds the loop for at most WEDGED holds nothing anybody is waiting on.
+      pending.set(id, { method, resolve, reject, timer });
       socket.send(JSON.stringify({ id, method, params: params || {}, sessionId }));
     });
 
-  const { targetId } = await send("Target.createTarget", { url: "about:blank" });
-  const { sessionId } = await send("Target.attachToTarget", { targetId, flatten: true });
-  await send("Page.bringToFront", {}, sessionId);
-  const session = (method, params) => send(method, params, sessionId);
-  session.on = (method, handler) => {
+  const on = (method, handler) => {
     listeners.set(method, (listeners.get(method) || []).concat(handler));
   };
-  return session;
+
+  return { send, on };
 }
 
 /** narrow tells the page it is on a small screen, media queries and all. */

--- a/scripts/chrome_test.mjs
+++ b/scripts/chrome_test.mjs
@@ -1,0 +1,131 @@
+// The part of the browser driver that has to settle, driven without a browser.
+//
+// Everything else in scripts/chrome.mjs is a thin wrapper over a DevTools
+// command and is tested by the gate using it. wire is different: what it owns is
+// what happens when the answer does not come, and staging a wedged Chrome is
+// awkward enough that the failure shipped untested and cost thirty five minutes
+// of a session sitting at a prompt with no output.
+//
+// A socket here is an object with the three methods wire uses. That is the whole
+// dependency, so the test can close it, break it, or simply never answer.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { wire } from "./chrome.mjs";
+
+// stub is a socket that records what was sent and answers only when told to.
+function stub() {
+  const listeners = new Map();
+  const sent = [];
+  return {
+    sent,
+    addEventListener(name, handler) {
+      listeners.set(name, (listeners.get(name) || []).concat(handler));
+    },
+    send(payload) {
+      sent.push(JSON.parse(payload));
+    },
+    // emit is the socket delivering an event to whoever attached to it.
+    emit(name, event) {
+      for (const handler of listeners.get(name) || []) handler(event);
+    },
+    // reply is the browser answering a command that was sent.
+    reply(message) {
+      this.emit("message", { data: JSON.stringify(message) });
+    },
+  };
+}
+
+test("a command that is answered resolves with the result", async () => {
+  const socket = stub();
+  const { send } = wire(socket);
+
+  const answer = send("Runtime.evaluate", { expression: "1 + 1" });
+  assert.equal(socket.sent[0].method, "Runtime.evaluate");
+  socket.reply({ id: socket.sent[0].id, result: { value: 2 } });
+
+  assert.deepEqual(await answer, { value: 2 });
+});
+
+test("a command the browser refuses rejects with what it said", async () => {
+  const socket = stub();
+  const { send } = wire(socket);
+
+  const answer = send("Page.navigate", { url: "about:blank" });
+  socket.reply({ id: socket.sent[0].id, error: { message: "Cannot navigate to invalid URL" } });
+
+  await assert.rejects(answer, /Cannot navigate to invalid URL/);
+});
+
+// The failure this file exists for. Before there was a deadline the promise
+// below never settled, so every wait built on top of it waited for as long as
+// the process lived.
+test("a command that is never answered rejects, saying which one", async () => {
+  const socket = stub();
+  const { send } = wire(socket, 20);
+
+  await assert.rejects(send("Runtime.evaluate", {}, "S1"), (err) => {
+    assert.match(err.message, /Runtime\.evaluate/);
+    assert.match(err.message, /session S1/);
+    assert.match(err.message, /wedged/);
+    return true;
+  });
+});
+
+test("a late answer to a command that already gave up is ignored", async () => {
+  const socket = stub();
+  const { send } = wire(socket, 20);
+
+  await assert.rejects(send("Runtime.evaluate", {}), /wedged/);
+  // The browser waking up after the fact must not throw out of an event
+  // handler, which is where an unhandled rejection would come from.
+  socket.reply({ id: socket.sent[0].id, result: { value: 2 } });
+});
+
+test("a connection that closes takes every outstanding command with it", async () => {
+  const socket = stub();
+  const { send } = wire(socket);
+
+  const first = send("Runtime.evaluate", {});
+  const second = send("Page.navigate", {});
+  socket.emit("close", {});
+
+  await assert.rejects(first, /Runtime\.evaluate was outstanding when the DevTools connection closed/);
+  await assert.rejects(second, /Page\.navigate was outstanding when the DevTools connection closed/);
+});
+
+test("a connection that errors takes every outstanding command with it", async () => {
+  const socket = stub();
+  const { send } = wire(socket);
+
+  const answer = send("Runtime.evaluate", {});
+  socket.emit("error", {});
+
+  await assert.rejects(answer, /the DevTools connection failed/);
+});
+
+test("a command sent after the connection went is refused rather than queued", async () => {
+  const socket = stub();
+  const { send } = wire(socket);
+
+  socket.emit("close", {});
+  await assert.rejects(send("Runtime.evaluate", {}), /was not sent because the DevTools connection closed/);
+  assert.equal(socket.sent.length, 0, "a command reached a socket nobody is reading");
+});
+
+test("an event goes to every handler that asked for it and to no command", async () => {
+  const socket = stub();
+  const { send, on } = wire(socket);
+
+  const seen = [];
+  on("Fetch.requestPaused", (params) => seen.push(params.requestId));
+  on("Fetch.requestPaused", (params) => seen.push(`again ${params.requestId}`));
+
+  const answer = send("Fetch.enable", {});
+  socket.reply({ method: "Fetch.requestPaused", params: { requestId: "R1" } });
+  socket.reply({ id: socket.sent[0].id, result: { ok: true } });
+
+  assert.deepEqual(seen, ["R1", "again R1"]);
+  assert.deepEqual(await answer, { ok: true });
+});

--- a/scripts/keyboard-walk.mjs
+++ b/scripts/keyboard-walk.mjs
@@ -274,15 +274,28 @@ async function walk(session) {
 
   // One ahead, so the next press paints from memory rather than from the
   // network. The cache is the app's own, reached the way the app reaches it.
-  await check(
-    session,
-    "the result under the one on screen has already been fetched",
-    `import('genba/cache.js').then(({ cache }) => {
-      const rows = [...document.querySelectorAll('.result__title')];
-      const next = rows[2].getAttribute('href').replace('/d/', '').split('?')[0];
-      return cache.read(cache.key('document', { id: decodeURIComponent(next) })).state !== 'miss';
-    })`,
-  );
+  //
+  // Waited for rather than sampled. What the prefetch leaves behind is a request
+  // in flight, and check gives an assertion five seconds because that is how
+  // long a paint after a fetch is allowed to take. Five seconds is a budget for
+  // slowness, and slowness is not what this line is about: the claim is that the
+  // prefetch happens at all. So it settles on the entry leaving the miss state
+  // first, with the deadline that means broken rather than the one that means
+  // busy, and only then reports. A run on a loaded machine now takes longer to
+  // say ok instead of saying FAIL for a reason that was never the interface.
+  const prefetched = `import('genba/cache.js').then(({ cache }) => {
+    const rows = [...document.querySelectorAll('.result__title')];
+    const next = rows[2].getAttribute('href').replace('/d/', '').split('?')[0];
+    return cache.read(cache.key('document', { id: decodeURIComponent(next) })).state !== 'miss';
+  })`;
+  try {
+    await settle(session, prefetched);
+  } catch {
+    // Reported by the check below, which is where a failure belongs. Throwing
+    // here would end the walk on this one line and lose the twenty checks after
+    // it, and a prefetch that never lands is worth exactly one FAIL.
+  }
+  await check(session, "the result under the one on screen has already been fetched", prefetched);
 
   await press(session, "k", "KeyK", 75);
   await check(

--- a/scripts/render-check.mjs
+++ b/scripts/render-check.mjs
@@ -197,26 +197,48 @@ async function run(session) {
   // neither of them is the file: a photograph off a phone is four megabytes and
   // the box it goes in is fifty six pixels across, so a list of twenty of them
   // downloaded as they are is eighty megabytes to draw a page.
+  //
+  // The only check here that watches something happen rather than reading what
+  // a renderer returned, and the two ways that goes wrong are both handled in
+  // the expression instead of by the retry above it. The request is issued from
+  // an intersection callback, which is a frame away on an idle machine and
+  // further than that on a loaded one, so it is waited for rather than slept
+  // through. And the module holds one fetch per id and size for as long as the
+  // page lives, so an id reused on a retry is answered out of that cache and
+  // the retry sees no request at all, which turns a slow first attempt into a
+  // failure nothing can recover from. Each attempt asks about a picture nobody
+  // has asked about yet.
   await check(
     session,
     "a picture in a row and a picture in a grid cell are thumbnails of two sizes, not the file",
     expr(`
       const { tile, cover, TILE, CELL } = await import('genba/content.js');
-      const { api } = await import('genba/api.js');
-      const hit = { id: 'repo:shot.png', media_type: 'image/png', kind: 'image', title: 'shot.png', modified_at: '7' };
+      const n = (window.__thumbnails = (window.__thumbnails || 0) + 1);
+      const hit = {
+        id: 'repo:shot-' + n + '.png',
+        media_type: 'image/png',
+        kind: 'image',
+        title: 'shot.png',
+        modified_at: '7',
+      };
       const asked = [];
       const sent = window.fetch;
       window.fetch = function (input) { asked.push(String((input && input.url) || input)); return sent.apply(this, arguments); };
+      const boxes = [tile(hit), cover(hit)];
+      const thumbs = () => asked.filter((u) => u.includes('/thumbnail?size='));
       try {
-        document.body.append(tile(hit), cover(hit));
-        await new Promise((done) => setTimeout(done, 400));
+        document.body.append(boxes[0], boxes[1]);
+        const until = Date.now() + 5000;
+        while (thumbs().length < 2 && Date.now() < until) {
+          await new Promise((done) => setTimeout(done, 50));
+        }
       } finally {
         window.fetch = sent;
+        for (const box of boxes) box.remove();
       }
-      const thumbs = asked.filter((u) => u.includes('/thumbnail?size='));
-      return thumbs.some((u) => u.includes('size=' + TILE)) &&
-        thumbs.some((u) => u.includes('size=' + CELL)) &&
-        thumbs.every((u) => u.includes('v=7')) &&
+      return thumbs().some((u) => u.includes('size=' + TILE)) &&
+        thumbs().some((u) => u.includes('size=' + CELL)) &&
+        thumbs().every((u) => u.includes('v=7')) &&
         !asked.some((u) => /\\/documents\\/[^/]+\\/content/.test(u)) &&
         TILE < CELL;
     `),

--- a/scripts/ui-gate.sh
+++ b/scripts/ui-gate.sh
@@ -66,6 +66,18 @@ if ! command -v node >/dev/null 2>&1; then
 	exit 0
 fi
 
+# The driver every check below is built on, tested before anything is started.
+#
+# It runs first and fails hard rather than setting status, because a driver that
+# cannot report a wedged browser makes every result underneath it a maybe. It
+# needs no browser and no server, so it costs a second and can run before either
+# exists.
+echo "ui-gate: driver"
+if ! node --test scripts/chrome_test.mjs; then
+	echo "ui-gate: the browser driver is broken, so nothing below it would mean anything" >&2
+	exit 1
+fi
+
 if [ ! -x "$BIN" ]; then
 	echo "ui-gate: $BIN is not there, run make build first" >&2
 	exit 1
@@ -269,7 +281,7 @@ if [ -n "${CHROMEDRIVER:-}" ]; then
 	DRIVER="--chromedriver-path $CHROMEDRIVER"
 fi
 
-# Thirteen screens, and they are states rather than layouts. Three of them, the
+# Fourteen screens, and they are states rather than layouts. Three of them, the
 # empty index, the query that matched nothing and the filter that matched
 # nothing, produce markup no other screen produces, and that markup is where an
 # accessibility bug survives longest: nobody looks at an empty page twice.


### PR DESCRIPTION
Closes #161.
Closes #150.

Two ways the interface gate reported something other than what it found.

## A wedged browser hung the gate instead of failing it

Every DevTools command went through a promise that only ever settled when a matching reply arrived on the socket.
There was no timer, and nothing rejected the outstanding entries when the socket closed.
A browser that stopped answering meant that promise never settled and whoever awaited it waited for as long as the process lived.

The deadlines that look like they cover this do not.
`settle` has twenty seconds and `reporter().check` has five, and both spend their wait inside an `await` on a command, so the clock is only read between polls and a poll that never returns means the loop never comes back round to notice.

A command now has a deadline of its own, and it is deliberately longer than the one above it.
Forty five seconds is not a budget for a slow page, which is what `settle`'s twenty is.
It is the point past which the answer is never coming.
The rejection names the method and the session, because that is what the log was missing: the last line printed was the check before the one that hung, which says nothing about which command was outstanding.
A socket that closes or errors takes every outstanding command with it, and a command sent afterwards is refused rather than queued into a socket nobody is reading.

The timer is not `unref`'d, and that is a decision rather than an oversight.
An unreferenced timer lets node decide the loop has nothing left to do and shut down with the promise still pending, which is the quiet version of the same bug.
Every script here exits explicitly when it is done, so a timer that holds the loop for at most the deadline holds nothing anybody is waiting on.

### It is tested now

The message pump is `wire`, exported, taking any object with the three socket methods it uses.
That is what makes the above testable without staging a wedged Chrome, which is why it shipped untested in the first place.

Eight cases in `scripts/chrome_test.mjs`: answered, refused, never answered, answered late after giving up, closed, errored, sent after close, and an event reaching its handlers rather than a command.

The gate runs them first and fails hard rather than setting `status`, because a driver that cannot report a wedged browser makes every result under it a maybe.
They need no browser and no server, so they cost a second and run before either exists.

## The walk reported on a race

The prefetch check reads the app's own cache and asserts the document one row below the preview is no longer a miss, and the thing that fills that entry is a request in flight.
`check` gives an assertion five seconds because that is how long a paint after a fetch is allowed to take, and on a loaded runner the request had been issued and had not landed.

Five seconds is a budget for slowness and slowness is not what that line is about.
The claim is that the prefetch happens at all.
So it settles on the entry leaving the miss state first, with the deadline that means broken rather than the one that means busy, and only then reports.
A settle that gives up is swallowed and left to the check below it, because throwing there would end the walk on that line and lose the twenty checks after it, and a prefetch that never lands is worth exactly one FAIL.

### The render check had it too

#150 asks whether the same shape is used anywhere else, and it is, in the thumbnail assertion of the render check.
That one appends a row and a grid cell, patches `fetch`, waits four hundred milliseconds and reads what was asked for, and the request it waits on is issued from an intersection callback, which is a frame away on an idle machine and further than that on a loaded one.
It failed once on server2 during this work and passes on either side of that.

The retry above it could not recover either.
`content.js` holds one fetch per id and size for as long as the page lives, so a second attempt was answered out of that cache and saw no request at all, which turns one slow first attempt into a failure nothing can get back from.

So it waits for the two requests instead of sleeping through them, and every attempt asks about a picture nobody has asked about yet.
Both of those live in the expression rather than in the retry, because the retry is the thing that cannot see either problem.

Nothing else in either script has the shape.
The other reads of the cache from a page are writes followed by a repaint, which is arranged rather than raced, and every other check in the render check reads what a renderer has already returned.

## Checks

`node --test scripts/chrome_test.mjs` passes eight of eight on node 22 on server2 and on the laptop.

The keyboard walk ran ten consecutive times on server2 against one server, 109 checks and zero failures every time, which is the second box on #150.

The render check ran ten consecutive times on server2, 23 checks and zero failures every time.

The full gate passes on server2 with the driver step in front of it.

Also the count in the axe comment, which still said thirteen screens after the fourteenth was added in #169.
