### PR TITLE
Keep a conversation's own access rule through a permission refresh

### DIFF
--- a/connector/connectortest/cases.go
+++ b/connector/connectortest/cases.go
@@ -354,6 +354,49 @@ func testPermissionChange(t *testing.T, f Fixture) {
 	}
 }
 
+// A document with a rule of its own keeps it when the rule above it changes.
+//
+// Access lives on the folder, the space or the project, and one document in
+// there having been taken out of that rule is not a corner case: it is what a
+// ticket's security level and a page's restriction are for, and it is the only
+// reason a connector is allowed to override a container at all. A permission
+// change that swept the container's new rule across everything inside it would
+// hand that document the rule it was deliberately excluded from.
+//
+// It is worth its own case because of when it happens. The refresh runs on a
+// schedule rather than because anybody edited anything, so this fails quietly,
+// on a source nobody touched, some hours after the connector was last looked at.
+func testPermissionChangeKeepsOverrides(t *testing.T, f Fixture) {
+	if f.Share == nil || f.Unresolvable == nil {
+		t.Skip("the fixture cannot both change who may read a container and give one document a rule of its own")
+	}
+	write(t, f, first, firstText)
+	write(t, f, second, secondText)
+	f.Unresolvable(t, second)
+
+	changes, cursor := syncFrom(t, f, connector.Cursor{})
+	was := find(changes, f.ID(second))
+	switch {
+	case was == nil:
+		t.Fatalf("a full sync emitted %v, and this case needs the document with a rule of its own in it", ids(changes))
+	case was.Document.Permissions.Mode != acl.ModeUnknown:
+		t.Fatalf("%s was given mode %v rather than being quarantined, so there is no override here to protect", f.ID(second), was.Document.Permissions.Mode)
+	}
+
+	f.Share(t, first)
+
+	changes, _ = syncFrom(t, f, cursor)
+	now := find(changes, f.ID(second))
+	if now == nil {
+		// Saying nothing about it is a correct answer. Its rule did not change,
+		// and the change to the container's rule is not its business.
+		return
+	}
+	if got := now.Document.Permissions.Mode; got != acl.ModeUnknown {
+		t.Errorf("%s had a rule of its own and the change to the rule above it replaced that with mode %v, which publishes the document somebody restricted", now.Document.ID, got)
+	}
+}
+
 // An enumeration and a sync have to agree on what is in the corpus. A sweep
 // built on a listing that says less than the sync does deletes documents that
 // are there, and one that says more refetches documents that are not.

--- a/connector/connectortest/connectortest.go
+++ b/connector/connectortest/connectortest.go
@@ -155,6 +155,7 @@ var cases = []testCase{
 	{"a document written after a sync is found by the next one", testNewDocument},
 	{"a deleted document stops being part of the source", testDeleted},
 	{"a permission change arrives without the content", testPermissionChange},
+	{"a permission change leaves a document's own rule alone", testPermissionChangeKeepsOverrides},
 	{"enumerate lists what a sync found", testEnumerate},
 	{"enumerate stops when the callback says so", testEnumerateEarlyStop},
 	{"fetch returns the document a sync would have", testFetch},

--- a/connector/jirasource/jirasource_test.go
+++ b/connector/jirasource/jirasource_test.go
@@ -584,6 +584,62 @@ func TestARemovedRoleMemberIsAppliedOnTheSchedule(t *testing.T) {
 	}
 }
 
