### PR TITLE
Index a Confluence site

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ func main() {
 | `connector/threadsource` | the crawl, cursor and permission refresh chat, ticket trackers and wikis share, [docs/ingestion.md](docs/ingestion.md) |
 | `connector/slacksource` | Slack, a thread at a time, with per method rate limits and a recorded workspace to test against |
 | `connector/jirasource` | Jira, an issue and its comments as one document, with security levels and a recorded site to test against |
+| `connector/confluencesource` | Confluence, a page and its comments as one document, with inherited page restrictions and both body formats |
 | `connector/limit` | the rate limit, backoff and circuit breaker every connector shares, as a round tripper |
 | `connector/recorded` | HTTP exchanges captured from a real service and replayed from a directory, so tests need no account |
 | `extract` | text and structure out of PDF, Word, PowerPoint, Excel, HTML and Markdown, [docs/extraction.md](docs/extraction.md) |
@@ -527,6 +528,14 @@ The sweep is still there and it is only for deletion, because nothing in JQL rep
 Permissions are the hard half instead: browse comes from the project's permission scheme, which grants it to some mixture of groups, named accounts and project roles, and a role is resolved to the people in it rather than left as the name of a thing.
 An issue security level replaces the project's answer rather than adding to it, which is the concrete case a conversation is allowed to override its container for, and a level this token cannot resolve quarantines the ticket instead of falling back to the project, because a security level is the one thing somebody set on purpose to keep other people out.
 A description is not text but a document tree, so it is rendered as Markdown rather than flattened, which keeps the stack trace in a code block and the table of readings a table, since a search result that shows somebody a flattened version of the thing they were looking for has answered the query and failed the person.
+
+`connector/confluencesource` is the third product on it and the one that shows the interface was worth writing, because a wiki turned out to be a container of conversations too and almost none of the crawl had to be written again.
+A space holds pages, a page holds the comments that correct it, and the page with its comments underneath it is one document, since a page saying the deploy runs at nine with a comment saying it moved to eleven is a page that answers with the wrong time on its own.
+CQL is a real change feed like JQL, but Confluence dates a comment and leaves the page alone, so the query asks for comments as well and resolves each one back to the page it is on.
+Permissions are decided twice: a space grants read to accounts, to groups or to anybody signed in, and a page restriction replaces that answer for the page it is on and for everything underneath it, so the ancestors have to be walked rather than assumed.
+A page carrying a restriction at two levels is quarantined instead of resolved, because Confluence means the intersection there and publishing the wider of the two would publish exactly the pages somebody restricted on purpose.
+The ancestor answers are cached for one crawl and thrown away at the start of the next, which is the difference between a saving and a revocation that never lands.
+Bodies come in two formats because the editor changed, so a page written in the old one is asked for a second time and its XHTML is rendered to Markdown, which matters because the old pages on any site worth indexing are the runbooks.
 
 What a connector is gets decided by `connector/connectortest` rather than by the interface.
 The interface says what compiles, and the suite says what works: that a full sync finds everything, that resuming from a cursor loses nothing that came after it, that a second sync of a source nothing changed in reads nothing, that a deleted document stops being part of the source one way or the other, and that every document says who may read it.

--- a/arch_test.go
+++ b/arch_test.go
@@ -176,6 +176,13 @@ var allowed = map[string][]string{
 	// document rather than on the container, which is what an issue security
 	// level is, and that is still acl and threadsource rather than anything new.
 	"connector/jirasource": {"acl", "connector", "connector/adf", "connector/limit", "connector/thread", "connector/threadsource", "doc"},
+	// confluencesource is the third adapter and the list is the same list again,
+	// which is the point of there being a list. A wiki has two things the other
+	// two do not, a body written in a markup of its own and a restriction on a
+	// single page that inherits down a tree, and neither of them is a dependency:
+	// the markup is rendered inside the package and the restriction is acl and
+	// threadsource like everything else.
+	"connector/confluencesource": {"acl", "connector", "connector/adf", "connector/limit", "connector/thread", "connector/threadsource", "doc"},
 	// adf imports nothing of ours. It turns one JSON tree into Markdown and it
 	// has never heard of a document, a connector or a permission, which is what
 	// lets two product adapters share it without either of them being able to

--- a/connector/confluencesource/api.go
+++ b/connector/confluencesource/api.go
@@ -1,0 +1,387 @@
+package confluencesource
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/connector/limit"
+)
+
+// limited builds the client every request goes out on.
+//
+// One bucket rather than the per method tiers a source with published rates
+// gets, because Atlassian publishes none: it bills by the cost of what was asked
+// for, and the way a client is told it has spent too much is a 429 with a
+// Retry-After on it. Obeying that header is [limit]'s job and it is the same
+// code every other connector here uses.
+func limited(email, token string, l limit.Limits) *http.Client {
+	if l.Burst == 0 {
+		// A page of search results followed immediately by the comments on
+		// something that was on it is a burst, and spacing those out would be
+		// slower for no benefit to anybody. A sustained burst is what a rate
+		// limit is for and that is still limited.
+		l.Burst = 10
+	}
+	return &http.Client{Transport: &basic{
+		auth: "Basic " + base64.StdEncoding.EncodeToString([]byte(email+":"+token)),
+		base: limit.NewTransport(l),
+	}}
+}
+
+// basic puts the credentials on every request.
+//
+// Confluence Cloud authenticates an API token with basic authentication over the
+// account's email address, which is a header rather than a query parameter, and
+// that is the half of it worth being deliberate about: a token in a query string
+// ends up in a server log, in a recording and in a bug report.
+type basic struct {
+	auth string
+	base http.RoundTripper
+}
+
+var _ http.RoundTripper = (*basic)(nil)
+
+func (b *basic) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("Authorization") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", b.auth)
+	}
+	return b.base.RoundTrip(req)
+}
+
+// Stats reports what this site has cost in requests, retries and waiting. A
+// client the caller supplied has no limiter in it and reports nothing.
+func (s *Service) Stats() limit.TransportStats {
+	b, ok := s.http.Transport.(*basic)
+	if !ok {
+		return limit.TransportStats{}
+	}
+	t, ok := b.base.(*limit.Transport)
+	if !ok {
+		return limit.TransportStats{}
+	}
+	return t.Stats()
+}
+
+// failure is the shape Confluence refuses in.
+type failure struct {
+	Message string `json:"message"`
+	Reason  string `json:"reason"`
+}
+
+// why is the sentence out of a refusal, which is the part worth keeping.
+func (f failure) why() string {
+	switch {
+	case f.Message != "" && f.Reason != "":
+		return f.Reason + ": " + f.Message
+	case f.Message != "":
+		return f.Message
+	default:
+		return f.Reason
+	}
+}
+
+// call asks the site one question and decodes the answer into out.
+//
+// Every call is a GET. The search endpoint has a POST form that takes a longer
+// query, and it is not worth it: a request carrying a body cannot be replayed by
+// a transport that has already handed the body away, so [limit] will not retry
+// one, and a 429 is the normal way this API asks a crawler to slow down rather
+// than an unusual event.
+func (s *Service) call(ctx context.Context, path string, form url.Values, out any) error {
+	u := s.wiki + path
+	if len(form) > 0 {
+		u += "?" + form.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("confluencesource: building the %s request: %w", path, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("confluencesource: %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Eight megabytes is far more than any of these endpoints returns at the page
+	// sizes this adapter asks for, and a bound is what keeps a site that has
+	// started answering with something else from being a memory problem. It is
+	// larger than the ticket adapter's because a page of wiki results carries
+	// fifty documents and a page of tickets carries a hundred summaries.
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return fmt.Errorf("confluencesource: reading the %s response: %w", path, err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		e := &Error{Path: path, Status: resp.StatusCode}
+		var f failure
+		if json.Unmarshal(raw, &f) == nil {
+			e.Message = f.why()
+		}
+		return e
+	}
+
+	if out != nil {
+		if err := json.Unmarshal(raw, out); err != nil {
+			return fmt.Errorf("confluencesource: decoding the %s response: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// links is what every Confluence listing carries alongside its results.
+type links struct {
+	Next string `json:"next"`
+}
+
+// pages walks a listing and hands each page of results to fn, which reports
+// whether to carry on.
+//
+// The end of a listing is the absence of a next link rather than a count, and
+// what is done with that link is the one thing worth explaining. It is not
+// followed. Only its query is taken, and the next request goes to the same path
+// with it, because the link itself is not something to rely on: version one
+// writes it relative to a context path, version two writes it relative to the
+// host, and a site behind a proxy writes it relative to whatever the proxy
+// thinks it is. The query is the only part of it that is information, and it is
+// the same query whether the endpoint pages by cursor or by offset.
+func pages[T any](ctx context.Context, s *Service, path string, form url.Values, fn func([]T) bool) error {
+	q := url.Values{}
+	for k, v := range form {
+		q[k] = append([]string(nil), v...)
+	}
+	q.Set("limit", strconv.Itoa(s.page))
+
+	// A listing that hands back a query it has already been asked is a listing
+	// that would be walked for ever, which is a thing a proxy rewriting links
+	// can produce out of a site that is behaving.
+	seen := map[string]bool{q.Encode(): true}
+
+	for {
+		var page struct {
+			Results []T   `json:"results"`
+			Links   links `json:"_links"`
+		}
+		if err := s.call(ctx, path, q, &page); err != nil {
+			return err
+		}
+		if len(page.Results) == 0 {
+			return nil
+		}
+		if !fn(page.Results) {
+			return nil
+		}
+		if page.Links.Next == "" {
+			return nil
+		}
+
+		next, err := url.Parse(page.Links.Next)
+		if err != nil {
+			return fmt.Errorf("confluencesource: the %s listing carried an unreadable next link: %w", path, err)
+		}
+		q = next.Query()
+		if len(q) == 0 || seen[q.Encode()] {
+			return nil
+		}
+		seen[q.Encode()] = true
+	}
+}
+
+// person is somebody, as Confluence reports one.
+//
+// The account id is the identifier and the display name is a label. They are not
+// the same thing and the difference matters: a display name is chosen by its
+// owner, two people may have the same one, and a permission rule written against
+// one would be a permission rule anybody could grant themselves.
+type person struct {
+	AccountID   string `json:"accountId"`
+	DisplayName string `json:"displayName"`
+	PublicName  string `json:"publicName"`
+	Email       string `json:"email"`
+}
+
+// group is a group, which is named rather than numbered because a name is what
+// an identity provider hands back when it is asked what somebody is in.
+type group struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
+
+// subjects is who a permission or a restriction names.
+//
+// The size is carried alongside the results because these lists are paged like
+// everything else here, and a restriction the site sent half of is a restriction
+// we do not know. The two numbers being different is the only way to find that
+// out, since a short page of results and the end of the list look the same.
+type subjects struct {
+	User struct {
+		Results []person `json:"results"`
+		Size    int      `json:"size"`
+	} `json:"user"`
+	Group struct {
+		Results []group `json:"results"`
+		Size    int     `json:"size"`
+	} `json:"group"`
+}
+
+// space is one entry of the space listing, with its permissions expanded.
+type space struct {
+	ID          int               `json:"id"`
+	Key         string            `json:"key"`
+	Name        string            `json:"name"`
+	Type        string            `json:"type"`
+	Status      string            `json:"status"`
+	Permissions []spacePermission `json:"permissions"`
+}
+
+// spacePermission is one grant on a space.
+type spacePermission struct {
+	Subjects  subjects `json:"subjects"`
+	Operation struct {
+		Operation  string `json:"operation"`
+		TargetType string `json:"targetType"`
+	} `json:"operation"`
+
+	// AnonymousAccess is a space that is readable without signing in, and
+	// UnlicensedAccess is one readable by everybody a service desk lets in.
+	// Neither is an access control list of nobody, which is what an adapter
+	// ignoring them would produce.
+	AnonymousAccess  bool `json:"anonymousAccess"`
+	UnlicensedAccess bool `json:"unlicensedAccess"`
+}
+
+// representation is a body in one of the formats Confluence keeps.
+type representation struct {
+	Value          string `json:"value"`
+	Representation string `json:"representation"`
+}
+
+// restriction is who may do one thing to one page.
+type restriction struct {
+	Operation    string   `json:"operation"`
+	Restrictions subjects `json:"restrictions"`
+}
+
+// content is a page or a comment, which are the same type to this API and are
+// told apart by the type field.
+type content struct {
+	ID     string `json:"id"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Title  string `json:"title"`
+
+	Space *struct {
+		ID   int    `json:"id"`
+		Key  string `json:"key"`
+		Name string `json:"name"`
+	} `json:"space"`
+
+	Body struct {
+		// ADF is the Atlassian document format, and it arrives as a string
+		// holding JSON rather than as JSON, which is the one surprise in this
+		// whole response.
+		ADF     *representation `json:"atlas_doc_format"`
+		Storage *representation `json:"storage"`
+	} `json:"body"`
+
+	History *struct {
+		CreatedBy   *person `json:"createdBy"`
+		CreatedDate string  `json:"createdDate"`
+	} `json:"history"`
+
+	Version *struct {
+		By     *person `json:"by"`
+		When   string  `json:"when"`
+		Number int     `json:"number"`
+	} `json:"version"`
+
+	// Container is what a comment is on, which is the only reason this field is
+	// asked for: a comment is a sentence in a page rather than a document, and
+	// the page it is a sentence in is what gets indexed.
+	Container *struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	} `json:"container"`
+
+	// Ancestors are the pages above this one, outermost first, and they are here
+	// because a read restriction on any of them restricts this one.
+	Ancestors []struct {
+		ID string `json:"id"`
+	} `json:"ancestors"`
+
+	Restrictions *struct {
+		Read *restriction `json:"read"`
+	} `json:"restrictions"`
+
+	Metadata *struct {
+		Labels *struct {
+			Results []struct {
+				Name string `json:"name"`
+			} `json:"results"`
+		} `json:"labels"`
+	} `json:"metadata"`
+
+	Children *struct {
+		Comment *struct {
+			Results []content `json:"results"`
+			Links   links     `json:"_links"`
+		} `json:"comment"`
+	} `json:"children"`
+
+	Links struct {
+		WebUI string `json:"webui"`
+	} `json:"_links"`
+}
+
+// stamp turns a Confluence timestamp into a time.
+//
+// The API writes them as ISO 8601 with milliseconds and an offset with a colon
+// in it, which is RFC 3339. The layout without the colon is tried as well,
+// because that is what the ticket half of the same product sends and a site
+// behind something that rewrites them should not be a crawl that thinks every
+// page changed at the zero time.
+func stamp(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999-0700",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// cqlTime is the format CQL wants a time in.
+//
+// It has no seconds. CQL compares to the minute and rejects anything finer, so
+// the time is rounded down rather than truncated to the minute and rounded up,
+// because the direction that costs a re-read of a few pages is the one that does
+// not lose them.
+func cqlTime(t time.Time) string {
+	return t.UTC().Truncate(time.Minute).Format("2006/01/02 15:04")
+}
+
+// quote puts a value into a CQL query.
+//
+// A space key is configurable, one of them will one day be a CQL keyword, and a
+// query that broke on the day somebody made a space called ORDER is not a thing
+// to debug twice.
+func quote(v string) string {
+	return `"` + strings.ReplaceAll(v, `"`, `\"`) + `"`
+}

--- a/connector/confluencesource/confluencesource.go
+++ b/connector/confluencesource/confluencesource.go
@@ -1,0 +1,298 @@
+// Package confluencesource indexes a Confluence site.
+//
+// It is an adapter and nothing more. The crawl, the cursor, the resume, the
+// reconciliation sweep and the permission refresh are all in [threadsource],
+// and what is here is the four questions that package asks, answered against
+// the Confluence Cloud REST API: list the spaces and say who may read each one,
+// walk the pages in a space that changed since a time, list the page ids a
+// space holds, and read one page by its id.
+//
+// # A page and its comments are one document
+//
+// A wiki page is a title, a body and the comments underneath it, and the
+// comments are where the correction usually is. The page says the deploy runs
+// at nine and the third comment says it moved to eleven eighteen months ago, so
+// a page indexed without them is a page that answers with the wrong time.
+//
+// So a page is fetched with its comments, assembled by
+// [thread.Conversation.Document] the same way a ticket and a chat thread are,
+// and indexed as a single result that ranks as a whole.
+//
+// # Permissions
+//
+// Confluence decides who may read a page in two places, and both of them are
+// here.
+//
+// The space is the first. A space's read permission is granted to accounts and
+// to groups, and it may be granted to anonymous users, which is a space that is
+// open rather than a space with an empty rule. What comes out of resolving it
+// is a list of accounts and a list of groups, which is an access control list. A
+// space nobody can resolve a rule for is quarantined rather than guessed at.
+//
+// A page restriction is the second, and it is the reason [threadsource] lets a
+// conversation override its container at all. A page with a read restriction on
+// it is readable by the people named in the restriction and by nobody else,
+// whatever the space says.
+//
+// Restrictions inherit, and that is the part worth being careful about. A page
+// with no restriction of its own under a parent that has one is restricted, so
+// the ancestors are consulted as well, and a chain carrying a restriction at
+// more than one level is quarantined rather than resolved. Confluence means the
+// intersection of the two there, and an intersection of a list of accounts with
+// a list of groups is not something that can be worked out from outside the
+// identity provider. Publishing the wider of the two would publish exactly the
+// pages somebody went out of their way to restrict.
+//
+// # What incremental means here
+//
+// Confluence has a real change feed and it is CQL. A page carries a version, an
+// edit moves it, a comment on the page does not, and CQL will both filter and
+// order by the time of the last change. So a sync asks for the pages in a space
+// modified at or after the cursor, oldest first, and that is the whole of it.
+//
+// The wrinkle is the one the ticket adapter has: CQL compares times to the
+// minute and rejects anything finer, so the query asks for the minute the cursor
+// is in and what arrived from the first half of it is dropped after the fact.
+// Rounding down rather than up is deliberate, because the direction that costs a
+// re-read of a few pages is the one that does not lose them.
+//
+// A comment moves nothing in the listing, which is a real gap and not one this
+// adapter can close from outside: Confluence dates the comment and not the page
+// it is on. The sweep is what catches it, because the version a page reports is
+// derived from the page and its comments together, so a page that was answered
+// and not edited still reports a version the index does not have.
+//
+// What the sweep is also for is deletion. Nothing in CQL reports a page that was
+// deleted, archived or moved to a space this token cannot see, and all three
+// leave the index holding a page that is no longer there.
+//
+// # Which API version
+//
+// Everything here is version one of the REST API rather than version two, and
+// that is a decision rather than an oversight. The two endpoints this connector
+// cannot do without, the read permissions on a space and the read restrictions
+// on a page, are version one endpoints, and version two neither replaces them
+// nor reports the group names that an access control list has to be written in.
+// Using both would mean two paging models, two shapes for the same page body and
+// two sets of field names for the same page, which is the sort of seam that ends
+// up with a permission read one way in one path and another way in the other.
+//
+// # Rate limits
+//
+// Confluence Cloud does not publish a request rate. It bills by the cost of what
+// was asked for, and the way a client is told it has spent too much is a 429
+// with a Retry-After on it. So there is one bucket, it is set to something a
+// shared site will tolerate, and the header is what actually governs. All of
+// that is [limit] doing the work, and it is the same code every other connector
+// in this repository uses.
+package confluencesource
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/connector/limit"
+	"github.com/tamnd/genba/connector/threadsource"
+)
+
+// DefaultName is the source name a document's id is prefixed with when the
+// caller does not choose one.
+const DefaultName = "confluence"
+
+// DefaultPageSize is how many items are asked for per page.
+//
+// Half what the ticket adapter asks for, because what comes back is different.
+// A page of search results from a tracker carries a hundred summaries and a page
+// of results from a wiki carries fifty documents, since a wiki page's body is
+// the document rather than a line describing one.
+const DefaultPageSize = 50
+
+// DefaultRate is how many requests a second the adapter allows itself.
+//
+// There is no published number to match. Confluence Cloud bills by cost and
+// answers with a Retry-After when the bill is too high, so this is a floor that
+// keeps a crawl from being the reason somebody else's integration starts seeing
+// 429s, and the header is what governs when it is not enough.
+const DefaultRate = 5
+
+// Service answers [threadsource.Service] against a Confluence site.
+type Service struct {
+	http       *http.Client
+	base       string
+	wiki       string
+	email      string
+	token      string
+	name       string
+	page       int
+	aclRefresh time.Duration
+	now        func() time.Time
+	restricted *restrictions
+	skipped    func(id string, reason error)
+}
+
+var _ threadsource.Service = (*Service)(nil)
+
+// Option configures a [Service].
+type Option func(*Service)
+
+// WithName sets the source name, which is what every document id from this site
+// is prefixed with. A deployment indexing two sites needs two names, because the
+// ids from them would otherwise collide.
+func WithName(name string) Option {
+	return func(s *Service) { s.name = name }
+}
+
+// WithHTTPClient replaces the client entirely, rate limiting included.
+//
+// A caller who passes one is taking on the limits themselves, which is right for
+// a test replaying a recording and wrong for anything talking to Confluence.
+func WithHTTPClient(c *http.Client) Option {
+	return func(s *Service) { s.http = c }
+}
+
+// WithLimits changes what the site is allowed to cost. Zero rate selects
+// [DefaultRate].
+func WithLimits(l limit.Limits) Option {
+	return func(s *Service) {
+		if l.Rate <= 0 {
+			l.Rate = DefaultRate
+		}
+		s.http = limited(s.email, s.token, l)
+	}
+}
+
+// WithPageSize sets how many items are asked for per page. Zero selects
+// [DefaultPageSize].
+func WithPageSize(n int) Option {
+	return func(s *Service) { s.page = n }
+}
+
+// WithSkipped is told about a space or a page that could not be indexed, with
+// the reason.
+//
+// The two worth having it for are a space whose permissions this token may not
+// read and a page whose restrictions could not be worked out. Both are
+// quarantined, and an index quietly missing what nobody could read looks exactly
+// like an index that is complete.
+func WithSkipped(f func(id string, reason error)) Option {
+	return func(s *Service) { s.skipped = f }
+}
+
+// WithClock replaces the clock the permission refresh schedule is measured
+// against, which is what a test needs to make a day pass without waiting one.
+func WithClock(now func() time.Time) Option {
+	return func(s *Service) { s.now = now }
+}
+
+// NewService builds the adapter on its own, which is what a caller wanting to
+// wrap it or test it against a recording needs.
+//
+// The site is the address of a Confluence Cloud instance, with or without the
+// /wiki on the end, because both are what people have in front of them: /wiki is
+// where the product lives and the bare host is what the browser bar says on the
+// way in. The credentials are an account's email address and an API token, which
+// is what Atlassian's basic authentication expects rather than a password.
+func NewService(site, email, token string, opts ...Option) (*Service, error) {
+	switch {
+	case site == "":
+		return nil, errors.New("confluencesource: a site URL is required")
+	case email == "":
+		return nil, errors.New("confluencesource: an account email is required")
+	case token == "":
+		return nil, errors.New("confluencesource: an API token is required")
+	}
+
+	base := strings.TrimSuffix(strings.TrimSuffix(site, "/"), "/wiki")
+	s := &Service{
+		base:  base,
+		wiki:  base + "/wiki",
+		email: email,
+		token: token,
+		name:  DefaultName,
+		page:  DefaultPageSize,
+		now:   time.Now,
+	}
+	s.http = limited(email, token, limit.Limits{Rate: DefaultRate})
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.name == "" {
+		return nil, errors.New("confluencesource: the source name cannot be empty")
+	}
+	if s.page < 1 {
+		s.page = DefaultPageSize
+	}
+	if s.now == nil {
+		s.now = time.Now
+	}
+	s.restricted = newRestrictions(s)
+	return s, nil
+}
+
+// New builds a connector over a Confluence site, ready to be handed to the
+// ingestion pipeline.
+func New(site, email, token string, opts ...Option) (*threadsource.Source, error) {
+	svc, err := NewService(site, email, token, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var wrapped []threadsource.Option
+	if svc.skipped != nil {
+		wrapped = append(wrapped, threadsource.WithSkipped(svc.skipped))
+	}
+	return threadsource.New(svc, svc.name, wrapped...)
+}
+
+// Name is the source name documents from this site are filed under.
+func (s *Service) Name() string { return s.name }
+
+// skip reports something that could not be indexed, if anybody asked to hear
+// about it.
+func (s *Service) skip(id string, reason error) {
+	if s.skipped != nil {
+		s.skipped(id, reason)
+	}
+}
+
+// Error is what Confluence says when it refuses.
+//
+// The status is what a caller matches on. The message is kept because a 400 from
+// CQL is a syntax error with the offending clause in it, and a crawl that threw
+// that away would report "bad request" for a thing the site was willing to
+// explain.
+type Error struct {
+	Path    string
+	Status  int
+	Message string
+}
+
+func (e *Error) Error() string {
+	if e.Message == "" {
+		return fmt.Sprintf("confluence: %s: %d", e.Path, e.Status)
+	}
+	return fmt.Sprintf("confluence: %s: %d: %s", e.Path, e.Status, e.Message)
+}
+
+// refused reports whether an error is Confluence saying no with this particular
+// status, which is how a caller tells "you may not read that space" from "the
+// network went away".
+func refused(err error, status int) bool {
+	var ce *Error
+	return errors.As(err, &ce) && ce.Status == status
+}
+
+// missing reports whether an error is Confluence saying the thing is not there.
+//
+// All three statuses mean it for our purposes. A 404 is a page that was deleted
+// or archived, a 403 on a single read is a page that moved somewhere this token
+// cannot follow, and a 401 on one page of a site the rest of which is answering
+// is the same thing again. From the index's point of view they are one event: it
+// is not ours to hold any more.
+func missing(err error) bool {
+	return refused(err, http.StatusNotFound) ||
+		refused(err, http.StatusForbidden) ||
+		refused(err, http.StatusUnauthorized)
+}

--- a/connector/confluencesource/confluencesource_test.go
+++ b/connector/confluencesource/confluencesource_test.go
@@ -1,0 +1,801 @@
+package confluencesource_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/confluencesource"
+	"github.com/tamnd/genba/connector/connectortest"
+	"github.com/tamnd/genba/connector/limit"
+	"github.com/tamnd/genba/connector/threadsource"
+	"github.com/tamnd/genba/doc"
+)
+
+// The account the crawl runs as, which is a service account rather than a
+// person. It is deliberately not one of the accounts in the fake, because the
+// recording is checked for the crawling credential and a check that matched a
+// display email on a page would pass for the wrong reason.
+const (
+	email = "search-crawler@acme.com"
+	token = "a-real-looking-api-token"
+)
+
+// quick is a rate limit that does not slow a test down while still being the
+// real limiter, retries, backoff, circuit breaker and all.
+var quick = limit.Limits{Rate: 10000, Burst: 50, MinBackoff: time.Millisecond, MaxBackoff: 5 * time.Millisecond}
+
+func newSource(t *testing.T, s *site, opts ...confluencesource.Option) *threadsource.Source {
+	t.Helper()
+	all := append([]confluencesource.Option{
+		confluencesource.WithLimits(quick),
+		confluencesource.WithClock(s.now),
+		// An hour rather than a day, so that a test that wants to be on the far
+		// side of a refresh interval can move the clock rather than wait a day.
+		confluencesource.WithACLRefresh(time.Hour),
+	}, opts...)
+	src, err := confluencesource.New(s.server(t)+"/wiki", email, token, all...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+	return src
+}
+
+func run(t *testing.T, src *threadsource.Source, from connector.Cursor) ([]connector.Change, connector.Cursor) {
+	t.Helper()
+	var got []connector.Change
+	next, err := src.Sync(t.Context(), from, func(_ context.Context, ch connector.Change) error {
+		got = append(got, ch)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	return got, next
+}
+
+func ids(changes []connector.Change) []string {
+	out := make([]string, 0, len(changes))
+	for _, ch := range changes {
+		out = append(out, ch.Document.ID)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func find(changes []connector.Change, id string) *connector.Change {
+	for i := range changes {
+		if changes[i].Document.ID == id {
+			return &changes[i]
+		}
+	}
+	return nil
+}
+
+// quarantined reports whether a document was indexed with nobody able to read
+// it, which is what a connector that could not work out an access control list
+// is required to produce rather than a guess.
+func quarantined(p acl.Permissions) bool { return p.Mode == acl.ModeUnknown }
+
+func values(refs []acl.Ref) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, r.Value)
+	}
+	return out
+}
+
+func enumerate(t *testing.T, src *threadsource.Source) []string {
+	t.Helper()
+	var out []string
+	if err := src.Enumerate(t.Context(), func(item connector.Item) bool {
+		out = append(out, item.ID)
+		return true
+	}); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// The conformance suite is what decides whether this is a connector, and
+// everything else in this file is about the parts that are specific to
+// Confluence.
+func TestConformance(t *testing.T) {
+	connectortest.Run(t, func(t *testing.T) connectortest.Fixture {
+		s := newSite()
+		src := newSource(t, s)
+		return connectortest.Fixture{
+			Connector: src,
+			ID:        func(name string) string { return "confluence:" + s.idOf(name) },
+			Write:     func(_ *testing.T, name, body string) { s.write(name, body) },
+			Remove:    func(_ *testing.T, name string) { s.remove(s.idOf(name)) },
+			Share: func(_ *testing.T, _ string) {
+				// A space's rule changes and not one page in it is touched, which
+				// is the case the schedule exists for. Nothing in Confluence
+				// reports the edit, so the clock is what carries it.
+				a := s.space(home)
+				a.groups = []string{"operations"}
+				a.users = nil
+				s.advance(time.Hour)
+			},
+			// A read restriction the site sends only part of is the concrete case
+			// of an access control list beyond working out, and a page
+			// restriction is the reason this connector can override a container's
+			// rule at all.
+			Unresolvable: func(_ *testing.T, name string) { s.truncate(s.idOf(name)) },
+		}
+	})
+}
+
+// A page and the argument underneath it are one document. The page says the
+// deploy runs at nine and the third comment says it moved to eleven, and a page
+// indexed without them answers with the wrong time.
+func TestAPageAndItsCommentsAreOneDocument(t *testing.T) {
+	s := newSite()
+	id := s.create(home, "Deploy", "The deploy runs at nine.")
+	s.comment(id, "acc-sam", "It moved to eleven in March.")
+	s.comment(id, "acc-lee", "Confirmed, eleven.")
+	s.create(home, "Rollback", "Roll back with the previous tag.")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	// Two documents and not four. A comment is a sentence in a page rather than
+	// a document, and the page is what gets indexed. The page arrives more than
+	// once because each comment on it is a change to be walked past, which costs
+	// the index an overwrite with the same bytes and is what moves the cursor.
+	if got := distinct(ids(changes)); len(got) != 2 {
+		t.Fatalf("a space with two pages and two comments produced %d documents: %v", len(got), got)
+	}
+
+	ch := find(changes, "confluence:"+id)
+	if ch == nil {
+		t.Fatalf("the page with the comments on it was not emitted: %v", ids(changes))
+	}
+	for _, want := range []string{"runs at nine", "moved to eleven", "Confirmed, eleven"} {
+		if !strings.Contains(ch.Document.Body, want) {
+			t.Errorf("the document does not say %q:\n%s", want, ch.Document.Body)
+		}
+	}
+	if ch.Document.Kind != doc.KindPage {
+		t.Errorf("a wiki page was indexed as %v", ch.Document.Kind)
+	}
+	if ch.Document.Title != "Deploy" {
+		t.Errorf("the document is titled %q rather than after its page", ch.Document.Title)
+	}
+}
+
+// Confluence dates a comment and leaves the page it is on alone, so a page
+// answered and never edited again is a page a query about pages reports as
+// unchanged for ever. Asking about comments as well is the whole of the fix, and
+// what comes back is still the page.
+func TestACommentBringsBackThePageItIsOn(t *testing.T) {
+	s := newSite()
+	id := s.create(home, "Deploy", "The deploy runs at nine.")
+	src := newSource(t, s)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	s.comment(id, "acc-sam", "It moved to eleven in March.")
+
+	changes, _ := run(t, src, cursor)
+	if got := distinct(ids(changes)); len(got) != 1 {
+		t.Fatalf("a comment on an unedited page produced %d documents: %v", len(got), got)
+	}
+	ch := changes[0]
+	if ch.Document.ID != "confluence:"+id {
+		t.Errorf("a comment came back as %s rather than as the page it is on", ch.Document.ID)
+	}
+	if !strings.Contains(ch.Document.Body, "moved to eleven") {
+		t.Errorf("the page came back without the comment that brought it back:\n%s", ch.Document.Body)
+	}
+}
+
+// A page edited and then commented on inside one sync window is one page, and
+// reading it twice is a request nobody needed.
+func TestAPageEditedAndCommentedOnIsReadOnce(t *testing.T) {
+	s := newSite()
+	id := s.create(home, "Deploy", "The deploy runs at nine.")
+	src := newSource(t, s)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	s.write("Deploy", "The deploy runs at eleven.")
+	s.comment(id, "acc-sam", "Fixed the time above.")
+	s.resetCounts()
+
+	changes, _ := run(t, src, cursor)
+	if len(changes) < 1 {
+		t.Fatal("a page that was edited and commented on came back as nothing")
+	}
+	for _, ch := range changes {
+		if ch.Document.ID != "confluence:"+id {
+			t.Errorf("something other than the page came back: %s", ch.Document.ID)
+		}
+	}
+	if got := s.counted("/rest/api/content/" + id); got != 0 {
+		t.Errorf("the page was read %d times by id, and the search that found it already carried it", got)
+	}
+}
+
+// The body of a page written before the editor changed is the storage format,
+// and there are a great many of those on any site old enough to be worth
+// searching. A connector that could not read them would index a wiki as the
+// pages somebody has touched since the migration.
+func TestAPageWrittenInTheOldEditorIsStillAPage(t *testing.T) {
+	s := newSite()
+	id := s.create(home, "Runbook", "placeholder")
+	s.legacy(id, `<h2>Restart</h2><p>Run <code>make deploy</code> and wait.</p>`)
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	ch := find(changes, "confluence:"+id)
+	if ch == nil {
+		t.Fatalf("a page with a storage format body was not emitted: %v", ids(changes))
+	}
+	for _, want := range []string{"## Restart", "`make deploy`"} {
+		if !strings.Contains(ch.Document.Body, want) {
+			t.Errorf("the rendered body does not have %q in it:\n%s", want, ch.Document.Body)
+		}
+	}
+}
+
+// The storage format is not asked for on the crawl, because asking means the
+// body of every page on a migrated site arriving twice. It is asked for one page
+// at a time, only for the pages that came back with nothing.
+func TestTheOldBodyIsAskedForOnlyForThePagesThatNeedIt(t *testing.T) {
+	s := newSite()
+	old := s.create(home, "Runbook", "placeholder")
+	s.legacy(old, `<p>Run make deploy.</p>`)
+	s.create(home, "Deploy", "The deploy runs at nine.")
+	s.create(home, "Rollback", "Roll back with the previous tag.")
+	src := newSource(t, s)
+
+	run(t, src, connector.Cursor{})
+
+	if got := s.counted("/rest/api/content/" + old); got != 1 {
+		t.Errorf("the page with no Atlassian document was read %d extra times, want one", got)
+	}
+	if strings.Contains(s.lastExpand("/rest/api/content/search"), "body.storage") {
+		t.Errorf("the crawl asked for both body formats: %s", s.lastExpand("/rest/api/content/search"))
+	}
+	for _, name := range []string{"Deploy", "Rollback"} {
+		if got := s.counted("/rest/api/content/" + s.idOf(name)); got != 0 {
+			t.Errorf("the page %s came back whole and was read %d more times", name, got)
+		}
+	}
+}
+
+// A space's read permission is a list of accounts and a list of groups, and that
+// is an access control list. Everything in the space inherits it.
+func TestASpacesPermissionsBecomeTheRuleOnItsPages(t *testing.T) {
+	s := newSite()
+	s.create(home, "Deploy", "The deploy runs at nine.")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 1 {
+		t.Fatalf("a space with one page produced %v", ids(changes))
+	}
+
+	p := changes[0].Document.Permissions
+	if p.Mode != acl.ModeACL {
+		t.Fatalf("a page in a space with a read permission on it was given mode %v", p.Mode)
+	}
+	if got, want := values(p.AllowUsers), []string{"acc-mei"}; !slices.Equal(got, want) {
+		t.Errorf("the rule allows the accounts %v, want %v", got, want)
+	}
+	if got, want := values(p.AllowGroups), []string{"engineering"}; !slices.Equal(got, want) {
+		t.Errorf("the rule allows the groups %v, want %v", got, want)
+	}
+}
+
+// A space readable without signing in is a space that is open, not a space with
+// an empty rule. An adapter that ignored the flag would hide the space instead
+// of describing it.
+func TestASpaceAnybodyCanReadIsOpenRatherThanEmpty(t *testing.T) {
+	s := newSite()
+	a := s.space(home)
+	a.open = true
+	s.create(home, "Deploy", "The deploy runs at nine.")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 1 {
+		t.Fatalf("a space with one page produced %v", ids(changes))
+	}
+	if got := changes[0].Document.Permissions.Mode; got != acl.ModePublicToTenant {
+		t.Errorf("a page in an anonymously readable space was given mode %v", got)
+	}
+}
+
+// A space whose permissions this token was not shown looks exactly like a space
+// with no permissions on it, and the two are the same answer here: we do not
+// know, so say so rather than publishing it.
+func TestASpaceWhosePermissionsAreNotReadableIsQuarantined(t *testing.T) {
+	s := newSite()
+	s.space(home).dark = true
+	s.create(home, "Deploy", "The deploy runs at nine.")
+
+	var skipped []string
+	src := newSource(t, s, confluencesource.WithSkipped(func(id string, _ error) {
+		skipped = append(skipped, id)
+	}))
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if len(changes) != 1 {
+		t.Fatalf("a space nobody could read the permissions of produced %v", ids(changes))
+	}
+	if !quarantined(changes[0].Document.Permissions) {
+		t.Errorf("a page in a space with unreadable permissions was given mode %v", changes[0].Document.Permissions.Mode)
+	}
+	if !slices.Contains(skipped, home) {
+		t.Errorf("nothing was reported about the space nobody could resolve, and an index quietly missing what nobody could read looks like an index that is complete, got %v", skipped)
+	}
+}
+
+// A read restriction on a page replaces the space's rule rather than adding to
+// it, which is what a restriction is and is the reason this connector overrides
+// its container at all.
+func TestAPageRestrictionReplacesTheSpacesRule(t *testing.T) {
+	s := newSite()
+	open := s.create(home, "Deploy", "The deploy runs at nine.")
+	shut := s.create(home, "Incident", "The pump failed on Tuesday.")
+	s.restrict(shut, []string{"acc-lee"}, nil)
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+
+	was := find(changes, "confluence:"+open)
+	if was == nil {
+		t.Fatalf("the unrestricted page was not emitted: %v", ids(changes))
+	}
+	if got, want := values(was.Document.Permissions.AllowGroups), []string{"engineering"}; !slices.Equal(got, want) {
+		t.Errorf("the unrestricted page allows the groups %v, want the space's %v", got, want)
+	}
+
+	now := find(changes, "confluence:"+shut)
+	if now == nil {
+		t.Fatalf("the restricted page was not emitted: %v", ids(changes))
+	}
+	if got, want := values(now.Document.Permissions.AllowUsers), []string{"acc-lee"}; !slices.Equal(got, want) {
+		t.Errorf("the restricted page allows the accounts %v, want %v", got, want)
+	}
+	if got := values(now.Document.Permissions.AllowGroups); len(got) != 0 {
+		t.Errorf("the restricted page kept the space's groups %v, and a restriction replaces the space rather than adding to it", got)
+	}
+}
+
+// Restrictions inherit. A page with no restriction of its own under a parent
+// that has one is restricted, and an adapter that only looked at the page would
+// publish every page in a restricted section.
+func TestARestrictionOnAParentReachesThePagesUnderIt(t *testing.T) {
+	s := newSite()
+	top := s.create(home, "Incidents", "Everything that went wrong.")
+	mid := s.create(home, "March", "What went wrong in March.")
+	low := s.create(home, "Pump failure", "The pump failed on Tuesday.")
+	s.nest(mid, top)
+	s.nest(low, mid)
+	s.restrict(top, []string{"acc-lee"}, nil)
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	for _, id := range []string{top, mid, low} {
+		ch := find(changes, "confluence:"+id)
+		if ch == nil {
+			t.Fatalf("a page in the restricted tree was not emitted: %v", ids(changes))
+		}
+		if got, want := values(ch.Document.Permissions.AllowUsers), []string{"acc-lee"}; !slices.Equal(got, want) {
+			t.Errorf("%s allows the accounts %v, want the restriction above it, %v", ch.Document.ID, got, want)
+		}
+	}
+}
+
+// A chain carrying a restriction at more than one level is quarantined rather
+// than resolved. Confluence means the intersection of the two, and an
+// intersection of a list of accounts with a list of groups is not something that
+// can be worked out from outside the identity provider, so publishing the wider
+// of the two would publish exactly the page somebody restricted.
+func TestAPageRestrictedAtTwoLevelsIsQuarantined(t *testing.T) {
+	s := newSite()
+	top := s.create(home, "Incidents", "Everything that went wrong.")
+	low := s.create(home, "Pump failure", "The pump failed on Tuesday.")
+	s.nest(low, top)
+	s.restrict(top, nil, []string{"operations"})
+	s.restrict(low, []string{"acc-lee"}, nil)
+
+	var skipped []string
+	src := newSource(t, s, confluencesource.WithSkipped(func(id string, _ error) {
+		skipped = append(skipped, id)
+	}))
+
+	changes, _ := run(t, src, connector.Cursor{})
+	ch := find(changes, "confluence:"+low)
+	if ch == nil {
+		t.Fatalf("the doubly restricted page was not emitted: %v", ids(changes))
+	}
+	if !quarantined(ch.Document.Permissions) {
+		t.Errorf("a page restricted at two levels was given mode %v and the accounts %v, which is one of the two rules rather than the intersection Confluence means",
+			ch.Document.Permissions.Mode, values(ch.Document.Permissions.AllowUsers))
+	}
+	if !slices.Contains(skipped, low) {
+		t.Errorf("nothing was reported about the page nobody could resolve, got %v", skipped)
+	}
+}
+
+// The tree above a page is walked once per crawl and not once per page. A
+// restricted section is a section where the same handful of ancestors is asked
+// about for every page in it, and on a real space that is most of the crawl.
+func TestTheTreeAboveAPageIsAskedAboutOnce(t *testing.T) {
+	s := newSite()
+	top := s.create(home, "Incidents", "Everything that went wrong.")
+	s.restrict(top, []string{"acc-lee"}, nil)
+	for _, title := range []string{"March", "April", "May", "June"} {
+		s.nest(s.create(home, title, "What went wrong in "+title+"."), top)
+	}
+	src := newSource(t, s)
+	s.resetCounts()
+
+	run(t, src, connector.Cursor{})
+
+	// The pages carry their own restriction on the listing, so the only thing
+	// that has to be asked about is the page above them.
+	if got := s.counted("/rest/api/content/" + top + "/restriction/byOperation/read"); got > 1 {
+		t.Errorf("the page above four restricted pages was asked about %d times, want at most one", got)
+	}
+}
+
+// A restriction the site sent half of is a restriction we do not know. Indexing
+// a page against the half that arrived is how somebody named on the second page
+// of the list stops being able to find their own document.
+func TestARestrictionSentInPartIsQuarantined(t *testing.T) {
+	s := newSite()
+	id := s.create(home, "Incident", "The pump failed on Tuesday.")
+	s.truncate(id)
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	ch := find(changes, "confluence:"+id)
+	if ch == nil {
+		t.Fatalf("the page with the half sent restriction was not emitted: %v", ids(changes))
+	}
+	if !quarantined(ch.Document.Permissions) {
+		t.Errorf("a page whose restriction arrived in part was indexed against the part that arrived, mode %v accounts %v",
+			ch.Document.Permissions.Mode, values(ch.Document.Permissions.AllowUsers))
+	}
+}
+
+// A restriction the site declines to answer for is the one thing that must not
+// fall back to the space, because the space is the wider rule and falling back
+// to it publishes the page.
+//
+// The page above is the one that has to be asked about here, and an incremental
+// sync is where that happens: the parent did not change, so it is not in the
+// sync, and the only way to know whether it restricts the child that did change
+// is to ask.
+func TestARestrictionThatCannotBeReadDoesNotFallBackToTheSpace(t *testing.T) {
+	s := newSite()
+	top := s.create(home, "Incidents", "Everything that went wrong.")
+	low := s.create(home, "Pump failure", "The pump failed on Tuesday.")
+	s.nest(low, top)
+	src := newSource(t, s)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	s.write("Pump failure", "The pump failed on Tuesday afternoon.")
+	s.refuse("/rest/api/content/"+top+"/restriction/byOperation/read", http.StatusInternalServerError)
+
+	changes, _ := run(t, src, cursor)
+	ch := find(changes, "confluence:"+low)
+	if ch == nil {
+		t.Fatalf("the page under the unreadable restriction was not emitted: %v", ids(changes))
+	}
+	if !quarantined(ch.Document.Permissions) {
+		t.Errorf("a page whose parent's restriction could not be read was given the space's rule, mode %v groups %v",
+			ch.Document.Permissions.Mode, values(ch.Document.Permissions.AllowGroups))
+	}
+}
+
+// A restriction put on a page above is a revocation, and nothing in Confluence
+// reports it: the parent's version does not move and neither does the child's.
+// What reaches the index is the next time the child is crawled for any reason,
+// and it has to reach it then rather than when the process next restarts.
+func TestARestrictionAddedAboveReachesTheNextCrawl(t *testing.T) {
+	s := newSite()
+	top := s.create(home, "Incidents", "Everything that went wrong.")
+	low := s.create(home, "Pump failure", "The pump failed on Tuesday.")
+	s.nest(low, top)
+	src := newSource(t, s)
+
+	changes, cursor := run(t, src, connector.Cursor{})
+	if ch := find(changes, "confluence:"+low); ch == nil || ch.Document.Permissions.Mode != acl.ModeACL {
+		t.Fatalf("the unrestricted page did not start out with the space's rule: %v", ids(changes))
+	}
+
+	s.restrict(top, []string{"acc-lee"}, nil)
+	s.write("Pump failure", "The pump failed on Tuesday afternoon.")
+
+	changes, _ = run(t, src, cursor)
+	ch := find(changes, "confluence:"+low)
+	if ch == nil {
+		t.Fatalf("the edited page was not emitted: %v", ids(changes))
+	}
+	if got, want := values(ch.Document.Permissions.AllowUsers), []string{"acc-lee"}; !slices.Equal(got, want) {
+		t.Errorf("the page allows the accounts %v after its parent was restricted, want %v", got, want)
+	}
+}
+
+// The listing is what the sweep compares against, and it carries a page's own
+// rule so that a scheduled permission refresh does not write the space's rule
+// over a page that was restricted out of the space. Getting that without reading
+// the pages is the whole point: a refresh that had to read a space would be a
+// recrawl, which is what the refresh exists instead of.
+func TestTheListingCarriesARuleAndNoBodies(t *testing.T) {
+	s := newSite()
+	shut := s.create(home, "Incident", "The pump failed on Tuesday.")
+	s.restrict(shut, []string{"acc-lee"}, nil)
+	s.create(home, "Deploy", "The deploy runs at nine.")
+	src := newSource(t, s)
+
+	run(t, src, connector.Cursor{})
+	s.resetCounts()
+
+	if got, want := enumerate(t, src), []string{"confluence:" + s.idOf("Deploy"), "confluence:" + shut}; !slices.Equal(got, sorted(want)) {
+		t.Errorf("the enumeration lists %v, want %v", got, sorted(want))
+	}
+	if got := s.lastExpand("/rest/api/content/search"); strings.Contains(got, "body") {
+		t.Errorf("the listing asked for page bodies: %s", got)
+	}
+	if got := s.counted("/rest/api/content/" + shut); got != 0 {
+		t.Errorf("the listing read %d page bodies, and a sweep that reads the space is a recrawl", got)
+	}
+}
+
+// The schedule reapplies a space's rule to the pages in it because nothing in
+// Confluence reports that a space's permissions changed. What it must not do is
+// reapply it over a page that has a rule of its own.
+func TestTheScheduleDoesNotWriteASpacesRuleOverARestriction(t *testing.T) {
+	s := newSite()
+	open := s.create(home, "Deploy", "The deploy runs at nine.")
+	shut := s.create(home, "Incident", "The pump failed on Tuesday.")
+	s.restrict(shut, []string{"acc-lee"}, nil)
+	src := newSource(t, s)
+
+	_, cursor := run(t, src, connector.Cursor{})
+
+	a := s.space(home)
+	a.groups = []string{"operations"}
+	a.users = nil
+	s.advance(time.Hour)
+
+	before := src.Counters()
+	changes, _ := run(t, src, cursor)
+	spent := src.Counters().Since(before)
+
+	was := find(changes, "confluence:"+open)
+	if was == nil {
+		t.Fatalf("the page that inherits the space did not get the new rule: %v", ids(changes))
+	}
+	if got, want := values(was.Document.Permissions.AllowGroups), []string{"operations"}; !slices.Equal(got, want) {
+		t.Errorf("the unrestricted page allows the groups %v after the space changed, want %v", got, want)
+	}
+
+	now := find(changes, "confluence:"+shut)
+	if now == nil {
+		t.Fatal("the restricted page was not touched by the refresh, which is a correct answer, so there is nothing more to check here")
+	}
+	if got, want := values(now.Document.Permissions.AllowUsers), []string{"acc-lee"}; !slices.Equal(got, want) {
+		t.Errorf("the restricted page allows the accounts %v after the space changed, want its own rule, %v", got, want)
+	}
+	if spent.Fetches != 0 {
+		t.Errorf("reapplying a space's rule read %d pages, and a refresh that reads the pages is a recrawl", spent.Fetches)
+	}
+}
+
+// A page put away is a page the wiki is not offering anybody. Nothing in CQL
+// reports that it happened, which is what the sweep is for.
+func TestAnArchivedPageStopsBeingPartOfTheSpace(t *testing.T) {
+	s := newSite()
+	id := s.create(home, "Deploy", "The deploy runs at nine.")
+	s.create(home, "Rollback", "Roll back with the previous tag.")
+	src := newSource(t, s)
+
+	run(t, src, connector.Cursor{})
+	s.archive(id)
+
+	if got := enumerate(t, src); slices.Contains(got, "confluence:"+id) {
+		t.Errorf("an archived page is still listed as part of the space: %v", got)
+	}
+}
+
+// An archived page is still readable by its id, and a fetch that handed one back
+// would put it in the index by the back door.
+func TestFetchingAnArchivedPageReportsItGone(t *testing.T) {
+	s := newSite()
+	id := s.create(home, "Deploy", "The deploy runs at nine.")
+	src := newSource(t, s)
+
+	run(t, src, connector.Cursor{})
+	s.archive(id)
+
+	if _, err := src.Fetch(t.Context(), "confluence:"+id); !errors.Is(err, connector.ErrGone) {
+		t.Errorf("fetching an archived page returned %v, want it reported as gone", err)
+	}
+}
+
+// The last editor is a property rather than a second author, because "pages Sam
+// wrote" and "pages Sam last touched" are different questions and an index that
+// conflated them would answer neither.
+func TestAPageKeepsItsAuthorAndItsLastEditorApart(t *testing.T) {
+	s := newSite()
+	id := s.create(home, "Deploy", "The deploy runs at nine.")
+	s.find(id).author = "acc-mei"
+	s.label(id, "runbook", "deploy")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	ch := find(changes, "confluence:"+id)
+	if ch == nil {
+		t.Fatalf("the page was not emitted: %v", ids(changes))
+	}
+	if got := ch.Document.Author.Subject; got != "acc-mei" {
+		t.Errorf("the document is attributed to %q rather than to the account that wrote the page", got)
+	}
+	if got := ch.Document.Properties["editor"]; got != "Mei Tanaka" {
+		t.Errorf("the last editor is recorded as %q", got)
+	}
+	if got := ch.Document.Properties["labels"]; got != "deploy, runbook" && got != "runbook, deploy" {
+		t.Errorf("the labels are recorded as %q", got)
+	}
+}
+
+// CQL compares times to the minute and the cursor does not, so a query asked for
+// the minute the cursor is in comes back with what changed in the first half of
+// it as well. Rounding down is deliberate, because the direction that costs a
+// re-read is the one that does not lose pages.
+func TestASecondSyncOfAnUnchangedSpaceEmitsNothing(t *testing.T) {
+	s := newSite()
+	s.create(home, "Deploy", "The deploy runs at nine.")
+	s.create(home, "Rollback", "Roll back with the previous tag.")
+	src := newSource(t, s)
+
+	_, cursor := run(t, src, connector.Cursor{})
+	changes, _ := run(t, src, cursor)
+	if len(changes) != 0 {
+		t.Errorf("a second sync of an unchanged space emitted %v", ids(changes))
+	}
+}
+
+// The address of a page has its title in it and a title is a thing people
+// change, so where a person goes to read it is what the site says rather than
+// something built here.
+func TestThePageAddressIsTheOneTheSiteGave(t *testing.T) {
+	s := newSite()
+	id := s.create(home, "Deploy", "The deploy runs at nine.")
+	src := newSource(t, s)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	ch := find(changes, "confluence:"+id)
+	if ch == nil {
+		t.Fatalf("the page was not emitted: %v", ids(changes))
+	}
+	if !strings.HasSuffix(ch.Document.URL, "/wiki/spaces/"+home+"/pages/"+id+"/Deploy") {
+		t.Errorf("the page address is %q, which is not what the site said it was", ch.Document.URL)
+	}
+}
+
+// A site address is what somebody has in front of them, and that is either the
+// bare host or the host with /wiki on it. Both have to work, because getting it
+// wrong means every request 404s and the error says nothing about why.
+func TestEitherFormOfTheSiteAddressWorks(t *testing.T) {
+	for _, suffix := range []string{"", "/wiki", "/wiki/", "/"} {
+		t.Run("site"+suffix, func(t *testing.T) {
+			s := newSite()
+			id := s.create(home, "Deploy", "The deploy runs at nine.")
+
+			src, err := confluencesource.New(s.server(t)+suffix, email, token,
+				confluencesource.WithLimits(quick), confluencesource.WithClock(s.now))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = src.Close() })
+
+			changes, _ := run(t, src, connector.Cursor{})
+			if find(changes, "confluence:"+id) == nil {
+				t.Errorf("a site address ending %q found %v", suffix, ids(changes))
+			}
+		})
+	}
+}
+
+// The credentials go in a header and never in a query string, because a token in
+// a query string ends up in a server log, in a recording and in a bug report.
+func TestTheTokenNeverGoesInAQueryString(t *testing.T) {
+	s := newSite()
+	s.create(home, "Deploy", "The deploy runs at nine.")
+
+	var asked []string
+	seen := &recorder{next: http.DefaultTransport, saw: func(u string) { asked = append(asked, u) }}
+	src, err := confluencesource.New(s.server(t), email, token,
+		confluencesource.WithHTTPClient(&http.Client{Transport: seen}),
+		confluencesource.WithClock(s.now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+
+	// The client here has no credentials on it, so the site refuses, which is
+	// itself the check that the header is the only place they were ever going.
+	_, _ = src.Sync(t.Context(), connector.Cursor{}, func(context.Context, connector.Change) error { return nil })
+
+	if len(asked) == 0 {
+		t.Fatal("no requests were made")
+	}
+	for _, u := range asked {
+		if strings.Contains(u, token) || strings.Contains(u, email) {
+			t.Errorf("a request carried the credentials in its address: %s", u)
+		}
+	}
+}
+
+type recorder struct {
+	next http.RoundTripper
+	saw  func(string)
+}
+
+func (r *recorder) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.saw(req.URL.String())
+	return r.next.RoundTrip(req)
+}
+
+// Confluence asks a crawler to wait with a 429 and a Retry-After, and obeying
+// that is the limiter's job rather than this adapter's. What is checked here is
+// that the adapter is on the limiter at all.
+func TestASiteAskingForAPauseIsWaitedFor(t *testing.T) {
+	s := newSite()
+	id := s.create(home, "Deploy", "The deploy runs at nine.")
+	src := newSource(t, s)
+	s.slowDown(3)
+
+	changes, _ := run(t, src, connector.Cursor{})
+	if find(changes, "confluence:"+id) == nil {
+		t.Errorf("a site that asked for a pause three times lost the sync: %v", ids(changes))
+	}
+}
+
+// An id this source could never have produced is a caller error rather than a
+// document that went away, and the two have to be told apart: one is a bug and
+// the other is Tuesday.
+func TestAnIdThisSourceNeverMintedIsNotAMissingPage(t *testing.T) {
+	s := newSite()
+	src := newSource(t, s)
+
+	_, err := src.Fetch(t.Context(), "confluence:not-a-number")
+	switch {
+	case err == nil:
+		t.Fatal("fetching a malformed id succeeded")
+	case errors.Is(err, connector.ErrGone):
+		t.Fatal("a malformed id was reported as a page that went away, which a sweep would act on")
+	}
+}
+
+// sorted is a copy of a list in order, for comparing against something the
+// source chose the order of.
+func sorted(in []string) []string {
+	out := slices.Clone(in)
+	slices.Sort(out)
+	return out
+}
+
+// distinct is how many different documents a sync was about, which is not the
+// same as how many changes it emitted. A page arrives once per change to be
+// walked past, and a comment is a change to the page.
+func distinct(in []string) []string {
+	out := slices.Clone(in)
+	slices.Sort(out)
+	return slices.Compact(out)
+}

--- a/connector/confluencesource/fake_test.go
+++ b/connector/confluencesource/fake_test.go
@@ -1,0 +1,987 @@
+package confluencesource_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A Confluence site with the parts that matter and none of the parts that do
+// not. It has spaces with read permissions on them, pages with bodies in both
+// formats and comments underneath, read restrictions that inherit down a tree,
+// two paging models, enough CQL to answer the two queries this adapter asks, a
+// clock that only moves when something happens to it, and the ability to be told
+// to refuse.
+//
+// It exists so that these tests do not need a site, and it is also what the
+// committed recording under testdata was made from. Everything asserted against
+// the recording is asserted against this first, so the two cannot drift without
+// a test going red.
+
+// start is when everything in these tests happens.
+//
+// CQL compares times to the minute, so the clock moves a minute at a time. A
+// fake that ticked by a second would make every test agree with every query for
+// the wrong reason.
+var start = time.Date(2026, 4, 6, 9, 0, 0, 0, time.UTC)
+
+type site struct {
+	mu     sync.Mutex
+	clock  time.Time
+	spaces []*area
+	pages  []*leaf
+	calls  map[string]int
+	expand map[string]string
+
+	// named is what a test called a page, which is not what Confluence calls it.
+	// The suite writes a document called a.md and the site answers with 100001.
+	named map[string]string
+
+	// fail makes one path refuse with a status, which is how a test asks what
+	// happens when a restriction cannot be read at all.
+	fail map[string]int
+
+	// throttle is how many more times the next request is answered with 429
+	// before it is answered properly.
+	throttle int
+
+	// page is how many items go in one page, which is small on purpose so that
+	// the paging is exercised by an ordinary sync rather than by one test.
+	page int
+
+	// counter is where page ids come from. Confluence ids are numbers and the
+	// adapter checks that they are, so a fake handing out names would be testing
+	// against something the real site cannot produce.
+	counter int
+}
+
+// area is a space and who may read it.
+type area struct {
+	id            int
+	key, name     string
+	users, groups []string
+
+	// open is a space readable without signing in, and dark is one whose
+	// permissions this token was not shown, which on a real site is every space
+	// it does not administer.
+	open bool
+	dark bool
+}
+
+// leaf is a page. The name is not "page" because that is what a listing calls
+// one of its own results.
+type leaf struct {
+	id      string
+	space   string
+	title   string
+	body    string
+	parent  string
+	created time.Time
+	updated time.Time
+	version int
+	author  string
+	labels  []string
+
+	// legacy is a page written before the editor changed, which has a body in
+	// the storage format and no Atlassian document at all.
+	legacy bool
+
+	// archived is a page somebody put away. It stays readable by id and stops
+	// being current, which is one of the three ways a page leaves the index.
+	archived bool
+
+	rule     *bar
+	comments []*note
+}
+
+// bar is a read restriction on one page.
+type bar struct {
+	users, groups []string
+
+	// short is a restriction the site sends only part of, which is what happens
+	// when it names more people than fit in one answer. The list is paged like
+	// everything else and the size is the only thing that says so.
+	short bool
+}
+
+type note struct {
+	id      string
+	author  string
+	body    string
+	created time.Time
+	updated time.Time
+}
+
+// home is the space the conformance suite works in.
+const home = "OPS"
+
+func newSite() *site {
+	s := &site{
+		clock:  start,
+		calls:  make(map[string]int),
+		expand: make(map[string]string),
+		named:  make(map[string]string),
+		fail:   make(map[string]int),
+		page:   2,
+	}
+	a := s.addSpace(home, "Line two operations")
+	a.groups = []string{"engineering"}
+	a.users = []string{"acc-mei"}
+	return s
+}
+
+// now is the site's clock, which is what the permission refresh schedule is
+// measured against.
+func (s *site) now() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.clock
+}
+
+// tick moves the clock on a minute and returns where it got to.
+//
+// A minute rather than a second, because CQL compares times to the minute. A
+// fake whose events all happened in the same minute would agree with every query
+// for the wrong reason.
+func (s *site) tick() time.Time {
+	s.clock = s.clock.Add(time.Minute)
+	return s.clock
+}
+
+// advance moves the clock without anything happening, which is how a test gets
+// to the far side of a permission refresh interval without waiting for it.
+func (s *site) advance(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clock = s.clock.Add(d)
+}
+
+func (s *site) addSpace(key, name string) *area {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	a := &area{id: 100 + len(s.spaces), key: key, name: name}
+	s.spaces = append(s.spaces, a)
+	return a
+}
+
+func (s *site) space(key string) *area {
+	for _, a := range s.spaces {
+		if a.key == key {
+			return a
+		}
+	}
+	return nil
+}
+
+// create writes a page and returns its id.
+func (s *site) create(space, title, body string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.add(space, title, body)
+}
+
+func (s *site) add(space, title, body string) string {
+	s.counter++
+	at := s.tick()
+	p := &leaf{
+		id:      strconv.Itoa(100000 + s.counter),
+		space:   space,
+		title:   title,
+		body:    body,
+		created: at,
+		updated: at,
+		version: 1,
+		author:  "acc-mei",
+	}
+	s.pages = append(s.pages, p)
+	s.named[title] = p.id
+	return p.id
+}
+
+// write puts a page in the space the conformance suite works in, or rewrites the
+// one already there under that title.
+func (s *site) write(title, body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if p := s.find(s.named[title]); p != nil {
+		p.body = body
+		p.version++
+		p.updated = s.tick()
+		return
+	}
+	s.add(home, title, body)
+}
+
+// idOf is the Confluence id of whatever a test wrote under a name.
+//
+// A name nothing was ever written under still gets an id, because the question
+// being asked is what this source would call that document and the answer does
+// not depend on whether the document is there. Confluence numbers content from
+// well above this, so nothing on the site is ever 1.
+func (s *site) idOf(title string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if id := s.named[title]; id != "" {
+		return id
+	}
+	return "1"
+}
+
+func (s *site) find(id string) *leaf {
+	for _, p := range s.pages {
+		if p.id == id {
+			return p
+		}
+	}
+	return nil
+}
+
+// nest puts one page under another, which is what makes a restriction on the
+// parent reach the child.
+func (s *site) nest(child, parent string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.find(child).parent = parent
+}
+
+// restrict puts a read restriction on a page.
+func (s *site) restrict(id string, users, groups []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.find(id).rule = &bar{users: users, groups: groups}
+}
+
+// truncate puts a restriction on a page and has the site send only part of it,
+// which is what a restriction naming more people than fit in one answer looks
+// like from outside.
+func (s *site) truncate(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.find(id).rule = &bar{users: []string{"acc-lee"}, short: true}
+}
+
+// comment adds to the argument underneath a page.
+//
+// It moves the comment and not the page, which is the gap this adapter exists to
+// work around: Confluence dates a comment and leaves the page it is on alone.
+func (s *site) comment(id, author, body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.find(id)
+	at := s.tick()
+	p.comments = append(p.comments, &note{
+		id:      strconv.Itoa(900000 + len(p.comments) + len(s.pages)*10),
+		author:  author,
+		body:    body,
+		created: at,
+		updated: at,
+	})
+}
+
+// label tags a page, which is a change with no words in it.
+func (s *site) label(id string, labels ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.find(id)
+	p.labels = labels
+	p.version++
+	p.updated = s.tick()
+}
+
+// legacy turns a page into one written before the editor changed, whose body is
+// the storage format and which has no Atlassian document at all.
+func (s *site) legacy(id, body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.find(id)
+	p.legacy = true
+	p.body = body
+	p.version++
+	p.updated = s.tick()
+}
+
+// archive puts a page away. It is still readable by id and it is no longer
+// current, which is one of the three ways a page leaves the index without
+// anything reporting that it has.
+func (s *site) archive(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.find(id).archived = true
+	s.tick()
+}
+
+// remove deletes a page. Nothing in CQL reports that it was ever there, which is
+// why the sweep exists.
+func (s *site) remove(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// The name stays behind on purpose. A test that deletes a page goes on to
+	// ask what its id was, and a fake that forgot would answer a different
+	// question.
+	s.pages = slices.DeleteFunc(s.pages, func(p *leaf) bool { return p.id == id })
+	s.tick()
+}
+
+// refuse makes one path answer with a status until it is told otherwise.
+func (s *site) refuse(path string, status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.fail[path] = status
+}
+
+// slowDown makes the next n requests come back as 429, which is how Confluence
+// asks a crawler to wait.
+func (s *site) slowDown(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.throttle = n
+}
+
+func (s *site) counted(path string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls[path]
+}
+
+// lastExpand is the expand parameter of the last request to a path, which is how
+// a test checks that a listing asked for what it needed and not for the body of
+// every page in the space.
+func (s *site) lastExpand(path string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.expand[path]
+}
+
+func (s *site) resetCounts() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = make(map[string]int)
+}
+
+// server starts the site on a listener and returns its base URL.
+//
+// The address handed back has no /wiki on it, because that is one of the two
+// things people have in front of them and the adapter is supposed to take
+// either.
+func (s *site) server(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(s.handle))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func (s *site) handle(rw http.ResponseWriter, req *http.Request) {
+	// Everything the product serves is under /wiki, and a request that went
+	// somewhere else is an adapter that built an address out of the bare host.
+	if !strings.HasPrefix(req.URL.Path, "/wiki/") {
+		s.deny(rw, http.StatusNotFound, "no such endpoint: "+req.URL.Path)
+		return
+	}
+	path := strings.TrimPrefix(req.URL.Path, "/wiki")
+
+	if err := req.ParseForm(); err != nil {
+		http.Error(rw, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	s.calls[path]++
+	s.expand[path] = req.Form.Get("expand")
+	if s.throttle > 0 {
+		s.throttle--
+		s.mu.Unlock()
+		rw.Header().Set("Retry-After", "0")
+		rw.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+	status, refusing := s.fail[path]
+	s.mu.Unlock()
+
+	if refusing {
+		s.deny(rw, status, "no")
+		return
+	}
+	// Basic authentication with an email and an API token, which is what a real
+	// site wants and what a request that forgot the header does not have.
+	if !strings.HasPrefix(req.Header.Get("Authorization"), "Basic ") {
+		s.deny(rw, http.StatusUnauthorized, "unauthorised")
+		return
+	}
+
+	switch {
+	case path == "/rest/api/space":
+		s.listSpaces(rw, req)
+	case path == "/rest/api/content/search":
+		s.search(rw, req)
+	case strings.HasSuffix(path, "/restriction/byOperation/read"):
+		s.readRestriction(rw, segment(path, "/rest/api/content/", "/restriction/byOperation/read"))
+	case strings.HasSuffix(path, "/child/comment"):
+		s.listComments(rw, req, segment(path, "/rest/api/content/", "/child/comment"))
+	case strings.HasPrefix(path, "/rest/api/content/"):
+		s.readPage(rw, req, strings.TrimPrefix(path, "/rest/api/content/"))
+	default:
+		s.deny(rw, http.StatusNotFound, "no such endpoint")
+	}
+}
+
+func (s *site) deny(rw http.ResponseWriter, status int, why string) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(status)
+	_, _ = rw.Write([]byte(`{"statusCode":` + strconv.Itoa(status) + `,"message":"` + why + `","reason":"refused"}`))
+}
+
+func (s *site) send(rw http.ResponseWriter, v any) {
+	rw.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(rw).Encode(v)
+}
+
+// listSpaces pages by offset, which is what the version one listings do.
+//
+// The next link it hands back is relative to the context path, which is the
+// shape a real site sends and the reason the adapter takes the query off it
+// rather than following it.
+func (s *site) listSpaces(rw http.ResponseWriter, req *http.Request) {
+	s.mu.Lock()
+	rows := make([]map[string]any, 0, len(s.spaces))
+	for _, a := range s.spaces {
+		rows = append(rows, s.spaceRow(a, req.Form.Get("expand")))
+	}
+	s.mu.Unlock()
+
+	at, size := offset(req, s.page)
+	page, last := window(rows, at, size)
+
+	out := map[string]any{
+		"results": page,
+		"start":   at,
+		"limit":   size,
+		"size":    len(page),
+	}
+	if !last {
+		q := url.Values{}
+		for k, v := range req.Form {
+			q[k] = append([]string(nil), v...)
+		}
+		q.Set("start", strconv.Itoa(at+size))
+		q.Set("limit", strconv.Itoa(size))
+		out["_links"] = map[string]any{"next": "/wiki/rest/api/space?" + q.Encode()}
+	}
+	s.send(rw, out)
+}
+
+func (s *site) spaceRow(a *area, expand string) map[string]any {
+	row := map[string]any{
+		"id":     a.id,
+		"key":    a.key,
+		"name":   a.name,
+		"type":   "global",
+		"status": "current",
+	}
+	if !has(split(expand), "permissions") || a.dark {
+		// A site that was not asked for the permissions does not send them, and
+		// neither does one asked by an account that may not see them. The adapter
+		// cannot tell those apart and is not supposed to guess at either.
+		return row
+	}
+
+	perms := []map[string]any{
+		// A grant to do something other than read, which is on every space and is
+		// not the question being asked.
+		{
+			"operation": map[string]any{"operation": "create", "targetType": "page"},
+			"subjects":  people(a.users, a.groups),
+		},
+	}
+	switch {
+	case a.open:
+		perms = append(perms, map[string]any{
+			"operation":       map[string]any{"operation": "read", "targetType": "space"},
+			"subjects":        map[string]any{},
+			"anonymousAccess": true,
+		})
+	default:
+		perms = append(perms, map[string]any{
+			"operation": map[string]any{"operation": "read", "targetType": "space"},
+			"subjects":  people(a.users, a.groups),
+		})
+	}
+	row["permissions"] = perms
+	return row
+}
+
+// people is the shape a set of accounts and groups arrives in, which is the same
+// shape for a space permission and for a page restriction.
+func people(users, groups []string) map[string]any {
+	u := make([]map[string]any, 0, len(users))
+	for _, id := range users {
+		u = append(u, who(id))
+	}
+	g := make([]map[string]any, 0, len(groups))
+	for _, name := range groups {
+		g = append(g, map[string]any{"name": name, "id": "g-" + name, "type": "group"})
+	}
+	return map[string]any{
+		"user":  map[string]any{"results": u, "size": len(u)},
+		"group": map[string]any{"results": g, "size": len(g)},
+	}
+}
+
+// cqlSpace, cqlSince and cqlComments are as much CQL as this fake understands,
+// which is exactly the clauses the adapter writes. A fake that parsed the whole
+// language would be a second Confluence with its own bugs in it.
+var (
+	cqlSpace = regexp.MustCompile(`space\s*=\s*"([^"]+)"`)
+	cqlSince = regexp.MustCompile(`lastModified\s*>=\s*"([^"]+)"`)
+)
+
+// search answers a CQL query, paging by cursor, which is what the search
+// endpoint does and the space listing does not.
+func (s *site) search(rw http.ResponseWriter, req *http.Request) {
+	cql := req.Form.Get("cql")
+
+	m := cqlSpace.FindStringSubmatch(cql)
+	if m == nil {
+		s.deny(rw, http.StatusBadRequest, "expected a space clause: "+cql)
+		return
+	}
+	key := m[1]
+
+	var since time.Time
+	if u := cqlSince.FindStringSubmatch(cql); u != nil {
+		got, err := time.Parse("2006/01/02 15:04", u[1])
+		if err != nil {
+			s.deny(rw, http.StatusBadRequest, "bad time in "+cql)
+			return
+		}
+		since = got.UTC()
+	}
+	comments := strings.Contains(cql, "type = comment")
+	byID := strings.Contains(cql, "order by id asc")
+
+	s.mu.Lock()
+	a := s.space(key)
+	var hits []hit
+	for _, p := range s.pages {
+		if p.space != key || p.archived {
+			continue
+		}
+		if since.IsZero() || !p.updated.Before(since) {
+			hits = append(hits, hit{page: p, at: p.updated})
+		}
+		if !comments {
+			continue
+		}
+		for _, c := range p.comments {
+			if since.IsZero() || !c.updated.Before(since) {
+				hits = append(hits, hit{page: p, note: c, at: c.updated})
+			}
+		}
+	}
+	if byID {
+		slices.SortFunc(hits, func(x, y hit) int { return strings.Compare(x.id(), y.id()) })
+	} else {
+		slices.SortFunc(hits, func(x, y hit) int {
+			if d := x.at.Compare(y.at); d != 0 {
+				return d
+			}
+			return strings.Compare(x.id(), y.id())
+		})
+	}
+
+	// The expands a search asks for are honoured, because a listing that asked
+	// for two fields and got the body of every page in the space would never
+	// notice it was paying for the bodies.
+	want := split(req.Form.Get("expand"))
+	rows := make([]map[string]any, 0, len(hits))
+	for _, h := range hits {
+		rows = append(rows, s.rowOf(h, want))
+	}
+	s.mu.Unlock()
+
+	if a == nil {
+		s.deny(rw, http.StatusBadRequest, "no such space: "+key)
+		return
+	}
+
+	at, size := cursor(req, s.page)
+	page, last := window(rows, at, size)
+	out := map[string]any{
+		"results":      page,
+		"start":        at,
+		"limit":        size,
+		"size":         len(page),
+		"totalSize":    len(rows),
+		"cqlQuery":     cql,
+		"searchDurati": 1,
+	}
+	if !last {
+		q := url.Values{}
+		for k, v := range req.Form {
+			q[k] = append([]string(nil), v...)
+		}
+		q.Set("cursor", encodeCursor(at+size))
+		q.Set("limit", strconv.Itoa(size))
+		out["_links"] = map[string]any{"next": "/wiki/rest/api/content/search?" + q.Encode()}
+	}
+	s.send(rw, out)
+}
+
+// hit is one result of a search, which is a page or a comment on one.
+type hit struct {
+	page *leaf
+	note *note
+	at   time.Time
+}
+
+func (h hit) id() string {
+	if h.note != nil {
+		return h.note.id
+	}
+	return h.page.id
+}
+
+func (s *site) rowOf(h hit, want []string) map[string]any {
+	if h.note != nil {
+		row := s.noteRow(h.note, want)
+		row["container"] = map[string]any{"id": h.page.id, "type": "page", "title": h.page.title}
+		return row
+	}
+	return s.pageRow(h.page, want)
+}
+
+func (s *site) readPage(rw http.ResponseWriter, req *http.Request, id string) {
+	s.mu.Lock()
+	p := s.find(id)
+	var row map[string]any
+	if p != nil {
+		row = s.pageRow(p, split(req.Form.Get("expand")))
+	}
+	s.mu.Unlock()
+
+	if p == nil {
+		s.deny(rw, http.StatusNotFound, "no such content")
+		return
+	}
+	s.send(rw, row)
+}
+
+func (s *site) listComments(rw http.ResponseWriter, req *http.Request, id string) {
+	s.mu.Lock()
+	p := s.find(id)
+	var rows []map[string]any
+	if p != nil {
+		want := split(req.Form.Get("expand"))
+		for _, c := range p.comments {
+			rows = append(rows, s.noteRow(c, want))
+		}
+	}
+	s.mu.Unlock()
+
+	if p == nil {
+		s.deny(rw, http.StatusNotFound, "no such content")
+		return
+	}
+
+	at, size := offset(req, s.page)
+	page, last := window(rows, at, size)
+	out := map[string]any{"results": page, "start": at, "limit": size, "size": len(page)}
+	if !last {
+		q := url.Values{}
+		for k, v := range req.Form {
+			q[k] = append([]string(nil), v...)
+		}
+		q.Set("start", strconv.Itoa(at+size))
+		q.Set("limit", strconv.Itoa(size))
+		out["_links"] = map[string]any{"next": "/wiki/rest/api/content/" + id + "/child/comment?" + q.Encode()}
+	}
+	s.send(rw, out)
+}
+
+func (s *site) readRestriction(rw http.ResponseWriter, id string) {
+	s.mu.Lock()
+	p := s.find(id)
+	var row map[string]any
+	if p != nil {
+		row = restrictionRow(p.rule)
+	}
+	s.mu.Unlock()
+
+	if p == nil {
+		s.deny(rw, http.StatusNotFound, "no such content")
+		return
+	}
+	s.send(rw, row)
+}
+
+// restrictionRow is a read restriction the way the API reports one, which is
+// sent for every page whether there is a restriction on it or not.
+func restrictionRow(r *bar) map[string]any {
+	row := map[string]any{"operation": "read"}
+	if r == nil {
+		row["restrictions"] = people(nil, nil)
+		return row
+	}
+	subjects := people(r.users, r.groups)
+	if r.short {
+		// One more than was sent, which is the site saying there is another page
+		// of this list and is the only thing that says so.
+		u, _ := subjects["user"].(map[string]any)
+		u["size"] = len(r.users) + 1
+	}
+	row["restrictions"] = subjects
+	return row
+}
+
+// pageRow is one page the way the API reports it, holding only what was asked
+// for.
+func (s *site) pageRow(p *leaf, want []string) map[string]any {
+	status := "current"
+	if p.archived {
+		status = "archived"
+	}
+	row := map[string]any{
+		"id":     p.id,
+		"type":   "page",
+		"status": status,
+		"title":  p.title,
+		"_links": map[string]any{"webui": "/spaces/" + p.space + "/pages/" + p.id + "/" + url.PathEscape(p.title)},
+	}
+
+	if has(want, "space") {
+		a := s.space(p.space)
+		row["space"] = map[string]any{"id": a.id, "key": a.key, "name": a.name}
+	}
+	if has(want, "version") {
+		row["version"] = map[string]any{
+			"by":     who(p.author),
+			"when":   wikiTime(p.updated),
+			"number": p.version,
+		}
+	}
+	if has(want, "history") {
+		row["history"] = map[string]any{
+			"createdBy":   who(p.author),
+			"createdDate": wikiTime(p.created),
+		}
+	}
+	if has(want, "ancestors") {
+		row["ancestors"] = s.ancestorsOf(p)
+	}
+	if has(want, "metadata.labels") {
+		labels := make([]map[string]any, 0, len(p.labels))
+		for _, l := range p.labels {
+			labels = append(labels, map[string]any{"name": l, "prefix": "global"})
+		}
+		row["metadata"] = map[string]any{"labels": map[string]any{"results": labels}}
+	}
+	if has(want, "restrictions.read") {
+		row["restrictions"] = map[string]any{"read": restrictionRow(p.rule)}
+	}
+	if body := s.bodyOf(p, want); body != nil {
+		row["body"] = body
+	}
+	if has(want, "children.comment") {
+		rows := make([]map[string]any, 0, len(p.comments))
+		for _, c := range p.comments {
+			rows = append(rows, s.noteRow(c, want))
+		}
+		// A read returns the first page of comments inline and links to the rest,
+		// which is most pages in one request rather than two.
+		page, last := window(rows, 0, s.page)
+		inline := map[string]any{"results": page, "start": 0, "limit": s.page, "size": len(page)}
+		if !last {
+			inline["_links"] = map[string]any{
+				"next": "/wiki/rest/api/content/" + p.id + "/child/comment?start=" + strconv.Itoa(s.page),
+			}
+		}
+		row["children"] = map[string]any{"comment": inline}
+	}
+	return row
+}
+
+// bodyOf is a page's body in whichever formats were asked for and exist.
+//
+// A page written before the editor changed has a storage body and no Atlassian
+// document at all, which is the case that costs the adapter a second request.
+func (s *site) bodyOf(p *leaf, want []string) map[string]any {
+	body := map[string]any{}
+	if has(want, "body.atlas_doc_format") {
+		value := ""
+		if !p.legacy {
+			value = adfOf(p.body)
+		}
+		body["atlas_doc_format"] = map[string]any{"value": value, "representation": "atlas_doc_format"}
+	}
+	if has(want, "body.storage") {
+		value := p.body
+		if !p.legacy {
+			value = "<p>" + p.body + "</p>"
+		}
+		body["storage"] = map[string]any{"value": value, "representation": "storage"}
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	return body
+}
+
+func (s *site) noteRow(c *note, want []string) map[string]any {
+	row := map[string]any{
+		"id":     c.id,
+		"type":   "comment",
+		"status": "current",
+		"title":  "Re: a page",
+	}
+	if has(want, "version") || has(want, "children.comment.version") {
+		row["version"] = map[string]any{"by": who(c.author), "when": wikiTime(c.updated), "number": 1}
+	}
+	if has(want, "history") || has(want, "children.comment.history") {
+		row["history"] = map[string]any{"createdBy": who(c.author), "createdDate": wikiTime(c.created)}
+	}
+	if has(want, "body.atlas_doc_format") || has(want, "children.comment.body.atlas_doc_format") {
+		row["body"] = map[string]any{
+			"atlas_doc_format": map[string]any{"value": adfOf(c.body), "representation": "atlas_doc_format"},
+		}
+	}
+	return row
+}
+
+// ancestorsOf is the pages above one, outermost first, which is the order
+// Confluence sends them in and the order the restriction walk expects.
+func (s *site) ancestorsOf(p *leaf) []map[string]any {
+	var up []map[string]any
+	for at, seen := p.parent, map[string]bool{p.id: true}; at != "" && !seen[at]; {
+		seen[at] = true
+		parent := s.find(at)
+		if parent == nil {
+			break
+		}
+		up = append([]map[string]any{{"id": parent.id, "type": "page", "title": parent.title}}, up...)
+		at = parent.parent
+	}
+	return up
+}
+
+func who(id string) map[string]any {
+	names := map[string]string{
+		"acc-mei": "Mei Tanaka",
+		"acc-sam": "Sam Okafor",
+		"acc-lee": "Lee Berger",
+	}
+	name := names[id]
+	if name == "" {
+		name = id
+	}
+	return map[string]any{
+		"type":        "known",
+		"accountId":   id,
+		"displayName": name,
+		"publicName":  name,
+		"email":       strings.TrimPrefix(id, "acc-") + "@acme.com",
+	}
+}
+
+// adfOf wraps a plain string in the smallest Atlassian document that holds it,
+// as a string holding JSON, which is how the body of a page actually arrives.
+func adfOf(text string) string {
+	if text == "" {
+		return ""
+	}
+	content := make([]any, 0, 1)
+	for _, para := range strings.Split(text, "\n\n") {
+		content = append(content, map[string]any{
+			"type":    "paragraph",
+			"content": []any{map[string]any{"type": "text", "text": para}},
+		})
+	}
+	raw, err := json.Marshal(map[string]any{"type": "doc", "version": 1, "content": content})
+	if err != nil {
+		panic(err)
+	}
+	return string(raw)
+}
+
+// wikiTime is the format a Confluence site writes a timestamp in, which is ISO
+// 8601 with milliseconds and an offset with a colon in it.
+func wikiTime(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05.000-07:00")
+}
+
+// split reads an expand parameter into the names in it.
+func split(expand string) []string {
+	if expand == "" {
+		return nil
+	}
+	out := strings.Split(expand, ",")
+	for i := range out {
+		out[i] = strings.TrimSpace(out[i])
+	}
+	return out
+}
+
+// has reports whether an expand parameter asked for something, counting a
+// request for a thing further in as a request for what holds it.
+func has(want []string, name string) bool {
+	for _, w := range want {
+		if w == name || strings.HasPrefix(w, name+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// offset reads the start and size off a request, which is how the version one
+// listings page.
+func offset(req *http.Request, fallback int) (at, size int) {
+	at, _ = strconv.Atoi(req.Form.Get("start"))
+	size, _ = strconv.Atoi(req.Form.Get("limit"))
+	if size <= 0 {
+		size = fallback
+	}
+	// A real site caps what it will return whatever was asked for, which is the
+	// behaviour that catches an adapter trusting the limit it sent.
+	return at, min(size, fallback)
+}
+
+// cursor reads the position off a request the way the search endpoint pages,
+// which is an opaque token rather than an offset.
+//
+// It is opaque on a real site and it is opaque here, in the sense that the
+// adapter is given no way to construct one. Everything it can do with it is hand
+// it back.
+func cursor(req *http.Request, fallback int) (at, size int) {
+	_, size = offset(req, fallback)
+	if raw := req.Form.Get("cursor"); raw != "" {
+		at = decodeCursor(raw)
+	}
+	return at, size
+}
+
+func encodeCursor(at int) string { return "raNDom" + strconv.Itoa(at) + "Token" }
+
+func decodeCursor(raw string) int {
+	at, _ := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(raw, "raNDom"), "Token"))
+	return at
+}
+
+// window cuts a page out of a listing and says whether it is the last one.
+func window[T any](items []T, at, size int) (page []T, last bool) {
+	if at > len(items) {
+		at = len(items)
+	}
+	to := min(at+size, len(items))
+	return items[at:to], to >= len(items)
+}
+
+// segment pulls the middle out of a path.
+func segment(path, prefix, suffix string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+}

--- a/connector/confluencesource/permissions.go
+++ b/connector/confluencesource/permissions.go
@@ -1,0 +1,380 @@
+package confluencesource
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/threadsource"
+)
+
+// DefaultACLRefresh is how often a space's rule is reapplied to the pages in it
+// even though nothing said it had changed.
+//
+// Confluence reports when a page changed and reports nothing at all about when
+// a space's permissions changed. Somebody taken off a space, a group emptied
+// out, a space made private: none of those touch a single page, and all of them
+// are revocations. A revocation that reaches the index when somebody next edits
+// a page is not a revocation.
+//
+// So the rule is reapplied on a schedule as well. A day is the default: it
+// bounds how long somebody who lost access keeps seeing a space's pages in their
+// results, and it costs one write per page in the space once a day rather than a
+// read of any of them.
+const DefaultACLRefresh = 24 * time.Hour
+
+// WithACLRefresh sets how often a space's rule is reapplied. Zero selects
+// [DefaultACLRefresh].
+func WithACLRefresh(d time.Duration) Option {
+	return func(s *Service) { s.aclRefresh = d }
+}
+
+// read is the operation that decides whether somebody may see something at all.
+// Everything else Confluence grants on a space is about changing things.
+const read = "read"
+
+// Containers lists the spaces this account can see, with who may read each.
+//
+// Archived spaces are left out. An archived space is one somebody put away, its
+// pages are not what the wiki offers anybody, and a search that answered with
+// them would be answering with the wiki as it was rather than as it is.
+func (s *Service) Containers(ctx context.Context) ([]threadsource.Container, error) {
+	// Every crawl starts here, which makes this the place the restriction cache
+	// is emptied. The cache is there so that a restricted subtree costs one
+	// request per ancestor rather than one per page, and that is a saving worth
+	// having within a crawl and a bug across them: a restriction put on a parent
+	// page is a revocation, and one the index only heard about when the process
+	// next restarted would not be one.
+	s.restricted.forget()
+
+	var found []space
+	err := pages(ctx, s, "/rest/api/space", url.Values{
+		"status": {"current"},
+		"expand": {"permissions"},
+	}, func(results []space) bool {
+		found = append(found, results...)
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	at := s.tick()
+	containers := make([]threadsource.Container, 0, len(found))
+	for _, sp := range found {
+		if sp.Key == "" {
+			continue
+		}
+		// The key is the id and the name is the label, because the key is what
+		// CQL calls the space and the name is what a person calls it.
+		containers = append(containers, threadsource.Container{
+			ID:       sp.Key,
+			Name:     sp.Name,
+			Access:   s.access(sp),
+			AccessAt: at,
+		})
+	}
+	return containers, nil
+}
+
+// access works out who may read a space.
+//
+// The answer comes out of the space's own permissions, which grant read to
+// accounts and to groups and may grant it to anonymous or unlicensed users. What
+// comes back for the ordinary case is what an access control list is: a set of
+// accounts and a set of groups.
+//
+// Nothing here asks the site a second question. The permissions arrive expanded
+// on the listing, which is one request for the whole site rather than one per
+// space, and a site with four hundred spaces is a site where that difference is
+// the crawl.
+func (s *Service) access(sp space) acl.Permissions {
+	if len(sp.Permissions) == 0 {
+		// Not a space nobody may read. A space whose permissions this token was
+		// not shown, which on many sites is every space it does not administer,
+		// and the two look identical from here.
+		s.skip(sp.Key, fmt.Errorf("who may read space %s: the listing carried no permissions, which needs an administrator on most sites", sp.Key))
+		return connector.Unresolved(s.name, fmt.Sprintf("the permissions on space %s were not readable by this account", sp.Key))
+	}
+
+	var (
+		users  []acl.Ref
+		groups []acl.Ref
+		anyone bool
+	)
+	for _, p := range sp.Permissions {
+		if p.Operation.Operation != read {
+			continue
+		}
+		if t := p.Operation.TargetType; t != "" && t != "space" {
+			// A grant to read one kind of thing in the space rather than the
+			// space, which is not the question being asked.
+			continue
+		}
+		if p.AnonymousAccess || p.UnlicensedAccess {
+			// A space readable without signing in, or readable by everybody a
+			// service desk lets in, is a space that is open to the tenant. It is
+			// a real configuration, and pretending it is an access control list
+			// of nobody would hide the space instead of describing it.
+			anyone = true
+			continue
+		}
+		users = append(users, refs(s.name, p.Subjects.User.Results, func(u person) string { return u.AccountID })...)
+		groups = append(groups, refs(s.name, p.Subjects.Group.Results, groupName)...)
+	}
+
+	switch {
+	case anyone:
+		return acl.Permissions{Mode: acl.ModePublicToTenant, Source: s.name}
+	case len(users) == 0 && len(groups) == 0:
+		// Permissions that grant read to nothing is not a space everybody can
+		// read, it is a space we failed to understand. Say so.
+		s.skip(sp.Key, fmt.Errorf("the permissions on space %s grant read to nobody", sp.Key))
+		return connector.Unresolved(s.name, fmt.Sprintf("the permissions on space %s grant read to nobody, which is a space we failed to understand rather than one everybody may read", sp.Key))
+	}
+
+	return acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      s.name,
+		AllowUsers:  tidy(users),
+		AllowGroups: tidy(groups),
+	}
+}
+
+// tick is the time a space's rule is reported to have changed at.
+//
+// Confluence reports nothing about that, so what is reported instead is the
+// start of the current refresh interval, which is what makes the schedule in
+// [DefaultACLRefresh] happen. It is quantised rather than measured from the last
+// sync so that the answer does not depend on when the syncs ran: two servers
+// reading the same site an hour apart agree about whether the rule has moved,
+// and a sync every five minutes still only reapplies it once.
+func (s *Service) tick() time.Time {
+	every := s.aclRefresh
+	if every <= 0 {
+		every = DefaultACLRefresh
+	}
+	return s.now().UTC().Truncate(every)
+}
+
+// restrictions resolves the read restriction on a page, walking up the pages
+// above it.
+//
+// It is a cache because of what the walk costs. A restriction on a page near the
+// top of a tree restricts everything under it, so the same handful of ancestors
+// is asked about once per page in the space, and a space with a restricted
+// section in it is a space where that is most of the crawl. A failure is cached
+// too, because a token that could not read a restriction this minute will not
+// read it next minute either, and asking again per page turns one refusal into a
+// thousand.
+type restrictions struct {
+	svc *Service
+
+	mu sync.Mutex
+	by map[string]own
+}
+
+// own is one page's own read restriction, without anything above it.
+type own struct {
+	// has is whether there is a restriction on this page at all, which is the
+	// question the inheritance rule is decided on rather than what the rule
+	// says. A page with no restriction of its own is not a page readable by
+	// nobody.
+	has bool
+
+	// rule is who the restriction names, or a quarantine when the site would
+	// not say.
+	rule acl.Permissions
+}
+
+func newRestrictions(s *Service) *restrictions {
+	return &restrictions{svc: s, by: make(map[string]own)}
+}
+
+// rule is who may read a page, and whether the page has a rule of its own at
+// all.
+//
+// A false second return is a page that inherits its space, which is almost every
+// page on almost every site, and it is what lets the crawl above leave the
+// container's rule in place.
+//
+// Restrictions inherit, so the pages above this one are consulted as well: a
+// page with no restriction of its own under a parent that has one is restricted.
+// A chain carrying a restriction at more than one level is quarantined rather
+// than resolved. Confluence means the intersection of the two there, and an
+// intersection of a list of accounts with a list of groups is not something that
+// can be worked out from outside the identity provider, so publishing the wider
+// of the two would publish exactly the pages somebody went out of their way to
+// restrict.
+func (r *restrictions) rule(ctx context.Context, p content) (acl.Permissions, bool) {
+	chain := make([]own, 0, len(p.Ancestors)+1)
+
+	// The page's own restriction arrived with it when the crawl asked for it,
+	// which is the ordinary path and costs nothing. A page that came from
+	// somewhere that did not ask is looked up.
+	if p.Restrictions != nil {
+		mine := readRule(r.svc, p.ID, p.Restrictions.Read)
+		r.remember(p.ID, mine)
+		chain = append(chain, mine)
+	} else {
+		chain = append(chain, r.of(ctx, p.ID))
+	}
+	for _, a := range p.Ancestors {
+		if a.ID == "" || a.ID == p.ID {
+			continue
+		}
+		chain = append(chain, r.of(ctx, a.ID))
+	}
+
+	var found []own
+	for _, o := range chain {
+		if o.has {
+			found = append(found, o)
+		}
+	}
+
+	switch len(found) {
+	case 0:
+		return acl.Permissions{}, false
+	case 1:
+		return found[0].rule, true
+	default:
+		r.svc.skip(p.ID, fmt.Errorf("page %s is restricted at %d levels of the tree above it and on it, and the intersection of those is not ours to work out", p.ID, len(found)))
+		return connector.Unresolved(r.svc.name, fmt.Sprintf("page %s carries a read restriction at more than one level, and Confluence means the intersection of them, which cannot be worked out from outside the identity provider", p.ID)), true
+	}
+}
+
+// of is one page's own restriction, from the cache or from the site.
+func (r *restrictions) of(ctx context.Context, id string) own {
+	r.mu.Lock()
+	got, ok := r.by[id]
+	r.mu.Unlock()
+	if ok {
+		return got
+	}
+
+	found := r.fetch(ctx, id)
+	r.remember(id, found)
+	return found
+}
+
+// forget empties the cache, which is what makes it last one crawl.
+func (r *restrictions) forget() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	clear(r.by)
+}
+
+// remember puts an answer in the cache.
+func (r *restrictions) remember(id string, o own) {
+	if id == "" {
+		return
+	}
+	r.mu.Lock()
+	r.by[id] = o
+	r.mu.Unlock()
+}
+
+// fetch asks the site who may read one page, which is one request that names
+// only that page and inherits nothing.
+func (r *restrictions) fetch(ctx context.Context, id string) own {
+	s := r.svc
+	if !looksLikeID(id) {
+		return own{}
+	}
+
+	var got restriction
+	err := s.call(ctx, "/rest/api/content/"+url.PathEscape(id)+"/restriction/byOperation/read", url.Values{
+		"expand": {"restrictions.user,restrictions.group"},
+	}, &got)
+	switch {
+	case err == nil:
+	case missing(err):
+		// The page went away while the tree above another one was being walked,
+		// which is a race every crawl has. A page that is not there restricts
+		// nothing, and the sweep is what takes it out of the index.
+		return own{}
+	default:
+		// Anything else is the site declining to say, and a restriction nobody
+		// can read is the one thing that must not fall back to the space.
+		s.skip(id, fmt.Errorf("who may read page %s: %w", id, err))
+		return own{has: true, rule: connector.Unresolved(s.name, fmt.Sprintf("the read restriction on page %s could not be read", id))}
+	}
+	return readRule(s, id, &got)
+}
+
+// readRule turns a read restriction into who it names.
+func readRule(s *Service, id string, got *restriction) own {
+	if got == nil {
+		return own{}
+	}
+
+	users := refs(s.name, got.Restrictions.User.Results, func(u person) string { return u.AccountID })
+	groups := refs(s.name, got.Restrictions.Group.Results, groupName)
+	if len(users) == 0 && len(groups) == 0 {
+		// Confluence sends the read restriction on every page whether there is
+		// one or not, and an empty one is the ordinary case rather than a page
+		// nobody may read.
+		return own{}
+	}
+
+	// A restriction the site sent only part of is a restriction we do not know.
+	// Indexing a page against the half of it that arrived is how somebody who
+	// was named on the second page of the list stops being able to find their
+	// own document, and it is how somebody who was not named starts.
+	if u, g := got.Restrictions.User, got.Restrictions.Group; u.Size > len(u.Results) || g.Size > len(g.Results) {
+		s.skip(id, fmt.Errorf("the read restriction on page %s names %d accounts and %d groups and the site sent %d and %d of them",
+			id, u.Size, g.Size, len(u.Results), len(g.Results)))
+		return own{has: true, rule: connector.Unresolved(s.name, fmt.Sprintf("the read restriction on page %s names more people than the site sent in one answer", id))}
+	}
+
+	return own{has: true, rule: acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      s.name,
+		AllowUsers:  tidy(users),
+		AllowGroups: tidy(groups),
+	}}
+}
+
+// refs turns whoever a permission or a restriction names into references, and
+// drops the entries that name nobody.
+func refs[T any](source string, in []T, value func(T) string) []acl.Ref {
+	out := make([]acl.Ref, 0, len(in))
+	for _, v := range in {
+		if got := value(v); got != "" {
+			out = append(out, acl.Ref{Source: source, Value: got})
+		}
+	}
+	return out
+}
+
+// groupName is what to write a group into an access control list as.
+//
+// The name rather than the id, because a name is what an identity provider hands
+// back when it is asked what somebody is in, and matching on the id would mean
+// resolving every group on the site to find out which one that was.
+func groupName(g group) string { return g.Name }
+
+// tidy puts a set of references in order and drops the repeats.
+//
+// The order Confluence lists anything in is not something anybody promised, and
+// a list that reorders itself between syncs is a permission change that never
+// happened, written to every page in the space.
+func tidy(refs []acl.Ref) []acl.Ref {
+	if len(refs) == 0 {
+		return nil
+	}
+	slices.SortFunc(refs, func(a, b acl.Ref) int {
+		if d := strings.Compare(a.Source, b.Source); d != 0 {
+			return d
+		}
+		return strings.Compare(a.Value, b.Value)
+	})
+	return slices.Compact(refs)
+}

--- a/connector/confluencesource/recording_test.go
+++ b/connector/confluencesource/recording_test.go
@@ -1,0 +1,379 @@
+package confluencesource_test
+
+import (
+	"encoding/base64"
+	"flag"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/confluencesource"
+	"github.com/tamnd/genba/connector/recorded"
+	"github.com/tamnd/genba/connector/threadsource"
+)
+
+// The fixture set is a crawl of a small site written down once and read back by
+// the tests below, so that the adapter is exercised against the bytes a
+// Confluence site actually sends without anybody needing an account or a token
+// to run the tests.
+//
+// The fake next to this file is the other half of the story and neither replaces
+// the other. The fake is where behaviour is written: it can be made to throttle,
+// to hide a space's permissions, to lose a page between two syncs. The recording
+// is where the wire format is pinned: it is the answer to "did we change what we
+// send" and it is the thing that would have to be refreshed if Atlassian changed
+// a field name.
+const fixtures = "testdata/site"
+
+// where the recording is replayed against. Nothing reaches it. It is the real
+// shape of a Confluence Cloud address because a reader opening one of these
+// files should see the request that would have gone to a site.
+const siteURL = "https://acme.atlassian.net"
+
+// The ids the recorded site produces, written down rather than worked out. A
+// test that derived them from the fake would pass just as happily against a
+// recording of something else entirely.
+const (
+	deployID  = "confluence:100001"
+	runbookID = "confluence:100002"
+	pumpID    = "confluence:100004"
+	specID    = "confluence:100005"
+)
+
+// pinned is what the clock says while the fixtures are being read back. A full
+// sync reads the whole site and asks for nothing that depends on the time, so
+// this only has to be steady rather than right.
+var pinned = func() time.Time { return start.Add(time.Hour) }
+
+var update = flag.Bool("update", false, "record the Confluence fixtures in testdata again")
+
+// recordingSite is the site the fixtures are a crawl of.
+//
+// It is small on purpose and every part of it is there for a reason: two spaces
+// so that the listing is more than one entry, one of them readable by named
+// groups and the other readable by anybody so that both resolutions are in the
+// recording, a page with an argument underneath it from two different people, a
+// page written in the old editor so that the second request for a storage format
+// body is in there, and a page restricted out of its space under a parent so
+// that the override and the inheritance walk are in there too.
+func recordingSite() *site {
+	s := newSite()
+
+	deploy := s.create(home, "Deploy", "The deploy runs at nine every weekday morning.")
+	s.label(deploy, "runbook", "deploy")
+	s.comment(deploy, "acc-sam", "It moved to eleven in March when the batch job was added.")
+	s.comment(deploy, "acc-lee", "Confirmed, eleven. The heading above is out of date.")
+
+	runbook := s.create(home, "Restarting line two", "placeholder")
+	s.legacy(runbook, `<h2>Restarting line two</h2>`+
+		`<p>Stop the feed, wait for the <strong>green</strong> light, then run:</p>`+
+		`<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter>`+
+		`<ac:plain-text-body><![CDATA[line2ctl stop --drain
+line2ctl start]]></ac:plain-text-body></ac:structured-macro>`+
+		`<ac:structured-macro ac:name="warning"><ac:parameter ac:name="title">Do not skip the drain</ac:parameter>`+
+		`<ac:rich-text-body><p>The gearbox will bind if the feed is still moving.</p></ac:rich-text-body>`+
+		`</ac:structured-macro>`)
+
+	incidents := s.create(home, "Incidents", "Everything that went wrong, one page each.")
+	pump := s.create(home, "Pump failure", "The coolant pump on line two failed on Tuesday afternoon.")
+	s.nest(pump, incidents)
+	s.restrict(pump, []string{"acc-lee"}, []string{"safety-officers"})
+
+	eng := s.addSpace("ENG", "Engineering")
+	eng.open = true
+	s.create("ENG", "Line two specification", "Line two runs at 1450 rpm under load.")
+
+	return s
+}
+
+// authed puts the credentials on the way the adapter does, so that what is
+// recorded is a real authenticated crawl rather than one made against a service
+// that was not asking.
+type authed struct{ base http.RoundTripper }
+
+func (a authed) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(email+":"+token)))
+	return a.base.RoundTrip(req)
+}
+
+// TestRecordTheFixtures writes the fixture set again. It is skipped unless the
+// flag is given, because a recording that refreshed itself on every run would
+// never fail: the thing it is there to catch is a change to what we send, and a
+// fixture regenerated alongside the change agrees with it by construction.
+func TestRecordTheFixtures(t *testing.T) {
+	if !*update {
+		t.Skip("run with -update to record the fixtures again")
+	}
+
+	s := recordingSite()
+	for _, want := range []struct{ title, id string }{
+		{"Deploy", deployID},
+		{"Restarting line two", runbookID},
+		{"Pump failure", pumpID},
+		{"Line two specification", specID},
+	} {
+		if got := "confluence:" + s.idOf(want.title); got != want.id {
+			t.Fatalf("the site filed %q under %s, and the tests below look for %s", want.title, got, want.id)
+		}
+	}
+
+	rec := recorded.Record(authed{http.DefaultTransport},
+		recorded.WithRedactedHeaders("Authorization"),
+	)
+	src, err := confluencesource.New(s.server(t), email, token,
+		confluencesource.WithHTTPClient(rec.Client()),
+		confluencesource.WithClock(pinned),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = src.Close() }()
+
+	crawl(t, src)
+
+	// A crawl asks the same listing question more than once: the sync, the sweep
+	// and a fetch each need to know what the spaces are and who may read each.
+	// Writing the answer down three times is three files to review and no more
+	// coverage, so the repeats are dropped and what is left is one file per
+	// distinct question.
+	var (
+		seen = map[string]bool{}
+		once []recorded.Exchange
+	)
+	for _, e := range rec.Exchanges() {
+		k := e.Request.Method + " " + e.Request.URL
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		once = append(once, settle(e))
+	}
+
+	if err := recorded.From(once).Save(fixtures); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %d of %d exchanges to %s", len(once), len(rec.Exchanges()), fixtures)
+}
+
+// settle takes the run out of a recorded exchange.
+//
+// Two things in one differ every time it is made: the address the test server
+// was given, and the date the answer came back on. Neither is matched against
+// and neither means anything, and leaving them in would make every refresh of
+// the fixtures a diff on every file with the real change somewhere in it.
+func settle(e recorded.Exchange) recorded.Exchange {
+	if u, err := url.Parse(e.Request.URL); err == nil {
+		site, err := url.Parse(siteURL)
+		if err != nil {
+			panic(err)
+		}
+		u.Scheme, u.Host = site.Scheme, site.Host
+		e.Request.URL = u.String()
+	}
+	delete(e.Response.Headers, "Date")
+	delete(e.Response.Headers, "Content-Length")
+	return e
+}
+
+// crawl is everything the fixture set has to answer, and it is shared so that
+// what is recorded and what is replayed cannot drift apart.
+func crawl(t *testing.T, src *threadsource.Source) []connector.Change {
+	t.Helper()
+
+	changes, _ := run(t, src, connector.Cursor{})
+
+	var listed []connector.Item
+	if err := src.Enumerate(t.Context(), func(item connector.Item) bool {
+		listed = append(listed, item)
+		return true
+	}); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(listed) == 0 {
+		t.Fatal("the listing found nothing")
+	}
+
+	if _, err := src.Fetch(t.Context(), deployID); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	return changes
+}
+
+// replaying is the adapter over the committed fixture set.
+func replaying(t *testing.T) *threadsource.Source {
+	t.Helper()
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := confluencesource.New(siteURL, email, token,
+		confluencesource.WithHTTPClient(rt.Client()),
+		confluencesource.WithClock(pinned),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+	return src
+}
+
+// TestTheRecordedSiteCrawlsWithoutAnAccount is the point of the fixture set: the
+// whole adapter, the real paging and the real decoding, against bytes that came
+// off a site and are now a file.
+func TestTheRecordedSiteCrawlsWithoutAnAccount(t *testing.T) {
+	changes := crawl(t, replaying(t))
+
+	want := []string{deployID, runbookID, "confluence:100003", pumpID, specID}
+	slices.Sort(want)
+	if got := distinct(ids(changes)); !slices.Equal(got, want) {
+		t.Fatalf("the recorded site crawled to %v, want %v", got, want)
+	}
+
+	deploy := find(changes, deployID)
+	if deploy == nil {
+		t.Fatal("the page with the argument on it is not in the crawl")
+	}
+	for _, phrase := range []string{
+		"runs at nine every weekday morning",
+		"moved to eleven in March",
+		"heading above is out of date",
+	} {
+		if !strings.Contains(deploy.Document.Body, phrase) {
+			t.Errorf("the page is missing %q:\n%s", phrase, deploy.Document.Body)
+		}
+	}
+	if got := deploy.Document.Properties["labels"]; got != "runbook, deploy" && got != "deploy, runbook" {
+		t.Errorf("the page carries the labels %q", got)
+	}
+
+	// Names came out of the recording too, which is the part a crawl without an
+	// account usually cannot show.
+	if got := deploy.Document.Author.Name; got != "Mei Tanaka" {
+		t.Errorf("the page is attributed to %q, want the name the recording holds", got)
+	}
+}
+
+// The storage format is in the recording as well, which is most of why it is
+// worth committing one for a wiki. A page written before the editor changed
+// arrives as XHTML rather than as an Atlassian document, and the structure in it
+// is the thing a reader was looking for.
+func TestTheRecordedSiteReadsAPageFromTheOldEditor(t *testing.T) {
+	changes := crawl(t, replaying(t))
+
+	runbook := find(changes, runbookID)
+	if runbook == nil {
+		t.Fatalf("the crawl emitted %v", distinct(ids(changes)))
+	}
+	for _, phrase := range []string{
+		"## Restarting line two",
+		"**green**",
+		"```bash\nline2ctl stop --drain\nline2ctl start\n```",
+		"> **Do not skip the drain**",
+		"gearbox will bind",
+	} {
+		if !strings.Contains(runbook.Document.Body, phrase) {
+			t.Errorf("the rendered page is missing %q:\n%s", phrase, runbook.Document.Body)
+		}
+	}
+}
+
+// The permission work is in the recording as well. A space granting read to a
+// group, a space anybody may read and a page restricted out of the space it is
+// in are three different answers, and the third one is the one that would
+// publish something if it went wrong.
+func TestTheRecordedSiteResolvesItsPermissions(t *testing.T) {
+	changes := crawl(t, replaying(t))
+
+	deploy := find(changes, deployID)
+	if deploy == nil {
+		t.Fatalf("the crawl emitted %v", distinct(ids(changes)))
+	}
+	if got, want := values(deploy.Document.Permissions.AllowGroups), []string{"engineering"}; !slices.Equal(got, want) {
+		t.Errorf("a page in the operations space allows the groups %v, want %v", got, want)
+	}
+
+	spec := find(changes, specID)
+	if spec == nil {
+		t.Fatalf("the crawl emitted %v", distinct(ids(changes)))
+	}
+	if got := spec.Document.Permissions.Mode; got != acl.ModePublicToTenant {
+		t.Errorf("a page in an anonymously readable space was given mode %v", got)
+	}
+
+	pump := find(changes, pumpID)
+	if pump == nil {
+		t.Fatalf("the crawl emitted %v", distinct(ids(changes)))
+	}
+	if got, want := values(pump.Document.Permissions.AllowUsers), []string{"acc-lee"}; !slices.Equal(got, want) {
+		t.Errorf("a restricted page allows the accounts %v, want only the restriction", got)
+	}
+	if got, want := values(pump.Document.Permissions.AllowGroups), []string{"safety-officers"}; !slices.Equal(got, want) {
+		t.Errorf("a restricted page allows the groups %v, want only the restriction", got)
+	}
+}
+
+// TestTheRecordingHoldsNothingItIsNotAskedFor keeps the fixture set from growing
+// a tail of responses nothing reads.
+//
+// A recording is a thing people add to and rarely take away from, and one that
+// has drifted is worse than none: a reviewer reading a file next to the test
+// reasonably assumes the test depends on it.
+func TestTheRecordingHoldsNothingItIsNotAskedFor(t *testing.T) {
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src, err := confluencesource.New(siteURL, email, token,
+		confluencesource.WithHTTPClient(rt.Client()),
+		confluencesource.WithClock(pinned),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = src.Close() }()
+
+	crawl(t, src)
+
+	if left := rt.Unused(); len(left) != 0 {
+		t.Errorf("the fixture set answers %d requests the crawl never makes:\n%s", len(left), strings.Join(left, "\n"))
+	}
+}
+
+// TestTheRecordingCarriesNoCredentials is the reason a fixture set is safe to
+// commit at all. It is a check on the recording rather than on the code, and it
+// is here because the file is here.
+func TestTheRecordingCarriesNoCredentials(t *testing.T) {
+	entries, err := os.ReadDir(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(fixtures, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		body := string(raw)
+		if strings.Contains(body, token) {
+			t.Errorf("%s holds the token it was recorded with", e.Name())
+		}
+		// The email address is half of a basic authentication credential on a
+		// Confluence site, so it does not belong in a committed file either.
+		if strings.Contains(body, email) {
+			t.Errorf("%s holds the account the recording was made with", e.Name())
+		}
+		if strings.Contains(body, base64.StdEncoding.EncodeToString([]byte(email+":"+token))) {
+			t.Errorf("%s holds an encoded credential", e.Name())
+		}
+	}
+}

--- a/connector/confluencesource/service.go
+++ b/connector/confluencesource/service.go
@@ -1,0 +1,535 @@
+package confluencesource
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector"
+	"github.com/tamnd/genba/connector/adf"
+	"github.com/tamnd/genba/connector/thread"
+	"github.com/tamnd/genba/connector/threadsource"
+	"github.com/tamnd/genba/doc"
+)
+
+// expanded is what a crawl asks for on every page.
+//
+// It is written down rather than left as the default, because the default is a
+// page with no body on it and the body is the document. Every name here is
+// something that ends up in what is indexed or in who may read it, and the
+// comments are on the list so that most pages are one request rather than two.
+var expanded = strings.Join([]string{
+	"body.atlas_doc_format",
+	"version",
+	"history",
+	"space",
+	"container",
+	"ancestors",
+	"metadata.labels",
+	"restrictions.read.restrictions.user",
+	"restrictions.read.restrictions.group",
+	"children.comment.body.atlas_doc_format",
+	"children.comment.version",
+	"children.comment.history",
+}, ",")
+
+// Threads walks the pages in a space that changed at or after since.
+//
+// The query asks for comments as well as pages, and that is the interesting part
+// of this adapter. Confluence dates a comment and does not date the page it is
+// on, so a page that was answered and never edited again is a page that a query
+// about pages alone reports as unchanged for ever. A comment that comes back is
+// resolved to the page it is on and the page is what gets emitted, because a
+// comment is a sentence in a document rather than a document.
+func (s *Service) Threads(ctx context.Context, c threadsource.Container, since time.Time, fn func(context.Context, threadsource.Thread) error) error {
+	cql := "(type = page or type = comment) and status = current and space = " + quote(c.ID)
+	if !since.IsZero() {
+		// At or after rather than after, because CQL compares to the minute and
+		// a page changed in the same minute as the cursor is one an exclusive
+		// query loses for ever. The cursor's edge set is what stops the repeat
+		// from being emitted twice.
+		cql += " and lastModified >= " + quote(cqlTime(since))
+	}
+	cql += " order by lastModified asc"
+
+	// What has already been read during this walk, so that a page edited and
+	// then commented on inside one sync window is fetched once. It is still
+	// emitted twice, with the later time on the second, because that time is
+	// what moves the cursor past the comment.
+	built := make(map[string]threadsource.Thread)
+
+	return s.search(ctx, cql, expanded, func(ctx context.Context, hit content) error {
+		at := changed(hit)
+		if at.Before(since) {
+			// CQL rounds to the minute and this does not, so a query asked for
+			// the minute the cursor is in comes back with what changed in the
+			// first half of it as well. Dropping those here rather than widening
+			// the query is what keeps the request cheap and the answer exact.
+			return nil
+		}
+
+		id, err := s.pageOf(hit)
+		if err != nil {
+			return err
+		}
+		if id == "" {
+			return nil
+		}
+
+		th, ok := built[id]
+		if !ok {
+			var err error
+			switch hit.Type {
+			case "page":
+				th, err = s.build(ctx, hit)
+			default:
+				th, err = s.Read(ctx, id)
+			}
+			switch {
+			case errors.Is(err, connector.ErrGone):
+				// The page went away between the search and the read, which is a
+				// race every crawl has. The sweep is what takes it out of the
+				// index, and it is already there to do that.
+				return nil
+			case err != nil:
+				return err
+			}
+			built[id] = th
+		}
+
+		th.Updated = at
+		return fn(ctx, th)
+	})
+}
+
+// pageOf is the page a search hit is about, which for a comment is the page it
+// was written on.
+func (s *Service) pageOf(hit content) (string, error) {
+	if hit.Type == "page" {
+		return hit.ID, nil
+	}
+	if hit.Container == nil || hit.Container.Type != "page" || hit.Container.ID == "" {
+		// A comment on something that is not a page, or one whose container the
+		// site declined to expand. Neither is a document and neither is an
+		// error, and saying so out loud is what keeps it from looking like an
+		// index that is complete.
+		s.skip(hit.ID, fmt.Errorf("a %s came back from the page query with no page under it", hit.Type))
+		return "", nil
+	}
+	return hit.Container.ID, nil
+}
+
+// listed is what a listing asks for, which is more than the version.
+//
+// The version is what the sweep compares. The restrictions and the ancestors are
+// what keep a scheduled permission refresh from writing the space's rule over a
+// page that was restricted out of the space, and they are asked for here because
+// here is the one place they can be had without reading the pages: a refresh
+// that had to read a space to find out which pages in it override the space is a
+// recrawl, which is what the refresh exists instead of.
+var listed = strings.Join([]string{
+	"version",
+	"ancestors",
+	"restrictions.read.restrictions.user",
+	"restrictions.read.restrictions.group",
+}, ",")
+
+// List reports every page the space currently holds, with the version the sweep
+// compares and the rule the page has of its own.
+//
+// Nothing in CQL reports a page that was deleted, archived or moved to a space
+// this token cannot see, so this is the only thing that ever takes one out of
+// the index.
+func (s *Service) List(ctx context.Context, c threadsource.Container, fn func(threadsource.Item) bool) error {
+	cql := "type = page and status = current and space = " + quote(c.ID) + " order by id asc"
+	err := s.search(ctx, cql, listed, func(ctx context.Context, p content) error {
+		item := threadsource.Item{Item: connector.Item{ID: p.ID, Version: revision(p)}}
+		if rule, restricted := s.restricted.rule(ctx, p); restricted {
+			item.Access = rule
+		}
+		if !fn(item) {
+			return errStop
+		}
+		return nil
+	})
+	if errors.Is(err, errStop) {
+		// A listing the caller ended on purpose is not a failed listing, and
+		// reporting it as one is how a reconciliation sweep ends up emptying an
+		// index.
+		return nil
+	}
+	return err
+}
+
+// errStop is how a caller that has seen enough gets out of a walk, and it never
+// leaves this package.
+var errStop = errors.New("confluencesource: enough")
+
+// search runs a CQL query and hands each result to fn.
+func (s *Service) search(ctx context.Context, cql, want string, fn func(context.Context, content) error) error {
+	var stopped error
+	err := pages(ctx, s, "/rest/api/content/search", url.Values{
+		"cql":    {cql},
+		"expand": {want},
+	}, func(results []content) bool {
+		for _, hit := range results {
+			if err := fn(ctx, hit); err != nil {
+				stopped = err
+				return false
+			}
+		}
+		return true
+	})
+	if stopped != nil {
+		return stopped
+	}
+	return err
+}
+
+// Read fetches one page by its id.
+func (s *Service) Read(ctx context.Context, id string) (threadsource.Thread, error) {
+	if !looksLikeID(id) {
+		return threadsource.Thread{}, fmt.Errorf("%w: %q", errBadID, id)
+	}
+
+	var p content
+	err := s.call(ctx, "/rest/api/content/"+url.PathEscape(id), url.Values{
+		"expand": {expanded},
+	}, &p)
+	switch {
+	case err == nil:
+	case missing(err):
+		// Deleted, archived, or moved somewhere this token cannot follow. From
+		// the index's point of view those are the same event.
+		return threadsource.Thread{}, connector.ErrGone
+	default:
+		return threadsource.Thread{}, err
+	}
+
+	if p.Status != "" && p.Status != "current" {
+		// An archived page is still readable by id and is not a page the wiki
+		// is offering anybody. Reporting it as gone is what takes it out.
+		return threadsource.Thread{}, connector.ErrGone
+	}
+	return s.build(ctx, p)
+}
+
+// build turns a page into the conversation the crawl above wants.
+func (s *Service) build(ctx context.Context, p content) (threadsource.Thread, error) {
+	body, err := s.text(ctx, p)
+	if err != nil {
+		return threadsource.Thread{}, err
+	}
+
+	all, err := s.comments(ctx, p)
+	if err != nil {
+		return threadsource.Thread{}, err
+	}
+	replies := make([]thread.Message, 0, len(all))
+	for _, c := range all {
+		said, err := s.text(ctx, c)
+		if err != nil {
+			return threadsource.Thread{}, err
+		}
+		replies = append(replies, thread.Message{
+			ID:     c.ID,
+			Author: authorOf(createdBy(c), s.name),
+			At:     created(c),
+			Edited: edited(c),
+			Text:   said,
+		})
+	}
+
+	conv := thread.Conversation{
+		ID:    p.ID,
+		Kind:  doc.KindPage,
+		Title: strings.TrimSpace(p.Title),
+		URL:   s.webURL(p),
+		Root: thread.Message{
+			ID: p.ID,
+			// Who wrote the page rather than who touched it last. A page a
+			// hundred people have tidied is still the page its author wrote,
+			// and who edited it last is a property for the people who want to
+			// ask that instead.
+			Author: authorOf(createdBy(p), s.name),
+			At:     created(p),
+			Edited: edited(p),
+			Text:   body,
+		},
+		Replies:    replies,
+		Revision:   revision(p),
+		Properties: properties(p),
+	}
+
+	th := threadsource.Thread{
+		Conversation: conv,
+		Container:    spaceOf(p),
+		Updated:      changed(p),
+	}
+
+	// A read restriction, if there is one anywhere above this page or on it,
+	// replaces the space's rule rather than adding to it. That is what a
+	// restriction is, and it is the reason the crawl above lets a conversation
+	// override its container.
+	access, restricted := s.restricted.rule(ctx, p)
+	if restricted {
+		th.Access = access
+	}
+	return th, nil
+}
+
+// comments reads the argument underneath a page.
+//
+// A search returns the first page of them inline, which is most pages in one
+// request rather than two, and the rest are paged for separately. Asking for
+// them unconditionally would be a request per page in the space to be told what
+// we were already holding.
+func (s *Service) comments(ctx context.Context, p content) ([]content, error) {
+	if p.Children == nil || p.Children.Comment == nil {
+		return nil, nil
+	}
+	inline := p.Children.Comment
+	if inline.Links.Next == "" {
+		return inline.Results, nil
+	}
+
+	var all []content
+	err := pages(ctx, s, "/rest/api/content/"+url.PathEscape(p.ID)+"/child/comment", url.Values{
+		"expand":   {"body.atlas_doc_format,version,history"},
+		"depth":    {"all"},
+		"location": {"footer,inline"},
+	}, func(results []content) bool {
+		all = append(all, results...)
+		return true
+	})
+	switch {
+	case err == nil:
+		return all, nil
+	case missing(err):
+		// The page went away between the search and this request. What is in
+		// hand is still worth indexing, and the sweep removes it if it really is
+		// gone.
+		return inline.Results, nil
+	default:
+		return nil, err
+	}
+}
+
+// text is what a page or a comment says, as Markdown.
+//
+// The body arrives as an Atlassian document, which is [adf]'s job, and the one
+// surprise is that it arrives as a string holding JSON rather than as JSON.
+//
+// A page written before the editor changed has no Atlassian document to give,
+// and what it has instead is the storage format, which is XHTML. The site will
+// send that too and it is not asked for on the crawl, because asking means the
+// body of every page on a migrated site arriving twice. It is asked for one page
+// at a time, only for the pages that came back with nothing, which costs one
+// extra request per legacy page and one per genuinely empty page.
+func (s *Service) text(ctx context.Context, c content) (string, error) {
+	if b := c.Body.ADF; b != nil && strings.TrimSpace(b.Value) != "" {
+		return adf.Render(json.RawMessage(b.Value)), nil
+	}
+	if b := c.Body.Storage; b != nil && strings.TrimSpace(b.Value) != "" {
+		return storage(b.Value), nil
+	}
+	return s.legacy(ctx, c.ID)
+}
+
+// legacy asks for one body in the storage format.
+func (s *Service) legacy(ctx context.Context, id string) (string, error) {
+	if !looksLikeID(id) {
+		return "", nil
+	}
+
+	var got content
+	err := s.call(ctx, "/rest/api/content/"+url.PathEscape(id), url.Values{
+		"expand": {"body.storage"},
+	}, &got)
+	switch {
+	case err == nil:
+	case missing(err):
+		// It went away while we were reading it. An empty body is the right
+		// answer here rather than a failed sync, because the sweep is what takes
+		// the page out and it is already going to.
+		return "", nil
+	default:
+		return "", err
+	}
+
+	if b := got.Body.Storage; b != nil {
+		return storage(b.Value), nil
+	}
+	return "", nil
+}
+
+// properties are the fields a person filters on rather than reads.
+//
+// The last editor is here rather than being a second author because "pages Sam
+// wrote" and "pages Sam last touched" are different questions, and an index that
+// conflated them would answer neither.
+func properties(p content) map[string]string {
+	out := make(map[string]string, 2)
+	if v := p.Version; v != nil && v.By != nil {
+		if name := nameOf(v.By); name != "" {
+			out["editor"] = name
+		}
+	}
+	if m := p.Metadata; m != nil && m.Labels != nil {
+		labels := make([]string, 0, len(m.Labels.Results))
+		for _, l := range m.Labels.Results {
+			if l.Name != "" {
+				labels = append(labels, l.Name)
+			}
+		}
+		if len(labels) > 0 {
+			out["labels"] = strings.Join(labels, ", ")
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// authorOf turns a Confluence account into who a document says wrote
+// something.
+//
+// The account id is the identity and the display name is a label, and they are
+// kept apart on purpose. A permission rule written against a display name is a
+// permission rule anybody can grant themselves by renaming.
+func authorOf(a *person, source string) doc.Person {
+	if a == nil || a.AccountID == "" {
+		return doc.Person{}
+	}
+	name := nameOf(a)
+	if name == "" {
+		name = a.AccountID
+	}
+	return doc.Person{
+		Subject:  a.AccountID,
+		Identity: acl.Identity{Source: source, Value: a.AccountID},
+		Name:     name,
+		Email:    a.Email,
+	}
+}
+
+// nameOf is what to call somebody.
+//
+// The display name is the one a site shows, and the public name is what is left
+// when a person has asked the site not to show the other one. Falling back to it
+// is the difference between a search result attributed to somebody and one
+// attributed to an account id.
+func nameOf(a *person) string {
+	if a == nil {
+		return ""
+	}
+	if a.DisplayName != "" {
+		return a.DisplayName
+	}
+	return a.PublicName
+}
+
+// createdBy is who wrote something, which is on the history rather than on the
+// version, because the version is who touched it last.
+func createdBy(c content) *person {
+	if c.History == nil {
+		return nil
+	}
+	return c.History.CreatedBy
+}
+
+// created is when something was written.
+func created(c content) time.Time {
+	if c.History == nil {
+		return time.Time{}
+	}
+	return stamp(c.History.CreatedDate)
+}
+
+// changed is when something was last touched, falling back to when it was
+// written for the sites and the objects that do not say.
+func changed(c content) time.Time {
+	if at := versionAt(c); !at.IsZero() {
+		return at
+	}
+	return created(c)
+}
+
+// edited is when something was last changed, and nothing when it never was.
+func edited(c content) time.Time {
+	at, was := versionAt(c), created(c)
+	if at.After(was) {
+		return at
+	}
+	return time.Time{}
+}
+
+func versionAt(c content) time.Time {
+	if c.Version == nil {
+		return time.Time{}
+	}
+	return stamp(c.Version.When)
+}
+
+// revision is the version the listing and the read have to agree on.
+//
+// It is the page's own version number and nothing else. A comment does not move
+// it, which would be a hole if the sync did not ask about comments directly, and
+// it does. Deriving it from the comments as well would mean the sweep expanding
+// every comment on every page in the space to find out what it already knows.
+func revision(p content) string {
+	if p.Version == nil || p.Version.Number == 0 {
+		return ""
+	}
+	return strconv.Itoa(p.Version.Number)
+}
+
+// spaceOf is the space key a page belongs to.
+func spaceOf(p content) string {
+	if p.Space == nil {
+		return ""
+	}
+	return p.Space.Key
+}
+
+// webURL is where a person goes to read the page at the source.
+//
+// The site says where that is, because the address of a page has the title in it
+// and a title is a thing people change. The fallback is the one address that
+// never moves, which is worth having for a site behind something that does not
+// send the link.
+func (s *Service) webURL(p content) string {
+	if p.Links.WebUI != "" {
+		return s.wiki + p.Links.WebUI
+	}
+	return s.wiki + "/pages/viewpage.action?pageId=" + url.QueryEscape(p.ID)
+}
+
+// errBadID is what an id that this source could never have produced comes back
+// as, which is different from an id it produced and no longer has.
+var errBadID = errors.New("confluencesource: not a page id")
+
+// looksLikeID reports whether an id is shaped like a Confluence content id,
+// which is a number.
+//
+// This is a check on our own ids rather than a validation of Confluence's, and
+// the reason it is here is that the alternative is putting whatever the caller
+// passed into a URL path.
+func looksLikeID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/connector/confluencesource/storage.go
+++ b/connector/confluencesource/storage.go
@@ -1,0 +1,685 @@
+package confluencesource
+
+import (
+	"encoding/xml"
+	"strconv"
+	"strings"
+)
+
+// The storage format is the other thing a Confluence page can be.
+//
+// A page written in the current editor arrives as an Atlassian document and
+// [adf] renders it. A page written before the editor changed, and there are a
+// great many of those on any site old enough to be worth searching, has no
+// Atlassian document to give. What it has is the storage format, which is XHTML
+// with a handful of Confluence's own elements mixed into it, and a connector
+// that could not read it would index a wiki as the pages somebody has touched
+// since the migration.
+//
+// It is rendered to Markdown for the same reason the Atlassian document is. A
+// runbook is a heading, a numbered list and three code blocks, and a search
+// result that hands the reader a flattened version of the thing they were
+// looking for has answered the query and failed the person.
+//
+// Two things about the input are worth knowing before reading any of this.
+//
+// It is not a document. It is a fragment, with no root element and no namespace
+// declarations, so `ac:structured-macro` is a well formed name to Confluence and
+// an undeclared prefix to a parser. It is read with the strict mode off, which
+// leaves the prefix where it was written and is exactly what is wanted here.
+//
+// It is also somebody else's markup, which is the reason for the depth limit and
+// the reason nothing in here returns an error. A page this cannot read is a page
+// with a title, an author and a comment thread, all of which are worth indexing,
+// and refusing the whole page over the shape of one element would lose more than
+// it saves.
+
+// maxStorageDepth is how far into a page this will walk.
+//
+// The same number the Atlassian document renderer uses, for the same reason. A
+// page is nested a handful of levels deep and nothing legitimate is near this.
+const maxStorageDepth = 32
+
+// autoClose is the tags that never have an end tag, so that a page written the
+// way people write HTML parses rather than swallowing the rest of itself.
+//
+// It is [xml.HTMLAutoClose] with link taken out, and that one omission is the
+// whole reason this exists. A prefix is not a name to a parser reading a
+// fragment that declares no namespaces, so ac:link arrives with the local name
+// link, and closing it on sight would end a Confluence link before its label,
+// leave a stray end tag, and take the rest of the sentence with it.
+var autoClose = []string{
+	"area", "base", "basefont", "br", "col", "frame",
+	"hr", "img", "input", "isindex", "meta", "param",
+}
+
+// element is one node of a parsed page: a tag with children, or a run of text.
+type element struct {
+	// name is the local name, lowercased, and it is empty on a text node.
+	name string
+
+	// attr is the attributes, keyed by prefix and local name where there was a
+	// prefix and by local name where there was not.
+	attr map[string]string
+
+	text string
+	kids []*element
+}
+
+// storage renders the Confluence storage format as Markdown.
+func storage(in string) string {
+	if strings.TrimSpace(in) == "" {
+		return ""
+	}
+	var b strings.Builder
+	elemBlocks(&b, parseStorage(in), 0, "")
+	return strings.TrimSpace(collapse(b.String()))
+}
+
+// parseStorage reads a page into a tree.
+//
+// The fragment is wrapped in a root element because a fragment with two
+// paragraphs in it is two documents to an XML parser and one page to everybody
+// else. What comes back is that root's children.
+//
+// Anything the parser will not read ends the walk and keeps what was read. A
+// page that stops making sense two thirds of the way down is two thirds of a
+// page in the index, which is better than none of it and much better than a
+// failed sync of the space it is in.
+func parseStorage(in string) []*element {
+	d := xml.NewDecoder(strings.NewReader("<genba>" + in + "</genba>"))
+	// Strict off is what makes an undeclared prefix readable, and it is what
+	// leaves ac and ri in place rather than resolving them to nothing.
+	d.Strict = false
+	d.AutoClose = autoClose
+	d.Entity = xml.HTMLEntity
+
+	root := &element{}
+	stack := []*element{root}
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			break
+		}
+		top := stack[len(stack)-1]
+		switch t := tok.(type) {
+		case xml.StartElement:
+			e := &element{name: strings.ToLower(t.Name.Local)}
+			for _, a := range t.Attr {
+				if e.attr == nil {
+					e.attr = make(map[string]string, len(t.Attr))
+				}
+				key := strings.ToLower(a.Name.Local)
+				if a.Name.Space != "" {
+					key = strings.ToLower(a.Name.Space) + ":" + key
+				}
+				e.attr[key] = a.Value
+			}
+			top.kids = append(top.kids, e)
+			if len(stack) < maxStorageDepth {
+				stack = append(stack, e)
+			}
+		case xml.EndElement:
+			if len(stack) > 1 {
+				stack = stack[:len(stack)-1]
+			}
+		case xml.CharData:
+			top.kids = append(top.kids, &element{text: string(t)})
+		}
+	}
+
+	if len(root.kids) == 1 && root.kids[0].name == "genba" {
+		return root.kids[0].kids
+	}
+	return root.kids
+}
+
+// at is the first of these attributes the element carries.
+//
+// More than one name is asked for because a prefix survives only while it is
+// undeclared. A site that sends the fragment inside something that declares the
+// Confluence namespaces gets the prefix resolved away, and the same attribute
+// then arrives under its bare local name.
+func (e *element) at(names ...string) string {
+	for _, n := range names {
+		if v := e.attr[n]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// child is the first child with one of these names, or nil.
+func (e *element) child(names ...string) *element {
+	if e == nil {
+		return nil
+	}
+	for _, k := range e.kids {
+		for _, n := range names {
+			if k.name == n {
+				return k
+			}
+		}
+	}
+	return nil
+}
+
+// textOf is every piece of text under an element, joined and nothing else.
+// It is what a code block and a macro parameter are.
+func textOf(e *element) string {
+	if e == nil {
+		return ""
+	}
+	var b strings.Builder
+	var walk func(*element, int)
+	walk = func(n *element, depth int) {
+		if depth > maxStorageDepth {
+			return
+		}
+		if n.name == "" {
+			b.WriteString(n.text)
+		}
+		for _, k := range n.kids {
+			walk(k, depth+1)
+		}
+	}
+	walk(e, 0)
+	return b.String()
+}
+
+// block reports whether an element stands on its own rather than sitting inside
+// a line.
+//
+// A macro is not on the list even though most of them are blocks, because the
+// ones that are not are inline in a sentence, and an element inside a paragraph
+// is rendered inline whatever this says.
+func (e *element) block() bool {
+	switch e.name {
+	case "h1", "h2", "h3", "h4", "h5", "h6",
+		"p", "hr", "blockquote", "ul", "ol", "pre", "table",
+		"div", "section", "body", "article",
+		"structured-macro", "rich-text-body", "task-list",
+		"layout", "layout-section", "layout-cell", "adf-extension":
+		return true
+	}
+	return false
+}
+
+// elemBlocks renders a run of elements with a blank line between them.
+//
+// The elements that are not blocks are gathered up as they go and become one
+// paragraph, which is what turns a cell holding a sentence and a bold word into
+// a sentence with a bold word in it rather than two paragraphs.
+func elemBlocks(b *strings.Builder, kids []*element, depth int, prefix string) {
+	if depth > maxStorageDepth {
+		return
+	}
+
+	first := true
+	var run []*element
+	gap := func() {
+		if !first {
+			line(b, strings.TrimRight(prefix, " "), "")
+		}
+		first = false
+	}
+	flush := func() {
+		if len(run) == 0 {
+			return
+		}
+		said := strings.TrimSpace(elemInline(run, depth+1))
+		run = nil
+		if said == "" {
+			return
+		}
+		gap()
+		line(b, prefix, said)
+	}
+
+	for _, k := range kids {
+		if !k.block() {
+			run = append(run, k)
+			continue
+		}
+		flush()
+
+		// A block is rendered aside first so that one which came to nothing can
+		// be left out rather than separated from its neighbours by a blank line.
+		// A table of contents is the ordinary way that happens, and a page whose
+		// first element is one should not begin with an empty line.
+		var one strings.Builder
+		elemBlock(&one, k, depth, prefix)
+		if strings.Trim(one.String(), ">| \t\n") == "" {
+			continue
+		}
+		gap()
+		b.WriteString(one.String())
+	}
+	flush()
+}
+
+// elemBlock renders one element that stands on its own.
+func elemBlock(b *strings.Builder, e *element, depth int, prefix string) {
+	if depth > maxStorageDepth {
+		return
+	}
+
+	switch e.name {
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		level, _ := strconv.Atoi(e.name[1:])
+		line(b, prefix, strings.Repeat("#", level)+" "+elemInline(e.kids, depth+1))
+
+	case "p":
+		line(b, prefix, elemInline(e.kids, depth+1))
+
+	case "hr":
+		line(b, prefix, "---")
+
+	case "blockquote":
+		elemBlocks(b, e.kids, depth+1, prefix+"> ")
+
+	case "ul", "ol":
+		listOf(b, e, depth+1, prefix)
+
+	case "pre":
+		fenced(b, "", textOf(e), prefix)
+
+	case "table":
+		tableOf(b, e, depth+1, prefix)
+
+	case "task-list":
+		tasksOf(b, e, depth+1, prefix)
+
+	case "structured-macro":
+		macroOf(b, e, depth+1, prefix)
+
+	default:
+		// A container of some sort, which is most of what is left: a div, a
+		// section, a page layout column, a macro's rich text body. What is
+		// interesting is inside it.
+		elemBlocks(b, e.kids, depth+1, prefix)
+	}
+}
+
+// listOf renders a bulleted or numbered list, including the lists inside it.
+func listOf(b *strings.Builder, e *element, depth int, prefix string) {
+	ordered := e.name == "ol"
+	start := 1
+	if got, err := strconv.Atoi(e.at("start")); err == nil && got > 0 {
+		start = got
+	}
+
+	n := 0
+	for _, item := range e.kids {
+		if item.name != "li" {
+			continue
+		}
+		bullet := "- "
+		if ordered {
+			bullet = strconv.Itoa(start+n) + ". "
+		}
+		n++
+
+		// Everything under the first line of an item is indented to sit under
+		// it, which is what keeps a paragraph belonging to its bullet instead of
+		// ending the list.
+		inner := prefix + strings.Repeat(" ", len(bullet))
+		var body strings.Builder
+		elemBlocks(&body, item.kids, depth+1, "")
+
+		lines := strings.Split(strings.TrimRight(body.String(), "\n"), "\n")
+		for i, l := range lines {
+			switch {
+			case i == 0:
+				line(b, prefix, bullet+l)
+			case strings.TrimSpace(l) == "":
+				line(b, "", "")
+			default:
+				line(b, inner, l)
+			}
+		}
+	}
+}
+
+// tableOf renders a table as a Markdown one.
+//
+// The first row is treated as the header whether or not its cells say they are,
+// because Markdown has no way to write a table without one and a table whose
+// first row is data reads better as a header than as nothing.
+func tableOf(b *strings.Builder, e *element, depth int, prefix string) {
+	var rows []*element
+	var walk func(*element, int)
+	walk = func(n *element, d int) {
+		if d > maxStorageDepth {
+			return
+		}
+		for _, k := range n.kids {
+			switch k.name {
+			case "tr":
+				rows = append(rows, k)
+			case "thead", "tbody", "tfoot", "colgroup":
+				walk(k, d+1)
+			}
+		}
+	}
+	walk(e, depth)
+	if len(rows) == 0 {
+		return
+	}
+
+	for i, row := range rows {
+		var cells []string
+		for _, c := range row.kids {
+			if c.name != "td" && c.name != "th" {
+				continue
+			}
+			var cell strings.Builder
+			elemBlocks(&cell, c.kids, depth+1, "")
+			// A newline inside a cell would end the table, so what was several
+			// paragraphs becomes one line.
+			cells = append(cells, strings.Join(strings.Fields(cell.String()), " "))
+		}
+		if len(cells) == 0 {
+			continue
+		}
+		line(b, prefix, "| "+strings.Join(cells, " | ")+" |")
+		if i == 0 {
+			line(b, prefix, "|"+strings.Repeat(" --- |", len(cells)))
+		}
+	}
+}
+
+// tasksOf renders a task list, which is the wiki's version of a checklist and is
+// very often the actual content of a page.
+func tasksOf(b *strings.Builder, e *element, depth int, prefix string) {
+	for _, t := range e.kids {
+		if t.name != "task" {
+			continue
+		}
+		box := "[ ] "
+		if strings.EqualFold(strings.TrimSpace(textOf(t.child("task-status"))), "complete") {
+			box = "[x] "
+		}
+		body := t.child("task-body")
+		if body == nil {
+			continue
+		}
+		line(b, prefix, "- "+box+elemInline(body.kids, depth+1))
+	}
+}
+
+// macroOf renders one of Confluence's own elements.
+//
+// A macro is where the page keeps the things a wiki has and a document does not,
+// and the three groups are worth telling apart. A code macro holds text that has
+// to survive exactly. A panel holds prose that has to be read. A table of
+// contents holds nothing at all: it is navigation, it is generated from the
+// headings that are already in the page, and indexing it would be indexing the
+// same words twice.
+func macroOf(b *strings.Builder, e *element, depth int, prefix string) {
+	switch strings.ToLower(e.at("ac:name", "name")) {
+	case "code":
+		fenced(b, param(e, "language"), textOf(e.child("plain-text-body")), prefix)
+
+	case "noformat":
+		fenced(b, "", textOf(e.child("plain-text-body")), prefix)
+
+	case "toc", "children", "pagetree", "recently-updated", "livesearch",
+		"contentbylabel", "include", "excerpt-include", "anchor", "gallery":
+		// Navigation and transclusion. Neither says anything the page says, and
+		// what they point at is indexed where it lives.
+
+	case "info", "note", "warning", "tip", "panel", "expand", "excerpt":
+		// A coloured box with a note in it, or an expander with the note hidden.
+		// The colour is the whole of what it adds and a quote is the closest
+		// thing Markdown has.
+		if title := param(e, "title"); title != "" {
+			line(b, prefix+"> ", "**"+title+"**")
+			// With no blank line after it the title and the first line under it
+			// are one paragraph, which is the opposite of what a panel is: a
+			// label and the thing under the label.
+			line(b, strings.TrimRight(prefix, " "), ">")
+		}
+		elemBlocks(b, bodyOf(e), depth+1, prefix+"> ")
+
+	default:
+		// An unknown macro is still rendered rather than dropped. Sites install
+		// their own, and a page written with one should be a page with its text
+		// in the index rather than a page that mysteriously has none.
+		if body := bodyOf(e); len(body) > 0 {
+			elemBlocks(b, body, depth+1, prefix)
+			return
+		}
+		if said := strings.TrimSpace(textOf(e.child("plain-text-body"))); said != "" {
+			line(b, prefix, said)
+		}
+	}
+}
+
+// bodyOf is what is inside a macro that holds prose.
+func bodyOf(e *element) []*element {
+	if body := e.child("rich-text-body"); body != nil {
+		return body.kids
+	}
+	return nil
+}
+
+// param is one of a macro's settings, which are elements rather than attributes.
+func param(e *element, name string) string {
+	for _, k := range e.kids {
+		if k.name == "parameter" && strings.EqualFold(k.at("ac:name", "name"), name) {
+			return strings.TrimSpace(textOf(k))
+		}
+	}
+	return ""
+}
+
+// fenced writes a code block.
+func fenced(b *strings.Builder, lang, body, prefix string) {
+	line(b, prefix, "```"+lang)
+	for _, l := range strings.Split(strings.Trim(body, "\n"), "\n") {
+		line(b, prefix, l)
+	}
+	line(b, prefix, "```")
+}
+
+// elemInline renders a run of elements that sit inside a line.
+func elemInline(kids []*element, depth int) string {
+	if depth > maxStorageDepth {
+		return ""
+	}
+	var b strings.Builder
+	for _, k := range kids {
+		said := inlineOne(k, depth)
+		// An element that comes to nothing sits between the space before it and
+		// the space after it and would otherwise leave both behind. A mention of
+		// somebody the page names only by account id is the one that happens.
+		if strings.HasPrefix(said, " ") && strings.HasSuffix(b.String(), " ") {
+			said = strings.TrimLeft(said, " ")
+		}
+		b.WriteString(said)
+	}
+	return b.String()
+}
+
+// inlineOne renders one element that sits inside a line.
+func inlineOne(e *element, depth int) string {
+	if e.name == "" {
+		// Whitespace in XHTML is layout rather than content, and a page written
+		// with one word per line is a paragraph rather than a column.
+		return spaced(e.text)
+	}
+
+	switch e.name {
+	case "br":
+		return "\n"
+
+	case "strong", "b":
+		return around("**", elemInline(e.kids, depth+1))
+
+	case "em", "i", "cite", "var":
+		return around("*", elemInline(e.kids, depth+1))
+
+	case "code", "kbd", "tt", "samp":
+		return around("`", elemInline(e.kids, depth+1))
+
+	case "del", "s", "strike":
+		return around("~~", elemInline(e.kids, depth+1))
+
+	case "a":
+		// The text of a link and where it goes are different things and both are
+		// worth having: somebody searching for a runbook by name should find the
+		// page that linked to it, and somebody reading the page should be able
+		// to follow it.
+		said := strings.TrimSpace(elemInline(e.kids, depth+1))
+		href := e.at("href")
+		switch {
+		case href == "" || href == said:
+			return said
+		case said == "":
+			return href
+		default:
+			return "[" + said + "](" + href + ")"
+		}
+
+	case "link":
+		return linkOf(e, depth)
+
+	case "image":
+		return imageOf(e)
+
+	case "emoticon":
+		// The fallback is the emoji itself, which is what the page says.
+		return e.at("ac:emoji-fallback", "emoji-fallback")
+
+	case "time":
+		if at := e.at("datetime"); at != "" {
+			return at
+		}
+		return elemInline(e.kids, depth+1)
+
+	case "script", "style":
+		// Not text anybody wrote and not text anybody reads.
+		return ""
+
+	default:
+		return elemInline(e.kids, depth+1)
+	}
+}
+
+// linkOf renders a link to something inside the wiki.
+//
+// It comes out as its label and no address, which is deliberate. The element
+// names what it points at, a page by title or an attachment by filename, and it
+// does not say where that is. Building an address out of a title would be
+// building one that stops working the day somebody renames the page, and the
+// page it points at is indexed under its own id anyway. The label is the part
+// worth keeping, because the label is the sentence.
+func linkOf(e *element, depth int) string {
+	if body := e.child("plain-text-link-body", "link-body"); body != nil {
+		if said := strings.TrimSpace(elemInline(body.kids, depth+1)); said != "" {
+			return said
+		}
+	}
+	for _, k := range e.kids {
+		switch k.name {
+		case "page", "blog-post":
+			return k.at("ri:content-title", "content-title")
+		case "attachment":
+			return k.at("ri:filename", "filename")
+		case "space":
+			return k.at("ri:space-key", "space-key")
+		}
+	}
+	// A mention is a link with an account id in it and no name anywhere, and an
+	// account id is not something to show anybody.
+	return ""
+}
+
+// imageOf renders an image the same way the Atlassian document renderer does.
+//
+// What is worth saying about an attachment is that it is there and what it is
+// called. The index does not hold the file, and a link to it would be a link
+// that stops working the day the token does.
+func imageOf(e *element) string {
+	name := e.at("ac:alt", "alt", "ac:title", "title")
+	if name == "" {
+		for _, k := range e.kids {
+			switch k.name {
+			case "attachment":
+				name = k.at("ri:filename", "filename")
+			case "url":
+				name = k.at("ri:value", "value")
+			}
+			if name != "" {
+				break
+			}
+		}
+	}
+	if name == "" {
+		return ""
+	}
+	return "(attachment: " + name + ")"
+}
+
+// around puts a mark on both sides of some text, and leaves empty text alone so
+// that an empty bold tag does not come out as four asterisks.
+func around(mark, said string) string {
+	if strings.TrimSpace(said) == "" {
+		return said
+	}
+	return mark + said + mark
+}
+
+// spaced turns a run of layout whitespace into one space.
+func spaced(s string) string {
+	if s == "" {
+		return ""
+	}
+	var (
+		b     strings.Builder
+		blank bool
+	)
+	for _, r := range s {
+		switch r {
+		case ' ', '\t', '\n', '\r', ' ':
+			if !blank {
+				b.WriteByte(' ')
+			}
+			blank = true
+		default:
+			blank = false
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// line writes one line with its prefix, leaving no trailing space on a line that
+// has nothing else on it.
+func line(b *strings.Builder, prefix, s string) {
+	b.WriteString(strings.TrimRight(prefix+s, " "))
+	b.WriteByte('\n')
+}
+
+// collapse turns any run of blank lines into one.
+//
+// A page that nests quotes inside lists inside macros produces a blank line per
+// level on the way out, and six of them in a row is not a paragraph break, it is
+// the renderer showing through.
+func collapse(s string) string {
+	var (
+		b     strings.Builder
+		blank bool
+	)
+	for _, l := range strings.Split(s, "\n") {
+		empty := strings.TrimSpace(strings.TrimLeft(l, ">| ")) == ""
+		if empty && blank {
+			continue
+		}
+		blank = empty
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/connector/confluencesource/storage_test.go
+++ b/connector/confluencesource/storage_test.go
@@ -1,0 +1,319 @@
+package confluencesource
+
+import (
+	"strings"
+	"testing"
+)
+
+// The storage format is the half of a wiki that the Atlassian document renderer
+// never sees, and it is the older half, so on a site worth searching it is most
+// of the pages. Each case below names the thing that would be lost by the
+// obvious wrong implementation, which is stripping the tags and keeping the
+// text between them.
+func TestTheShapeOfAPageSurvives(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "a heading is a heading at the level it says",
+			in:   `<h2>Deploy</h2><p>It runs at nine.</p>`,
+			want: "## Deploy\n\nIt runs at nine.",
+		},
+		{
+			name: "a bulleted list keeps one line per item",
+			in:   `<ul><li>first</li><li>second</li></ul>`,
+			want: "- first\n- second",
+		},
+		{
+			name: "a numbered list counts from where it says it does",
+			in:   `<ol start="4"><li>Drain it</li><li>Refill it</li></ol>`,
+			want: "4. Drain it\n5. Refill it",
+		},
+		{
+			name: "a list inside a list is indented under its bullet",
+			in:   `<ul><li>first</li><li>second<ul><li>nested</li></ul></li></ul>`,
+			want: "- first\n- second\n\n  - nested",
+		},
+		{
+			name: "a table is a table with a header row",
+			in:   `<table><tbody><tr><th>Step</th><th>Who</th></tr><tr><td>Build</td><td>CI</td></tr></tbody></table>`,
+			want: "| Step | Who |\n| --- | --- |\n| Build | CI |",
+		},
+		{
+			name: "a table whose first row is data still gets a header, since Markdown has no other kind",
+			in:   `<table><tr><td>Build</td><td>CI</td></tr><tr><td>Ship</td><td>ops</td></tr></table>`,
+			want: "| Build | CI |\n| --- | --- |\n| Ship | ops |",
+		},
+		{
+			name: "a quote is quoted on every line it covers",
+			in:   `<blockquote><p>It has always done that.</p><p>Since the rebuild.</p></blockquote>`,
+			want: "> It has always done that.\n>\n> Since the rebuild.",
+		},
+		{
+			name: "a rule is a rule",
+			in:   `<p>before</p><hr/><p>after</p>`,
+			want: "before\n\n---\n\nafter",
+		},
+		{
+			name: "a preformatted block keeps its fence",
+			in:   "<pre>make deploy\nmake check</pre>",
+			want: "```\nmake deploy\nmake check\n```",
+		},
+		{
+			name: "a layout column is a container and not content",
+			in:   `<ac:layout><ac:layout-section><ac:layout-cell><p>In the left column.</p></ac:layout-cell></ac:layout-section></ac:layout>`,
+			want: "In the left column.",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := storage(tt.in); got != tt.want {
+				t.Errorf("rendered\n%s\nwant\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+// The marks are the other half, and the entities are the part nobody thinks
+// about until a page full of non breaking spaces arrives looking like one word.
+func TestFormattingSurvives(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "bold and italic and struck through and code",
+			in:   `<p><strong>very</strong> <em>quietly</em> <del>wrong</del> <code>restart --hard</code></p>`,
+			want: "**very** *quietly* ~~wrong~~ `restart --hard`",
+		},
+		{
+			name: "a link keeps its words and its address",
+			in:   `<p>See <a href="https://ops.example.com/runbook">the runbook</a>.</p>`,
+			want: "See [the runbook](https://ops.example.com/runbook).",
+		},
+		{
+			name: "a link whose words are already the address is written once",
+			in:   `<p><a href="https://ops.example.com/runbook">https://ops.example.com/runbook</a></p>`,
+			want: "https://ops.example.com/runbook",
+		},
+		{
+			name: "an empty tag does not come out as its own marks",
+			in:   `<p>plain <strong></strong>text</p>`,
+			want: "plain text",
+		},
+		{
+			name: "an entity is the character it stands for",
+			in:   `<p>Coolant&nbsp;pump &amp; filter</p>`,
+			want: "Coolant pump & filter",
+		},
+		{
+			name: "a line break is a break and not a space",
+			in:   `<p>Line one<br/>Line two</p>`,
+			want: "Line one\nLine two",
+		},
+		{
+			name: "the layout somebody wrote the markup with is not content",
+			in:   "<p>one\n    word\n    per\n    line</p>",
+			want: "one word per line",
+		},
+		{
+			name: "a script is neither written by anybody nor read by anybody",
+			in:   `<p>before<script>alert(1)</script>after</p>`,
+			want: "beforeafter",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := storage(tt.in); got != tt.want {
+				t.Errorf("rendered %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The Confluence elements are what makes this not an HTML renderer. A macro is
+// where a wiki keeps the things a document does not have, and the three kinds of
+// them are worth telling apart: one holds text that has to survive exactly, one
+// holds prose that has to be read, and one holds nothing at all.
+func TestTheWikisOwnElements(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "a code macro keeps its fence and its language",
+			in: `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter>` +
+				"<ac:plain-text-body><![CDATA[make deploy\nmake check]]></ac:plain-text-body></ac:structured-macro>",
+			want: "```bash\nmake deploy\nmake check\n```",
+		},
+		{
+			name: "a code macro with no language still has a fence",
+			in: `<ac:structured-macro ac:name="code">` +
+				"<ac:plain-text-body><![CDATA[make build]]></ac:plain-text-body></ac:structured-macro>",
+			want: "```\nmake build\n```",
+		},
+		{
+			name: "a panel is a quote with its title above what it says",
+			in: `<ac:structured-macro ac:name="info"><ac:parameter ac:name="title">Careful</ac:parameter>` +
+				`<ac:rich-text-body><p>It moved to eleven.</p></ac:rich-text-body></ac:structured-macro>`,
+			want: "> **Careful**\n>\n> It moved to eleven.",
+		},
+		{
+			name: "a panel with no title is just the quote",
+			in: `<ac:structured-macro ac:name="warning">` +
+				`<ac:rich-text-body><p>Not on a Friday.</p></ac:rich-text-body></ac:structured-macro>`,
+			want: "> Not on a Friday.",
+		},
+		{
+			name: "a table of contents is navigation and says nothing the page does not",
+			in:   `<ac:structured-macro ac:name="toc"/><p>after</p>`,
+			want: "after",
+		},
+		{
+			name: "a macro nobody has heard of still gives up its text",
+			in: `<ac:structured-macro ac:name="acme-status-board">` +
+				`<ac:rich-text-body><p>Everything is green.</p></ac:rich-text-body></ac:structured-macro>`,
+			want: "Everything is green.",
+		},
+		{
+			name: "a task list keeps which ones are done",
+			in: `<ac:task-list>` +
+				`<ac:task><ac:task-id>1</ac:task-id><ac:task-status>complete</ac:task-status><ac:task-body>Ship it</ac:task-body></ac:task>` +
+				`<ac:task><ac:task-id>2</ac:task-id><ac:task-status>incomplete</ac:task-status><ac:task-body>Tell people</ac:task-body></ac:task>` +
+				`</ac:task-list>`,
+			want: "- [x] Ship it\n- [ ] Tell people",
+		},
+		{
+			name: "an attachment is named, since the bytes are not here",
+			in:   `<p><ac:image ac:alt="Line two"><ri:attachment ri:filename="line.png"/></ac:image></p>`,
+			want: "(attachment: Line two)",
+		},
+		{
+			name: "an attachment with nothing said about it is named by its file",
+			in:   `<p><ac:image><ri:attachment ri:filename="gearbox.png"/></ac:image></p>`,
+			want: "(attachment: gearbox.png)",
+		},
+		{
+			name: "an emoticon is the character the page shows",
+			in:   `<p>Shipped <ac:emoticon ac:name="tick" ac:emoji-fallback="✅"/></p>`,
+			want: "Shipped ✅",
+		},
+		{
+			name: "a link to a page is its label, since the page is indexed under its own id",
+			in: `<p>See <ac:link><ri:page ri:content-title="Runbook"/>` +
+				"<ac:plain-text-link-body><![CDATA[the runbook]]></ac:plain-text-link-body></ac:link> first.</p>",
+			want: "See the runbook first.",
+		},
+		{
+			name: "a link with no label of its own reads as what it points at",
+			in:   `<p>See <ac:link><ri:page ri:content-title="Runbook"/></ac:link> first.</p>`,
+			want: "See Runbook first.",
+		},
+		{
+			name: "a mention with no name is nothing, because an account id is not a name",
+			in:   `<p>Ask <ac:link><ri:user ri:account-id="557058:9c1"/></ac:link> about it.</p>`,
+			want: "Ask about it.",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := storage(tt.in); got != tt.want {
+				t.Errorf("rendered %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A Confluence link arrives with the local name link, because a prefix is not a
+// name to a parser reading a fragment that declares no namespaces. Closing it on
+// sight, which is what the standard list of void elements says to do with a
+// link, ends it before its label and takes the rest of the sentence with it.
+// This is that bug, and it cost a sentence off the end of every paragraph that
+// mentioned another page.
+func TestALinkDoesNotSwallowTheRestOfItsSentence(t *testing.T) {
+	got := storage(`<p>The deploy is <ac:link><ri:page ri:content-title="Runbook"/>` +
+		"<ac:plain-text-link-body><![CDATA[here]]></ac:plain-text-link-body></ac:link>" +
+		` and it runs at nine.</p><p>The rollback is separate.</p>`)
+
+	want := "The deploy is here and it runs at nine.\n\nThe rollback is separate."
+	if got != want {
+		t.Errorf("rendered\n%s\nwant\n%s", got, want)
+	}
+}
+
+// What arrives is somebody else's markup, written by hand over a decade by
+// people who were not thinking about a parser. The rule throughout is that a
+// page this cannot read costs its body and not the page: a page with a title, an
+// author and a comment thread is worth indexing either way.
+func TestWhatCannotBeReadCostsOnlyItself(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"nothing at all", "", ""},
+		{"whitespace", "   \n  ", ""},
+		{"a tag that was never closed", `<p>unclosed <b>bold</p>`, "unclosed **bold**"},
+		{"an end tag with no start, which keeps the page up to where it stopped making sense", `<p>one</p></div><p>two</p>`, "one"},
+		{"a page that is only text", `Just a sentence.`, "Just a sentence."},
+		{"an empty paragraph", `<p></p>`, ""},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := storage(tt.in); got != tt.want {
+				t.Errorf("rendered %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The walk is recursive and the input is a stranger's, so a page that nests
+// itself further than anything legitimate is flattened rather than followed all
+// the way down. The text at the bottom of it is still text somebody wrote and it
+// is kept. What is dropped is the nesting, which past thirty levels is not
+// telling a reader anything.
+func TestAPageThatNestsForeverIsFlattenedRatherThanFatal(t *testing.T) {
+	in := "<p>the bottom</p>"
+	for range 5000 {
+		in = "<blockquote>" + in + "</blockquote>"
+	}
+
+	done := make(chan string, 1)
+	go func() { done <- storage(in) }()
+	got := <-done
+
+	if !strings.Contains(got, "the bottom") {
+		t.Errorf("a deeply nested page lost the text at the bottom of it:\n%q", got)
+	}
+	if lines := strings.Count(got, "\n") + 1; lines > 4 {
+		t.Errorf("a deeply nested page came out as %d lines:\n%q", lines, got)
+	}
+	if depth := strings.Count(got, "> "); depth > maxStorageDepth {
+		t.Errorf("a page nested five thousand deep was quoted %d levels deep", depth)
+	}
+}
+
+// Six blank lines in a row is not a paragraph break, it is the renderer showing
+// through, and a wiki page nests deeply enough to produce them: a panel inside a
+// list item inside a quote is three levels each leaving one behind.
+func TestNestingDoesNotLeaveItsBlankLinesBehind(t *testing.T) {
+	got := storage(`<blockquote><ul><li><ac:structured-macro ac:name="note"><ac:rich-text-body>` +
+		`<p>Deep.</p><p>Deeper.</p></ac:rich-text-body></ac:structured-macro></li></ul></blockquote>`)
+
+	if strings.Contains(got, "\n\n\n") {
+		t.Errorf("the rendering has a run of blank lines in it:\n%q", got)
+	}
+	for _, want := range []string{"Deep.", "Deeper."} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the rendering lost %q:\n%s", want, got)
+		}
+	}
+}

--- a/connector/confluencesource/testdata/site/0001-get-wiki-rest-api-space-expand-permissions-limit-50-status-current.json
+++ b/connector/confluencesource/testdata/site/0001-get-wiki-rest-api-space-expand-permissions-limit-50-status-current.json
@@ -1,0 +1,130 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/wiki/rest/api/space?expand=permissions\u0026limit=50\u0026status=current",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "limit": 2,
+        "results": [
+          {
+            "id": 100,
+            "key": "OPS",
+            "name": "Line two operations",
+            "permissions": [
+              {
+                "operation": {
+                  "operation": "create",
+                  "targetType": "page"
+                },
+                "subjects": {
+                  "group": {
+                    "results": [
+                      {
+                        "id": "g-engineering",
+                        "name": "engineering",
+                        "type": "group"
+                      }
+                    ],
+                    "size": 1
+                  },
+                  "user": {
+                    "results": [
+                      {
+                        "accountId": "acc-mei",
+                        "displayName": "Mei Tanaka",
+                        "email": "mei@acme.com",
+                        "publicName": "Mei Tanaka",
+                        "type": "known"
+                      }
+                    ],
+                    "size": 1
+                  }
+                }
+              },
+              {
+                "operation": {
+                  "operation": "read",
+                  "targetType": "space"
+                },
+                "subjects": {
+                  "group": {
+                    "results": [
+                      {
+                        "id": "g-engineering",
+                        "name": "engineering",
+                        "type": "group"
+                      }
+                    ],
+                    "size": 1
+                  },
+                  "user": {
+                    "results": [
+                      {
+                        "accountId": "acc-mei",
+                        "displayName": "Mei Tanaka",
+                        "email": "mei@acme.com",
+                        "publicName": "Mei Tanaka",
+                        "type": "known"
+                      }
+                    ],
+                    "size": 1
+                  }
+                }
+              }
+            ],
+            "status": "current",
+            "type": "global"
+          },
+          {
+            "id": 101,
+            "key": "ENG",
+            "name": "Engineering",
+            "permissions": [
+              {
+                "operation": {
+                  "operation": "create",
+                  "targetType": "page"
+                },
+                "subjects": {
+                  "group": {
+                    "results": [],
+                    "size": 0
+                  },
+                  "user": {
+                    "results": [],
+                    "size": 0
+                  }
+                }
+              },
+              {
+                "anonymousAccess": true,
+                "operation": {
+                  "operation": "read",
+                  "targetType": "space"
+                },
+                "subjects": {}
+              }
+            ],
+            "status": "current",
+            "type": "global"
+          }
+        ],
+        "size": 2,
+        "start": 0
+      }
+    }
+  }
+}

--- a/connector/confluencesource/testdata/site/0002-get-wiki-rest-api-content-search-cql-type-page-or-type-comment-and-status.json
+++ b/connector/confluencesource/testdata/site/0002-get-wiki-rest-api-content-search-cql-type-page-or-type-comment-and-status.json
@@ -1,0 +1,101 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/wiki/rest/api/content/search?cql=%28type+%3D+page+or+type+%3D+comment%29+and+status+%3D+current+and+space+%3D+%22ENG%22+order+by+lastModified+asc\u0026expand=body.atlas_doc_format%2Cversion%2Chistory%2Cspace%2Ccontainer%2Cancestors%2Cmetadata.labels%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group%2Cchildren.comment.body.atlas_doc_format%2Cchildren.comment.version%2Cchildren.comment.history\u0026limit=50",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "cqlQuery": "(type = page or type = comment) and status = current and space = \"ENG\" order by lastModified asc",
+        "limit": 2,
+        "results": [
+          {
+            "_links": {
+              "webui": "/spaces/ENG/pages/100005/Line%20two%20specification"
+            },
+            "ancestors": null,
+            "body": {
+              "atlas_doc_format": {
+                "representation": "atlas_doc_format",
+                "value": "{\"content\":[{\"content\":[{\"text\":\"Line two runs at 1450 rpm under load.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+              }
+            },
+            "children": {
+              "comment": {
+                "limit": 2,
+                "results": [],
+                "size": 0,
+                "start": 0
+              }
+            },
+            "history": {
+              "createdBy": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "createdDate": "2026-04-06T09:09:00.000+00:00"
+            },
+            "id": "100005",
+            "metadata": {
+              "labels": {
+                "results": []
+              }
+            },
+            "restrictions": {
+              "read": {
+                "operation": "read",
+                "restrictions": {
+                  "group": {
+                    "results": [],
+                    "size": 0
+                  },
+                  "user": {
+                    "results": [],
+                    "size": 0
+                  }
+                }
+              }
+            },
+            "space": {
+              "id": 101,
+              "key": "ENG",
+              "name": "Engineering"
+            },
+            "status": "current",
+            "title": "Line two specification",
+            "type": "page",
+            "version": {
+              "by": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "number": 1,
+              "when": "2026-04-06T09:09:00.000+00:00"
+            }
+          }
+        ],
+        "searchDurati": 1,
+        "size": 1,
+        "start": 0,
+        "totalSize": 1
+      }
+    }
+  }
+}

--- a/connector/confluencesource/testdata/site/0003-get-wiki-rest-api-content-search-cql-type-page-or-type-comment-and-status.json
+++ b/connector/confluencesource/testdata/site/0003-get-wiki-rest-api-content-search-cql-type-page-or-type-comment-and-status.json
@@ -1,0 +1,218 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/wiki/rest/api/content/search?cql=%28type+%3D+page+or+type+%3D+comment%29+and+status+%3D+current+and+space+%3D+%22OPS%22+order+by+lastModified+asc\u0026expand=body.atlas_doc_format%2Cversion%2Chistory%2Cspace%2Ccontainer%2Cancestors%2Cmetadata.labels%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group%2Cchildren.comment.body.atlas_doc_format%2Cchildren.comment.version%2Cchildren.comment.history\u0026limit=50",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "_links": {
+          "next": "/wiki/rest/api/content/search?cql=%28type+%3D+page+or+type+%3D+comment%29+and+status+%3D+current+and+space+%3D+%22OPS%22+order+by+lastModified+asc\u0026cursor=raNDom2Token\u0026expand=body.atlas_doc_format%2Cversion%2Chistory%2Cspace%2Ccontainer%2Cancestors%2Cmetadata.labels%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group%2Cchildren.comment.body.atlas_doc_format%2Cchildren.comment.version%2Cchildren.comment.history\u0026limit=2"
+        },
+        "cqlQuery": "(type = page or type = comment) and status = current and space = \"OPS\" order by lastModified asc",
+        "limit": 2,
+        "results": [
+          {
+            "_links": {
+              "webui": "/spaces/OPS/pages/100001/Deploy"
+            },
+            "ancestors": null,
+            "body": {
+              "atlas_doc_format": {
+                "representation": "atlas_doc_format",
+                "value": "{\"content\":[{\"content\":[{\"text\":\"The deploy runs at nine every weekday morning.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+              }
+            },
+            "children": {
+              "comment": {
+                "limit": 2,
+                "results": [
+                  {
+                    "body": {
+                      "atlas_doc_format": {
+                        "representation": "atlas_doc_format",
+                        "value": "{\"content\":[{\"content\":[{\"text\":\"It moved to eleven in March when the batch job was added.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+                      }
+                    },
+                    "history": {
+                      "createdBy": {
+                        "accountId": "acc-sam",
+                        "displayName": "Sam Okafor",
+                        "email": "sam@acme.com",
+                        "publicName": "Sam Okafor",
+                        "type": "known"
+                      },
+                      "createdDate": "2026-04-06T09:03:00.000+00:00"
+                    },
+                    "id": "900010",
+                    "status": "current",
+                    "title": "Re: a page",
+                    "type": "comment",
+                    "version": {
+                      "by": {
+                        "accountId": "acc-sam",
+                        "displayName": "Sam Okafor",
+                        "email": "sam@acme.com",
+                        "publicName": "Sam Okafor",
+                        "type": "known"
+                      },
+                      "number": 1,
+                      "when": "2026-04-06T09:03:00.000+00:00"
+                    }
+                  },
+                  {
+                    "body": {
+                      "atlas_doc_format": {
+                        "representation": "atlas_doc_format",
+                        "value": "{\"content\":[{\"content\":[{\"text\":\"Confirmed, eleven. The heading above is out of date.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+                      }
+                    },
+                    "history": {
+                      "createdBy": {
+                        "accountId": "acc-lee",
+                        "displayName": "Lee Berger",
+                        "email": "lee@acme.com",
+                        "publicName": "Lee Berger",
+                        "type": "known"
+                      },
+                      "createdDate": "2026-04-06T09:04:00.000+00:00"
+                    },
+                    "id": "900011",
+                    "status": "current",
+                    "title": "Re: a page",
+                    "type": "comment",
+                    "version": {
+                      "by": {
+                        "accountId": "acc-lee",
+                        "displayName": "Lee Berger",
+                        "email": "lee@acme.com",
+                        "publicName": "Lee Berger",
+                        "type": "known"
+                      },
+                      "number": 1,
+                      "when": "2026-04-06T09:04:00.000+00:00"
+                    }
+                  }
+                ],
+                "size": 2,
+                "start": 0
+              }
+            },
+            "history": {
+              "createdBy": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "createdDate": "2026-04-06T09:01:00.000+00:00"
+            },
+            "id": "100001",
+            "metadata": {
+              "labels": {
+                "results": [
+                  {
+                    "name": "runbook",
+                    "prefix": "global"
+                  },
+                  {
+                    "name": "deploy",
+                    "prefix": "global"
+                  }
+                ]
+              }
+            },
+            "restrictions": {
+              "read": {
+                "operation": "read",
+                "restrictions": {
+                  "group": {
+                    "results": [],
+                    "size": 0
+                  },
+                  "user": {
+                    "results": [],
+                    "size": 0
+                  }
+                }
+              }
+            },
+            "space": {
+              "id": 100,
+              "key": "OPS",
+              "name": "Line two operations"
+            },
+            "status": "current",
+            "title": "Deploy",
+            "type": "page",
+            "version": {
+              "by": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "number": 2,
+              "when": "2026-04-06T09:02:00.000+00:00"
+            }
+          },
+          {
+            "body": {
+              "atlas_doc_format": {
+                "representation": "atlas_doc_format",
+                "value": "{\"content\":[{\"content\":[{\"text\":\"It moved to eleven in March when the batch job was added.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+              }
+            },
+            "container": {
+              "id": "100001",
+              "title": "Deploy",
+              "type": "page"
+            },
+            "history": {
+              "createdBy": {
+                "accountId": "acc-sam",
+                "displayName": "Sam Okafor",
+                "email": "sam@acme.com",
+                "publicName": "Sam Okafor",
+                "type": "known"
+              },
+              "createdDate": "2026-04-06T09:03:00.000+00:00"
+            },
+            "id": "900010",
+            "status": "current",
+            "title": "Re: a page",
+            "type": "comment",
+            "version": {
+              "by": {
+                "accountId": "acc-sam",
+                "displayName": "Sam Okafor",
+                "email": "sam@acme.com",
+                "publicName": "Sam Okafor",
+                "type": "known"
+              },
+              "number": 1,
+              "when": "2026-04-06T09:03:00.000+00:00"
+            }
+          }
+        ],
+        "searchDurati": 1,
+        "size": 2,
+        "start": 0,
+        "totalSize": 6
+      }
+    }
+  }
+}

--- a/connector/confluencesource/testdata/site/0004-get-wiki-rest-api-content-search-cql-type-page-or-type-comment-and-status.json
+++ b/connector/confluencesource/testdata/site/0004-get-wiki-rest-api-content-search-cql-type-page-or-type-comment-and-status.json
@@ -1,0 +1,142 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/wiki/rest/api/content/search?cql=%28type+%3D+page+or+type+%3D+comment%29+and+status+%3D+current+and+space+%3D+%22OPS%22+order+by+lastModified+asc\u0026cursor=raNDom2Token\u0026expand=body.atlas_doc_format%2Cversion%2Chistory%2Cspace%2Ccontainer%2Cancestors%2Cmetadata.labels%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group%2Cchildren.comment.body.atlas_doc_format%2Cchildren.comment.version%2Cchildren.comment.history\u0026limit=2",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "_links": {
+          "next": "/wiki/rest/api/content/search?cql=%28type+%3D+page+or+type+%3D+comment%29+and+status+%3D+current+and+space+%3D+%22OPS%22+order+by+lastModified+asc\u0026cursor=raNDom4Token\u0026expand=body.atlas_doc_format%2Cversion%2Chistory%2Cspace%2Ccontainer%2Cancestors%2Cmetadata.labels%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group%2Cchildren.comment.body.atlas_doc_format%2Cchildren.comment.version%2Cchildren.comment.history\u0026limit=2"
+        },
+        "cqlQuery": "(type = page or type = comment) and status = current and space = \"OPS\" order by lastModified asc",
+        "limit": 2,
+        "results": [
+          {
+            "body": {
+              "atlas_doc_format": {
+                "representation": "atlas_doc_format",
+                "value": "{\"content\":[{\"content\":[{\"text\":\"Confirmed, eleven. The heading above is out of date.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+              }
+            },
+            "container": {
+              "id": "100001",
+              "title": "Deploy",
+              "type": "page"
+            },
+            "history": {
+              "createdBy": {
+                "accountId": "acc-lee",
+                "displayName": "Lee Berger",
+                "email": "lee@acme.com",
+                "publicName": "Lee Berger",
+                "type": "known"
+              },
+              "createdDate": "2026-04-06T09:04:00.000+00:00"
+            },
+            "id": "900011",
+            "status": "current",
+            "title": "Re: a page",
+            "type": "comment",
+            "version": {
+              "by": {
+                "accountId": "acc-lee",
+                "displayName": "Lee Berger",
+                "email": "lee@acme.com",
+                "publicName": "Lee Berger",
+                "type": "known"
+              },
+              "number": 1,
+              "when": "2026-04-06T09:04:00.000+00:00"
+            }
+          },
+          {
+            "_links": {
+              "webui": "/spaces/OPS/pages/100002/Restarting%20line%20two"
+            },
+            "ancestors": null,
+            "body": {
+              "atlas_doc_format": {
+                "representation": "atlas_doc_format",
+                "value": ""
+              }
+            },
+            "children": {
+              "comment": {
+                "limit": 2,
+                "results": [],
+                "size": 0,
+                "start": 0
+              }
+            },
+            "history": {
+              "createdBy": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "createdDate": "2026-04-06T09:05:00.000+00:00"
+            },
+            "id": "100002",
+            "metadata": {
+              "labels": {
+                "results": []
+              }
+            },
+            "restrictions": {
+              "read": {
+                "operation": "read",
+                "restrictions": {
+                  "group": {
+                    "results": [],
+                    "size": 0
+                  },
+                  "user": {
+                    "results": [],
+                    "size": 0
+                  }
+                }
+              }
+            },
+            "space": {
+              "id": 100,
+              "key": "OPS",
+              "name": "Line two operations"
+            },
+            "status": "current",
+            "title": "Restarting line two",
+            "type": "page",
+            "version": {
+              "by": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "number": 2,
+              "when": "2026-04-06T09:06:00.000+00:00"
+            }
+          }
+        ],
+        "searchDurati": 1,
+        "size": 2,
+        "start": 2,
+        "totalSize": 6
+      }
+    }
+  }
+}

--- a/connector/confluencesource/testdata/site/0005-get-wiki-rest-api-content-100002-expand-body.storage.json
+++ b/connector/confluencesource/testdata/site/0005-get-wiki-rest-api-content-100002-expand-body.storage.json
@@ -1,0 +1,36 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/wiki/rest/api/content/100002?expand=body.storage",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "_links": {
+          "webui": "/spaces/OPS/pages/100002/Restarting%20line%20two"
+        },
+        "body": {
+          "storage": {
+            "representation": "storage",
+            "value": "\u003ch2\u003eRestarting line two\u003c/h2\u003e\u003cp\u003eStop the feed, wait for the \u003cstrong\u003egreen\u003c/strong\u003e light, then run:\u003c/p\u003e\u003cac:structured-macro ac:name=\"code\"\u003e\u003cac:parameter ac:name=\"language\"\u003ebash\u003c/ac:parameter\u003e\u003cac:plain-text-body\u003e\u003c![CDATA[line2ctl stop --drain\nline2ctl start]]\u003e\u003c/ac:plain-text-body\u003e\u003c/ac:structured-macro\u003e\u003cac:structured-macro ac:name=\"warning\"\u003e\u003cac:parameter ac:name=\"title\"\u003eDo not skip the drain\u003c/ac:parameter\u003e\u003cac:rich-text-body\u003e\u003cp\u003eThe gearbox will bind if the feed is still moving.\u003c/p\u003e\u003c/ac:rich-text-body\u003e\u003c/ac:structured-macro\u003e"
+          }
+        },
+        "id": "100002",
+        "status": "current",
+        "title": "Restarting line two",
+        "type": "page"
+      }
+    }
+  }
+}

--- a/connector/confluencesource/testdata/site/0006-get-wiki-rest-api-content-search-cql-type-page-or-type-comment-and-status.json
+++ b/connector/confluencesource/testdata/site/0006-get-wiki-rest-api-content-search-cql-type-page-or-type-comment-and-status.json
@@ -1,0 +1,191 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/wiki/rest/api/content/search?cql=%28type+%3D+page+or+type+%3D+comment%29+and+status+%3D+current+and+space+%3D+%22OPS%22+order+by+lastModified+asc\u0026cursor=raNDom4Token\u0026expand=body.atlas_doc_format%2Cversion%2Chistory%2Cspace%2Ccontainer%2Cancestors%2Cmetadata.labels%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group%2Cchildren.comment.body.atlas_doc_format%2Cchildren.comment.version%2Cchildren.comment.history\u0026limit=2",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "cqlQuery": "(type = page or type = comment) and status = current and space = \"OPS\" order by lastModified asc",
+        "limit": 2,
+        "results": [
+          {
+            "_links": {
+              "webui": "/spaces/OPS/pages/100003/Incidents"
+            },
+            "ancestors": null,
+            "body": {
+              "atlas_doc_format": {
+                "representation": "atlas_doc_format",
+                "value": "{\"content\":[{\"content\":[{\"text\":\"Everything that went wrong, one page each.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+              }
+            },
+            "children": {
+              "comment": {
+                "limit": 2,
+                "results": [],
+                "size": 0,
+                "start": 0
+              }
+            },
+            "history": {
+              "createdBy": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "createdDate": "2026-04-06T09:07:00.000+00:00"
+            },
+            "id": "100003",
+            "metadata": {
+              "labels": {
+                "results": []
+              }
+            },
+            "restrictions": {
+              "read": {
+                "operation": "read",
+                "restrictions": {
+                  "group": {
+                    "results": [],
+                    "size": 0
+                  },
+                  "user": {
+                    "results": [],
+                    "size": 0
+                  }
+                }
+              }
+            },
+            "space": {
+              "id": 100,
+              "key": "OPS",
+              "name": "Line two operations"
+            },
+            "status": "current",
+            "title": "Incidents",
+            "type": "page",
+            "version": {
+              "by": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "number": 1,
+              "when": "2026-04-06T09:07:00.000+00:00"
+            }
+          },
+          {
+            "_links": {
+              "webui": "/spaces/OPS/pages/100004/Pump%20failure"
+            },
+            "ancestors": [
+              {
+                "id": "100003",
+                "title": "Incidents",
+                "type": "page"
+              }
+            ],
+            "body": {
+              "atlas_doc_format": {
+                "representation": "atlas_doc_format",
+                "value": "{\"content\":[{\"content\":[{\"text\":\"The coolant pump on line two failed on Tuesday afternoon.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+              }
+            },
+            "children": {
+              "comment": {
+                "limit": 2,
+                "results": [],
+                "size": 0,
+                "start": 0
+              }
+            },
+            "history": {
+              "createdBy": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "createdDate": "2026-04-06T09:08:00.000+00:00"
+            },
+            "id": "100004",
+            "metadata": {
+              "labels": {
+                "results": []
+              }
+            },
+            "restrictions": {
+              "read": {
+                "operation": "read",
+                "restrictions": {
+                  "group": {
+                    "results": [
+                      {
+                        "id": "g-safety-officers",
+                        "name": "safety-officers",
+                        "type": "group"
+                      }
+                    ],
+                    "size": 1
+                  },
+                  "user": {
+                    "results": [
+                      {
+                        "accountId": "acc-lee",
+                        "displayName": "Lee Berger",
+                        "email": "lee@acme.com",
+                        "publicName": "Lee Berger",
+                        "type": "known"
+                      }
+                    ],
+                    "size": 1
+                  }
+                }
+              }
+            },
+            "space": {
+              "id": 100,
+              "key": "OPS",
+              "name": "Line two operations"
+            },
+            "status": "current",
+            "title": "Pump failure",
+            "type": "page",
+            "version": {
+              "by": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "number": 1,
+              "when": "2026-04-06T09:08:00.000+00:00"
+            }
+          }
+        ],
+        "searchDurati": 1,
+        "size": 2,
+        "start": 4,
+        "totalSize": 6
+      }
+    }
+  }
+}

--- a/connector/confluencesource/testdata/site/0007-get-wiki-rest-api-content-search-cql-type-page-and-status-current-and-space-eng.json
+++ b/connector/confluencesource/testdata/site/0007-get-wiki-rest-api-content-search-cql-type-page-and-status-current-and-space-eng.json
@@ -1,0 +1,67 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/wiki/rest/api/content/search?cql=type+%3D+page+and+status+%3D+current+and+space+%3D+%22ENG%22+order+by+id+asc\u0026expand=version%2Cancestors%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group\u0026limit=50",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "cqlQuery": "type = page and status = current and space = \"ENG\" order by id asc",
+        "limit": 2,
+        "results": [
+          {
+            "_links": {
+              "webui": "/spaces/ENG/pages/100005/Line%20two%20specification"
+            },
+            "ancestors": null,
+            "id": "100005",
+            "restrictions": {
+              "read": {
+                "operation": "read",
+                "restrictions": {
+                  "group": {
+                    "results": [],
+                    "size": 0
+                  },
+                  "user": {
+                    "results": [],
+                    "size": 0
+                  }
+                }
+              }
+            },
+            "status": "current",
+            "title": "Line two specification",
+            "type": "page",
+            "version": {
+              "by": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "number": 1,
+              "when": "2026-04-06T09:09:00.000+00:00"
+            }
+          }
+        ],
+        "searchDurati": 1,
+        "size": 1,
+        "start": 0,
+        "totalSize": 1
+      }
+    }
+  }
+}

