### PR TITLE
Move the Atlassian document renderer out of the Jira adapter (#15)

### DIFF
--- a/arch_test.go
+++ b/arch_test.go
@@ -175,7 +175,14 @@ var allowed = map[string][]string{
 	// The one thing it has that the chat adapter does not is a rule on a single
 	// document rather than on the container, which is what an issue security
 	// level is, and that is still acl and threadsource rather than anything new.
-	"connector/jirasource": {"acl", "connector", "connector/limit", "connector/thread", "connector/threadsource", "doc"},
+	"connector/jirasource": {"acl", "connector", "connector/adf", "connector/limit", "connector/thread", "connector/threadsource", "doc"},
+	// adf imports nothing of ours. It turns one JSON tree into Markdown and it
+	// has never heard of a document, a connector or a permission, which is what
+	// lets two product adapters share it without either of them being able to
+	// bend it towards their own product. It is at this level rather than beside
+	// thread because the format belongs to the editor: it is the same tree in a
+	// ticket description, a page body and a comment on either.
+	"connector/adf": nil,
 	// recorded imports nothing of ours either. It is a round tripper over a
 	// directory of files, it deals in requests and responses, and it has never
 	// heard of a document or a connector. Keeping it that way is what lets it be

--- a/connector/adf/adf.go
+++ b/connector/adf/adf.go
@@ -1,14 +1,9 @@
-package jirasource
-
-import (
-	"encoding/json"
-	"strconv"
-	"strings"
-)
-
-// A Jira description is not text. It is a document tree, and turning it back
-// into something a person and an index can both read is most of what this file
-// does.
+// Package adf renders an Atlassian document as Markdown.
+//
+// A Jira description is not text. Neither is a Confluence page, a comment on
+// either of them, or anything else written in the editor those products share.
+// It is a document tree, and turning it back into something a person and an
+// index can both read is the whole of what this package does.
 //
 // Two ways of getting it wrong are worth naming, because both are common.
 //
@@ -25,6 +20,20 @@ import (
 // code blocks keep their fences and their language, lists stay lists and tables
 // stay tables. The index reads it as text and the interface renders it as what
 // it is.
+//
+// It is a package rather than a file inside one connector because the format
+// belongs to the editor rather than to the product. Every Atlassian connector
+// meets the same tree, and the second one to want it should get this and not a
+// second renderer that agrees with this one on the cases somebody thought to
+// test.
+package adf
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
 
 // node is one element of an Atlassian document.
 type node struct {
@@ -50,14 +59,16 @@ type mark struct {
 // be a truncated description rather than a crashed indexer.
 const maxDepth = 32
 
-// text renders an Atlassian document as Markdown.
+// Render turns an Atlassian document into Markdown.
 //
 // Anything that will not parse comes back empty rather than as an error. A
-// description this adapter cannot read is a ticket with a summary, a reporter,
-// a status and a comment thread, all of which are worth indexing, and refusing
-// the whole issue over the shape of one field would be losing more than it
-// saves.
-func text(raw json.RawMessage) string {
+// description this cannot read is a ticket with a summary, a reporter, a status
+// and a comment thread, all of which are worth indexing, and refusing the whole
+// issue over the shape of one field would be losing more than it saves.
+//
+// A plain string is accepted as well as a tree, because a site on the older API
+// and a field somebody set through a script both send one.
+func Render(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return ""
 	}
@@ -171,6 +182,10 @@ func block(b *strings.Builder, n node, depth int, prefix string) {
 	case "expand", "nestedExpand":
 		if title, ok := str(n.Attrs, "title"); ok && title != "" {
 			line(b, prefix, "**"+title+"**")
+			// With no blank line after it the title and the first line under it
+			// are one paragraph in Markdown, which is the opposite of what an
+			// expander is: a label and the thing it was hiding.
+			line(b, strings.TrimRight(prefix, " "), "")
 		}
 		blocks(b, children(n), depth+1, prefix)
 
@@ -391,6 +406,12 @@ func collapse(s string) string {
 func str(attrs map[string]any, name string) (string, bool) {
 	v, ok := attrs[name].(string)
 	return v, ok
+}
+
+// stampMillis renders a date node's timestamp, which arrives as milliseconds
+// since the epoch and is a date rather than an instant.
+func stampMillis(ms int64) string {
+	return time.UnixMilli(ms).UTC().Format("2006-01-02")
 }
 
 // number reads a numeric attribute. JSON numbers decode as float64, and a

--- a/connector/adf/adf_test.go
+++ b/connector/adf/adf_test.go
@@ -1,0 +1,358 @@
+package adf_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/connector/adf"
+)
+
+// doc wraps a run of nodes in the document node every Atlassian document has at
+// its root, so a case below is the part that is actually being tested.
+func document(content ...any) json.RawMessage {
+	raw, err := json.Marshal(map[string]any{"type": "doc", "version": 1, "content": content})
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+// text is a text node, with any marks on it.
+func text(s string, marks ...any) map[string]any {
+	n := map[string]any{"type": "text", "text": s}
+	if len(marks) > 0 {
+		n["marks"] = marks
+	}
+	return n
+}
+
+func mark(kind string, attrs map[string]any) map[string]any {
+	m := map[string]any{"type": kind}
+	if attrs != nil {
+		m["attrs"] = attrs
+	}
+	return m
+}
+
+func para(content ...any) map[string]any {
+	return map[string]any{"type": "paragraph", "content": content}
+}
+
+func item(content ...any) map[string]any {
+	return map[string]any{"type": "listItem", "content": content}
+}
+
+func cell(s string) map[string]any {
+	return map[string]any{"type": "tableCell", "content": []any{para(text(s))}}
+}
+
+func row(cells ...string) map[string]any {
+	out := make([]any, 0, len(cells))
+	for _, c := range cells {
+		out = append(out, cell(c))
+	}
+	return map[string]any{"type": "tableRow", "content": out}
+}
+
+// The renderer's job is that structure survives. Each case names the thing that
+// would be lost by the obvious wrong implementation, which is concatenating
+// every text node in the tree.
+func TestStructureSurvives(t *testing.T) {
+	cases := []struct {
+		name string
+		in   json.RawMessage
+		want string
+	}{
+		{
+			name: "a heading is a heading at the level it says",
+			in: document(map[string]any{
+				"type":    "heading",
+				"attrs":   map[string]any{"level": 3},
+				"content": []any{text("What we tried")},
+			}),
+			want: "### What we tried",
+		},
+		{
+			name: "a heading with no level is a heading anyway",
+			in: document(map[string]any{
+				"type":    "heading",
+				"content": []any{text("Summary")},
+			}),
+			want: "# Summary",
+		},
+		{
+			name: "a bulleted list keeps one line per item",
+			in: document(map[string]any{
+				"type":    "bulletList",
+				"content": []any{item(para(text("Replaced the bearing"))), item(para(text("Checked the alignment")))},
+			}),
+			want: "- Replaced the bearing\n- Checked the alignment",
+		},
+		{
+			name: "a numbered list counts from where it says it does",
+			in: document(map[string]any{
+				"type":    "orderedList",
+				"attrs":   map[string]any{"order": 4},
+				"content": []any{item(para(text("Drain it"))), item(para(text("Refill it")))},
+			}),
+			want: "4. Drain it\n5. Refill it",
+		},
+		{
+			name: "a code block keeps its fence and its language",
+			in: document(map[string]any{
+				"type":    "codeBlock",
+				"attrs":   map[string]any{"language": "go"},
+				"content": []any{text("panic: index out of range [3]")},
+			}),
+			want: "```go\npanic: index out of range [3]\n```",
+		},
+		{
+			name: "a code block with no language still has a fence",
+			in: document(map[string]any{
+				"type":    "codeBlock",
+				"content": []any{text("make build")},
+			}),
+			want: "```\nmake build\n```",
+		},
+		{
+			name: "a table is a table with a header row",
+			in: document(map[string]any{
+				"type":    "table",
+				"content": []any{row("Shift", "Temperature"), row("Morning", "62")},
+			}),
+			want: "| Shift | Temperature |\n| --- | --- |\n| Morning | 62 |",
+		},
+		{
+			name: "a quote is quoted on every line it covers",
+			in: document(map[string]any{
+				"type":    "blockquote",
+				"content": []any{para(text("It has always done that.")), para(text("Since the rebuild."))},
+			}),
+			want: "> It has always done that.\n>\n> Since the rebuild.",
+		},
+		{
+			name: "a panel is a quote, since the colour is all it added",
+			in: document(map[string]any{
+				"type":    "panel",
+				"attrs":   map[string]any{"panelType": "warning"},
+				"content": []any{para(text("Do not run this on a Friday."))},
+			}),
+			want: "> Do not run this on a Friday.",
+		},
+		{
+			name: "a task list keeps which ones are done",
+			in: document(map[string]any{
+				"type": "taskList",
+				"content": []any{
+					map[string]any{"type": "taskItem", "attrs": map[string]any{"state": "DONE"}, "content": []any{text("Order the part")}},
+					map[string]any{"type": "taskItem", "attrs": map[string]any{"state": "TODO"}, "content": []any{text("Fit the part")}},
+				},
+			}),
+			want: "- [x] Order the part\n- [ ] Fit the part",
+		},
+		{
+			name: "a rule is a rule",
+			in:   document(map[string]any{"type": "rule"}),
+			want: "---",
+		},
+		{
+			name: "an expander keeps its title and what was folded under it",
+			in: document(map[string]any{
+				"type":    "expand",
+				"attrs":   map[string]any{"title": "The long version"},
+				"content": []any{para(text("It started in March."))},
+			}),
+			want: "**The long version**\n\nIt started in March.",
+		},
+		{
+			name: "a list inside a list is indented under its bullet",
+			in: document(map[string]any{
+				"type": "bulletList",
+				"content": []any{item(
+					para(text("Check the pump")),
+					map[string]any{"type": "bulletList", "content": []any{item(para(text("Inlet")))}},
+				)},
+			}),
+			want: "- Check the pump\n\n  - Inlet",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := adf.Render(tt.in); got != tt.want {
+				t.Errorf("rendered\n%s\nwant\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+// The marks are the other half. A link is the one that earns its place: the
+// words and where they go are two different things, and somebody searching for
+// a runbook by name should find the ticket that linked to it.
+func TestFormattingSurvives(t *testing.T) {
+	cases := []struct {
+		name string
+		in   json.RawMessage
+		want string
+	}{
+		{
+			name: "code stays code",
+			in:   document(para(text("restart --hard", mark("code", nil)))),
+			want: "`restart --hard`",
+		},
+		{
+			name: "bold and italic and struck through",
+			in: document(para(
+				text("very", mark("strong", nil)),
+				text(" "),
+				text("quietly", mark("em", nil)),
+				text(" "),
+				text("wrong", mark("strike", nil)),
+			)),
+			want: "**very** *quietly* ~~wrong~~",
+		},
+		{
+			name: "a link keeps its words and its address",
+			in: document(para(
+				text("See "),
+				text("the runbook", mark("link", map[string]any{"href": "https://wiki.acme.com/runbook"})),
+			)),
+			want: "See [the runbook](https://wiki.acme.com/runbook)",
+		},
+		{
+			name: "a link whose words are already the address is written once",
+			in: document(para(
+				text("https://wiki.acme.com/runbook", mark("link", map[string]any{"href": "https://wiki.acme.com/runbook"})),
+			)),
+			want: "https://wiki.acme.com/runbook",
+		},
+		{
+			name: "a mention reads as the name it carries",
+			in: document(para(
+				text("Assigned to "),
+				map[string]any{"type": "mention", "attrs": map[string]any{"id": "5f3a", "text": "@ade"}},
+			)),
+			want: "Assigned to @ade",
+		},
+		{
+			name: "a mention with no name is better as an id than as nothing",
+			in: document(para(
+				text("Assigned to "),
+				map[string]any{"type": "mention", "attrs": map[string]any{"id": "5f3a"}},
+			)),
+			want: "Assigned to @5f3a",
+		},
+		{
+			name: "a date is a date rather than a number of milliseconds",
+			in: document(para(
+				text("Due "),
+				map[string]any{"type": "date", "attrs": map[string]any{"timestamp": "1755561600000"}},
+			)),
+			want: "Due 2025-08-19",
+		},
+		{
+			name: "a card is the address it points at",
+			in:   document(para(map[string]any{"type": "inlineCard", "attrs": map[string]any{"url": "https://acme.atlassian.net/browse/OPS-4"}})),
+			want: "https://acme.atlassian.net/browse/OPS-4",
+		},
+		{
+			name: "an attachment is named, since the bytes are not here",
+			in: document(map[string]any{
+				"type":    "mediaSingle",
+				"content": []any{map[string]any{"type": "media", "attrs": map[string]any{"alt": "gearbox.png", "id": "9c1"}}},
+			}),
+			want: "(attachment: gearbox.png)",
+		},
+		{
+			name: "a hard break is a break and not a space",
+			in:   document(para(text("Line one"), map[string]any{"type": "hardBreak"}, text("Line two"))),
+			want: "Line one\nLine two",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := adf.Render(tt.in); got != tt.want {
+				t.Errorf("rendered %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// What arrives is somebody else's JSON, and the rule throughout is that a
+// document this cannot read costs its text and not the whole item it was
+// attached to. A ticket with a description nothing could parse still has a
+// summary, a reporter, a status and a comment thread.
+func TestWhatCannotBeReadCostsOnlyItself(t *testing.T) {
+	cases := []struct {
+		name string
+		in   json.RawMessage
+		want string
+	}{
+		{"nothing at all", nil, ""},
+		{"an empty document", document(), ""},
+		{"a plain string, which the older API sends", json.RawMessage(`"  Just a sentence.  "`), "Just a sentence."},
+		{"something that is not JSON", json.RawMessage(`{oh no`), ""},
+		{"a number where a document should be", json.RawMessage(`42`), ""},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := adf.Render(tt.in); got != tt.want {
+				t.Errorf("rendered %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A node type nobody has heard of is still rendered. The format gains node
+// types, and a description written with next year's editor should be a ticket
+// with its text in the index rather than a ticket that mysteriously has none.
+func TestANodeTypeNobodyKnowsStillGivesUpItsText(t *testing.T) {
+	got := adf.Render(document(map[string]any{
+		"type":    "decisionList",
+		"content": []any{map[string]any{"type": "decisionItem", "content": []any{text("We are replacing it.")}}},
+	}))
+	if got != "We are replacing it." {
+		t.Errorf("rendered %q, want the text out of an unknown node", got)
+	}
+}
+
+// The input is a stranger's JSON and the walk is recursive, so a document that
+// nests itself further than anything legitimate is a truncated body rather than
+// a crashed indexer.
+func TestADocumentThatNestsForeverIsTruncatedRatherThanFatal(t *testing.T) {
+	deep := map[string]any{"type": "paragraph", "content": []any{text("the bottom")}}
+	for range 5000 {
+		deep = map[string]any{"type": "blockquote", "content": []any{deep}}
+	}
+
+	done := make(chan string, 1)
+	go func() { done <- adf.Render(document(deep)) }()
+	got := <-done
+
+	if strings.Contains(got, "the bottom") {
+		t.Error("a document nested five thousand deep was walked all the way down")
+	}
+}
+
+// Six blank lines in a row is not a paragraph break, it is the renderer showing
+// through. Nesting produces one on the way out of every level.
+func TestNestingDoesNotLeaveItsBlankLinesBehind(t *testing.T) {
+	got := adf.Render(document(map[string]any{
+		"type": "blockquote",
+		"content": []any{map[string]any{
+			"type":    "bulletList",
+			"content": []any{item(map[string]any{"type": "panel", "content": []any{para(text("Deep.")), para(text("Deeper."))}})},
+		}},
+	}))
+	if strings.Contains(got, "\n\n\n") {
+		t.Errorf("the rendering has a run of blank lines in it:\n%q", got)
+	}
+	for _, want := range []string{"Deep.", "Deeper."} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the rendering lost %q:\n%s", want, got)
+		}
+	}
+}

--- a/connector/jirasource/api.go
+++ b/connector/jirasource/api.go
@@ -301,12 +301,6 @@ func stamp(s string) time.Time {
 	return time.Time{}
 }
 
-// stampMillis renders a date node's timestamp, which arrives as milliseconds
-// since the epoch and is a date rather than an instant.
-func stampMillis(ms int64) string {
-	return time.UnixMilli(ms).UTC().Format("2006-01-02")
-}
-
 // jqlTime is the format JQL wants a time in.
 //
 // It has no seconds. JQL compares to the minute and rejects anything finer, so

--- a/connector/jirasource/service.go
+++ b/connector/jirasource/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/adf"
 	"github.com/tamnd/genba/connector/thread"
 	"github.com/tamnd/genba/connector/threadsource"
 	"github.com/tamnd/genba/doc"
@@ -155,7 +156,7 @@ func (s *Service) build(ctx context.Context, is issue) (threadsource.Thread, err
 			Author: person(c.Author, s.name),
 			At:     stamp(c.Created),
 			Edited: edited(c),
-			Text:   text(c.Body),
+			Text:   adf.Render(c.Body),
 		})
 	}
 
@@ -172,7 +173,7 @@ func (s *Service) build(ctx context.Context, is issue) (threadsource.Thread, err
 			// is who a search for their tickets means.
 			Author: person(reporterOf(is), s.name),
 			At:     stamp(is.Fields.Created),
-			Text:   text(is.Fields.Description),
+			Text:   adf.Render(is.Fields.Description),
 		},
 		Replies:    replies,
 		Revision:   is.Fields.Updated,

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -531,7 +531,8 @@ Obeying that header is `connector/limit`'s job and it is the same code every oth
 Every call is a GET for the same reason it is in the Slack adapter, that a request carrying a body is never retried, and the fields a search asks for are written down rather than left as everything, because everything on a site with three hundred custom fields is a page of results the size of a small database.
 
 The last part is the description, which is not text.
-It arrives as an Atlassian document tree, and there are two ways to get it wrong.
+It arrives as an Atlassian document tree, which is `connector/adf`'s job rather than the adapter's, because the format belongs to the editor and not to the product: the same tree is a ticket description, a page body and a comment on either.
+There are two ways to get it wrong.
 Concatenating every text node produces a wall with the heading run into the paragraph, and an index built on that cannot tell a phrase somebody wrote from a phrase made by two unrelated lines meeting.
 Throwing the structure away is worse, because a ticket's description is very often a stack trace, a snippet of configuration or a table of what was tried, and a search result that shows the reader a flattened version of the thing they were looking for has answered the query and failed the person.
 So it renders Markdown: headings stay headings, code blocks keep their fences and their language, lists stay lists and tables stay tables.


### PR DESCRIPTION
Groundwork for the last part of #15, which is the wiki connector.

A Confluence page body is the Atlassian document format, and so is a Jira description, and so is a comment on either.
The format belongs to the editor those products share rather than to any one product, so the renderer moves to `connector/adf` and the Jira adapter calls it.

The alternative is a second renderer, and a second renderer is not a copy for long.
It agrees with this one on the cases somebody thought to test and drifts everywhere else, which shows up later as a table that survives in a ticket and does not survive on the page that quoted it.

`connector/adf` imports nothing of ours.
It turns one JSON tree into Markdown and has never heard of a document, a connector or a permission, which is what lets two adapters share it without either of them being able to bend it towards its own product.
The layering map in `arch_test.go` says so.

`stampMillis` moved with it, because a date node's timestamp is part of the format and nothing else in the Jira adapter was calling it.

## The one behaviour change

The package has its own tests now, thirty odd cases over the structure, the marks, the things that will not parse and the node types nobody has heard of.
Before this they were reachable only through a whole crawl, which is how the expander stayed wrong: it wrote its title and the first line under it with no blank line between them, so Markdown read the label and the thing it was hiding as a single paragraph.

That is fixed here and it is the only behaviour change in the commit.
Everything else is a move.

## Checks

The Jira tests are untouched and pass, including the two that render a description end to end through the crawl.
`go test ./...` and the dependency direction test are clean.