+// An issue behind a security level is readable by that level and by nobody
+// else, whatever the project it sits in says. The scheduled reapplication above
+// is the one place that is easy to get wrong, because it does not read the
+// issues: it has the project's rule and a listing, and a listing that did not
+// report the security level would have it hand every restricted ticket on the
+// site the rule of the project it was restricted out of, once a day, without
+// anybody having done anything.
+func TestTheScheduleDoesNotWriteAProjectsRuleOverASecurityLevel(t *testing.T) {
+	s := newSite()
+	s.addLevel("10500", "Incident reports", "acc-lee")
+	open := s.file(home, "Gearbox noise", "The gearbox on line two is making a noise.")
+	hidden := s.file(home, "Line two incident", "What happened on line two.")
+	s.restrict(hidden, "10500")
+	src := newSource(t, s)
+
+	changes, cursor := run(t, src, connector.Cursor{})
+	was := find(changes, "jira:"+hidden)
+	if was == nil {
+		t.Fatalf("a first sync emitted %v", ids(changes))
+	}
+	if got := was.Document.Permissions.AllowUsers; len(got) != 1 || got[0].Value != "acc-lee" {
+		t.Fatalf("the first sync gave the restricted issue %v rather than the members of its security level", got)
+	}
+
+	// The project's rule is rewritten and the schedule comes round, which is the
+	// refresh with nothing in hand but the project.
+	s.project(home).grants = []grant{{"group", "engineering"}}
+	s.advance(time.Hour)
+
+	before := src.Counters()
+	changes, _ = run(t, src, cursor)
+
+	now := find(changes, "jira:"+hidden)
+	if now == nil {
+		t.Fatalf("the schedule emitted %v, want the restricted issue among them", ids(changes))
+	}
+	if got := now.Document.Permissions.AllowUsers; len(got) != 1 || got[0].Value != "acc-lee" {
+		t.Errorf("the schedule gave the restricted issue users %v and groups %v, which is the project's rule written over its security level",
+			got, now.Document.Permissions.AllowGroups)
+	}
+
+	// The unrestricted issue takes the project's new rule, because that is what
+	// the schedule is for.
+	if plain := find(changes, "jira:"+open); plain == nil {
+		t.Error("the issue with no security level was left out of the reapplication")
+	} else if got := plain.Document.Permissions.AllowGroups; len(got) != 1 || got[0].Value != "engineering" {
+		t.Errorf("the issue with no security level came back with groups %v rather than the project's new rule", got)
+	}
+
+	// And none of it read an issue, which is the whole reason the level is asked
+	// for on the listing rather than one issue at a time.
+	if spent := src.Counters().Since(before); spent.Fetches != 0 {
+		t.Errorf("the reapplication read %d issues, and the point of it is that it reads none", spent.Fetches)
+	}
+}
+
 // Nothing in JQL reports an issue that was deleted, so the sweep is the only
 // thing that ever takes one out of the index.
 func TestADeletedIssueIsOnlyFoundByTheSweep(t *testing.T) {
@@ -833,10 +889,11 @@ func TestOnlyTheFieldsThatEndUpInTheDocumentAreAskedFor(t *testing.T) {
 	if err := src.Enumerate(t.Context(), func(connector.Item) bool { return true }); err != nil {
 		t.Fatal(err)
 	}
-	// The sweep needs one field, and asking for the description of every issue
-	// in a site to work out which of them changed would be the expensive way to
-	// learn nothing.
-	if got := s.lastFields("/rest/api/3/search"); got != "updated" {
-		t.Errorf("the listing asked for the fields %q, want only the one the sweep compares", got)
+	// The sweep needs the updated time and the permission refresh needs the
+	// security level, and asking for the description of every issue in a site to
+	// work out which of them changed would be the expensive way to learn
+	// nothing.
+	if got := s.lastFields("/rest/api/3/search"); got != "updated,security" {
+		t.Errorf("the listing asked for the fields %q, want the version the sweep compares and the rule the refresh needs", got)
 	}
 }

--- a/connector/jirasource/service.go
+++ b/connector/jirasource/service.go
@@ -62,14 +62,31 @@ func (s *Service) Threads(ctx context.Context, c threadsource.Container, since t
 	})
 }
 
+// listFields is what a listing asks for, which is two fields rather than one.
+//
+// The updated time is the version the sweep compares. The security level is what
+// keeps a scheduled permission refresh from writing the project's rule over an
+// issue that was restricted out of the project, and it is asked for here because
+// here is the one place it can be had without reading anything: a refresh that
+// had to read an issue to find out whether it overrides its project is a
+// recrawl, which is what the refresh exists instead of.
+const listFields = "updated,security"
+
 // List reports every issue the project currently holds, with the version the