--- a/connector/confluencesource/testdata/site/0008-get-wiki-rest-api-content-search-cql-type-page-and-status-current-and-space-ops.json
+++ b/connector/confluencesource/testdata/site/0008-get-wiki-rest-api-content-search-cql-type-page-and-status-current-and-space-ops.json
@@ -1,0 +1,106 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/wiki/rest/api/content/search?cql=type+%3D+page+and+status+%3D+current+and+space+%3D+%22OPS%22+order+by+id+asc\u0026expand=version%2Cancestors%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group\u0026limit=50",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "_links": {
+          "next": "/wiki/rest/api/content/search?cql=type+%3D+page+and+status+%3D+current+and+space+%3D+%22OPS%22+order+by+id+asc\u0026cursor=raNDom2Token\u0026expand=version%2Cancestors%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group\u0026limit=2"
+        },
+        "cqlQuery": "type = page and status = current and space = \"OPS\" order by id asc",
+        "limit": 2,
+        "results": [
+          {
+            "_links": {
+              "webui": "/spaces/OPS/pages/100001/Deploy"
+            },
+            "ancestors": null,
+            "id": "100001",
+            "restrictions": {
+              "read": {
+                "operation": "read",
+                "restrictions": {
+                  "group": {
+                    "results": [],
+                    "size": 0
+                  },
+                  "user": {
+                    "results": [],
+                    "size": 0
+                  }
+                }
+              }
+            },
+            "status": "current",
+            "title": "Deploy",
+            "type": "page",
+            "version": {
+              "by": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "number": 2,
+              "when": "2026-04-06T09:02:00.000+00:00"
+            }
+          },
+          {
+            "_links": {
+              "webui": "/spaces/OPS/pages/100002/Restarting%20line%20two"
+            },
+            "ancestors": null,
+            "id": "100002",
+            "restrictions": {
+              "read": {
+                "operation": "read",
+                "restrictions": {
+                  "group": {
+                    "results": [],
+                    "size": 0
+                  },
+                  "user": {
+                    "results": [],
+                    "size": 0
+                  }
+                }
+              }
+            },
+            "status": "current",
+            "title": "Restarting line two",
+            "type": "page",
+            "version": {
+              "by": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "number": 2,
+              "when": "2026-04-06T09:06:00.000+00:00"
+            }
+          }
+        ],
+        "searchDurati": 1,
+        "size": 2,
+        "start": 0,
+        "totalSize": 4
+      }
+    }
+  }
+}

