### PR TITLE
Give the first read a pace, and the test watching it a guarantee (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ The one exception is the object storage credentials, which are read from the env
 | `-corpus-refresh` | `0` | how often to sync again, zero for once at startup |
 | `-corpus-watch` | `false` | ask the operating system what changed instead of walking the tree, needs `-corpus-refresh` |
 | `-corpus-reconcile` | `0` | how often to sweep the index against the tree, zero for after every sync |
+| `-corpus-rate` | `0` | files a second the read keeps itself under, zero for as fast as the disk allows |
 
 `-corpus-watch` is what makes a short refresh interval affordable on a large tree.
 Without it every refresh walks, which is a stat of every file to find the four that moved, and with it the cost of a refresh is a function of how much changed rather than of how large the corpus is.
@@ -234,6 +235,11 @@ A machine that cannot give out that many watches logs a line and carries on walk
 
 `-corpus-reconcile` exists because of it.
 The sweep that finds deleted files walks the tree, so on a watched server it is the whole remaining cost of a refresh, and separating the two lets a change be noticed in a second while both sides are still counted every few minutes.
+
+`-corpus-rate` is for the first read of a large tree, and most servers do not want it.
+The server answers from the first second and says on screen that what it is answering from is not all of it yet, and the point of that is that those first minutes are usable.
+A read going flat out is the one thing on the machine competing with them for the same disk, and a ceiling on files a second is the only lever that helps, because the work cannot be made smaller: every file has to be read once.
+Zero means no ceiling, which is the opposite of what the same number means for a bucket, and the difference is that a local disk refuses nobody.
 
 ```
 genbad -tenant acme -corpus ~/src/handbook -corpus-refresh 1s -corpus-watch -corpus-reconcile 5m

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/tamnd/genba/connector/fssource"
+	"github.com/tamnd/genba/connector/limit"
 	"github.com/tamnd/genba/store"
 )
 
@@ -51,6 +52,22 @@ type corpusOptions struct {
 	// that walks, which is what it would have done anyway.
 	Watch bool
 
+	// Rate is how many files a second the read may take, and zero is as fast as
+	// the disk allows.
+	//
+	// Zero means unlimited here, which is the opposite of what the same number
+	// means for a bucket, and the difference is who is on the other end. A remote
+	// service that is asked for too much revokes the token, so there the absence
+	// of a ceiling is the bug. A local disk refuses nobody: the only thing a fast
+	// read costs is the queries this server is answering out of the same disk
+	// while it happens, and on most trees it does not cost them enough to be
+	// worth slowing anything down for.
+	//
+	// It is worth setting on the trees where it does. A first read of a large
+	// corpus is minutes of a disk at full tilt, and the whole reason the server
+	// answers during it is that those minutes are meant to be usable.
+	Rate float64
+
 	// Reconcile is how often to sweep the index against the tree. Zero sweeps
 	// after every sync.
 	//
@@ -93,6 +110,9 @@ func (o corpusOptions) validate() error {
 	}
 	if o.Reconcile < 0 {
 		return errors.New("corpus reconcile interval is negative")
+	}
+	if o.Rate < 0 {
+		return errors.New("corpus rate is negative")
 	}
 	if o.Watch && o.Refresh <= 0 {
 		// A watcher records what changes between one sync and the next, and with
@@ -191,7 +211,17 @@ func corpusFeed(cfg corpusOptions, tenant string, track *indexing, ops *operatio
 		}
 	}
 
-	src, err := fssource.New(cfg.Dir, cfg.Name, policy, fssource.WithWatcher(watcher))
+	opts := []fssource.Option{fssource.WithWatcher(watcher)}
+	if cfg.Rate > 0 {
+		// Burst of one, so the number is a pace rather than a ceiling averaged
+		// over a window. A burst is worth having against a service that counts
+		// requests per minute and does not care how they were spaced inside it,
+		// and it is worth nothing against a disk, where ten reads back to back is
+		// exactly the spike the rate was set to avoid.
+		opts = append(opts, fssource.WithPace(limit.NewLimiter(limit.Limits{Rate: cfg.Rate, Burst: 1}, nil).Wait))
+	}
+
+	src, err := fssource.New(cfg.Dir, cfg.Name, policy, opts...)
 	if err != nil {
 		if watcher != nil {
 			_ = watcher.Close()

--- a/cmd/genbad/first_read_test.go
+++ b/cmd/genbad/first_read_test.go
@@ -22,10 +22,14 @@ import (
 // that the first answers come out of an index that is still filling. So it says
 // so, on every screen, until it is done.
 
-// bigTree writes enough files that reading them takes long enough to watch. The
-// count is not arbitrary: the whole point of the test is to look at the server
-// while a first read is in flight, and a tree of eight files is read faster than
-// a request can be sent.
+// bigTree writes a corpus with more files in it than a test wants to wait for.
+//
+// How many is not what keeps the read in flight, and it used to be. A tree of
+// two thousand small files is under a second on a warm page cache, so the test
+// below made four requests and hoped the fourth landed before the read was
+// over, which is a race it lost on a fast runner and won everywhere it was
+// looked at. What holds the read open now is -corpus-rate, so the count only
+// has to be more than the read can get through while the test is looking.
 func bigTree(t *testing.T, files int) string {
 	t.Helper()
 	root := t.TempDir()
@@ -44,21 +48,23 @@ func bigTree(t *testing.T, files int) string {
 
 // startCorpus starts a server on a directory and returns its address and a
 // function that shuts it down. It deliberately does not wait for the index.
-func startCorpus(t *testing.T, root string) (addr string, stop func()) {
+func startCorpus(t *testing.T, root string, extra ...string) (addr string, stop func()) {
 	t.Helper()
 	addr = freeAddr(t)
+
+	args := append([]string{
+		"-addr", addr,
+		"-tenant", "acme",
+		"-corpus", root,
+		"-corpus-name", "handbook",
+		"-log-level", "error",
+	}, extra...)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
 	go func() {
 		var out, errOut bytes.Buffer
-		done <- run(ctx, []string{
-			"-addr", addr,
-			"-tenant", "acme",
-			"-corpus", root,
-			"-corpus-name", "handbook",
-			"-log-level", "error",
-		}, env(nil), &out, &errOut)
+		done <- run(ctx, args, env(nil), &out, &errOut)
 	}()
 	return addr, func() {
 		cancel()
@@ -70,8 +76,23 @@ func startCorpus(t *testing.T, root string) (addr string, stop func()) {
 	}
 }
 
+// The read is paced so that the assertions below are exact rather than likely.
+//
+// Two hundred files at four a second is fifty seconds of reading, and every
+// request this test makes is answered in milliseconds, so the read is still
+// running when each of them lands however fast the machine is. The count that
+// fills in the second number is not paced, because it is a walk rather than a
+// read, so the test can say what the total should be as well.
+//
+// Shutting down does not wait for the fifty seconds. Pacing waits on the
+// context, so cancelling it ends the sync at whichever file it was holding.
+const (
+	corpusFiles = 200
+	corpusRate  = "4"
+)
+
 func TestTheServerAnswersBeforeTheCorpusIsReadAndSaysSo(t *testing.T) {
-	addr, stop := startCorpus(t, bigTree(t, 2000))
+	addr, stop := startCorpus(t, bigTree(t, corpusFiles), "-corpus-rate", corpusRate)
 	defer stop()
 
 	// This is the assertion. The health check answering at all, on a corpus that
@@ -113,8 +134,17 @@ func TestTheServerAnswersBeforeTheCorpusIsReadAndSaysSo(t *testing.T) {
 	if stats.Indexing.Source != "handbook" {
 		t.Errorf("indexing names %q, want the source from -corpus-name", stats.Indexing.Source)
 	}
-	if stats.Indexing.Done > stats.Indexing.Total && stats.Indexing.Total != 0 {
-		t.Errorf("indexing = %+v, more read than there is to read", *stats.Indexing)
+	if stats.Indexing.Done >= corpusFiles {
+		t.Errorf("indexing = %+v, a read that is still running has read the whole corpus", *stats.Indexing)
+	}
+
+	// The second number is the one the banner needs before it can draw a bar,
+	// and it arrives on its own schedule: the count runs before the sync does,
+	// so a request that lands between the two is told a read is running and not
+	// yet told how much of one. That window is microseconds and this waits it
+	// out rather than asserting into the middle of it.
+	if got := waitForTotal(t, addr); got != corpusFiles {
+		t.Errorf("indexing counted %d documents, want the %d in the tree", got, corpusFiles)
 	}
 }
 
@@ -138,6 +168,30 @@ func TestNothingIsReportedOnceTheCorpusIsRead(t *testing.T) {
 	// would arrive.
 	if res := searchAs(t, addr, "alice", "deploying"); res.Total == 0 {
 		t.Error("the first read finished and the corpus is not searchable")
+	}
+}
+
+// waitForTotal returns how much there is to read once the count has come back,
+// and fails the test if the read finishes or the count never arrives.
+//
+// The first of those is the one worth being loud about. A total that stays at
+// zero because the sync is already over is exactly the bug the pace was added
+// to rule out, and reporting it as "the count never arrived" would send the
+// next person to read this looking in the wrong place.
+func waitForTotal(t *testing.T, addr string) int {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		s := statsAs(t, addr, "alice")
+		switch {
+		case s.Indexing == nil:
+			t.Fatal("the first read finished while the test was watching it, so the pace is not holding it open")
+		case s.Indexing.Total > 0:
+			return s.Indexing.Total
+		case time.Now().After(deadline):
+			t.Fatal("the count of what there is to read never came back")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -85,6 +85,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	fs.DurationVar(&corpus.Refresh, "corpus-refresh", 0, "how often to reindex the directory, zero for once")
 	fs.BoolVar(&corpus.Watch, "corpus-watch", false, "ask the operating system what changed instead of walking the tree, needs -corpus-refresh")
 	fs.DurationVar(&corpus.Reconcile, "corpus-reconcile", 0, "how often to sweep the index against the directory, zero for after every sync")
+	fs.Float64Var(&corpus.Rate, "corpus-rate", 0, "files a second the read keeps itself under, zero for as fast as the disk allows")
 
 	var bucket bucketOptions
 	fs.StringVar(&bucket.Bucket, "bucket", "", "S3 compatible bucket to index at startup")

--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -208,6 +208,7 @@ type Source struct {
 	includeIf func(name string) bool
 	skipped   func(path string, reason error)
 	watcher   *Watcher
+	pacing    func(context.Context) error
 
 	counters counters
 }
@@ -307,6 +308,32 @@ func WithInclude(f func(name string) bool) Option {
 // which is what [WithWatchSkipDir] is for.
 func WithWatcher(w *Watcher) Option {
 	return func(s *Source) { s.watcher = w }
+}
+
+// WithPace makes the source wait before it reads each file's content.
+//
+// A first read of a large tree is the one moment this connector competes with
+// the server it is feeding. The walk is stat calls and the reads are the disk,
+// and a process doing both flat out is a process whose queries are answered off
+// a disk that is busy with something else. Slowing the read down is the only
+// lever that helps, because the work itself cannot be made smaller: every file
+// has to be read once.
+//
+// It is a function rather than a number so that what the pace is stays with
+// whoever chose it. A token bucket, a semaphore shared with something else and
+// a plain sleep are all the same shape from here, and the connector has no
+// opinion about which of them a deployment wants.
+//
+//	l := limit.NewLimiter(limit.Limits{Rate: 200, Burst: 1}, nil)
+//	src, err := fssource.New(root, "docs", policy, fssource.WithPace(l.Wait))
+//
+// The error it returns stops the sync rather than skipping the file, because
+// the only thing that makes a pace fail is the context being done, and a sync
+// that carried on from there would spend a shutdown reading the rest of the
+// tree. A nil function is what passing no option means: read as fast as the
+// disk allows.
+func WithPace(wait func(context.Context) error) Option {
+	return func(s *Source) { s.pacing = wait }
 }
 
 // New returns a source reading root, naming itself name, and asking policy who
@@ -421,6 +448,10 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 		// reports it.
 		if at, err := s.changedAt(ctx, rel, info); err == nil && at.After(highest) {
 			highest = at
+		}
+
+		if err := s.pace(ctx); err != nil {
+			return err
 		}
 
 		full := filepath.Join(s.root, filepath.FromSlash(rel))
@@ -572,6 +603,10 @@ func (s *Source) syncWatched(ctx context.Context, from connector.Cursor, since t
 			highest = at
 		}
 
+		if err := s.pace(ctx); err != nil {
+			return connector.Cursor{}, err
+		}
+
 		document, err := s.read(ctx, full, rel, info)
 		if err != nil {
 			s.skipped(full, err)
@@ -677,6 +712,20 @@ func (s *Source) limitFor(name string) int64 {
 	default:
 		return s.maxSize
 	}
+}
+
+// pace waits for whatever [WithPace] installed, and for nothing when a source
+// was built without one.
+//
+// It sits in front of the content read and not in front of the walk, because
+// the walk is the cheap half. Pacing the stat calls would put the second number
+// in the progress report behind the same wall as the first and leave a first
+// read that says nothing about how much there is to do.
+func (s *Source) pace(ctx context.Context) error {
+	if s.pacing == nil {
+		return ctx.Err()
+	}
+	return s.pacing(ctx)
 }
 
 // read turns one file into a document.

--- a/connector/fssource/pace_test.go
+++ b/connector/fssource/pace_test.go
@@ -1,0 +1,109 @@
+package fssource_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/fssource"
+)
+
+// Reading a tree as fast as the disk allows is the right default and the wrong
+// thing on the one tree where it matters. A first read of a large corpus is
+// minutes of a busy disk, and the server is answering queries out of that same
+// disk the whole time, which is the entire reason it opens its listener before
+// the read is finished. Those minutes are meant to be usable.
+//
+// So the read can be given a pace. What the pace is stays with whoever chose
+// it, because a token bucket, a semaphore shared with something else and a
+// plain sleep are all one function from in here.
+
+func TestTheReadWaitsOnceForEachFileItReads(t *testing.T) {
+	root := tree(t, map[string]string{
+		"handbook/deploying.md": "How to deploy.",
+		"handbook/oncall.md":    "Who to call.",
+		"notes/standup.md":      "What we said.",
+	})
+
+	var waited int
+	src, err := fssource.New(root, "docs", fssource.PublicToTenant("docs"), fssource.WithPace(func(context.Context) error {
+		waited++
+		return nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	docs, next := collect(t, src, connector.Cursor{})
+	if len(docs) != 3 {
+		t.Fatalf("read %v, want the three files in the tree", ids(docs))
+	}
+	if waited != 3 {
+		t.Errorf("waited %d times for three files, want one wait each", waited)
+	}
+
+	// And nothing is waited for on a sync that reads nothing. A pace in front of
+	// the walk rather than in front of the read would charge a refresh over an
+	// unchanged tree the same as a first read, which on a server refreshing
+	// every second is a ceiling that never stops binding.
+	waited = 0
+	if docs, _ := collect(t, src, next); len(docs) != 0 {
+		t.Fatalf("a second sync over an unchanged tree read %v", ids(docs))
+	}
+	if waited != 0 {
+		t.Errorf("waited %d times on a sync that read nothing", waited)
+	}
+}
+
+func TestAPaceThatGivesUpStopsTheReadRatherThanSkippingTheFile(t *testing.T) {
+	root := tree(t, map[string]string{
+		"a.md": "One.",
+		"b.md": "Two.",
+		"c.md": "Three.",
+	})
+
+	// The only thing that makes a pace fail is the process shutting down, and a
+	// sync that treated that as one unreadable file would spend the shutdown
+	// reading the rest of the tree.
+	stop := errors.New("closing time")
+	var read int
+	src, err := fssource.New(root, "docs", fssource.PublicToTenant("docs"), fssource.WithPace(func(context.Context) error {
+		read++
+		if read > 1 {
+			return stop
+		}
+		return nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var emitted int
+	if _, err := src.Sync(t.Context(), connector.Cursor{}, func(context.Context, connector.Change) error {
+		emitted++
+		return nil
+	}); !errors.Is(err, stop) {
+		t.Fatalf("sync returned %v, want the pace's own error", err)
+	}
+	if emitted != 1 {
+		t.Errorf("emitted %d documents after the pace gave up on the second, want 1", emitted)
+	}
+}
+
+func TestAReadWithNoPaceStillStopsWhenTheContextDoes(t *testing.T) {
+	root := tree(t, map[string]string{"a.md": "One.", "b.md": "Two."})
+	src, err := fssource.New(root, "docs", fssource.PublicToTenant("docs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := src.Sync(ctx, connector.Cursor{}, func(context.Context, connector.Change) error {
+		t.Error("a sync on a cancelled context read a file")
+		return nil
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("sync returned %v, want the cancellation", err)
+	}
+}

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -260,6 +260,12 @@ genbad \
 `-corpus-acl owners` reads the OWNERS files in the tree, which is a real access control list maintained by real people.
 The other two are `tenant`, where everybody in the tenant may read everything, and `os`, which reads the mode bits and needs `-corpus-identity` to say which directory the account names belong to.
 
+`-corpus-rate` puts a ceiling on files a second, and it is about the first read rather than the refreshes.
+The server opens its listener before the corpus has been read and says on every screen that the answers are partial until it has, and the point of that is that the minutes in between are usable.
+A read going as fast as the disk allows is the one thing competing with those queries for the same disk, and a rate is the only lever, because the work cannot be made smaller: every file has to be read once.
+It is applied to the content read and not to the walk, so the count of how much there is to do still arrives immediately and the progress on screen still has both of its numbers.
+The default is zero, meaning no ceiling, which is the opposite of what the same number means for a bucket: a remote service that is asked for too much revokes the token, and a local disk refuses nobody.
+
 A bucket, listed every thirty seconds, scoped to one prefix:
 
 ```


### PR DESCRIPTION
Closes #168.

`TestTheServerAnswersBeforeTheCorpusIsReadAndSaysSo` hoped the read was still running rather than arranging it.

It started a server on two thousand small files and made four requests in order: `/healthz`, `/readyz`, a search, and `/api/v1/stats`.
The `/readyz` assertion said a read was in flight and the `/api/v1/stats` assertion said the same read was still being reported, so the window the read had to survive was one search request.
Two thousand paragraphs on a warm page cache is not much work, and on a fast runner it finished inside that window.

Making the tree bigger moves the odds without changing the shape, and it makes every run of the suite slower for the sake of a test that only needs the read to be unfinished at one instant.

## The pace

`-corpus-rate` is files a second, and zero is as fast as the disk allows.

In the connector it is `fssource.WithPace(func(context.Context) error)` rather than a number, because a token bucket, a semaphore shared with something else and a plain sleep are all one call from in there, and which of them a deployment wants is not the connector's business.
`cmd/genbad` fills it with a `limit.Limiter` at a burst of one, so the number is a pace and not a ceiling averaged over a window.
A burst is worth having against a service that counts requests per minute and does not care how they were spaced inside it, and it is worth nothing against a disk, where ten reads back to back is the spike the rate was set to avoid.

The error a pace returns stops the sync instead of skipping the file.
The only thing that makes a pace fail is the context being done, and a sync that carried on from there would spend a shutdown reading the rest of the tree.

## Why this is not only a test lever

The server opens its listener before the corpus has been read and says on every screen that the answers are partial until it has.
The point of that is that the minutes in between are usable.
A read going flat out is the one thing on the machine competing with those queries for the same disk, and a rate is the only lever that helps, because the work cannot be made smaller: every file has to be read once.

Zero meaning no ceiling is the opposite of what the same number means for a bucket.
That difference is deliberate and it is written down in both places: a remote service asked for too much revokes the token, so there the absence of a ceiling is the bug, and a local disk refuses nobody.

The pace sits in front of the content read and not in front of the walk.
The count that fills in how much there is to do is a metadata pass, and pacing that would put both numbers on the progress report behind the same wall and leave a first read that cannot say how far along it is.

## What the test says now

Two hundred files at four a second is fifty seconds of reading, against requests that are answered in milliseconds, so the read is still running when each of them lands however fast the machine is.
The assertions got stronger with the guarantee.
It now says the read has not got through the whole corpus, rather than the old check that it had not overrun the count, and it waits for the second number to arrive instead of asserting into the microseconds between the count and the sync.
The wait fails loudly and separately if the read finished while it was watching, because that is the failure the pace exists to rule out and reporting it as a missing count would send the next reader to the wrong place.

Shutting down does not wait for the fifty seconds, since the pace waits on the context.

Three cases on the option itself: one wait per file the read reads, no waits at all on a refresh over an unchanged tree, and a pace that gives up stops the sync with its own error after the documents that were already emitted.

## Checks

The two tests in the file pass twenty times in a row on an unloaded machine, where the flake was found, and the suite is faster than it was because the tree is a tenth of the size.
Removing the reporting the test exists to protect makes it fail: with `indexing.State` changed to report nothing, it fails on the readiness assertion.
Full `go test ./...` and `golangci-lint run ./...` are clean.