-// sweep compares.
+// sweep compares and the rule the issue has of its own.
 //
 // Nothing in JQL reports an issue that was deleted or moved to another project,
 // so this is the only thing that ever takes one out of the index.
-func (s *Service) List(ctx context.Context, c threadsource.Container, fn func(connector.Item) bool) error {
-	err := s.search(ctx, c, "project = "+quote(c.ID)+" ORDER BY key ASC", "updated", func(_ context.Context, is issue) error {
-		if !fn(connector.Item{ID: is.Key, Version: is.Fields.Updated}) {
+func (s *Service) List(ctx context.Context, c threadsource.Container, fn func(threadsource.Item) bool) error {
+	err := s.search(ctx, c, "project = "+quote(c.ID)+" ORDER BY key ASC", listFields, func(ctx context.Context, is issue) error {
+		item := threadsource.Item{Item: connector.Item{ID: is.Key, Version: is.Fields.Updated}}
+		if sec := is.Fields.Security; sec != nil && sec.ID != "" {
+			// The same cache the sync resolves levels through, so a project with
+			// a security scheme on thousands of issues costs one request per
+			// level rather than one per issue.
+			item.Access = s.levels.level(ctx, sec.ID, sec.Name)
+		}
+		if !fn(item) {
 			return errStop
 		}
 		return nil

--- a/connector/jirasource/testdata/site/0008-get-rest-api-3-search-fields-updated-security-jql-project-line-order-by-key-asc.json
+++ b/connector/jirasource/testdata/site/0008-get-rest-api-3-search-fields-updated-security-jql-project-line-order-by-key-asc.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "https://acme.atlassian.net/rest/api/3/search?fields=updated\u0026jql=project+%3D+%22LINE%22+ORDER+BY+key+ASC\u0026maxResults=100\u0026startAt=0",
+    "url": "https://acme.atlassian.net/rest/api/3/search?fields=updated%2Csecurity\u0026jql=project+%3D+%22LINE%22+ORDER+BY+key+ASC\u0026maxResults=100\u0026startAt=0",
     "headers": {
       "Accept": [
         "application/json"

--- a/connector/jirasource/testdata/site/0009-get-rest-api-3-search-fields-updated-security-jql-project-safety-order-by-key.json
+++ b/connector/jirasource/testdata/site/0009-get-rest-api-3-search-fields-updated-security-jql-project-safety-order-by-key.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "https://acme.atlassian.net/rest/api/3/search?fields=updated\u0026jql=project+%3D+%22SAFETY%22+ORDER+BY+key+ASC\u0026maxResults=100\u0026startAt=0",
+    "url": "https://acme.atlassian.net/rest/api/3/search?fields=updated%2Csecurity\u0026jql=project+%3D+%22SAFETY%22+ORDER+BY+key+ASC\u0026maxResults=100\u0026startAt=0",
     "headers": {
       "Accept": [
         "application/json"
@@ -20,6 +20,10 @@
         "issues": [
           {
             "fields": {
+              "security": {
+                "id": "10500",
+                "name": "Incident reports"
+              },
               "updated": "2026-03-02T09:10:00.000+0000"
             },
             "id": "iSAFETY-1",

--- a/connector/slacksource/service.go
+++ b/connector/slacksource/service.go
@@ -247,7 +247,11 @@ func (s *Service) oldest(since time.Time) time.Time {
 // This is the only thing that ever removes a deleted thread from the index, and
 // the version is what repairs a thread whose late reply the change feed could
 // not see.
-func (s *Service) List(ctx context.Context, c threadsource.Container, fn func(connector.Item) bool) error {
+//
+// No rule is reported alongside the ids, and that is not an omission. Slack has
+// nowhere to put one: a message is readable by whoever is in the channel it is
+// in, so there is nothing here that could override its container.
+func (s *Service) List(ctx context.Context, c threadsource.Container, fn func(threadsource.Item) bool) error {
 	parents, err := s.history(ctx, c.ID, time.Time{})
 	switch {
 	case err == nil:
@@ -260,10 +264,10 @@ func (s *Service) List(ctx context.Context, c threadsource.Container, fn func(co
 		return err
 	}
 	for _, m := range parents {
-		if !fn(connector.Item{
+		if !fn(threadsource.Item{Item: connector.Item{
 			ID:      s.threadID(c.ID, m.TS),
 			Version: version(m),
-		}) {
+		}}) {
 			return nil
 		}
 	}

--- a/connector/threadsource/fake_test.go
+++ b/connector/threadsource/fake_test.go
@@ -236,7 +236,7 @@ func (f *fake) Threads(ctx context.Context, c threadsource.Container, since time
 	return nil
 }
 
-func (f *fake) List(_ context.Context, c threadsource.Container, fn func(connector.Item) bool) error {
+func (f *fake) List(_ context.Context, c threadsource.Container, fn func(threadsource.Item) bool) error {
 	f.mu.Lock()
 	if f.failList != nil {
 		err := f.failList
@@ -244,13 +244,16 @@ func (f *fake) List(_ context.Context, c threadsource.Container, fn func(connect
 		return err
 	}
 	f.listed = append(f.listed, c.ID)
-	var items []connector.Item
+	var items []threadsource.Item
 	for _, cv := range f.rooms[c.ID].convs {
-		items = append(items, connector.Item{ID: cv.id, Version: cv.updated.UTC().Format(time.RFC3339Nano)})
+		items = append(items, threadsource.Item{
+			Item:   connector.Item{ID: cv.id, Version: cv.updated.UTC().Format(time.RFC3339Nano)},
+			Access: cv.access,
+		})
 	}
 	f.mu.Unlock()
 
-	slices.SortFunc(items, func(a, b connector.Item) int { return strings.Compare(a.ID, b.ID) })
+	slices.SortFunc(items, func(a, b threadsource.Item) int { return strings.Compare(a.ID, b.ID) })
 	for _, item := range items {
 		if !fn(item) {
 			return nil

--- a/connector/threadsource/threadsource.go
+++ b/connector/threadsource/threadsource.go
@@ -61,6 +61,12 @@
 // when the rule last changed turns that into a permission change carrying no
 // body, which is how a revocation reaches the index without the channel being
 // read again.
+//
+// The conversations that override their container are the exception, and they
+// are the reason a listing reports a rule as well as an id. A refresh that gave
+// them the container's new rule would be handing the rule of a project to the
+// ticket somebody put a security level on, on a schedule, without anybody having
+// done anything.
 package threadsource
 
 import (
@@ -129,6 +135,32 @@ type Thread struct {
 	Updated time.Time
 }
 
+// Item is one conversation as a listing reports it.
+//
+// It is a [connector.Item] with room for the conversation's own access rule
+// beside it, and that rule is there for one reason, which is the permission
+// refresh below.
+type Item struct {
+	connector.Item
+
+	// Access is the conversation's own rule, and the zero value means it
+	// inherits its container's.
+	//
+	// It is on the listing rather than being read one conversation at a time
+	// because reading them is the thing the refresh exists to avoid. A refresh
+	// that had to read a container to find out which conversations in it
+	// override the container is a recrawl, and a recrawl is what the whole
+	// mechanism is instead of.
+	//
+	// An adapter for a product where a conversation cannot carry its own rule
+	// leaves this alone and nothing changes. An adapter for one where it can has
+	// to fill it in, because the alternative is a scheduled refresh handing a
+	// restricted conversation the rule of the container it was restricted out
+	// of, which publishes exactly the documents somebody went out of their way
+	// to keep.
+	Access acl.Permissions
+}
+
 // Service is what a product's API has to be able to answer.
 //
 // An implementation talks to one product and is where every difference between
@@ -162,7 +194,7 @@ type Service interface {
 	// It has to be complete or it has to fail. A listing that quietly returns
 	// part of a channel reads, to the sweep above it, as a channel the rest of
 	// which was deleted.
-	List(ctx context.Context, c Container, fn func(connector.Item) bool) error
+	List(ctx context.Context, c Container, fn func(Item) bool) error
 
 	// Read returns one conversation by the source's own id, which is the
 	// document id with the source name taken off the front.
@@ -421,15 +453,24 @@ func (s *Source) wanted(th Thread, at time.Time, start syncPoint, since time.Tim
 // makes a channel private and nothing inside it is touched, so a sync that only
 // asked what changed would find nothing at all and the index would keep
 // answering with the old rule.
+//
+// A conversation that carries its own rule is the one thing the container's new
+// rule must not be written over. It was restricted out of the container, so
+// giving it the container's answer is not a refresh, it is a disclosure, and it
+// is one that happens on a schedule rather than because anybody did anything.
 func (s *Source) refresh(ctx context.Context, c Container, start syncPoint, emit func(context.Context, connector.Change) error) error {
-	perms := s.access(Thread{}, c)
+	inherited := s.access(Thread{}, c)
 	cursor := resume(start, c.ID, start.At)
 
 	var failed error
 	s.lists.Add(1)
-	err := s.service.List(ctx, c, func(item connector.Item) bool {
+	err := s.service.List(ctx, c, func(item Item) bool {
 		if item.ID == "" {
 			return true
+		}
+		perms := inherited
+		if resolved(item.Access) {
+			perms = item.Access
 		}
 		s.metadata.Add(1)
 		failed = emit(ctx, connector.Change{
@@ -462,12 +503,16 @@ func (s *Source) Enumerate(ctx context.Context, fn func(connector.Item) bool) er
 		}
 		stopped := false
 		s.lists.Add(1)
-		err := s.service.List(ctx, c, func(item connector.Item) bool {
+		err := s.service.List(ctx, c, func(item Item) bool {
 			if item.ID == "" {
 				return true
 			}
-			item.ID = s.id(item.ID)
-			if !fn(item) {
+			// The rule an adapter reported alongside the id is for the refresh
+			// and is nothing to a sweep, which compares versions and has no
+			// opinion about who may read what.
+			out := item.Item
+			out.ID = s.id(out.ID)
+			if !fn(out) {
 				stopped = true
 				return false
 			}

--- a/connector/threadsource/threadsource_test.go
+++ b/connector/threadsource/threadsource_test.go
@@ -222,6 +222,57 @@ func TestMakingAChannelPrivateReachesTheIndexWithoutReadingIt(t *testing.T) {
 	}
 }
 
+// A conversation that was taken out of its container's rule is the one thing a
+// permission change must not write over. It is a ticket with a security level on
+// it or a page with a restriction on it, which is to say it is exactly the
+// document somebody went out of their way to keep, and handing it the rule of
+// the container it was kept out of publishes it.
+//
+// The refresh is where this goes wrong, because the refresh does not read the
+// conversations. What it has is the container's new rule and a listing, so the
+// listing is what has to say which conversations carry a rule of their own.
+func TestAPermissionChangeLeavesAThreadsOwnRuleAlone(t *testing.T) {
+	f := newFake()
+	f.write("r1", "gearbox", "The gearbox on line two is making a noise.")
+	f.write("r1", "incident", "The line two incident report.")
+	// One thread is readable by one person whatever the channel says, which is
+	// the shape a security level has.
+	own := acl.Permissions{
+		Mode:       acl.ModeACL,
+		Source:     source,
+		AllowUsers: []acl.Ref{{Source: source, Value: "lee"}},
+	}
+	f.restrict("r1", "incident", own)
+	src := newSource(t, f)
+
+	changes, cursor := run(t, src, connector.Cursor{})
+	if got := find(changes, "chat:incident"); got == nil {
+		t.Fatalf("a first sync emitted %v", ids(changes))
+	} else if !slices.Equal(got.Document.Permissions.AllowUsers, own.AllowUsers) {
+		t.Fatalf("the first sync gave the restricted thread %v rather than its own rule", got.Document.Permissions.AllowUsers)
+	}
+
+	f.share("r1")
+	changes, _ = run(t, src, cursor)
+
+	got := find(changes, "chat:incident")
+	if got == nil {
+		t.Fatalf("making the channel private emitted %v, want the restricted thread in it", ids(changes))
+	}
+	if !slices.Equal(got.Document.Permissions.AllowUsers, own.AllowUsers) {
+		t.Errorf("the restricted thread came back allowing users %v and groups %v, which is the channel's rule written over the rule the thread was restricted with",
+			got.Document.Permissions.AllowUsers, got.Document.Permissions.AllowGroups)
+	}
+
+	// The thread that had no rule of its own still gets the channel's, because
+	// that is what the refresh is for.
+	if plain := find(changes, "chat:gearbox"); plain == nil {
+		t.Error("the thread with no rule of its own was left out of the permission change")
+	} else if len(plain.Document.Permissions.AllowGroups) != 1 {
+		t.Errorf("the thread with no rule of its own came back with groups %v rather than the channel's", plain.Document.Permissions.AllowGroups)
+	}
+}
+
 // A full sync already emits every conversation with the rule its container has
 // right now, so emitting a permission change alongside each one would be saying
 // the same thing twice and doubling the first sync of a workspace.
@@ -593,7 +644,7 @@ func (nameless) Threads(ctx context.Context, _ threadsource.Container, _ time.Ti
 	})
 }
 
-func (nameless) List(context.Context, threadsource.Container, func(connector.Item) bool) error {
+func (nameless) List(context.Context, threadsource.Container, func(threadsource.Item) bool) error {
 	return nil
 }
 

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -435,7 +435,7 @@ An adapter answers four questions.
 type Service interface {
 	Containers(ctx context.Context) ([]Container, error)
 	Threads(ctx context.Context, c Container, since time.Time, fn func(context.Context, Thread) error) error
-	List(ctx context.Context, c Container, fn func(connector.Item) bool) error
+	List(ctx context.Context, c Container, fn func(Item) bool) error
 	Read(ctx context.Context, id string) (Thread, error)
 }
 ```
@@ -454,6 +454,15 @@ Making a channel private touches no message in it, so a sync that only asked wha
 An adapter reports when the rule changed, and when that is newer than the cursor the source lists the container and emits a permission change per conversation in it, carrying the new rule and no body.
 That costs one write per thread rather than a refetch of the channel, and the run after it says nothing, because the rule has not changed again.
 A full sync refreshes nothing, because every conversation it emits already carries the rule its container has right now, and emitting a permission change alongside each one would double the first sync of a workspace to say the same thing twice.
+
+The conversations that override their container are why a listing reports a rule and not only an id and a version.
+A `threadsource.Item` is a `connector.Item` with room for the conversation's own rule beside it, and the refresh uses that rule where there is one and the container's where there is not.
+It has to come off the listing, because reading the conversations is the thing the refresh exists to avoid: a refresh that had to read a container to find out which conversations in it override the container is a recrawl, and a recrawl is what the whole mechanism is instead of.
+An adapter for a product where a conversation cannot carry its own rule leaves the field alone and nothing changes.
+An adapter for one where it can has to fill it in, and it costs one more field name on a request that is being made anyway.
+`connector/jirasource` asks for `updated,security` rather than `updated` for exactly this reason.
+The alternative is a scheduled refresh handing a restricted conversation the rule of the container it was restricted out of, which publishes the documents somebody went out of their way to keep, once per refresh interval, without anybody having done anything.
+The conformance suite in `connector/connectortest` holds every connector to it.
 
 The cursor is a time plus an edge set, and the edge set is what makes it correct.
 Two conversations that changed in the same instant is the case a bare timestamp gets wrong in both directions: asking for what changed strictly after the cursor loses the second one for ever, and asking for what changed at or after it emits both again on every run until something else happens.
@@ -511,6 +520,7 @@ Rounding the query down rather than up is deliberate: the direction that costs a
 The sweep is still there, and it is only for deletion.
 Nothing in JQL reports an issue that was deleted, or one that was moved to a project this token cannot see, and both of those leave the index holding a ticket that no longer exists.
 So `List` walks the project by key and reports the `updated` field as the version, which is the same string `Threads` puts in `Revision`, because a listing and a read that disagree on the version make every sweep refetch the whole project.
+It asks for the security level alongside it, so an issue that was restricted out of its project keeps that restriction when the project's rule is reapplied on the schedule.
 
 Permissions are where the work is.
 Browse comes from the project's permission scheme, which grants it to some mixture of groups, named accounts, project roles and, on a site with a service desk, everybody with a licence.


### PR DESCRIPTION
Closes #175.

A scheduled permission refresh was replacing a conversation's own access rule with its container's, which widens access to exactly the documents somebody restricted on purpose.

`threadsource.Thread.Access` exists so that a conversation can override the rule it would inherit from its container.
A Jira issue with a security level on it is the case it was built for: the issue is readable by that level's members and by nobody else, whatever the project says.
The sync gets this right.
The refresh did not.
When a container's `AccessAt` moved past the cursor, `refresh` listed the container and emitted a permissions only change for every item in it carrying `s.access(Thread{}, c)`, which is the container's rule with no thread in hand, so every conversation in the container got it, including the ones that were overriding it.

The sweep does not catch it either.
A permissions only change does not move the version the source reports, so the sweep sees a document whose version matches and leaves it alone.
The refresh interval defaults to a day, so on a site with issue security levels this happened once a day to every restricted ticket, and it stayed wrong until somebody edited the ticket.

## The fix

The refresh has to know which conversations carry their own rule, and it has to know without reading them, because reading them is the thing the refresh exists to avoid.
A refresh that had to read a container to find out which conversations in it override the container is a recrawl, and a recrawl is what the whole mechanism is instead of.

So the listing reports it.
`Service.List` now hands over a `threadsource.Item`, which is a `connector.Item` with the conversation's own rule beside it, and `refresh` emits that rule where there is one and the container's where there is not.

- `connector/slacksource` leaves the field alone, and that is not an omission. Slack has nowhere to put a rule on a message: a message is readable by whoever is in the channel it is in, so there is nothing there that could override its container.
- `connector/jirasource` asks for `updated,security` rather than `updated`, and resolves the level through the same cache the sync uses, so a project with a security scheme on thousands of issues costs one request per level rather than one per issue.
- `Enumerate` drops the rule on the way past. A sweep compares versions and has no opinion about who may read what.

## Tests

Three, and each of them fails on the code before this change.

`connector/connectortest` gets a case, so this is a property of a connector rather than of one adapter, and both adapters are held to it. Without the fix:

```
--- FAIL: TestConformance/a_permission_change_leaves_a_document's_own_rule_alone
    cases.go:396: chat:b.md had a rule of its own and the change to the rule above it
    replaced that with mode 1, which publishes the document somebody restricted
--- FAIL: TestConformance/a_permission_change_leaves_a_document's_own_rule_alone
    cases.go:396: jira:LINE-2 had a rule of its own and the change to the rule above it
    replaced that with mode 1, which publishes the document somebody restricted
```

`connector/threadsource` gets one for the mechanism, which also checks that a conversation with no rule of its own still takes the container's, since that is what the refresh is for.

`connector/jirasource` gets one for the real case, an issue behind a security level in a project whose scheme is then rewritten, and it asserts that the reapplication still reads no issues.

The recorded site under `connector/jirasource/testdata/site` was refreshed, since the listing asks for one more field than it used to.

## Docs

`docs/ingestion.md` says what a listing is required to report and why, in the section on the shared crawl and again in the Jira section.