--- a/connector/confluencesource/testdata/site/0009-get-wiki-rest-api-content-search-cql-type-page-and-status-current-and-space-ops.json
+++ b/connector/confluencesource/testdata/site/0009-get-wiki-rest-api-content-search-cql-type-page-and-status-current-and-space-ops.json
@@ -1,0 +1,123 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/wiki/rest/api/content/search?cql=type+%3D+page+and+status+%3D+current+and+space+%3D+%22OPS%22+order+by+id+asc\u0026cursor=raNDom2Token\u0026expand=version%2Cancestors%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group\u0026limit=2",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "cqlQuery": "type = page and status = current and space = \"OPS\" order by id asc",
+        "limit": 2,
+        "results": [
+          {
+            "_links": {
+              "webui": "/spaces/OPS/pages/100003/Incidents"
+            },
+            "ancestors": null,
+            "id": "100003",
+            "restrictions": {
+              "read": {
+                "operation": "read",
+                "restrictions": {
+                  "group": {
+                    "results": [],
+                    "size": 0
+                  },
+                  "user": {
+                    "results": [],
+                    "size": 0
+                  }
+                }
+              }
+            },
+            "status": "current",
+            "title": "Incidents",
+            "type": "page",
+            "version": {
+              "by": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "number": 1,
+              "when": "2026-04-06T09:07:00.000+00:00"
+            }
+          },
+          {
+            "_links": {
+              "webui": "/spaces/OPS/pages/100004/Pump%20failure"
+            },
+            "ancestors": [
+              {
+                "id": "100003",
+                "title": "Incidents",
+                "type": "page"
+              }
+            ],
+            "id": "100004",
+            "restrictions": {
+              "read": {
+                "operation": "read",
+                "restrictions": {
+                  "group": {
+                    "results": [
+                      {
+                        "id": "g-safety-officers",
+                        "name": "safety-officers",
+                        "type": "group"
+                      }
+                    ],
+                    "size": 1
+                  },
+                  "user": {
+                    "results": [
+                      {
+                        "accountId": "acc-lee",
+                        "displayName": "Lee Berger",
+                        "email": "lee@acme.com",
+                        "publicName": "Lee Berger",
+                        "type": "known"
+                      }
+                    ],
+                    "size": 1
+                  }
+                }
+              }
+            },
+            "status": "current",
+            "title": "Pump failure",
+            "type": "page",
+            "version": {
+              "by": {
+                "accountId": "acc-mei",
+                "displayName": "Mei Tanaka",
+                "email": "mei@acme.com",
+                "publicName": "Mei Tanaka",
+                "type": "known"
+              },
+              "number": 1,
+              "when": "2026-04-06T09:08:00.000+00:00"
+            }
+          }
+        ],
+        "searchDurati": 1,
+        "size": 2,
+        "start": 2,
+        "totalSize": 4
+      }
+    }
+  }
+}

