### PR TITLE
Turn a person into a set of groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ func main() {
 | Package | What lives there |
 | --- | --- |
 | `acl` | principals, groups, permission descriptors, visibility bitmaps |
+| `directory` | a person resolved into the groups they are in, with cycle detection and a version, [docs/identity.md](docs/identity.md) |
+| `directory/directorytest` | the conformance suite that defines what a directory adapter is |
 | `doc` | the canonical document model every connector normalises into |
 | `store` | the storage interface, plus `storetest`, the conformance suite |
 | `store/memstore` | the reference in memory driver |
@@ -490,6 +492,14 @@ Every system names permissions differently, and the same idea is a `reader` in o
 Mapping each of those is easy on its own, and the collection of them is where a search engine leaks, because every connector would otherwise decide on its own what a grant to a partner's domain means and what to do with a statement it does not understand.
 So a refusal beats a grant everywhere, a link share is recorded rather than inferred from the absence of a restriction, and anything that cannot be represented faithfully is quarantined and counted by reason instead of approximated.
 [docs/permissions.md](docs/permissions.md) has the mapping table for each source and the reasoning behind the awkward cases.
+
+That is one half of a permission decision, and `directory` is the other.
+Nobody grants access to a person, they grant it to `engineering`, which contains `platform`, which contains `storage`, so the question of which groups somebody is in is a transitive closure over a graph that somebody else maintains, changes without telling us, and did not design to be walked.
+A provider adapter answers two lookups, what one subject is directly a member of and what one group is directly a member of, and the closure, the cycle detection, the bound on how much one expansion may cost and the concurrency are written once above them.
+Those are the parts that are easy to get subtly wrong and impossible to notice from the outside, and a group that ended up inside itself during a reorganisation hangs a walk in production rather than in a test.
+The group set is stamped with a version derived from the answer, so a membership change invalidates everything cached from it the moment it lands, and a change that does not touch this person's closure does not invalidate this person.
+A directory that cannot be reached refuses the request rather than resolving somebody to no groups, because an empty group set is a valid answer that everything above is built to trust.
+[docs/identity.md](docs/identity.md) is the whole of it.
 
 A connector hands the pipeline a body, and for the PDF attached to a ticket or the deck a quarter was reviewed from, the bytes are not it.
 `extract` turns those into text using the standard library and nothing else: no office suite, no headless browser and nothing to install alongside the binary.

--- a/api/api.go
+++ b/api/api.go
@@ -258,7 +258,17 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) authenticated(h func(http.ResponseWriter, *http.Request, *acl.Principal)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p, err := s.auth.Authenticate(r)
-		if err != nil || p == nil {
+		switch {
+		case errors.Is(err, ErrDirectoryUnavailable):
+			// The credential was fine and the request is refused anyway,
+			// because the groups behind it could not be resolved. Saying so is
+			// worth the extra case: an operator watching a wall of 401s during
+			// a directory outage goes looking at the wrong system, and a client
+			// that sees a 503 knows to come back rather than to sign in again.
+			s.log.Error("the directory could not resolve a principal", "path", r.URL.Path, "error", err)
+			writeError(w, http.StatusServiceUnavailable, "unavailable", "the directory could not be reached, so this request cannot be answered")
+			return
+		case err != nil, p == nil:
 			writeError(w, http.StatusUnauthorized, "unauthenticated", "this request needs a credential")
 			return
 		}

--- a/api/resolve.go
+++ b/api/resolve.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/directory"
+)
+
+// Resolving wraps an authenticator so that a request's group membership comes
+// from a directory rather than from whoever authenticated it.
+//
+// The two are different questions and it is worth keeping them apart. Who this
+// is comes from a credential and is the authenticator's job. What they are a
+// member of is a fact about the company, it changes without anybody signing in
+// again, and no token is a good place to keep it. A proxy that passes a group
+// list down is passing on a copy of an answer somebody else cached, and the day
+// somebody is taken out of a group is the day the copy is wrong.
+//
+// So this replaces the group set entirely rather than adding to it. A wrapped
+// authenticator that puts groups on the principal has them thrown away, which
+// is the point: if the directory is the answer then a header saying otherwise
+// is not a second opinion, it is a way in.
+//
+// Identities are merged rather than replaced, because those come from two
+// places legitimately. A token can say which Slack account signed in and the
+// directory can say which Jira account is the same person.
+type Resolving struct {
+	// Auth says who is asking. It is usually [HeaderAuth] behind a proxy, and
+	// it is whatever a deployment authenticates with.
+	Auth Authenticator
+
+	// Resolver is the directory the groups come from.
+	Resolver *directory.Resolver
+
+	// Lookup says how the principal is named in the directory, and it is
+	// optional. The default is the identity the principal carries for the
+	// directory's own source if there is one, and the authenticated subject
+	// otherwise, which is right whenever people sign in with the identity
+	// provider the directory is.
+	Lookup func(p *acl.Principal) string
+}
+
+// ErrDirectoryUnavailable is what [Resolving] returns when the directory could
+// not answer.
+//
+// It is deliberately not [ErrUnauthenticated]. The credential was fine and the
+// request is refused anyway, and an operator reading a wall of 401s during a
+// directory outage would go looking at the wrong system. The request still
+// fails, because the alternative is serving somebody with no groups and calling
+// it a search result.
+var ErrDirectoryUnavailable = errors.New("api: the directory could not be reached")
+
+// Authenticate resolves the request and then resolves its groups.
+func (rs Resolving) Authenticate(r *http.Request) (*acl.Principal, error) {
+	if rs.Auth == nil || rs.Resolver == nil {
+		return nil, ErrUnauthenticated
+	}
+	p, err := rs.Auth.Authenticate(r)
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, ErrUnauthenticated
+	}
+
+	id := rs.name(p)
+	if id == "" {
+		return nil, ErrUnauthenticated
+	}
+
+	got, err := rs.Resolver.Expand(r.Context(), id)
+	switch {
+	case errors.Is(err, directory.ErrNoSubject), errors.Is(err, directory.ErrDisabled):
+		// Somebody the directory does not hold, or holds and has closed. Both
+		// are the directory answering rather than failing, and both are a no.
+		return nil, ErrUnauthenticated
+	case err != nil:
+		return nil, fmt.Errorf("%w: %w", ErrDirectoryUnavailable, err)
+	}
+
+	// The group set is replaced rather than merged. Anything the wrapped
+	// authenticator claimed about membership is gone by here.
+	p.Groups = acl.GroupSet{}
+	got.Apply(p)
+	return p, nil
+}
+
+// name is who to look up.
+func (rs Resolving) name(p *acl.Principal) string {
+	if rs.Lookup != nil {
+		return rs.Lookup(p)
+	}
+	if id, ok := p.IdentityIn(rs.Resolver.Name()); ok {
+		return id
+	}
+	return p.Subject
+}