--- a/connector/confluencesource/testdata/site/0010-get-wiki-rest-api-content-100001-expand-body.atlas-doc-format-version-history.json
+++ b/connector/confluencesource/testdata/site/0010-get-wiki-rest-api-content-100001-expand-body.atlas-doc-format-version-history.json
@@ -1,0 +1,167 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.atlassian.net/wiki/rest/api/content/100001?expand=body.atlas_doc_format%2Cversion%2Chistory%2Cspace%2Ccontainer%2Cancestors%2Cmetadata.labels%2Crestrictions.read.restrictions.user%2Crestrictions.read.restrictions.group%2Cchildren.comment.body.atlas_doc_format%2Cchildren.comment.version%2Cchildren.comment.history",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "_links": {
+          "webui": "/spaces/OPS/pages/100001/Deploy"
+        },
+        "ancestors": null,
+        "body": {
+          "atlas_doc_format": {
+            "representation": "atlas_doc_format",
+            "value": "{\"content\":[{\"content\":[{\"text\":\"The deploy runs at nine every weekday morning.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+          }
+        },
+        "children": {
+          "comment": {
+            "limit": 2,
+            "results": [
+              {
+                "body": {
+                  "atlas_doc_format": {
+                    "representation": "atlas_doc_format",
+                    "value": "{\"content\":[{\"content\":[{\"text\":\"It moved to eleven in March when the batch job was added.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+                  }
+                },
+                "history": {
+                  "createdBy": {
+                    "accountId": "acc-sam",
+                    "displayName": "Sam Okafor",
+                    "email": "sam@acme.com",
+                    "publicName": "Sam Okafor",
+                    "type": "known"
+                  },
+                  "createdDate": "2026-04-06T09:03:00.000+00:00"
+                },
+                "id": "900010",
+                "status": "current",
+                "title": "Re: a page",
+                "type": "comment",
+                "version": {
+                  "by": {
+                    "accountId": "acc-sam",
+                    "displayName": "Sam Okafor",
+                    "email": "sam@acme.com",
+                    "publicName": "Sam Okafor",
+                    "type": "known"
+                  },
+                  "number": 1,
+                  "when": "2026-04-06T09:03:00.000+00:00"
+                }
+              },
+              {
+                "body": {
+                  "atlas_doc_format": {
+                    "representation": "atlas_doc_format",
+                    "value": "{\"content\":[{\"content\":[{\"text\":\"Confirmed, eleven. The heading above is out of date.\",\"type\":\"text\"}],\"type\":\"paragraph\"}],\"type\":\"doc\",\"version\":1}"
+                  }
+                },
+                "history": {
+                  "createdBy": {
+                    "accountId": "acc-lee",
+                    "displayName": "Lee Berger",
+                    "email": "lee@acme.com",
+                    "publicName": "Lee Berger",
+                    "type": "known"
+                  },
+                  "createdDate": "2026-04-06T09:04:00.000+00:00"
+                },
+                "id": "900011",
+                "status": "current",
+                "title": "Re: a page",
+                "type": "comment",
+                "version": {
+                  "by": {
+                    "accountId": "acc-lee",
+                    "displayName": "Lee Berger",
+                    "email": "lee@acme.com",
+                    "publicName": "Lee Berger",
+                    "type": "known"
+                  },
+                  "number": 1,
+                  "when": "2026-04-06T09:04:00.000+00:00"
+                }
+              }
+            ],
+            "size": 2,
+            "start": 0
+          }
+        },
+        "history": {
+          "createdBy": {
+            "accountId": "acc-mei",
+            "displayName": "Mei Tanaka",
+            "email": "mei@acme.com",
+            "publicName": "Mei Tanaka",
+            "type": "known"
+          },
+          "createdDate": "2026-04-06T09:01:00.000+00:00"
+        },
+        "id": "100001",
+        "metadata": {
+          "labels": {
+            "results": [
+              {
+                "name": "runbook",
+                "prefix": "global"
+              },
+              {
+                "name": "deploy",
+                "prefix": "global"
+              }
+            ]
+          }
+        },
+        "restrictions": {
+          "read": {
+            "operation": "read",
+            "restrictions": {
+              "group": {
+                "results": [],
+                "size": 0
+              },
+              "user": {
+                "results": [],
+                "size": 0
+              }
+            }
+          }
+        },
+        "space": {
+          "id": 100,
+          "key": "OPS",
+          "name": "Line two operations"
+        },
+        "status": "current",
+        "title": "Deploy",
+        "type": "page",
+        "version": {
+          "by": {
+            "accountId": "acc-mei",
+            "displayName": "Mei Tanaka",
+            "email": "mei@acme.com",
+            "publicName": "Mei Tanaka",
+            "type": "known"
+          },
+          "number": 2,
+          "when": "2026-04-06T09:02:00.000+00:00"
+        }
+      }
+    }
+  }
+}

--- a/connector/confluencesource/testdata/site/README.md
+++ b/connector/confluencesource/testdata/site/README.md
@@ -1,0 +1,50 @@
+# A recorded Confluence site
+
+These files are one crawl of a small Confluence site, written down so the tests
+next to them can exercise the whole adapter without an account, a token or a
+network.
+Each file is one request and the answer it got, numbered in the order the crawl
+made them.
+
+The site has two spaces.
+`OPS` grants read to a group, and holds a page with two comments from two
+different people and a pair of labels, a page written before the editor changed
+whose body is storage format with a code macro and a warning panel in it, and a
+page nested under a parent and restricted to one account and one group so that a
+rule overriding the space it is in is in here too.
+`ENG` is readable by anybody signed in, which is the other permission shape a
+space can have, and holds one ordinary page.
+Between them they cover the space listing, the space permissions, the CQL
+search, the cursor paging, the comment assembly, the inline read restrictions,
+the second request for an old body and a single page read.
+
+## Refreshing them
+
+    go test ./connector/confluencesource/ -run TestRecordTheFixtures -update
+
+That runs the crawl again against the fake site in `fake_test.go` and rewrites
+every numbered file here.
+It does not touch this README.
+
+Two things are taken out before the files are written: the address the fake was
+listening on, which is replaced with a Confluence Cloud one, and the response
+headers that say how long the body was and what time it was.
+All of them change on every run and none of them is matched against, so leaving
+them in would turn every refresh into a diff on every file.
+
+The repeated requests are dropped as well.
+A crawl asks what the spaces are three times, once for the sync, once for the
+sweep and once for a fetch, and three copies of the same answer is three files
+to review and no more coverage.
+
+## What is not in here
+
+No credentials.
+The API token is sent as basic authentication in a header and the header is
+redacted before anything is written, and there is a test that reads these files
+back and fails if the token, the crawling account or an encoded credential is in
+them.
+
+Nothing real either.
+The people, the spaces and the pages are made up, and the site they came from is
+the fake in `fake_test.go` rather than anybody's Confluence.

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -548,6 +548,42 @@ Throwing the structure away is worse, because a ticket's description is very oft
 So it renders Markdown: headings stay headings, code blocks keep their fences and their language, lists stay lists and tables stay tables.
 A description that will not parse comes back empty rather than as an error, because a ticket with a summary, a reporter, a status and a comment thread is still worth indexing.
 