--- a/api/resolve_test.go
+++ b/api/resolve_test.go
@@ -1,0 +1,214 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// site is the directory the cases below resolve against: one person in one
+// group that is inside another, one person who was deactivated, and nobody
+// else.
+func site(t *testing.T) *directory.Resolver {
+	t.Helper()
+	d := directory.NewStatic("acme")
+	d.PutGroup(directory.Group{ID: "everyone"})
+	d.PutGroup(directory.Group{ID: "engineering", MemberOf: []string{"everyone"}})
+	d.Put(directory.Subject{
+		ID:         "mei",
+		Identities: []acl.Identity{{Source: "jira", Value: "acc-mei"}},
+		MemberOf:   []string{"engineering"},
+	})
+	d.Put(directory.Subject{ID: "lee", MemberOf: []string{"engineering"}, Disabled: true})
+
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func asking(subject string, header ...string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=gearbox", http.NoBody)
+	r.Header.Set(api.HeaderSubject, subject)
+	for i := 0; i+1 < len(header); i += 2 {
+		r.Header.Set(header[i], header[i+1])
+	}
+	return r
+}
+
+func TestTheDirectoryDecidesTheGroups(t *testing.T) {
+	auth := api.Resolving{
+		Auth:     api.HeaderAuth{Tenant: "acme"},
+		Resolver: site(t),
+	}
+
+	p, err := auth.Authenticate(asking("mei"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"acme:engineering", "acme:everyone"}
+	if !slices.Equal(p.Groups.Members, want) {
+		t.Errorf("mei resolved to %v, want %v", p.Groups.Members, want)
+	}
+	if p.Groups.Version == 0 {
+		t.Error("the principal came back with version zero")
+	}
+	if !slices.Contains(p.Identities, (acl.Identity{Source: "jira", Value: "acc-mei"})) {
+		t.Errorf("the directory's identity did not reach the principal: %v", p.Identities)
+	}
+}
+
+// The whole reason this type exists. A header saying which groups somebody is
+// in is a copy of an answer, and a copy somebody can edit is a way in.
+func TestAGroupsHeaderIsThrownAwayRatherThanBelieved(t *testing.T) {
+	auth := api.Resolving{
+		Auth:     api.HeaderAuth{Tenant: "acme"},
+		Resolver: site(t),
+	}
+
+	r := asking("mei", api.HeaderGroups, "acme:administrators,acme:finance")
+	p, err := auth.Authenticate(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(p.Groups.Members, "acme:administrators") {
+		t.Fatalf("a group from the request survived into the principal: %v", p.Groups.Members)
+	}
+	if want := []string{"acme:engineering", "acme:everyone"}; !slices.Equal(p.Groups.Members, want) {
+		t.Errorf("the principal carries %v, want %v", p.Groups.Members, want)
+	}
+}
+
+func TestASubjectTheDirectoryDoesNotHoldIsRefused(t *testing.T) {
+	auth := api.Resolving{
+		Auth:     api.HeaderAuth{Tenant: "acme"},
+		Resolver: site(t),
+	}
+	if _, err := auth.Authenticate(asking("nobody")); !errors.Is(err, api.ErrUnauthenticated) {
+		t.Errorf("a subject the directory does not hold gave %v, want ErrUnauthenticated", err)
+	}
+}
+
+// An account closed on Friday stops resolving on Friday, whatever the token in
+// somebody's browser still says.
+func TestADeactivatedSubjectIsRefused(t *testing.T) {
+	auth := api.Resolving{
+		Auth:     api.HeaderAuth{Tenant: "acme"},
+		Resolver: site(t),
+	}
+	if _, err := auth.Authenticate(asking("lee")); !errors.Is(err, api.ErrUnauthenticated) {
+		t.Errorf("a deactivated subject gave %v, want ErrUnauthenticated", err)
+	}
+}
+
+// down is a directory that cannot answer.
+type down struct{ *directory.Static }
+
+var errDown = errors.New("connection refused")
+
+func (down) Subject(context.Context, string) (directory.Subject, error) {
+	return directory.Subject{}, errDown
+}
+
+func TestADirectoryThatCannotBeReachedIsNotACredentialProblem(t *testing.T) {
+	r, err := directory.New(down{directory.NewStatic("acme")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth := api.Resolving{Auth: api.HeaderAuth{Tenant: "acme"}, Resolver: r}
+
+	p, err := auth.Authenticate(asking("mei"))
+	if !errors.Is(err, api.ErrDirectoryUnavailable) {
+		t.Fatalf("a directory that could not answer gave %v", err)
+	}
+	if errors.Is(err, api.ErrUnauthenticated) {
+		t.Error("a directory outage was reported as a bad credential")
+	}
+	if p != nil {
+		t.Errorf("a refused request still produced a principal: %+v", p)
+	}
+}
+
+// And the server says so, because a wall of 401s during a directory outage
+// sends whoever is on call to the wrong system.
+func TestTheServerAnswersUnavailableWhenTheDirectoryIs(t *testing.T) {
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	r, err := directory.New(down{directory.NewStatic("acme")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := api.New(st, index.New(st), api.Resolving{
+		Auth:     api.HeaderAuth{Tenant: "acme"},
+		Resolver: r,
+	})
+
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, asking("mei"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("a request during a directory outage answered %d, want 503", rec.Code)
+	}
+}
+
+// The identity the directory knows people by is not always the one they sign in
+// with, and a deployment that federates two providers has to be able to say so.
+func TestTheLookupSaysWhoToAskAbout(t *testing.T) {
+	d := directory.NewStatic("acme")
+	d.PutGroup(directory.Group{ID: "engineering"})
+	d.Put(directory.Subject{ID: "mei@acme.com", MemberOf: []string{"engineering"}})
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	auth := api.Resolving{
+		Auth:     api.HeaderAuth{Tenant: "acme"},
+		Resolver: r,
+		Lookup:   func(p *acl.Principal) string { return p.Subject + "@acme.com" },
+	}
+	p, err := auth.Authenticate(asking("mei"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"acme:engineering"}; !slices.Equal(p.Groups.Members, want) {
+		t.Errorf("the principal carries %v, want %v", p.Groups.Members, want)
+	}
+}
+
+// Without a lookup, an identity for the directory's own source wins over the
+// authenticated subject, which is what a proxy in front of an identity provider
+// hands down.
+func TestAnIdentityForTheDirectoryIsPreferredOverTheSubject(t *testing.T) {
+	auth := api.Resolving{
+		Auth:     api.HeaderAuth{Tenant: "acme"},
+		Resolver: site(t),
+	}
+	r := asking("u-12345", api.HeaderIdentities, "acme:mei")
+	p, err := auth.Authenticate(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"acme:engineering", "acme:everyone"}; !slices.Equal(p.Groups.Members, want) {
+		t.Errorf("the principal carries %v, want %v", p.Groups.Members, want)
+	}
+}
+
+func TestAWrapperWithNothingToWrapRefuses(t *testing.T) {
+	if _, err := (api.Resolving{}).Authenticate(asking("mei")); !errors.Is(err, api.ErrUnauthenticated) {
+		t.Errorf("an unconfigured wrapper gave %v", err)
+	}
+	if _, err := (api.Resolving{Auth: api.HeaderAuth{Tenant: "acme"}}).Authenticate(asking("mei")); !errors.Is(err, api.ErrUnauthenticated) {
+		t.Errorf("a wrapper with no directory gave %v", err)
+	}
+}

--- a/arch_test.go
+++ b/arch_test.go
@@ -27,6 +27,16 @@ var allowed = map[string][]string{
 	"acl": nil,
 	"doc": {"acl"},
 
+	// directory sits under the permission model rather than beside it. It
+	// resolves a person into groups and hands acl the strings it compares, and
+	// the one thing it imports is acl, for the identity and group set types
+	// that are the shape of its answer. It has never heard of a document, a
+	// store or a query, and it must not: a directory that could see what it was
+	// resolving somebody for is a directory that could be asked leading
+	// questions.
+	"directory":               {"acl"},
+	"directory/directorytest": {"acl", "directory"},
+
 	// cache is a map with a lock on it and imports nothing of ours, which is
 	// what lets index depend on it without the dependency meaning anything. A
 	// cache that knew about principals would be a second copy of the permission
@@ -104,7 +114,7 @@ var allowed = map[string][]string{
 	"index":             {"acl", "cache", "doc", "store"},
 	"config":            nil,
 	"web":               nil,
-	"api":               {"", "acl", "cache", "doc", "index", "metric", "store", "thumb"},
+	"api":               {"", "acl", "cache", "directory", "doc", "index", "metric", "store", "thumb"},
 
 	// thumb imports nothing of ours. It is handed bytes and a size and hands
 	// back a smaller picture, which means the package that decodes files a

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -1,0 +1,192 @@
+// Package directory resolves a person into the set of groups they are in.
+//
+// It sits underneath the permission model rather than beside it. A document's
+// access rules name groups, a group contains other groups, and the answer to
+// "may this person read this" is only as good as the expansion of that graph.
+// [acl] compares two lists of strings and is deliberately incapable of asking
+// anybody anything. This package is where the asking happens.
+//
+// # Why the graph is the hard part
+//
+// Nobody grants access to a person. They grant it to "engineering", which
+// contains "platform", which contains "storage", which contains four people and
+// a service account, and the person who joined last week is in the index under
+// a group nobody named in a rule anywhere. So a membership is a reachability
+// question over a directed graph that somebody else maintains, and every real
+// directory has three properties that make walking it interesting.
+//
+// It is big. A person at a large company is in a few hundred groups and the
+// tail is in the thousands, and the expansion happens when a session starts, in
+// front of somebody waiting for a search box to work.
+//
+// It has cycles. Not because anybody meant to: two groups end up in each other
+// through a third one that was added during a reorganisation, and the directory
+// itself does not mind because it never walks the graph the way we do. A walk
+// written without a seen set hangs, and it hangs in production rather than in a
+// test, because the test directory is a diagram somebody drew on purpose.
+//
+// It changes. Somebody is removed from a group at eleven and the thing that
+// matters is not how fast the change is noticed but that everything derived
+// from the old answer stops being used when it is. That is what
+// [acl.GroupSet.Version] is for, and this package is where the number comes
+// from.
+//
+// # What a provider has to answer
+//
+// [Directory] is two lookups, and it is small on purpose. Okta, Entra ID,
+// Google Workspace and LDAP disagree about almost everything else, but every
+// one of them will say what one subject is directly a member of and what one
+// group is directly a member of. Everything above that, the closure, the cycle
+// detection, the bound on how much work one expansion may cost and the version
+// the answer is stamped with, is written once here and shared, because those
+// are exactly the parts that are easy to get subtly wrong and impossible to
+// notice from the outside.
+//
+// A provider that already expands transitively, and Entra ID does, is not
+// penalised for it: it returns the closure it was given, the walk finds nothing
+// new above it and stops. A provider that only knows direct edges gets the same
+// answer for more requests.
+//
+// # The version is a fingerprint, not a clock
+//
+// [Expansion.Groups] carries a version, and it is derived from the answer
+// rather than read off a timer. It is a hash of every group in the closure and
+// of whatever revision the directory gave for each, so it moves when and only
+// when the set of groups this person is in moves.
+//
+// That has two consequences worth stating. A directory with no revision of its
+// own still gets correct invalidation, because the group names are in the hash.
+// And a membership change somewhere in the directory that does not change this
+// person's closure does not invalidate this person's cached state, which is the
+// difference between a cache that works at a company with fifty thousand groups
+// and one that does not.
+//
+// # Which way it fails
+//
+// A directory that cannot be reached fails the expansion. It does not return an
+// empty group set, and no caller here turns an error into one, because an empty
+// group set is a valid answer that happens to mean "this person is in no groups
+// at all" and the whole system is built to trust it. Refusing the request is
+// visible and recoverable. Quietly demoting somebody to no groups is a support
+// ticket about missing search results and, on the sources that grant to a
+// person directly, a partial answer that looks complete.
+//
+// A subject the directory has never heard of is [ErrNoSubject], and a subject
+// the directory holds but has deactivated is [ErrDisabled]. Both refuse. An
+// account that was closed on Friday should stop resolving on Friday rather than
+// when the last cache entry expires.
+//
+// A group named in a membership that the directory does not hold is the one
+// case that does not refuse. The directory has said this person is in it, which
+// is a statement about them, and the only thing missing is what that group is
+// itself a member of. Dropping the group would take away access the directory
+// granted, so it is kept, its parents are not walked, and it is reported in
+// [Expansion.Unknown] so that an inconsistent directory is something an
+// operator can see rather than something a user reports.
+package directory
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// Errors a [Directory] returns for the two cases a caller has to tell apart
+// from a directory that could not answer at all.
+//
+// Anything else is an outage: a timeout, a refusal, a rate limit, a certificate
+// nobody renewed. Those fail the expansion, and they are meant to.
+var (
+	// ErrNoSubject means the directory does not hold this subject. It is a
+	// complete answer rather than a failure to answer, and it refuses.
+	ErrNoSubject = errors.New("directory: no such subject")
+
+	// ErrNoGroup means the directory does not hold this group. It is what makes
+	// a group appear in [Expansion.Unknown] rather than failing the expansion.
+	ErrNoGroup = errors.New("directory: no such group")
+
+	// ErrDisabled means the subject exists and has been deactivated. It refuses
+	// for the same reason ErrNoSubject does.
+	ErrDisabled = errors.New("directory: subject is disabled")
+)
+
+// Subject is what a directory says about one person, service account or bot.
+type Subject struct {
+	// ID is how this directory names them, and it is what was asked for.
+	ID string
+
+	// Name and Email are for display and for the audit record. Neither is used
+	// to decide anything.
+	Name  string
+	Email string
+
+	// Version is the directory's own revision of this subject, if it keeps one.
+	// It is an opaque string that changes when their memberships change, and an
+	// empty one is fine: see the note about fingerprints in the package
+	// documentation.
+	Version string
+
+	// Identities is the same person in the systems being indexed, which is what
+	// lets a rule naming a Slack member id apply to somebody who signed in with
+	// an email address. A directory that cannot say is not required to.
+	Identities []acl.Identity
+
+	// MemberOf is the groups this subject is directly in, named the way this
+	// directory names groups. The expansion turns it into the closure.
+	MemberOf []string
+
+	// Disabled is an account that exists and has been deactivated. It is
+	// separate from the subject being absent because directories rarely delete
+	// anybody, and an offboarded account that still resolves is the difference
+	// between a leaver and a leaver with a search session.
+	Disabled bool
+}
+
+// Group is what a directory says about one group.
+//
+// It deliberately does not carry the members. Listing them is the expensive
+// direction, it is the one large directories rate limit hardest, and nothing
+// here needs it: the walk goes upwards from a person, not downwards from a
+// group.
+type Group struct {
+	// ID is how this directory names the group, and it is the value that ends
+	// up in [acl.GroupSet.Members] with the directory's name in front of it.
+	ID string
+
+	// Name is for display. A rule is never matched against it, because a
+	// display name is a thing people rename.
+	Name string
+
+	// Version is the directory's revision of this group's membership, if it
+	// keeps one, and it goes into the fingerprint.
+	Version string
+
+	// MemberOf is the groups this group is directly in. This is the edge that
+	// makes the whole thing a graph rather than a list.
+	MemberOf []string
+}
+
+// Directory is one identity provider.
+//
+// Both methods are lookups of one thing by its id, and that is the whole
+// interface. See the package documentation for why it is this small.
+//
+// An implementation must be safe for concurrent use. The expansion looks up a
+// level of the graph in parallel, because the alternative is a person in three
+// hundred groups waiting for three hundred round trips one after another.
+type Directory interface {
+	// Name is the identity source these ids belong to, and it is the same
+	// string a connector puts in [acl.Ref.Source] for a group. It is what makes
+	// "engineering" from one provider and "engineering" from another two
+	// different groups, which they are.
+	Name() string
+
+	// Subject returns one subject by id. It returns [ErrNoSubject] if the
+	// directory does not hold them.
+	Subject(ctx context.Context, id string) (Subject, error)
+
+	// Group returns one group by id. It returns [ErrNoGroup] if the directory
+	// does not hold it.
+	Group(ctx context.Context, id string) (Group, error)
+}

--- a/directory/directory_test.go
+++ b/directory/directory_test.go
@@ -1,0 +1,407 @@
+package directory_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/directorytest"
+)
+
+func TestConformance(t *testing.T) {
+	directorytest.Run(t, func(t *testing.T) directorytest.Fixture {
+		d := directory.NewStatic("acme")
+		return directorytest.Fixture{
+			Directory: d,
+			Put:       func(_ *testing.T, s directory.Subject) { d.Put(s) },
+			PutGroup:  func(_ *testing.T, g directory.Group) { d.PutGroup(g) },
+			Drop:      func(_ *testing.T, group string) { d.RemoveGroup(group) },
+		}
+	})
+}
+
+// flaky is a directory that answers out of a static one and can be told to
+// break, which is the half of the contract a conformance suite over a working
+// directory cannot reach.
+type flaky struct {
+	*directory.Static
+
+	mu     sync.Mutex
+	broken map[string]error
+
+	asked atomic.Int64
+}
+
+func newFlaky(name string) *flaky {
+	return &flaky{Static: directory.NewStatic(name), broken: make(map[string]error)}
+}
+
+func (f *flaky) breakGroup(id string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.broken[id] = err
+}
+
+func (f *flaky) Group(ctx context.Context, id string) (directory.Group, error) {
+	f.asked.Add(1)
+
+	f.mu.Lock()
+	err, broken := f.broken[id]
+	f.mu.Unlock()
+
+	if broken {
+		return directory.Group{}, err
+	}
+	return f.Static.Group(ctx, id)
+}
+
+var errDown = errors.New("the directory is having a bad afternoon")
+
+// The whole reason this package refuses rather than returning what it has. An
+// empty group set is a valid answer that means somebody is in no groups, and
+// every layer above is built to trust it.
+func TestADirectoryThatCannotAnswerFailsRatherThanResolvingToNothing(t *testing.T) {
+	d := newFlaky("acme")
+	d.PutGroup(directory.Group{ID: "engineering", MemberOf: []string{"everyone"}})
+	d.PutGroup(directory.Group{ID: "everyone"})
+	d.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	d.breakGroup("everyone", errDown)
+
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := r.Expand(t.Context(), "mei")
+	if !errors.Is(err, errDown) {
+		t.Fatalf("a directory that could not answer gave %v", err)
+	}
+	if len(got.Groups.Members) != 0 {
+		t.Errorf("a failed expansion handed back %v", got.Groups.Members)
+	}
+	if got.Groups.Version != 0 {
+		t.Errorf("a failed expansion was stamped with version %d", got.Groups.Version)
+	}
+}
+
+// A failure in one lookup is the whole level thrown away, so the requests that
+// have not started yet should not be made. On a directory that has just started
+// refusing, the alternative is a sign in storm turning into a few hundred
+// requests each against a service that is already unhappy.
+func TestOneFailedLookupStopsTheRestOfItsLevel(t *testing.T) {
+	d := newFlaky("acme")
+	var in []string
+	for i := range 200 {
+		id := "g" + strconv.Itoa(i)
+		d.PutGroup(directory.Group{ID: id})
+		in = append(in, id)
+	}
+	d.Put(directory.Subject{ID: "mei", MemberOf: in})
+	for _, id := range in {
+		d.breakGroup(id, errDown)
+	}
+
+	// Four at a time, so at most four are past the point of no return when the
+	// first one fails and the rest are never started.
+	r, err := directory.New(d, directory.WithWidth(4))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Expand(t.Context(), "mei"); !errors.Is(err, errDown) {
+		t.Fatalf("a broken lookup gave %v, want the directory's error", err)
+	}
+
+	if asked := d.asked.Load(); asked > 20 {
+		t.Errorf("a level of %d that fails on the first entry still made %d requests", len(in), asked)
+	}
+}
+
+// The width is a promise to the far side rather than a tuning knob. A directory
+// is shared by every session that starts, so an expansion that goes as wide as
+// it likes makes every other expansion slower.
+func TestNoMoreLookupsRunAtOnceThanTheWidthAllows(t *testing.T) {
+	d := newFlaky("acme")
+	var in []string
+	for i := range 64 {
+		id := "g" + strconv.Itoa(i)
+		d.PutGroup(directory.Group{ID: id})
+		in = append(in, id)
+	}
+	d.Put(directory.Subject{ID: "mei", MemberOf: in})
+
+	var (
+		mu   sync.Mutex
+		now  int
+		peak int
+	)
+	counted := &counting{Directory: d, enter: func() {
+		mu.Lock()
+		now++
+		if now > peak {
+			peak = now
+		}
+		mu.Unlock()
+	}, leave: func() {
+		mu.Lock()
+		now--
+		mu.Unlock()
+	}}
+
+	r, err := directory.New(counted, directory.WithWidth(4))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Expand(t.Context(), "mei"); err != nil {
+		t.Fatal(err)
+	}
+	if peak > 4 {
+		t.Errorf("a width of 4 ran %d lookups at once", peak)
+	}
+}
+
+type counting struct {
+	directory.Directory
+	enter func()
+	leave func()
+}
+
+func (c *counting) Group(ctx context.Context, id string) (directory.Group, error) {
+	c.enter()
+	defer c.leave()
+	return c.Directory.Group(ctx, id)
+}
+
+func TestTheCountersAddUp(t *testing.T) {
+	d := newFlaky("acme")
+	d.PutGroup(directory.Group{ID: "everyone"})
+	d.PutGroup(directory.Group{ID: "engineering", MemberOf: []string{"everyone", "gone"}})
+	d.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	d.Put(directory.Subject{ID: "lee", Disabled: true})
+
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Expand(t.Context(), "mei"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Expand(t.Context(), "nobody"); !errors.Is(err, directory.ErrNoSubject) {
+		t.Fatalf("expanding a subject that is not there gave %v", err)
+	}
+	if _, err := r.Expand(t.Context(), "lee"); !errors.Is(err, directory.ErrDisabled) {
+		t.Fatalf("expanding a deactivated subject gave %v", err)
+	}
+
+	want := directory.Counters{
+		Expansions: 1,
+		Failures:   2,
+		// mei, engineering, then everyone and gone together, plus the two
+		// subject lookups that failed.
+		Lookups:    6,
+		Missing:    1,
+		Disabled:   1,
+		Unresolved: 1,
+	}
+	if got := r.Counters(); got != want {
+		t.Errorf("the counters read %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyLeavesEverythingItIsNotAbout(t *testing.T) {
+	d := directory.NewStatic("acme")
+	d.PutGroup(directory.Group{ID: "engineering"})
+	d.Put(directory.Subject{
+		ID:         "mei",
+		Identities: []acl.Identity{{Source: "slack", Value: "U04AB"}, {Source: "jira", Value: "acc-mei"}},
+		MemberOf:   []string{"engineering"},
+	})
+
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := r.Expand(t.Context(), "mei")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &acl.Principal{
+		Tenant:     "acme",
+		Subject:    "mei",
+		Kind:       acl.KindUser,
+		Roles:      []string{acl.RoleAdmin},
+		Identities: []acl.Identity{{Source: "slack", Value: "U04AB"}},
+	}
+	got.Apply(p)
+
+	if !slices.Equal(p.Roles, []string{acl.RoleAdmin}) {
+		t.Errorf("applying an expansion changed the roles to %v", p.Roles)
+	}
+	if p.Tenant != "acme" || p.Subject != "mei" {
+		t.Errorf("applying an expansion changed the principal to %s/%s", p.Tenant, p.Subject)
+	}
+	// The identity the principal already had is not added a second time, and
+	// the one only the directory knew is.
+	want := []acl.Identity{{Source: "slack", Value: "U04AB"}, {Source: "jira", Value: "acc-mei"}}
+	if !slices.Equal(p.Identities, want) {
+		t.Errorf("the principal carries the identities %v, want %v", p.Identities, want)
+	}
+	if !slices.Equal(p.Groups.Members, []string{"acme:engineering"}) {
+		t.Errorf("the principal carries the groups %v", p.Groups.Members)
+	}
+}
+
+// Two directories under different names are two sets of groups, because they
+// are. A rule granting read to "engineering" at one company and the same name
+// at an acquisition that has not been merged yet are different rules, and
+// folding them together is the kind of mistake nobody finds by looking.
+func TestGroupsFromTwoDirectoriesDoNotCollide(t *testing.T) {
+	one := directory.NewStatic("acme")
+	one.PutGroup(directory.Group{ID: "engineering"})
+	one.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	other := directory.NewStatic("northwind")
+	other.PutGroup(directory.Group{ID: "engineering"})
+	other.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	first := expandWith(t, one, "mei")
+	second := expandWith(t, other, "mei")
+
+	if slices.Equal(first.Groups.Members, second.Groups.Members) {
+		t.Fatalf("both directories resolved to %v", first.Groups.Members)
+	}
+	if first.Groups.Version == second.Groups.Version {
+		t.Error("the same group name in two directories produced the same version")
+	}
+
+	p := &acl.Principal{Tenant: "acme", Subject: "mei", Kind: acl.KindUser}
+	first.Apply(p)
+	perm := acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "northwind",
+		AllowGroups: []acl.Ref{{Source: "northwind", Value: "engineering"}},
+	}
+	if perm.Allows(p) {
+		t.Error("a rule about the other directory's engineering group allowed somebody from this one")
+	}
+}
+
+// A directory's revision moving is enough on its own, without the membership
+// changing, because a provider that keeps one is saying something we should
+// believe.
+func TestADirectoryRevisionMovesTheVersion(t *testing.T) {
+	d := directory.NewStatic("acme")
+	d.PutGroup(directory.Group{ID: "engineering", Version: "1"})
+	d.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	before := expandWith(t, d, "mei").Groups.Version
+
+	d.PutGroup(directory.Group{ID: "engineering", Version: "2"})
+	after := expandWith(t, d, "mei").Groups.Version
+
+	if before == after {
+		t.Fatalf("the group's revision moved and the version stayed at %d", before)
+	}
+}
+
+func TestAResolverNeedsADirectoryWithAName(t *testing.T) {
+	if _, err := directory.New(nil); err == nil {
+		t.Error("a resolver over no directory was built without complaint")
+	}
+	if _, err := directory.New(directory.NewStatic("")); err == nil {
+		t.Error("a resolver over an unnamed directory was built without complaint")
+	}
+}
+
+func TestLoadIsOneStep(t *testing.T) {
+	d := directory.NewStatic("acme")
+	d.Put(directory.Subject{ID: "old"})
+	d.PutGroup(directory.Group{ID: "retired"})
+
+	d.Load(
+		[]directory.Subject{{ID: "mei", MemberOf: []string{"engineering"}}, {ID: ""}},
+		[]directory.Group{{ID: "engineering"}, {ID: ""}},
+	)
+
+	if _, err := d.Subject(t.Context(), "old"); !errors.Is(err, directory.ErrNoSubject) {
+		t.Errorf("a subject from before the reload gave %v", err)
+	}
+	subs, groups := d.Snapshot()
+	if len(subs) != 1 || subs[0].ID != "mei" {
+		t.Errorf("the directory holds the subjects %v", subs)
+	}
+	if len(groups) != 1 || groups[0].ID != "engineering" {
+		t.Errorf("the directory holds the groups %v", groups)
+	}
+}
+
+// What a caller does with an answer must not reach back into what the next
+// caller is given, which is easy to get wrong with a map of structs holding
+// slices and impossible to notice until two sessions share a group.
+func TestAnAnswerCannotBeWrittenBackIntoTheDirectory(t *testing.T) {
+	d := directory.NewStatic("acme")
+	d.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	got, err := d.Subject(t.Context(), "mei")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got.MemberOf[0] = "administrators"
+
+	again, err := d.Subject(t.Context(), "mei")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(again.MemberOf, []string{"engineering"}) {
+		t.Fatalf("writing to one answer changed the directory to %v", again.MemberOf)
+	}
+}
+
+func TestReadingAndWritingAtTheSameTimeIsSafe(t *testing.T) {
+	d := directory.NewStatic("acme")
+	d.PutGroup(directory.Group{ID: "engineering"})
+	d.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Go(func() {
+			for n := range 50 {
+				d.PutGroup(directory.Group{ID: "engineering", Version: fmt.Sprint(i, n)})
+			}
+		})
+	}
+	for range 8 {
+		wg.Go(func() {
+			for range 50 {
+				if _, err := r.Expand(context.Background(), "mei"); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+}
+
+func expandWith(t *testing.T, d directory.Directory, id string) directory.Expansion {
+	t.Helper()
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := r.Expand(t.Context(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}

--- a/directory/directorytest/directorytest.go
+++ b/directory/directorytest/directorytest.go
@@ -1,0 +1,470 @@
+// Package directorytest is the conformance suite every directory adapter has
+// to pass.
+//
+// A directory adapter is a small amount of code in front of somebody else's
+// API, and the amount of damage it can do is out of all proportion to its size.
+// Every one of them is written by whoever needed that provider, usually against
+// one tenant with a directory that is tidy, and the failure modes only appear
+// against a directory that is not: a group that is a member of itself, a
+// membership naming a group that was deleted last year, an account somebody
+// deactivated on Friday, a person in four hundred groups.
+//
+// None of those is visible from above. A person who was quietly given nobody
+// else's groups gets fewer search results and blames the search engine. A
+// person who was quietly given somebody else's groups does not notice at all.
+//
+// So this suite is the definition of a directory rather than the interface
+// being it. The interface says what compiles. This says what the answers have
+// to mean.
+//
+// # What it tests
+//
+// Two things at once, and that is deliberate. The cases exercise [directory.Directory]
+// directly for the answers only the adapter can give, and they exercise
+// [directory.Resolver] over the same adapter for the properties that only
+// appear once the graph is walked. An adapter is never used without the
+// resolver, so testing it without one would leave the interesting half untested.
+//
+// # Usage
+//
+//	func TestConformance(t *testing.T) {
+//		directorytest.Run(t, func(t *testing.T) directorytest.Fixture {
+//			d := directory.NewStatic("acme")
+//			return directorytest.Fixture{
+//				Directory: d,
+//				Put:       func(t *testing.T, s directory.Subject) { d.Put(s) },
+//				PutGroup:  func(t *testing.T, g directory.Group) { d.PutGroup(g) },
+//				Drop:      func(t *testing.T, group string) { d.RemoveGroup(group) },
+//			}
+//		})
+//	}
+package directorytest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/directory"
+)
+
+// Fixture is one directory under test, plus the handful of things the suite
+// needs to be able to do to whatever is behind it.
+//
+// The suite never assumes it can write to a live provider. What it assumes is
+// that the fixture can put a subject and a group into whatever the adapter
+// reads, which for a real provider means a fake of it and for [directory.Static]
+// means the type itself.
+type Fixture struct {
+	// Directory is the thing being tested.
+	Directory directory.Directory
+
+	// Put adds or replaces one subject.
+	Put func(t *testing.T, s directory.Subject)
+
+	// PutGroup adds or replaces one group.
+	PutGroup func(t *testing.T, g directory.Group)
+
+	// Drop removes a group while leaving the memberships that name it alone.
+	// It is optional, and a fixture that cannot do it skips the case about an
+	// inconsistent directory rather than failing it.
+	Drop func(t *testing.T, group string)
+}
+
+// Factory builds a fresh fixture for one case. Every case gets its own, because
+// a suite where one case can be affected by another is a suite that reports the
+// wrong thing when it goes red.
+type Factory func(t *testing.T) Fixture
+
+// Run runs the whole suite against one adapter.
+func Run(t *testing.T, newFixture Factory) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := newFixture(t)
+			switch {
+			case f.Directory == nil:
+				t.Fatal("the fixture has no directory in it")
+			case f.Put == nil:
+				t.Fatal("the fixture cannot put a subject in the directory, and every case starts by doing that")
+			case f.PutGroup == nil:
+				t.Fatal("the fixture cannot put a group in the directory")
+			}
+			c.run(t, f)
+		})
+	}
+}
+
+type testCase struct {
+	name string
+	run  func(t *testing.T, f Fixture)
+}
+
+var cases = []testCase{
+	{"the directory names itself", testName},
+	{"a subject resolves to the groups they are directly in", testDirect},
+	{"a nested group brings the groups above it", testNested},
+	{"a diamond in the graph is one answer and one lookup each", testDiamond},
+	{"a cycle in the graph terminates", testCycle},
+	{"a group that is a member of itself terminates", testSelfCycle},
+	{"a subject in no groups resolves to no groups", testNoGroups},
+	{"a subject the directory does not hold is refused", testMissingSubject},
+	{"a deactivated subject is refused", testDisabled},
+	{"a group named in a membership and not held is reported rather than fatal", testUnknownGroup},
+	{"the version moves when a membership moves", testVersionMoves},
+	{"the version is the same for the same answer", testVersionStable},
+	{"the version does not move for a change that misses this subject", testVersionScoped},
+	{"identities the directory knows reach the principal", testIdentities},
+	{"a bound on the closure refuses rather than truncating", testBounded},
+	{"a thousand groups resolve inside the budget", testWide},
+	{"a cancelled expansion stops", testCancel},
+}
+
+func testName(t *testing.T, f Fixture) {
+	if f.Directory.Name() == "" {
+		t.Error("the directory has no name, so nothing can tell its groups from another directory's")
+	}
+}
+
+func testDirect(t *testing.T, f Fixture) {
+	f.PutGroup(t, directory.Group{ID: "engineering"})
+	f.PutGroup(t, directory.Group{ID: "on-call"})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering", "on-call"}})
+
+	got := expand(t, f, "mei")
+	want := keys(f, "engineering", "on-call")
+	if !slices.Equal(got.Groups.Members, want) {
+		t.Errorf("mei resolved to %v, want %v", got.Groups.Members, want)
+	}
+}
+
+func testNested(t *testing.T, f Fixture) {
+	f.PutGroup(t, directory.Group{ID: "everyone"})
+	f.PutGroup(t, directory.Group{ID: "engineering", MemberOf: []string{"everyone"}})
+	f.PutGroup(t, directory.Group{ID: "storage", MemberOf: []string{"engineering"}})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"storage"}})
+
+	got := expand(t, f, "mei")
+	want := keys(f, "engineering", "everyone", "storage")
+	if !slices.Equal(got.Groups.Members, want) {
+		t.Fatalf("a three level nest resolved to %v, want %v", got.Groups.Members, want)
+	}
+	if got.Depth != 3 {
+		t.Errorf("a three level nest was walked %d levels deep", got.Depth)
+	}
+}
+
+func testDiamond(t *testing.T, f Fixture) {
+	// Two paths to the same group is the ordinary shape of a real directory
+	// rather than a corner case, and looking the shared group up twice is how
+	// an expansion over a few hundred groups turns into a few thousand
+	// requests.
+	f.PutGroup(t, directory.Group{ID: "everyone"})
+	f.PutGroup(t, directory.Group{ID: "engineering", MemberOf: []string{"everyone"}})
+	f.PutGroup(t, directory.Group{ID: "operations", MemberOf: []string{"everyone"}})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering", "operations"}})
+
+	got := expand(t, f, "mei")
+	want := keys(f, "engineering", "everyone", "operations")
+	if !slices.Equal(got.Groups.Members, want) {
+		t.Fatalf("a diamond resolved to %v, want %v", got.Groups.Members, want)
+	}
+	// The subject, the two groups below and the one they share.
+	if got.Lookups != 4 {
+		t.Errorf("a diamond cost %d lookups, want 4", got.Lookups)
+	}
+}
+
+func testCycle(t *testing.T, f Fixture) {
+	f.PutGroup(t, directory.Group{ID: "a", MemberOf: []string{"b"}})
+	f.PutGroup(t, directory.Group{ID: "b", MemberOf: []string{"c"}})
+	f.PutGroup(t, directory.Group{ID: "c", MemberOf: []string{"a"}})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"a"}})
+
+	got, err := within(t, f, "mei")
+	if err != nil {
+		t.Fatalf("a cycle in the group graph did not terminate: %v", err)
+	}
+	if want := keys(f, "a", "b", "c"); !slices.Equal(got.Groups.Members, want) {
+		t.Errorf("a cycle resolved to %v, want %v", got.Groups.Members, want)
+	}
+}
+
+func testSelfCycle(t *testing.T, f Fixture) {
+	f.PutGroup(t, directory.Group{ID: "recursive", MemberOf: []string{"recursive"}})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"recursive"}})
+
+	got, err := within(t, f, "mei")
+	if err != nil {
+		t.Fatalf("a group that is a member of itself did not terminate: %v", err)
+	}
+	if want := keys(f, "recursive"); !slices.Equal(got.Groups.Members, want) {
+		t.Errorf("a group inside itself resolved to %v, want %v", got.Groups.Members, want)
+	}
+}
+
+func testNoGroups(t *testing.T, f Fixture) {
+	f.Put(t, directory.Subject{ID: "mei"})
+
+	got := expand(t, f, "mei")
+	if len(got.Groups.Members) != 0 {
+		t.Errorf("a subject in no groups resolved to %v", got.Groups.Members)
+	}
+	if got.Groups.Version == 0 {
+		t.Error("a resolved subject was stamped with version zero, which is what an unresolved one looks like")
+	}
+}
+
+func testMissingSubject(t *testing.T, f Fixture) {
+	// Nothing is put in the directory at all, which is the point.
+	r := resolver(t, f)
+	_, err := r.Expand(t.Context(), "nobody")
+	if !errors.Is(err, directory.ErrNoSubject) {
+		t.Fatalf("a subject the directory does not hold gave %v, want ErrNoSubject", err)
+	}
+}
+
+func testDisabled(t *testing.T, f Fixture) {
+	f.PutGroup(t, directory.Group{ID: "engineering"})
+	f.Put(t, directory.Subject{ID: "lee", MemberOf: []string{"engineering"}, Disabled: true})
+
+	r := resolver(t, f)
+	got, err := r.Expand(t.Context(), "lee")
+	if !errors.Is(err, directory.ErrDisabled) {
+		t.Fatalf("a deactivated subject gave %v, want ErrDisabled", err)
+	}
+	if len(got.Groups.Members) != 0 {
+		t.Errorf("a refused expansion still handed back the groups %v", got.Groups.Members)
+	}
+}
+
+func testUnknownGroup(t *testing.T, f Fixture) {
+	if f.Drop == nil {
+		t.Skip("the fixture cannot remove a group while leaving the memberships that name it")
+	}
+	f.PutGroup(t, directory.Group{ID: "engineering"})
+	f.PutGroup(t, directory.Group{ID: "reorganised"})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering", "reorganised"}})
+	f.Drop(t, "reorganised")
+
+	got := expand(t, f, "mei")
+	// The group stays. The directory said this person is in it, and taking it
+	// away would take away access on the strength of a lookup that failed.
+	if want := keys(f, "engineering", "reorganised"); !slices.Equal(got.Groups.Members, want) {
+		t.Errorf("a membership naming a group the directory does not hold resolved to %v, want %v", got.Groups.Members, want)
+	}
+	if !slices.Equal(got.Unknown, []string{"reorganised"}) {
+		t.Errorf("the unresolved group was reported as %v, want [reorganised]", got.Unknown)
+	}
+}
+
+func testVersionMoves(t *testing.T, f Fixture) {
+	f.PutGroup(t, directory.Group{ID: "engineering"})
+	f.PutGroup(t, directory.Group{ID: "on-call"})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering", "on-call"}})
+	before := expand(t, f, "mei").Groups.Version
+
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	after := expand(t, f, "mei").Groups.Version
+
+	if before == after {
+		t.Fatalf("taking somebody out of a group left the version at %d, so nothing derived from it is invalidated", before)
+	}
+}
+
+func testVersionStable(t *testing.T, f Fixture) {
+	f.PutGroup(t, directory.Group{ID: "everyone"})
+	f.PutGroup(t, directory.Group{ID: "engineering", MemberOf: []string{"everyone"}})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	first := expand(t, f, "mei").Groups.Version
+	second := expand(t, f, "mei").Groups.Version
+	if first != second {
+		t.Fatalf("the same membership resolved to versions %d and %d, so nothing derived from it is ever reused", first, second)
+	}
+}
+
+func testVersionScoped(t *testing.T, f Fixture) {
+	// A version that moved whenever anything in the directory moved would be
+	// correct and useless: at a company with fifty thousand groups something
+	// changes every second and nobody's cached state would survive.
+	f.PutGroup(t, directory.Group{ID: "engineering"})
+	f.PutGroup(t, directory.Group{ID: "facilities"})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	f.Put(t, directory.Subject{ID: "sam", MemberOf: []string{"facilities"}})
+
+	before := expand(t, f, "mei").Groups.Version
+	f.Put(t, directory.Subject{ID: "sam", MemberOf: []string{"facilities", "engineering"}})
+	after := expand(t, f, "mei").Groups.Version
+
+	if before != after {
+		t.Errorf("somebody else joining a group moved mei's version from %d to %d", before, after)
+	}
+}
+
+func testIdentities(t *testing.T, f Fixture) {
+	f.PutGroup(t, directory.Group{ID: "engineering"})
+	f.Put(t, directory.Subject{
+		ID:         "mei",
+		Identities: []acl.Identity{{Source: "slack", Value: "U04AB"}},
+		MemberOf:   []string{"engineering"},
+	})
+
+	got := expand(t, f, "mei")
+	if !slices.Contains(got.Subject.Identities, acl.Identity{Source: "slack", Value: "U04AB"}) {
+		t.Fatalf("the identity the directory holds did not survive the expansion: %v", got.Subject.Identities)
+	}
+
+	// The whole point of an identity is that a rule written in one source's
+	// vocabulary applies to somebody who signed in through another.
+	p := &acl.Principal{Tenant: "acme", Subject: "mei", Kind: acl.KindUser}
+	got.Apply(p)
+	perm := acl.Permissions{
+		Mode:       acl.ModeACL,
+		Source:     "slack",
+		AllowUsers: []acl.Ref{{Source: "slack", Value: "U04AB"}},
+	}
+	if !perm.Allows(p) {
+		t.Error("a rule naming the subject by their Slack identity did not allow them")
+	}
+}
+
+func testBounded(t *testing.T, f Fixture) {
+	for i := range 40 {
+		f.PutGroup(t, directory.Group{ID: "g" + strconv.Itoa(i)})
+	}
+	in := make([]string, 0, 40)
+	for i := range 40 {
+		in = append(in, "g"+strconv.Itoa(i))
+	}
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: in})
+
+	r, err := directory.New(f.Directory, directory.WithMaxGroups(10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := r.Expand(t.Context(), "mei")
+	if !errors.Is(err, directory.ErrTooManyGroups) {
+		t.Fatalf("a closure past the bound gave %v, want ErrTooManyGroups", err)
+	}
+	// Refusing rather than truncating, because a truncated group set is not a
+	// smaller answer, it is a wrong one, and nothing above here could tell.
+	if len(got.Groups.Members) != 0 {
+		t.Errorf("a refused expansion handed back %d groups anyway", len(got.Groups.Members))
+	}
+}
+
+func testWide(t *testing.T, f Fixture) {
+	if testing.Short() {
+		t.Skip("the wide case is about latency and there is nothing to learn from it in a short run")
+	}
+	// The budget in the issue this was written for is a person in a thousand
+	// groups. The number below is not a benchmark, it is a bound: an adapter
+	// that walks the level serially against a fake that answers instantly still
+	// passes, and one that is accidentally quadratic does not.
+	const n = 1000
+	in := make([]string, 0, n)
+	for i := range n {
+		id := "g" + strconv.Itoa(i)
+		f.PutGroup(t, directory.Group{ID: id, MemberOf: []string{"everyone"}})
+		in = append(in, id)
+	}
+	f.PutGroup(t, directory.Group{ID: "everyone"})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: in})
+
+	start := time.Now()
+	got := expand(t, f, "mei")
+	took := time.Since(start)
+
+	if len(got.Groups.Members) != n+1 {
+		t.Fatalf("a subject in %d groups resolved to %d", n, len(got.Groups.Members))
+	}
+	// The subject, the thousand groups, and the one they all point at.
+	if got.Lookups != n+2 {
+		t.Errorf("a subject in %d groups cost %d lookups, want %d", n, got.Lookups, n+2)
+	}
+	if took > 10*time.Second {
+		t.Errorf("a subject in %d groups took %s", n, took.Round(time.Millisecond))
+	}
+	t.Logf("%d groups in %s over %d lookups", len(got.Groups.Members), took.Round(time.Millisecond), got.Lookups)
+}
+
+func testCancel(t *testing.T, f Fixture) {
+	f.PutGroup(t, directory.Group{ID: "engineering"})
+	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	r := resolver(t, f)
+	if _, err := r.Expand(ctx, "mei"); err == nil {
+		t.Error("an expansion under a cancelled context came back without an error")
+	}
+}
+
+// resolver is the resolver every case runs through, with the defaults, because
+// the defaults are what a deployment gets.
+func resolver(t *testing.T, f Fixture) *directory.Resolver {
+	t.Helper()
+	r, err := directory.New(f.Directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+// expand resolves one subject and fails the test if it could not.
+func expand(t *testing.T, f Fixture, id string) directory.Expansion {
+	t.Helper()
+	got, err := resolver(t, f).Expand(t.Context(), id)
+	if err != nil {
+		t.Fatalf("expanding %q: %v", id, err)
+	}
+	return got
+}
+
+// within resolves one subject under a deadline, so that a walk which never
+// terminates fails the case rather than hanging the whole run until the test
+// binary is killed and nobody knows which case it was.
+//
+// The expansion itself runs on another goroutine, so nothing here may call
+// [testing.T.Fatal] from inside it.
+func within(t *testing.T, f Fixture, id string) (directory.Expansion, error) {
+	t.Helper()
+
+	type result struct {
+		got directory.Expansion
+		err error
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	done := make(chan result, 1)
+	r := resolver(t, f)
+	go func() {
+		got, err := r.Expand(ctx, id)
+		done <- result{got, err}
+	}()
+	select {
+	case out := <-done:
+		return out.got, out.err
+	case <-ctx.Done():
+		return directory.Expansion{}, ctx.Err()
+	}
+}
+
+// keys is the group ids written the way a rule is compared against them, sorted
+// the way an expansion returns them.
+func keys(f Fixture, ids ...string) []string {
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = fmt.Sprintf("%s:%s", f.Directory.Name(), id)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/directory/expand.go
+++ b/directory/expand.go
@@ -1,0 +1,424 @@
+package directory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"slices"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// Defaults for a [Resolver].
+const (
+	// DefaultWidth is how many lookups one expansion has in flight at once.
+	//
+	// It is the number that decides whether a person in three hundred groups
+	// waits for one round trip or for three hundred, and it is not larger
+	// because the far side is somebody else's rate limit. A directory is shared
+	// by every session that starts, so an expansion that goes as wide as it can
+	// is an expansion that makes every other expansion slower.
+	DefaultWidth = 16
+
+	// DefaultMaxGroups is the most groups one expansion may reach before it is
+	// refused.
+	//
+	// It is a bound on a walk over a graph somebody else maintains, which is
+	// the reason it exists at all: without one, a directory that has grown a
+	// pathological shape turns one sign in into an unbounded amount of work
+	// against a service everybody else is also using.
+	//
+	// Ten thousand is far past what anybody is legitimately in. The tail of a
+	// large company is in the low thousands, so this is a limit that catches a
+	// mistake rather than a limit somebody has to think about.
+	DefaultMaxGroups = 10000
+)
+
+// ErrTooManyGroups is returned when an expansion reaches [Option] WithMaxGroups
+// entries.
+//
+// It refuses rather than returning what it had. A truncated group set is not a
+// smaller answer, it is a wrong one, and the way it is wrong is that somebody
+// stops seeing documents they can read with no error anywhere to explain it.
+var ErrTooManyGroups = errors.New("directory: too many groups")
+
+// Expansion is one resolved subject.
+type Expansion struct {
+	// Subject is what the directory said about them, unchanged.
+	Subject Subject
+
+	// Groups is the transitive closure, in the form [acl.Permissions] compares
+	// against, with a version derived from the closure itself.
+	Groups acl.GroupSet
+
+	// Unknown is the groups the directory said this subject is in, directly or
+	// through another group, and then did not hold when asked about. They are
+	// in Groups, because the directory's statement that somebody is a member is
+	// a statement about them, and whatever those groups are themselves members
+	// of is not in Groups, because nothing could be asked.
+	//
+	// A non empty Unknown is an inconsistent directory and worth an alert. It
+	// is not worth failing a sign in over, which is why it is a field rather
+	// than an error.
+	Unknown []string
+
+	// Lookups is how many requests the directory answered, the subject
+	// included. It is what the latency of an expansion is a function of.
+	Lookups int
+
+	// Depth is how many levels of nesting were walked. One means the subject's
+	// groups are in no groups themselves.
+	Depth int
+}
+
+// Apply puts the expansion onto a principal.
+//
+// It sets the group set and merges in any identities the directory knew that
+// the principal did not already carry. It does not touch the tenant, the roles
+// or the subject, because none of those is a directory's business.
+func (e Expansion) Apply(p *acl.Principal) {
+	if p == nil {
+		return
+	}
+	p.Groups = e.Groups
+	for _, id := range e.Subject.Identities {
+		if !slices.Contains(p.Identities, id) {
+			p.Identities = append(p.Identities, id)
+		}
+	}
+}
+
+// Counters are the numbers one resolver has produced since it was made.
+type Counters struct {
+	// Expansions is how many completed, and Failures how many did not. A
+	// failure is a directory that could not answer, not a subject it does not
+	// hold.
+	Expansions uint64
+	Failures   uint64
+
+	// Lookups is every request made of the directory, which is the number that
+	// tells an operator what the directory is being asked to carry.
+	Lookups uint64
+
+	// Missing is subjects the directory does not hold, Disabled is subjects it
+	// holds and has deactivated, and Unresolved is groups named in a membership
+	// that the directory did not hold when asked. The last one is the number to
+	// alert on: the other two are ordinary.
+	Missing    uint64
+	Disabled   uint64
+	Unresolved uint64
+}
+
+// Resolver expands subjects against one directory.
+//
+// It holds no cache. That is deliberate and it is not an oversight: caching a
+// group membership correctly is a harder problem than expanding one, it needs
+// the version this package produces in order to be invalidated, and putting the
+// two in the same type is how the cache ends up with a timeout instead.
+//
+// A Resolver is safe for concurrent use.
+type Resolver struct {
+	dir   Directory
+	width int
+	max   int
+
+	expansions atomic.Uint64
+	failures   atomic.Uint64
+	lookups    atomic.Uint64
+	missing    atomic.Uint64
+	disabled   atomic.Uint64
+	unresolved atomic.Uint64
+}
+
+// Option changes a [Resolver].
+type Option func(*Resolver)
+
+// WithWidth sets how many lookups one expansion has in flight at once. A width
+// below one selects [DefaultWidth].
+func WithWidth(n int) Option {
+	return func(r *Resolver) {
+		if n < 1 {
+			n = DefaultWidth
+		}
+		r.width = n
+	}
+}
+
+// WithMaxGroups sets the most groups one expansion may reach before it is
+// refused with [ErrTooManyGroups]. A bound below one selects
+// [DefaultMaxGroups].
+func WithMaxGroups(n int) Option {
+	return func(r *Resolver) {
+		if n < 1 {
+			n = DefaultMaxGroups
+		}
+		r.max = n
+	}
+}
+
+// New returns a resolver over one directory.
+func New(d Directory, opts ...Option) (*Resolver, error) {
+	if d == nil {
+		return nil, errors.New("directory: a directory is required")
+	}
+	if d.Name() == "" {
+		return nil, errors.New("directory: a directory must have a name")
+	}
+	r := &Resolver{dir: d, width: DefaultWidth, max: DefaultMaxGroups}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r, nil
+}
+
+// Name is the identity source this resolver's groups belong to.
+func (r *Resolver) Name() string { return r.dir.Name() }
+
+// Counters returns the numbers so far.
+func (r *Resolver) Counters() Counters {
+	return Counters{
+		Expansions: r.expansions.Load(),
+		Failures:   r.failures.Load(),
+		Lookups:    r.lookups.Load(),
+		Missing:    r.missing.Load(),
+		Disabled:   r.disabled.Load(),
+		Unresolved: r.unresolved.Load(),
+	}
+}
+
+// Expand resolves one subject into the groups they are in.
+//
+// The walk is breadth first, one level at a time, with the lookups in a level
+// running together. Breadth first rather than depth first is what makes the
+// concurrency worth having: the groups at one level are independent of each
+// other, and the ones at the level above cannot be named until this level has
+// answered.
+//
+// A group already seen is never looked up again, which is both the cycle
+// detection and most of the speed. Real directories converge hard: a few
+// hundred groups at the bottom reach the same dozen at the top.
+func (r *Resolver) Expand(ctx context.Context, id string) (Expansion, error) {
+	// Checked here rather than left to the directory, because whether an
+	// adapter looks at the context is up to the adapter and whether an
+	// expansion runs after the request that wanted it went away is not.
+	if err := ctx.Err(); err != nil {
+		return Expansion{}, fmt.Errorf("directory %s: %q: %w", r.dir.Name(), id, err)
+	}
+
+	sub, err := r.dir.Subject(ctx, id)
+	r.lookups.Add(1)
+	switch {
+	case errors.Is(err, ErrNoSubject):
+		r.missing.Add(1)
+		r.failures.Add(1)
+		return Expansion{}, fmt.Errorf("directory %s: %q: %w", r.dir.Name(), id, err)
+	case err != nil:
+		r.failures.Add(1)
+		return Expansion{}, fmt.Errorf("directory %s: %q: %w", r.dir.Name(), id, err)
+	}
+	if sub.Disabled {
+		r.disabled.Add(1)
+		r.failures.Add(1)
+		return Expansion{}, fmt.Errorf("directory %s: %q: %w", r.dir.Name(), id, ErrDisabled)
+	}
+	if sub.ID == "" {
+		sub.ID = id
+	}
+
+	var (
+		// seen is the closure and the cycle detection in one. A group is put in
+		// it when it is scheduled rather than when it is answered, so a group
+		// two of its children both point at is looked up once.
+		seen     = make(map[string]string)
+		unknown  []string
+		frontier = dedupe(sub.MemberOf)
+		lookups  = 1
+		depth    int
+	)
+	for _, g := range frontier {
+		seen[g] = ""
+	}
+	if len(seen) > r.max {
+		r.failures.Add(1)
+		return Expansion{}, fmt.Errorf("directory %s: %q is directly in %d groups: %w", r.dir.Name(), id, len(seen), ErrTooManyGroups)
+	}
+
+	for len(frontier) > 0 {
+		if err := ctx.Err(); err != nil {
+			r.failures.Add(1)
+			return Expansion{}, fmt.Errorf("directory %s: expanding %q: %w", r.dir.Name(), id, err)
+		}
+		depth++
+		found, err := r.level(ctx, frontier)
+		lookups += len(frontier)
+		r.lookups.Add(uint64(len(frontier)))
+		if err != nil {
+			r.failures.Add(1)
+			return Expansion{}, fmt.Errorf("directory %s: expanding %q: %w", r.dir.Name(), id, err)
+		}
+
+		var next []string
+		for i, got := range found {
+			if got.absent {
+				unknown = append(unknown, frontier[i])
+				continue
+			}
+			seen[frontier[i]] = got.group.Version
+			for _, up := range got.group.MemberOf {
+				if up == "" {
+					continue
+				}
+				if _, ok := seen[up]; ok {
+					continue
+				}
+				seen[up] = ""
+				next = append(next, up)
+			}
+		}
+		if len(seen) > r.max {
+			r.failures.Add(1)
+			return Expansion{}, fmt.Errorf("directory %s: %q reaches at least %d groups: %w", r.dir.Name(), id, len(seen), ErrTooManyGroups)
+		}
+		frontier = next
+	}
+
+	ids := make([]string, 0, len(seen))
+	for g := range seen {
+		ids = append(ids, g)
+	}
+	sort.Strings(ids)
+	sort.Strings(unknown)
+
+	members := make([]string, len(ids))
+	for i, g := range ids {
+		members[i] = acl.Ref{Source: r.dir.Name(), Value: g}.GroupKey()
+	}
+
+	r.expansions.Add(1)
+	r.unresolved.Add(uint64(len(unknown)))
+
+	return Expansion{
+		Subject: sub,
+		Groups: acl.GroupSet{
+			Version: fingerprint(r.dir.Name(), sub.Version, ids, seen),
+			Members: members,
+		},
+		Unknown: unknown,
+		Lookups: lookups,
+		Depth:   depth,
+	}, nil
+}
+
+// answer is one group lookup, with absent kept apart from an error because the
+// two mean opposite things: absent is the directory answering, and an error is
+// the directory not answering.
+type answer struct {
+	group  Group
+	absent bool
+}
+
+// level looks up one breadth first level, together.
+//
+// The first failure cancels the rest, because they are all about to be thrown
+// away: an expansion that cannot see the whole graph does not return part of
+// it. The others are still waited for, so that nothing is left running against
+// the directory after this returns.
+func (r *Resolver) level(ctx context.Context, ids []string) ([]answer, error) {
+	out := make([]answer, len(ids))
+	errs := make([]error, len(ids))
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var (
+		wg   sync.WaitGroup
+		sem  = make(chan struct{}, min(r.width, len(ids)))
+		fail atomic.Bool
+	)
+	for i, id := range ids {
+		wg.Go(func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			if fail.Load() {
+				// Somebody else has already failed the level, so this lookup
+				// would be discarded. Not making it is one less request against
+				// a directory that may be the thing having the bad day, and it
+				// records nothing because the failure is already recorded.
+				return
+			}
+			g, err := r.dir.Group(ctx, id)
+			switch {
+			case errors.Is(err, ErrNoGroup):
+				out[i] = answer{absent: true}
+			case err != nil:
+				errs[i] = err
+				fail.Store(true)
+				cancel()
+			default:
+				if g.ID == "" {
+					g.ID = id
+				}
+				out[i] = answer{group: g}
+			}
+		})
+	}
+	wg.Wait()
+
+	// In order rather than whichever failed first, so that the same directory
+	// in the same state produces the same message twice running. A real failure
+	// is preferred over a cancellation because the cancellation is very often
+	// this level reacting to that failure, and the message an operator reads
+	// should name the thing that went wrong rather than the consequence.
+	for i, err := range errs {
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return nil, fmt.Errorf("group %q: %w", ids[i], err)
+		}
+	}
+	for i, err := range errs {
+		if err != nil {
+			return nil, fmt.Errorf("group %q: %w", ids[i], err)
+		}
+	}
+	return out, nil
+}
+
+// fingerprint is the version stamped on a group set.
+//
+// It is a hash of the answer: the source, the subject's own revision, and every
+// group in the closure with whatever revision the directory gave for it. See
+// the package documentation for why it is derived rather than counted.
+//
+// Zero is avoided because a version of zero is what an unset field looks like,
+// and a cache key that cannot tell "not expanded yet" from "expanded, and the
+// hash happened to be zero" is a cache key with one very rare bug in it.
+func fingerprint(source, subject string, ids []string, versions map[string]string) uint64 {
+	h := fnv.New64a()
+	fmt.Fprintf(h, "%s\x00%s\x00", source, subject)
+	for _, id := range ids {
+		fmt.Fprintf(h, "%s\x00%s\x00", id, versions[id])
+	}
+	if v := h.Sum64(); v != 0 {
+		return v
+	}
+	return 1
+}
+
+// dedupe returns the ids once each, in the order they first appeared, with the
+// empty ones dropped.
+func dedupe(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if v == "" || slices.Contains(out, v) {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}

--- a/directory/static.go
+++ b/directory/static.go
@@ -1,0 +1,154 @@
+package directory
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
+)
+
+// Static is a directory held in memory.
+//
+// It is the reference implementation, in the sense that [directorytest] runs
+// against it and a provider adapter that behaves differently is the one that is
+// wrong. It is also the directory a small deployment actually uses: a company
+// with forty people and six groups has the whole thing in its configuration
+// file, and making them stand up an identity provider to try a search engine is
+// how a search engine does not get tried.
+//
+// It is safe for concurrent use, and it is meant to be written to while it is
+// being read from, because that is what reloading a configuration file is.
+type Static struct {
+	name string
+
+	mu       sync.RWMutex
+	subjects map[string]Subject
+	groups   map[string]Group
+}
+
+// NewStatic returns an empty directory under the given identity source name.
+func NewStatic(name string) *Static {
+	return &Static{
+		name:     name,
+		subjects: make(map[string]Subject),
+		groups:   make(map[string]Group),
+	}
+}
+
+// Name is the identity source these ids belong to.
+func (s *Static) Name() string { return s.name }
+
+// Put adds or replaces one subject. A subject with no id is ignored rather than
+// stored under the empty string, since the only thing that could look it up is
+// a bug.
+func (s *Static) Put(sub Subject) {
+	if sub.ID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.subjects[sub.ID] = clone(sub)
+}
+
+// PutGroup adds or replaces one group.
+func (s *Static) PutGroup(g Group) {
+	if g.ID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	g.MemberOf = slices.Clone(g.MemberOf)
+	s.groups[g.ID] = g
+}
+
+// Remove takes a subject out, which is what a deletion in the upstream
+// directory looks like here. Deactivating somebody is [Static.Put] with
+// [Subject.Disabled] set, and it is the one to reach for: directories rarely
+// delete anybody, and a subject that vanished and one that was closed are
+// different facts.
+func (s *Static) Remove(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.subjects, id)
+}
+
+// RemoveGroup takes a group out. Nothing rewrites the memberships that named
+// it, on purpose: an expansion that reaches a group this directory no longer
+// holds is exactly the inconsistency [Expansion.Unknown] exists to report, and
+// a fake that tidied up after itself could not produce it.
+func (s *Static) RemoveGroup(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.groups, id)
+}
+
+// Subject returns one subject by id.
+func (s *Static) Subject(_ context.Context, id string) (Subject, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sub, ok := s.subjects[id]
+	if !ok {
+		return Subject{}, fmt.Errorf("%q: %w", id, ErrNoSubject)
+	}
+	return clone(sub), nil
+}
+
+// Group returns one group by id.
+func (s *Static) Group(_ context.Context, id string) (Group, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	g, ok := s.groups[id]
+	if !ok {
+		return Group{}, fmt.Errorf("%q: %w", id, ErrNoGroup)
+	}
+	g.MemberOf = slices.Clone(g.MemberOf)
+	return g, nil
+}
+
+// Load replaces the whole directory in one step, which is what a configuration
+// reload wants: a reader either sees all of the old contents or all of the new
+// ones, and never a moment in the middle where somebody is in no groups.
+func (s *Static) Load(subjects []Subject, groups []Group) {
+	subs := make(map[string]Subject, len(subjects))
+	for _, sub := range subjects {
+		if sub.ID != "" {
+			subs[sub.ID] = clone(sub)
+		}
+	}
+	gs := make(map[string]Group, len(groups))
+	for _, g := range groups {
+		if g.ID != "" {
+			g.MemberOf = slices.Clone(g.MemberOf)
+			gs[g.ID] = g
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.subjects, s.groups = subs, gs
+}
+
+// Snapshot returns what the directory holds, for an admin screen and for tests.
+func (s *Static) Snapshot() ([]Subject, []Group) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	subs := make([]Subject, 0, len(s.subjects))
+	for _, sub := range slices.Sorted(maps.Keys(s.subjects)) {
+		subs = append(subs, clone(s.subjects[sub]))
+	}
+	gs := make([]Group, 0, len(s.groups))
+	for _, id := range slices.Sorted(maps.Keys(s.groups)) {
+		g := s.groups[id]
+		g.MemberOf = slices.Clone(g.MemberOf)
+		gs = append(gs, g)
+	}
+	return subs, gs
+}
+
+// clone copies the slices in a subject, so that what a caller does with the
+// answer cannot reach back into what the next caller is given.
+func clone(sub Subject) Subject {
+	sub.MemberOf = slices.Clone(sub.MemberOf)
+	sub.Identities = slices.Clone(sub.Identities)
+	return sub
+}

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -1,0 +1,149 @@
+# Turning a person into a set of groups
+
+Every permission decision in this system is set membership on two lists of strings.
+A document carries the references its source granted read to, a request carries the references that name the person asking, and the answer is whether the two sets intersect.
+That is deliberately dull, it is written down once in `acl`, and a storage driver evaluates the same comparison in its own query language so the filter runs while the driver walks its own data.
+
+`docs/permissions.md` is about the first list, the one a source produces.
+This is about the second, which is harder for a reason that has nothing to do with us: it is a reachability question over a graph that somebody else maintains, changes without telling us, and did not design to be walked.
+
+## Nobody grants access to a person
+
+They grant it to `engineering`, which contains `platform`, which contains `storage`, which contains four people and a service account.
+The person who joined last week can read the runbook because of a group nobody named in a rule anywhere.
+
+So the question "which groups is this person in" is not a field lookup.
+It is a transitive closure, and every real directory has three properties that make walking one interesting.
+
+It is big.
+Somebody at a large company is in a few hundred groups and the tail is in the thousands, and the expansion happens when a session starts, in front of a person waiting for a search box to work.
+
+It has cycles.
+Not because anybody meant to: two groups end up inside each other through a third one that was added during a reorganisation, and the directory does not mind because it never walks the graph the way we do.
+A walk written without a seen set hangs, and it hangs in production rather than in a test, because the test directory is a diagram somebody drew on purpose.
+
+It changes.
+Somebody is removed from a group at eleven, and what matters is not how quickly that is noticed but that everything derived from the old answer stops being used the moment it is.
+
+## What a provider has to answer
+
+`directory.Directory` is two lookups and that is the whole interface.
+
+```go
+type Directory interface {
+	Name() string
+	Subject(ctx context.Context, id string) (Subject, error)
+	Group(ctx context.Context, id string) (Group, error)
+}
+```
+
+Okta, Entra ID, Google Workspace and LDAP disagree about almost everything else, and every one of them will say what one subject is directly a member of and what one group is directly a member of.
+Everything above that is written once and shared: the closure, the cycle detection, the bound on how much work one expansion may cost, the concurrency, and the version the answer is stamped with.
+Those are exactly the parts that are easy to get subtly wrong and impossible to notice from the outside, and leaving them to each adapter would mean four implementations of a graph walk written by four people who each needed one provider.
+
+A provider that already expands transitively, and Entra ID does, is not penalised for it.
+It returns the closure it was given, the walk finds nothing new above it and stops after one level.
+A provider that only knows direct edges gets the same answer for more requests.
+
+`Group` deliberately does not carry its members.
+Listing them is the expensive direction, it is the one large directories rate limit hardest, and nothing here needs it: the walk goes upwards from a person, never downwards from a group.
+
+## The walk
+
+Breadth first, one level at a time, with the lookups within a level running together.
+Breadth first rather than depth first is what makes the concurrency worth having, because the groups at one level are independent of each other and the ones above cannot be named until this level has answered.
+
+A group already seen is never looked up again, which is both the cycle detection and most of the speed.
+Real directories converge hard: a few hundred groups at the bottom reach the same dozen at the top, and a diamond costs one lookup rather than two.
+
+The width is sixteen by default and it is a promise to the far side rather than a tuning knob.
+A directory is shared by every session that starts, so an expansion that goes as wide as it can is an expansion that makes every other expansion slower.
+
+The closure is bounded at ten thousand groups, and reaching the bound refuses rather than truncating.
+A truncated group set is not a smaller answer, it is a wrong one, and the way it is wrong is that somebody stops seeing documents they can read with no error anywhere to explain it.
+Ten thousand is far past what anybody is legitimately in, so it is a limit that catches a mistake rather than one somebody has to think about.
+
+## The version is a fingerprint, not a clock
+
+`acl.GroupSet` carries a version, and it is part of the cache key of every bitmap derived from the set.
+When somebody is removed from a group the version moves, every key derived from the old membership stops matching, and the cached state is dead the moment the change lands rather than when a timer expires.
+
+The number is a hash of the answer rather than a counter: the source, the subject's own revision if the directory keeps one, and every group in the closure with whatever revision the directory gave for it.
+
+Two consequences are worth stating.
+A directory with no revision of its own still gets correct invalidation, because the group names are in the hash and taking somebody out of a group changes them.
+And a membership change somewhere in the directory that does not change this person's closure does not invalidate this person's state, which is the difference between a cache that works at a company with fifty thousand groups and one that does not.
+
+## Which way it fails
+
+A directory that cannot be reached fails the expansion.
+It does not return an empty group set, and nothing in the path turns the error into one, because an empty group set is a valid answer that happens to mean "this person is in no groups at all" and everything above is built to trust it.
+Refusing is visible and recoverable.
+Quietly demoting somebody to no groups is a support ticket about missing search results, and on the sources that grant to a person directly it is a partial answer that looks complete.
+
+A subject the directory has never heard of is refused, and so is one it holds and has deactivated.
+Those are two different facts and both are a no: an account closed on Friday should stop resolving on Friday rather than when the last cached entry expires, and directories rarely delete anybody, so the deactivated case is the one that actually happens.
+
+A group named in a membership that the directory does not hold is the one case that does not refuse.
+The directory has said this person is in it, which is a statement about them, and the only thing missing is what that group is itself a member of.
+Dropping it would take away access the directory granted on the strength of a lookup that failed, so the group is kept, its parents are not walked, and it is reported in `Expansion.Unknown` and counted.
+A non empty `Unknown` is an inconsistent directory and worth an alert, and it is not worth failing a sign in over, which is why it is a field rather than an error.
+
+## At the edge of the API
+
+`api.Resolving` wraps an authenticator so that the group membership on a request comes from the directory rather than from whoever authenticated it.
+
+```go
+s := api.New(st, searcher, api.Resolving{
+	Auth:     api.HeaderAuth{Tenant: "acme", Admins: []string{"u_mei"}},
+	Resolver: resolver,
+})
+```
+
+Who this is comes from a credential and is the authenticator's job.
+What they are a member of is a fact about the company, it changes without anybody signing in again, and no token is a good place to keep it.
+A proxy that passes a group list down is passing on a copy of an answer somebody else cached, and the day somebody is taken out of a group is the day the copy is wrong.
+
+So the group set is replaced entirely rather than merged.
+If the directory is the answer then a header saying otherwise is not a second opinion, it is a way in.
+Identities are merged rather than replaced, because those legitimately come from two places: a token can say which Slack account signed in and the directory can say which Jira account is the same person.
+
+A directory outage answers 503 rather than 401.
+The credential was fine and the request is refused anyway, and an operator watching a wall of 401s during a directory outage would go looking at the wrong system.
+
+## The conformance suite is the definition
+
+`directory/directorytest` is what an adapter has to pass, and it rather than the interface is the definition of one.
+
+A directory adapter is a small amount of code in front of somebody else's API and the damage it can do is out of all proportion to its size.
+Each one is written by whoever needed that provider, usually against one tenant with a tidy directory, and the failure modes only appear against one that is not: a group inside itself, a membership naming a group deleted last year, an account deactivated on Friday, a person in four hundred groups.
+None of that is visible from above.
+Somebody quietly given nobody else's groups gets fewer results and blames the search engine.
+Somebody quietly given somebody else's groups does not notice at all.
+
+The suite exercises the adapter directly for the answers only it can give, and exercises the shared resolver over the same adapter for the properties that only appear once the graph is walked, because an adapter is never used without the resolver.
+
+```go
+func TestConformance(t *testing.T) {
+	directorytest.Run(t, func(t *testing.T) directorytest.Fixture {
+		d := directory.NewStatic("acme")
+		return directorytest.Fixture{
+			Directory: d,
+			Put:       func(_ *testing.T, s directory.Subject) { d.Put(s) },
+			PutGroup:  func(_ *testing.T, g directory.Group) { d.PutGroup(g) },
+			Drop:      func(_ *testing.T, group string) { d.RemoveGroup(group) },
+		}
+	})
+}
+```
+
+`directory.Static` is the reference implementation the suite runs against, and it is also the directory a small deployment actually uses.
+A company with forty people and six groups has the whole thing in its configuration file, and making them stand up an identity provider to try a search engine is how a search engine does not get tried.
+
+## What is not here yet
+
+Caching.
+The resolver holds none, deliberately: caching a group membership correctly is a harder problem than expanding one, it needs the version this package produces in order to be invalidated, and putting the two in the same type is how the cache ends up with a timeout instead.
+
+Adapters for the hosted providers.
+The interface is two methods and the suite is what they have to pass, so each is a small amount of code and a fake, in the shape the connectors already use.


### PR DESCRIPTION
Closes nothing on its own, this is the first of three pieces of #18.

## What changed

The group set on a request now comes from the directory instead of from the request.

Until now `HeaderAuth` read a groups header and the server believed it, which is fine for a test and is a way in for anything else.
A group list on a request is a copy of an answer somebody else cached, and the day somebody is taken out of a group is the day the copy is wrong.
`api.Resolving` wraps any authenticator, keeps who it says this is, throws the group set away and asks the directory instead.
Identities are merged rather than replaced, because those legitimately come from two places: a token can say which Slack account signed in and the directory can say which Jira account is the same person.

## The interface is two lookups

```go
type Directory interface {
	Name() string
	Subject(ctx context.Context, id string) (Subject, error)
	Group(ctx context.Context, id string) (Group, error)
}
```

Okta, Entra ID, Google Workspace and LDAP disagree about almost everything else, and every one of them will answer those two.
Everything above them is written once in `directory.Resolver` and shared: the transitive closure, the cycle detection, the bound on how much work one expansion may cost, the concurrency, and the version the answer is stamped with.
Those are exactly the parts that are easy to get subtly wrong and impossible to notice from the outside, so leaving them to each adapter would mean four graph walks written by four people who each needed one provider.

`Group` deliberately does not carry its members.
Listing them is the expensive direction, it is the one large directories rate limit hardest, and nothing here needs it, because the walk goes upwards from a person and never downwards from a group.

A provider that already expands transitively, and Entra ID does, is not penalised for it.
It returns the closure it was given, the walk finds nothing new above it and stops after one level.

## The walk

Breadth first, one level at a time, sixteen lookups wide by default.
Breadth first rather than depth first is what makes the concurrency worth having, since the groups at one level are independent of each other and the ones above them cannot be named until this level has answered.

A group already seen is never looked up again, which is both the cycle detection and most of the speed.
Real directories converge hard, a few hundred groups at the bottom reach the same dozen at the top, and a diamond costs one lookup rather than two.

The width is a promise to the far side rather than a tuning knob.
A directory is shared by every session that starts, so an expansion that goes as wide as it can is an expansion that makes every other expansion slower.

The closure is bounded at ten thousand groups and reaching the bound refuses rather than truncating.
A truncated group set is not a smaller answer, it is a wrong one, and the way it is wrong is that somebody stops seeing documents they can read with no error anywhere to explain it.

## The version is a fingerprint, not a clock

`acl.GroupSet` already carries a version and it is part of the cache key of every bitmap derived from the set.
The number this produces is a hash of the answer rather than a counter: the source, the subject's own revision if the directory keeps one, and every group in the closure with whatever revision the directory gave for it.

Two consequences are worth stating.
A directory with no revision of its own still gets correct invalidation, because the group names are in the hash and taking somebody out of a group changes them.
And a membership change somewhere in the directory that does not touch this person's closure does not invalidate this person, which is the difference between a cache that works at a company with fifty thousand groups and one that does not.

## Which way it fails

A directory that cannot be reached fails the expansion, and nothing in the path turns that error into an empty group set.
An empty group set is a valid answer that happens to mean "this person is in no groups at all" and everything above is built to trust it.
Refusing is visible and recoverable, quietly demoting somebody to no groups is a support ticket about missing search results.

The API answers 503 rather than 401 for that case.
The credential was fine and the request is refused anyway, and an operator watching a wall of 401s during a directory outage would go looking at the wrong system.

A missing subject and a deactivated one both refuse, and they are two different facts.
Directories rarely delete anybody, so the deactivated case is the one that actually happens.

A group named in a membership that the directory does not hold is the one case that does not refuse.
The directory has said this person is in it, which is a statement about them, and the only thing missing is what that group is itself a member of.
So the group is kept, its parents are not walked, and it is reported in `Expansion.Unknown` and counted.
A non empty `Unknown` is an inconsistent directory and worth an alert, and it is not worth failing a sign in over, which is why it is a field rather than an error.

## The suite is the definition

`directory/directorytest` is seventeen cases and it rather than the interface is what an adapter has to pass.

A directory adapter is a small amount of code in front of somebody else's API and the damage it can do is out of all proportion to its size.
Each one gets written against one tenant with a tidy directory, and the failure modes only appear against one that is not: a group inside itself, a membership naming a group deleted last year, an account deactivated on Friday, a person in four hundred groups.
None of that is visible from above.
Somebody quietly given nobody else's groups gets fewer results and blames the search engine, and somebody quietly given somebody else's groups does not notice at all.

The suite exercises the provider directly for the answers only it can give, and the resolver over the same provider for the properties that only appear once the graph is walked, because an adapter is never used without the resolver.

`directory.Static` is the reference implementation the suite runs against, and it is also the directory a small deployment actually uses.
A company with forty people and six groups has the whole thing in its configuration file, and making them stand up an identity provider in order to try a search engine is how a search engine does not get tried.

## On the checklist for #18

Three of the four boxes are done here.
A cycle terminates, a self referencing group terminates, and both are cases in the suite.
A thousand groups resolve in well under a second on the test machine, with the lookup count asserted at exactly one per group plus the subject plus the empty final level.
An unreachable directory refuses rather than allows, at the resolver and again at the API.

The box about a real export is not, and it belongs with the provider adapters rather than here.
That is the next piece: Okta, Entra ID and Google Workspace over this suite, each with a fake and a recorded fixture in the shape the connectors already use, plus a `Multi` directory that unions several providers into one group set.
The third piece is the cache, which is #19, and it is deliberately not in this package.
Caching a group membership correctly is a harder problem than expanding one, it needs the version this produces in order to be invalidated, and putting the two in the same type is how the cache ends up with a timeout instead.

## Notes

`docs/identity.md` is the long version of all of the above.

Refs #18