+### Confluence, and a product that changed its mind
+
+`connector/confluencesource` is the third adapter on that interface and the one where the four methods carry the least new weight, which is the result the shared crawl was built for.
+A wiki is a container of conversations the same way a workspace and a project are: a space holds pages, a page holds comments, and a page with its comments underneath it is one document rather than a document and a pile of fragments.
+The page says the deploy runs at nine and the third comment says it moved to eleven eighteen months ago, so a page indexed without its comments answers with the wrong time.
+
+The change feed is real and it is CQL.
+A page carries a version, an edit moves it, and CQL will filter and order by the time of the last change, so a sync is one query per space and there is no reply window and nothing to guess at.
+It has the same wrinkle Jira has, that CQL compares times to the minute and rejects anything finer, and it is handled the same way: ask for the minute the cursor is in and drop what arrived from the first half of it.
+
+The gap is comments.
+Confluence dates the comment and leaves the page alone, so a page that was answered and never edited again is one that a query about pages reports as unchanged for ever.
+So the query asks for comments as well, and a comment that comes back is resolved to the page it is on and the page is what gets emitted, because a comment is a sentence in a document rather than a document.
+That means a page with two new comments is emitted twice in one sync, with the later time on the second, and that is deliberate: the time on a comment is what moves the cursor past it, so an adapter that deduplicated within the sync would read the same comments again on the next one.
+
+Permissions are decided in two places and both of them are here.
+A space's read permission is granted to accounts and to groups, and it may be granted to anonymous users, which is a space that is open rather than a space with an empty rule.
+A page restriction is the second, and it is the concrete case `Thread.Access` exists for: a page with a read restriction is readable by the people named in it and by nobody else, whatever the space says.
+Restrictions inherit, so a page with no restriction of its own under a parent that has one is restricted, and the ancestors have to be consulted rather than assumed.
+A chain carrying a restriction at more than one level is quarantined rather than resolved, because Confluence means the intersection of the two and an intersection of a list of accounts with a list of groups is not something that can be worked out from outside the identity provider.
+Publishing the wider of the two would publish exactly the pages somebody went out of their way to restrict.
+
+The ancestor walk is cached, and the lifetime of that cache is the one thing in this adapter worth reading twice.
+A restricted subtree costs one request per ancestor rather than one per page, which is a saving worth having inside a crawl and a bug across them.
+A restriction put on a parent page is a revocation, and a revocation the index only heard about when the process next restarted is not one.
+So the cache is emptied at the top of every crawl, which is the call that lists the spaces, and there is a test that fails if it is not.
+
+The last part is the body, and it is where Confluence differs from the other two.
+The current editor stores a page as an Atlassian document, which is `connector/adf`'s job and already written for tickets.
+Pages written before that editor changed have no Atlassian document at all and a body in storage format instead, which is XHTML with two undeclared namespace prefixes in it, and there are a lot of those pages on any site old enough to be worth indexing.
+So the adapter asks for the structured body on every page, notices when it came back empty, and pays a second request for the old one only for the pages that need it.
+Rendering it is `storage()` in the same package, and it renders Markdown for the same reason the ticket adapter does: a runbook is mostly a heading, a code block and a table, and a search result that shows the reader a flattened version of the thing they were looking for has answered the query and failed the person.
+One detail in there is worth knowing because it cost an afternoon.
+Go's XML decoder auto closes the HTML tags that never have an end tag, `link` among them, and a fragment that declares no namespaces hands it `ac:link` as a local name of `link`, so the default list ends a Confluence link before its label and takes the rest of the sentence with it.
+The list is written out here with that one entry removed.
+
 ### The conformance suite is the definition
 
 `connector/connectortest` is what a connector has to pass, and it rather than the interface is the definition of one.
@@ -639,4 +675,6 @@ Two of its rules are worth copying: the repeated requests are dropped, since a c
 Leaving those in makes every refresh a diff on every file with the real change somewhere inside it.
 
 `connector/jirasource/testdata/site` is the same thing for tickets, ten files refreshed the same way, and it is worth looking at as the second example because the shape held.
+`connector/confluencesource/testdata/site` is the third and it held again, ten files with one thing in them the other two do not have: a page written in the old editor, whose body arrives as storage format rather than as an Atlassian document.
+That is the file that would go red the day Atlassian changed what a code macro looks like on the wire, and it is the reason committing a recording for a wiki is worth more than committing one for a chat product.
 The same fake, the same `-update` flag, the same dedupe, the same settling, and the same three tests over it: that the crawl works, that the recording answers nothing the crawl does not ask, and that no credential is in the files.


### PR DESCRIPTION
The wiki connector, which is the last thing open on #15.

A wiki turned out to be a container of conversations the same way a chat workspace and an issue tracker are, so this is an adapter on the crawl in `connector/threadsource` rather than a new subsystem.
A space holds pages, a page holds the comments that correct it, and a page with its comments underneath it is one document.
The page says the deploy runs at nine and the third comment says it moved to eleven eighteen months ago, so a page indexed without them answers with the wrong time.

## What changed

CQL is a real change feed, the way JQL is, so a sync is one query per space and there is no reply window and nothing to guess at.
It has the same wrinkle Jira has, that CQL compares times to the minute and rejects anything finer, and it is handled the same way: ask for the minute the cursor is in and drop what arrived from the first half of it.

The gap is comments.
Confluence dates the comment and leaves the page alone, so a page that was answered and never edited again is one a query about pages reports as unchanged for ever.
The query asks for comments as well and resolves each one back to the page it is on, because a comment is a sentence in a document rather than a document.
A page with two new comments is therefore emitted twice in one sync, with the later time on the second, and that is deliberate: the time on a comment is what moves the cursor past it.

## Permissions

Decided in two places and both of them are here.

A space's read permission is granted to accounts and to groups, and it may be granted to anonymous users, which is a space that is open rather than a space with an empty rule.
A page restriction is the second, and it is the concrete case `Thread.Access` exists for: a page with one is readable by the people named in it and by nobody else, whatever the space says.
Restrictions inherit, so a page with no restriction of its own under a parent that has one is restricted, and the ancestors are walked rather than assumed.

A chain carrying a restriction at more than one level is quarantined rather than resolved.
Confluence means the intersection of the two there, an intersection of a list of accounts with a list of groups is not something that can be worked out from outside the identity provider, and publishing the wider of the two would publish exactly the pages somebody went out of their way to restrict.

The ancestor walk is cached and the lifetime of that cache is the part worth reading twice.
A restricted subtree costs one request per ancestor rather than one per page, which is a saving inside a crawl and a bug across them, because a restriction put on a parent is a revocation and one the index only hears about when the process next restarts is not one.
So the cache is emptied at the top of every crawl, which is the call that lists the spaces, and there are two tests that fail if it is not.

## Two body formats

The current editor stores a page as an Atlassian document, which `connector/adf` already renders for ticket descriptions.
Pages written before it changed have no Atlassian document at all and a body in storage format instead, which is XHTML with two undeclared namespace prefixes in it, and there are a lot of those on any site old enough to be worth indexing.
So the adapter asks for the structured body on every page, notices when it came back empty, and pays a second request only for the pages that need it.

One detail in the renderer is worth calling out because it cost an afternoon.
Go's XML decoder auto closes the HTML tags that never have an end tag, `link` among them, and a fragment that declares no namespaces hands it `ac:link` as a local name of `link`.
The default list therefore ends a Confluence link before its label, leaves a stray end tag, and takes the rest of the sentence with it.
The list is written out here with that one entry removed, and `TestALinkDoesNotSwallowTheRestOfItsSentence` is the regression test.

## Testing

Twice over, the way the other two adapters are tested.

`fake_test.go` is a fake Confluence Cloud site and it is where behaviour is written: it can be told to throttle, to hide a space's permissions, to send half a restriction, to archive a page between two syncs and to refuse a specific endpoint.
The full 19 case `connectortest.Run` conformance suite runs against it, plus about thirty cases of its own.

`testdata/site` is a committed recording of one crawl and it is where the wire format is pinned.
Ten files, refreshed with `go test ./connector/confluencesource/ -run TestRecordTheFixtures -update`, and it holds a page written in the old editor so the storage format is in the recording rather than only in a hand written string.
There is a test that reads the files back and fails if the token, the crawling account or an encoded credential is in any of them.

`docs/ingestion.md` gets a section next to the Slack and Jira ones, and the README gets a row and a paragraph.
