### PR TITLE
Hold the answer for a minute, and one minute only

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ func main() {
 | Package | What lives there |
 | --- | --- |
 | `acl` | principals, groups, permission descriptors, visibility bitmaps |
-| `directory` | a person resolved into the groups they are in, with cycle detection and a version, [docs/identity.md](docs/identity.md) |
+| `directory` | a person resolved into the groups they are in, with cycle detection, a version and one cache layer, [docs/identity.md](docs/identity.md) |
 | `directory/directorytest` | the conformance suite that defines what a directory adapter is |
 | `doc` | the canonical document model every connector normalises into |
 | `store` | the storage interface, plus `storetest`, the conformance suite |
@@ -499,6 +499,8 @@ A provider adapter answers two lookups, what one subject is directly a member of
 Those are the parts that are easy to get subtly wrong and impossible to notice from the outside, and a group that ended up inside itself during a reorganisation hangs a walk in production rather than in a test.
 The group set is stamped with a version derived from the answer, so a membership change invalidates everything cached from it the moment it lands, and a change that does not touch this person's closure does not invalidate this person.
 A directory that cannot be reached refuses the request rather than resolving somebody to no groups, because an empty group set is a valid answer that everything above is built to trust.
+Expanding on every request is not affordable, so there is a cache, and there is exactly one layer of it: caching the group edges as well would mean an answer built out of edges that were themselves already old, and a worst case age that is the sum of two lifetimes is a number nobody can state without drawing a diagram.
+One layer means the maximum staleness of any group set is the lifetime, which is configured in one place and published as a metric.
 [docs/identity.md](docs/identity.md) is the whole of it.
 
 A connector hands the pipeline a body, and for the PDF attached to a ticket or the deck a quarter was reviewed from, the bytes are not it.

--- a/api/api.go
+++ b/api/api.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -1101,6 +1102,11 @@ func (s *Server) cacheStats() map[string]cache.Stats {
 		out = make(map[string]cache.Stats, 1)
 	}
 	out["thumbnail"] = s.thumbs.Stats()
+	if reporter, ok := s.auth.(interface {
+		CacheStats() map[string]cache.Stats
+	}); ok {
+		maps.Copy(out, reporter.CacheStats())
+	}
 	return out
 }
 

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -21,6 +21,7 @@ const (
 	MetricCacheMisses     = "genba_cache_misses_total"
 	MetricCacheEvictions  = "genba_cache_evictions_total"
 	MetricCacheEntries    = "genba_cache_entries"
+	MetricGroupStaleness  = "genba_directory_staleness_seconds"
 	MetricStoreRows       = "genba_store_rows_total"
 	MetricStoreStatements = "genba_store_statements_total"
 	MetricStoreDecodes    = "genba_store_decodes_total"
@@ -68,7 +69,7 @@ func newMetrics(s *Server) *metrics {
 	cacheStat := func(pick func(hits, misses, evictions, entries int64) int64) func() map[string]float64 {
 		return func() map[string]float64 {
 			out := map[string]float64{}
-			for layer, st := range s.searcher.CacheStats() {
+			for layer, st := range s.cacheStats() {
 				out[layer] = float64(pick(st.Hits, st.Misses, st.Evictions, int64(st.Entries)))
 			}
 			return out
@@ -82,6 +83,25 @@ func newMetrics(s *Server) *metrics {
 		cacheStat(func(_, _, evictions, _ int64) int64 { return evictions }))
 	r.Counters(MetricCacheEntries, "Entries currently held, per layer.", "layer", "gauge",
 		cacheStat(func(_, _, _, entries int64) int64 { return entries }))
+
+	// How long a membership change can take to be noticed. It is published
+	// because it is a promise the deployment is making about its permissions,
+	// and a promise that only exists in a configuration file is one nobody is
+	// checking. A deployment that resolves without a cache publishes nothing
+	// here, which is the truth: there is no staleness to bound.
+	r.Counters(MetricGroupStaleness,
+		"The most out of date a resolved group set can be, which is the directory cache lifetime.",
+		"", "gauge", func() map[string]float64 {
+			bounded, ok := s.auth.(interface{ staleness() (float64, bool) })
+			if !ok {
+				return nil
+			}
+			seconds, ok := bounded.staleness()
+			if !ok {
+				return nil
+			}
+			return map[string]float64{"": seconds}
+		})
 
 	// A driver is not obliged to be measurable. One that is publishes the same
 	// numbers the CI gate asserts on, so a slow deployment can be compared with

--- a/api/resolve.go
+++ b/api/resolve.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/cache"
 	"github.com/tamnd/genba/directory"
 )
 
@@ -32,8 +34,10 @@ type Resolving struct {
 	// it is whatever a deployment authenticates with.
 	Auth Authenticator
 
-	// Resolver is the directory the groups come from.
-	Resolver *directory.Resolver
+	// Resolver is the directory the groups come from. It is a
+	// [directory.Resolver] on its own, or one wrapped in a
+	// [directory.Cache], and nothing here can tell the difference.
+	Resolver directory.Expander
 
 	// Lookup says how the principal is named in the directory, and it is
 	// optional. The default is the identity the principal carries for the
@@ -86,6 +90,31 @@ func (rs Resolving) Authenticate(r *http.Request) (*acl.Principal, error) {
 	p.Groups = acl.GroupSet{}
 	got.Apply(p)
 	return p, nil
+}
+
+// CacheStats reports the directory layer under the name the stats endpoint and
+// the metrics file it under, and nothing at all when the deployment resolves
+// without a cache.
+//
+// Publishing a layer that is not there as a row of zeros would be worse than
+// leaving it out, because a hit rate of zero and no cache look the same on a
+// dashboard and mean opposite things.
+func (rs Resolving) CacheStats() map[string]cache.Stats {
+	reporter, ok := rs.Resolver.(interface{ Stats() cache.Stats })
+	if !ok {
+		return nil
+	}
+	return map[string]cache.Stats{"directory": reporter.Stats()}
+}
+
+// staleness is the directory cache's bound in seconds, and false when there is
+// no cache to have one.
+func (rs Resolving) staleness() (float64, bool) {
+	bounded, ok := rs.Resolver.(interface{ Staleness() time.Duration })
+	if !ok {
+		return 0, false
+	}
+	return bounded.Staleness().Seconds(), true
 }
 
 // name is who to look up.

--- a/api/resolve_test.go
+++ b/api/resolve_test.go
@@ -2,14 +2,18 @@ package api_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/cache"
 	"github.com/tamnd/genba/directory"
 	"github.com/tamnd/genba/index"
 	"github.com/tamnd/genba/store/memstore"
@@ -210,5 +214,118 @@ func TestAWrapperWithNothingToWrapRefuses(t *testing.T) {
 	}
 	if _, err := (api.Resolving{Auth: api.HeaderAuth{Tenant: "acme"}}).Authenticate(asking("mei")); !errors.Is(err, api.ErrUnauthenticated) {
 		t.Errorf("a wrapper with no directory gave %v", err)
+	}
+}
+
+// caching wraps the site directory in a cache, which is how a deployment
+// resolves once the traffic is real.
+func caching(t *testing.T, opts ...directory.CacheOption) *directory.Cache {
+	t.Helper()
+	c, err := directory.NewCache(site(t), opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// Nothing at the edge of the API can tell a cache from a resolver, which is the
+// point of the interface being two methods.
+func TestACachedDirectoryAnswersTheSame(t *testing.T) {
+	auth := api.Resolving{Auth: api.HeaderAuth{Tenant: "acme"}, Resolver: caching(t)}
+
+	first, err := auth.Authenticate(asking("mei"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := auth.Authenticate(asking("mei"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"acme:engineering", "acme:everyone"}
+	if !slices.Equal(second.Groups.Members, want) {
+		t.Errorf("the cached answer is %v, want %v", second.Groups.Members, want)
+	}
+	if first.Groups.Version != second.Groups.Version {
+		t.Error("two requests for the same person got different versions")
+	}
+}
+
+// A cache layer nobody can see the hit rate of is a cache layer nobody can tell
+// is broken, and this one decides how hard the directory is being hit.
+func TestTheDirectoryLayerIsOnTheStatsEndpoint(t *testing.T) {
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	s := api.New(st, index.New(st), api.Resolving{
+		Auth:     api.HeaderAuth{Tenant: "acme", Admins: []string{"mei"}},
+		Resolver: caching(t),
+	})
+	h := s.Handler()
+
+	for range 2 {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, asking("mei"))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("a search answered %d: %s", rec.Code, rec.Body.String())
+		}
+	}
+
+	stats := asking("mei")
+	stats.URL.Path = "/api/v1/stats"
+	stats.URL.RawQuery = ""
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, stats)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("the stats endpoint answered %d", rec.Code)
+	}
+	var body struct {
+		Cache map[string]cache.Stats `json:"cache"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := body.Cache["directory"]
+	if !ok {
+		t.Fatalf("no directory layer in %v", body.Cache)
+	}
+	if got.Hits == 0 {
+		t.Errorf("the second request did not hit the directory cache: %+v", got)
+	}
+}
+
+// The bound is a promise the deployment is making about its permissions, and a
+// promise that only exists in a configuration file is one nobody is checking.
+func TestTheStalenessBoundIsPublished(t *testing.T) {
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	s := api.New(st, index.New(st), api.Resolving{
+		Auth:     api.HeaderAuth{Tenant: "acme"},
+		Resolver: caching(t, directory.WithTTL(30*time.Second)),
+	})
+
+	rec := httptest.NewRecorder()
+	s.Metrics().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", http.NoBody))
+	if !strings.Contains(rec.Body.String(), "\n"+api.MetricGroupStaleness+" 30\n") {
+		t.Errorf("the staleness bound is not published:\n%s", rec.Body.String())
+	}
+}
+
+// A hit rate of zero and no cache at all look the same on a dashboard and mean
+// opposite things, so a deployment that resolves without one publishes neither.
+func TestADeploymentWithoutADirectoryCachePublishesNoLayer(t *testing.T) {
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	s := api.New(st, index.New(st), api.Resolving{
+		Auth:     api.HeaderAuth{Tenant: "acme"},
+		Resolver: site(t),
+	})
+
+	rec := httptest.NewRecorder()
+	s.Metrics().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", http.NoBody))
+	body := rec.Body.String()
+	if strings.Contains(body, `genba_cache_hits_total{layer="directory"}`) {
+		t.Error("a deployment with no directory cache published a directory layer")
+	}
+	if strings.Contains(body, "\n"+api.MetricGroupStaleness+" ") {
+		t.Error("a deployment with no directory cache published a staleness bound")
 	}
 }

--- a/arch_test.go
+++ b/arch_test.go
@@ -28,13 +28,13 @@ var allowed = map[string][]string{
 	"doc": {"acl"},
 
 	// directory sits under the permission model rather than beside it. It
-	// resolves a person into groups and hands acl the strings it compares, and
-	// the one thing it imports is acl, for the identity and group set types
-	// that are the shape of its answer. It has never heard of a document, a
-	// store or a query, and it must not: a directory that could see what it was
-	// resolving somebody for is a directory that could be asked leading
-	// questions.
-	"directory":               {"acl"},
+	// resolves a person into groups and hands acl the strings it compares, so
+	// it imports acl for the identity and group set types that are the shape of
+	// its answer, and cache for the one layer that holds those answers. It has
+	// never heard of a document, a store or a query, and it must not: a
+	// directory that could see what it was resolving somebody for is a
+	// directory that could be asked leading questions.
+	"directory":               {"acl", "cache"},
 	"directory/directorytest": {"acl", "directory"},
 
 	// cache is a map with a lock on it and imports nothing of ours, which is

--- a/directory/cached.go
+++ b/directory/cached.go
@@ -1,0 +1,237 @@
+package directory
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/cache"
+)
+
+// Defaults for a [Cache].
+const (
+	// DefaultTTL is how long a resolved expansion is served for, and therefore
+	// how long after a membership change somebody can still be acting on the
+	// old one.
+	//
+	// A minute is a compromise between two things that pull in opposite
+	// directions. Long is what makes the cache worth having, because a session
+	// makes many requests a minute and every one of them would otherwise be a
+	// walk over somebody else's directory. Short is what keeps the window in
+	// which a person removed from a group still has its documents down to
+	// something an operator can say out loud.
+	//
+	// It is a minute rather than five because this is a permission input. The
+	// hit rate barely moves between the two, since the traffic that matters is
+	// one person making forty requests while they are looking at something.
+	DefaultTTL = time.Minute
+
+	// DefaultCapacity is how many subjects are held. Reaching it evicts the
+	// least recently used, which for this cache means the people who have
+	// stopped asking.
+	DefaultCapacity = 10000
+)
+
+// Expander turns a subject into the groups they are in.
+//
+// It is what the edge of the API needs, and both [Resolver] and [Cache] satisfy
+// it, so a deployment adds or removes caching without anything above it
+// changing.
+type Expander interface {
+	// Name is the identity source the groups belong to.
+	Name() string
+
+	// Expand resolves one subject.
+	Expand(ctx context.Context, id string) (Expansion, error)
+}
+
+// Cache is an [Expander] that remembers what the directory said.
+//
+// Expanding on every request is not affordable. A person in three hundred
+// groups costs three hundred lookups against a service shared by everybody
+// else, and a search box that feels instant cannot start by doing that.
+//
+// # There is exactly one cache and this is it
+//
+// The obvious second layer, remembering what each group is a member of, is
+// deliberately absent. It would help, because real directories converge and the
+// same dozen groups sit above everybody. It would also mean an answer could be
+// built out of edges that were themselves already a minute old, so the worst
+// case age of a group set would be the sum of two lifetimes rather than one.
+// That is a staleness bound nobody can state without drawing a diagram, and a
+// staleness bound nobody can state is one nobody is holding anyone to.
+//
+// So there is one layer, it is the whole expansion, and the maximum age of any
+// group set this hands out is the TTL. That is the number, it is configured in
+// one place, and [Cache.Staleness] returns it.
+//
+// # What the version does and what the TTL does
+//
+// These are two mechanisms doing two different jobs and they are easy to
+// confuse.
+//
+// The TTL bounds how long it takes to notice a membership change. Nothing else
+// can, because a directory does not call to say somebody was removed from a
+// group, so noticing means asking again.
+//
+// The version bounds how long anything built on top of a group set outlives it.
+// Every bitmap, every filter and every cached result keyed by [acl.GroupSet]
+// carries the version in its key, so the moment a refreshed expansion produces
+// a different closure, all of it stops matching at once. Without that, a minute
+// of staleness here would be an unbounded amount of staleness in every layer
+// above, and the person removed from a group would keep its documents until
+// something unrelated happened to expire.
+//
+// A Cache is safe for concurrent use.
+type Cache struct {
+	res     Expander
+	entries *cache.Cache[Expansion]
+	ttl     time.Duration
+}
+
+// CacheOption changes a [Cache].
+type CacheOption func(*cacheConfig)
+
+type cacheConfig struct {
+	capacity int
+	ttl      time.Duration
+	now      func() time.Time
+}
+
+// WithTTL sets how long an expansion is served for, which is the maximum
+// staleness of every group set the cache hands out. A duration below one
+// selects [DefaultTTL].
+func WithTTL(d time.Duration) CacheOption {
+	return func(c *cacheConfig) {
+		if d < 1 {
+			d = DefaultTTL
+		}
+		c.ttl = d
+	}
+}
+
+// WithCapacity sets how many subjects are held. A capacity below one selects
+// [DefaultCapacity].
+func WithCapacity(n int) CacheOption {
+	return func(c *cacheConfig) {
+		if n < 1 {
+			n = DefaultCapacity
+		}
+		c.capacity = n
+	}
+}
+
+// WithCacheClock replaces the clock, so that a test about a staleness bound
+// measures the bound rather than the machine it ran on.
+func WithCacheClock(now func() time.Time) CacheOption {
+	return func(c *cacheConfig) {
+		if now != nil {
+			c.now = now
+		}
+	}
+}
+
+// NewCache wraps an expander.
+func NewCache(e Expander, opts ...CacheOption) (*Cache, error) {
+	if e == nil {
+		return nil, errors.New("directory: an expander is required")
+	}
+	if e.Name() == "" {
+		return nil, errors.New("directory: an expander must have a name")
+	}
+	cfg := cacheConfig{capacity: DefaultCapacity, ttl: DefaultTTL, now: time.Now}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &Cache{
+		res:     e,
+		ttl:     cfg.ttl,
+		entries: cache.New(cfg.capacity, cfg.ttl, cache.WithClock[Expansion](cfg.now)),
+	}, nil
+}
+
+// Name is the identity source the groups belong to.
+func (c *Cache) Name() string { return c.res.Name() }
+
+// Staleness is the most out of date any group set this returns can be.
+//
+// It is a configured number rather than something to be measured, which is the
+// point of there being one layer. An operator can answer "how long after I
+// remove somebody does it take effect" by reading it, and the answer does not
+// depend on the traffic.
+func (c *Cache) Staleness() time.Duration { return c.ttl }
+
+// Stats is what the cache has done, for the stats endpoint and the metrics.
+func (c *Cache) Stats() cache.Stats { return c.entries.Stats() }
+
+// Counters returns whatever the wrapped expander has counted, so a resolver
+// underneath a cache is still measurable. It is the zero value if the expander
+// counts nothing.
+func (c *Cache) Counters() Counters {
+	if counted, ok := c.res.(interface{ Counters() Counters }); ok {
+		return counted.Counters()
+	}
+	return Counters{}
+}
+
+// Expand returns the groups a subject is in, from the cache when it has a
+// fresh answer and from the directory otherwise.
+//
+// Concurrent requests for the same subject do one expansion between them. That
+// matters more here than in most caches: everybody arrives at nine o'clock, a
+// cold cache and a thousand people is a thousand walks over the same directory,
+// and the directory is the one part of this that belongs to somebody else.
+//
+// An error is never stored. A directory that was unreachable for a moment is
+// not a fact about a subject, and remembering it would turn a blip into a
+// minute of refusals.
+func (c *Cache) Expand(ctx context.Context, id string) (Expansion, error) {
+	// The cache is asked for a value it does not have a context for, so the
+	// cancellation of the request that happens to be the one doing the work is
+	// checked here rather than lost.
+	if err := ctx.Err(); err != nil {
+		return Expansion{}, err
+	}
+	got, err := c.entries.Do(id, func() (Expansion, error) {
+		return c.res.Expand(ctx, id)
+	})
+	if err != nil {
+		return Expansion{}, err
+	}
+	// A cached answer handed to two requests would otherwise be one slice
+	// handed to two requests. Everything above is free to keep a principal, put
+	// it in another structure and sort what it carries, and this is a
+	// permission set, so it is copied on the way out rather than trusted not to
+	// be touched.
+	return got.clone(), nil
+}
+
+// Forget drops what is held about these subjects, so that the next request for
+// one of them asks the directory.
+//
+// It exists because there are moments when waiting for the TTL is the wrong
+// answer and they are the moments that matter. Somebody is taken out of a group
+// during an incident, an account is closed, a provider sends a webhook. Those
+// are about one person, and flushing everybody to deal with one person means a
+// sign in storm against the directory at exactly the time nobody wants one.
+//
+// Forgetting a subject that is not held is not an error.
+func (c *Cache) Forget(ids ...string) { c.entries.Delete(ids...) }
+
+// Clear drops everything. It is for a configuration change that invalidates the
+// lot, such as pointing at a different directory, and not for a membership
+// change, which is what [Cache.Forget] is.
+func (c *Cache) Clear() { c.entries.Clear() }
+
+// clone deep copies the parts of an expansion that anything above could hold on
+// to.
+func (e Expansion) clone() Expansion {
+	out := e
+	out.Subject.Identities = slices.Clone(e.Subject.Identities)
+	out.Subject.MemberOf = slices.Clone(e.Subject.MemberOf)
+	out.Groups = acl.GroupSet{Version: e.Groups.Version, Members: slices.Clone(e.Groups.Members)}
+	out.Unknown = slices.Clone(e.Unknown)
+	return out
+}

--- a/directory/cached_test.go
+++ b/directory/cached_test.go
@@ -1,0 +1,381 @@
+package directory_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/directory"
+)
+
+var epoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// tick is a hand wound clock, so that a test about a staleness bound measures
+// the bound rather than the machine it ran on.
+type tick struct{ nanos atomic.Int64 }
+
+func newTick() *tick {
+	c := &tick{}
+	c.nanos.Store(epoch.UnixNano())
+	return c
+}
+
+func (c *tick) now() time.Time      { return time.Unix(0, c.nanos.Load()) }
+func (c *tick) add(d time.Duration) { c.nanos.Add(int64(d)) }
+
+// counted is a directory that says how often it was asked anything.
+type counted struct {
+	*directory.Static
+	asked atomic.Int64
+}
+
+func (c *counted) Subject(ctx context.Context, id string) (directory.Subject, error) {
+	c.asked.Add(1)
+	return c.Static.Subject(ctx, id)
+}
+
+func (c *counted) Group(ctx context.Context, id string) (directory.Group, error) {
+	c.asked.Add(1)
+	return c.Static.Group(ctx, id)
+}
+
+// company is the directory the cases below resolve against, wrapped so that the
+// requests it answers can be counted.
+func company(t *testing.T) *counted {
+	t.Helper()
+	d := &counted{Static: directory.NewStatic("acme")}
+	d.PutGroup(directory.Group{ID: "everyone"})
+	d.PutGroup(directory.Group{ID: "engineering", MemberOf: []string{"everyone"}})
+	d.PutGroup(directory.Group{ID: "finance", MemberOf: []string{"everyone"}})
+	d.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	d.Put(directory.Subject{ID: "sam", MemberOf: []string{"finance"}})
+	return d
+}
+
+// cached builds a cache over a directory, with whatever options the case cares
+// about.
+func cached(t *testing.T, d directory.Directory, opts ...directory.CacheOption) *directory.Cache {
+	t.Helper()
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := directory.NewCache(r, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func resolved(t *testing.T, c *directory.Cache, id string) directory.Expansion {
+	t.Helper()
+	got, err := c.Expand(t.Context(), id)
+	if err != nil {
+		t.Fatalf("expanding %s: %v", id, err)
+	}
+	return got
+}
+
+func TestASecondRequestForTheSamePersonDoesNotAskTheDirectoryAgain(t *testing.T) {
+	d := company(t)
+	c := cached(t, d)
+
+	first := resolved(t, c, "mei")
+	after := d.asked.Load()
+	if after == 0 {
+		t.Fatal("the first expansion asked the directory nothing")
+	}
+
+	second := resolved(t, c, "mei")
+	if d.asked.Load() != after {
+		t.Errorf("the second expansion asked the directory %d more times", d.asked.Load()-after)
+	}
+	if second.Groups.Version != first.Groups.Version {
+		t.Error("the same answer came back with a different version")
+	}
+	if st := c.Stats(); st.Hits != 1 || st.Misses != 1 {
+		t.Errorf("the cache reports %d hits and %d misses, want one of each", st.Hits, st.Misses)
+	}
+}
+
+// The box this is here for. A membership change is noticed within the bound,
+// and until then it is not, and both halves are the promise.
+func TestAMembershipChangeIsSeenWithinTheBound(t *testing.T) {
+	clock := newTick()
+	d := company(t)
+	c := cached(t, d, directory.WithTTL(time.Minute), directory.WithCacheClock(clock.now))
+
+	before := resolved(t, c, "mei")
+
+	d.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering", "finance"}})
+
+	clock.add(59 * time.Second)
+	still := resolved(t, c, "mei")
+	if still.Groups.Version != before.Groups.Version {
+		t.Fatal("the change was seen before the bound, which means the bound is not what is being tested")
+	}
+
+	clock.add(2 * time.Second)
+	now := resolved(t, c, "mei")
+	if now.Groups.Version == before.Groups.Version {
+		t.Fatal("the change was still not seen after the bound had passed")
+	}
+	if want := "acme:finance"; !slices.Contains(now.Groups.Members, want) {
+		t.Errorf("the refreshed answer is %v, and %s is not in it", now.Groups.Members, want)
+	}
+}
+
+// The version is the other half. Noticing a change within a minute is worth
+// nothing if what was built on the old answer outlives it, and everything above
+// keys on this number.
+func TestTheVersionMovesWithTheAnswerRatherThanWithTheClock(t *testing.T) {
+	clock := newTick()
+	d := company(t)
+	c := cached(t, d, directory.WithTTL(time.Minute), directory.WithCacheClock(clock.now))
+
+	before := resolved(t, c, "mei")
+
+	// A refresh that finds nothing new keeps the version, so nothing derived
+	// from it is thrown away for no reason.
+	clock.add(2 * time.Minute)
+	same := resolved(t, c, "mei")
+	if same.Groups.Version != before.Groups.Version {
+		t.Error("an unchanged membership came back with a new version, which invalidates every bitmap keyed on it for nothing")
+	}
+
+	// Somebody else changing does not move this person's version either.
+	d.Put(directory.Subject{ID: "sam", MemberOf: []string{"finance", "engineering"}})
+	clock.add(2 * time.Minute)
+	if again := resolved(t, c, "mei"); again.Groups.Version != before.Groups.Version {
+		t.Error("a change to somebody else moved this person's version")
+	}
+}
+
+func TestTheStalenessBoundIsTheNumberItWasGiven(t *testing.T) {
+	if got := cached(t, company(t)).Staleness(); got != directory.DefaultTTL {
+		t.Errorf("the default bound is %v, want %v", got, directory.DefaultTTL)
+	}
+	if got := cached(t, company(t), directory.WithTTL(30*time.Second)).Staleness(); got != 30*time.Second {
+		t.Errorf("the bound is %v, want 30s", got)
+	}
+	// A bound below one is a configuration mistake rather than a request for a
+	// cache that never hits, and it takes the default.
+	if got := cached(t, company(t), directory.WithTTL(0)).Staleness(); got != directory.DefaultTTL {
+		t.Errorf("a zero bound gave %v, want the default", got)
+	}
+}
+
+func TestForgettingOnePersonDoesNotFlushEverybody(t *testing.T) {
+	d := company(t)
+	c := cached(t, d)
+
+	resolved(t, c, "mei")
+	resolved(t, c, "sam")
+	after := d.asked.Load()
+
+	c.Forget("mei")
+
+	resolved(t, c, "sam")
+	if d.asked.Load() != after {
+		t.Error("forgetting one person sent somebody else back to the directory")
+	}
+	resolved(t, c, "mei")
+	if d.asked.Load() == after {
+		t.Error("the forgotten person was still served from the cache")
+	}
+}
+
+func TestForgettingSomebodyWhoIsNotHeldIsFine(t *testing.T) {
+	c := cached(t, company(t))
+	c.Forget("nobody", "")
+	c.Forget()
+}
+
+func TestClearDropsEverything(t *testing.T) {
+	d := company(t)
+	c := cached(t, d)
+	resolved(t, c, "mei")
+	resolved(t, c, "sam")
+	after := d.asked.Load()
+
+	c.Clear()
+
+	resolved(t, c, "mei")
+	resolved(t, c, "sam")
+	if d.asked.Load() == after {
+		t.Error("a cleared cache still answered from what it held")
+	}
+	if entries := c.Stats().Entries; entries != 2 {
+		t.Errorf("the cache holds %d entries after being refilled, want 2", entries)
+	}
+}
+
+// Everybody arrives at nine o'clock. A cold cache and a thousand people has to
+// be one walk over the directory per person, not one per request.
+func TestPeopleArrivingTogetherShareOneExpansion(t *testing.T) {
+	d := company(t)
+	c := cached(t, d)
+
+	var wg sync.WaitGroup
+	for range 64 {
+		wg.Go(func() {
+			if _, err := c.Expand(context.Background(), "mei"); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+	wg.Wait()
+
+	// The subject, the group below and the one above it, and the empty level
+	// that ends the walk costs nothing.
+	if got := d.asked.Load(); got != 3 {
+		t.Errorf("sixty four requests for one person asked the directory %d times, want 3", got)
+	}
+}
+
+// broken answers once it has been told to.
+type broken struct {
+	*directory.Static
+	down atomic.Bool
+}
+
+var errDirectoryDown = errors.New("connection refused")
+
+func (b *broken) Subject(ctx context.Context, id string) (directory.Subject, error) {
+	if b.down.Load() {
+		return directory.Subject{}, errDirectoryDown
+	}
+	return b.Static.Subject(ctx, id)
+}
+
+// A directory that was unreachable for a moment is not a fact about a subject,
+// and remembering it would turn a blip into a minute of refusals.
+func TestAFailureIsNotRemembered(t *testing.T) {
+	d := &broken{Static: directory.NewStatic("acme")}
+	d.PutGroup(directory.Group{ID: "engineering"})
+	d.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	d.down.Store(true)
+
+	c := cached(t, d)
+	if _, err := c.Expand(t.Context(), "mei"); !errors.Is(err, errDirectoryDown) {
+		t.Fatalf("a directory that was down gave %v", err)
+	}
+
+	d.down.Store(false)
+	if got := resolved(t, c, "mei"); len(got.Groups.Members) != 1 {
+		t.Errorf("the recovered directory resolved to %v", got.Groups.Members)
+	}
+}
+
+// A refusal the directory meant is a different thing, and it still refuses.
+func TestASubjectTheDirectoryDoesNotHoldStillRefuses(t *testing.T) {
+	c := cached(t, company(t))
+	if _, err := c.Expand(t.Context(), "nobody"); !errors.Is(err, directory.ErrNoSubject) {
+		t.Errorf("an unknown subject gave %v, want ErrNoSubject", err)
+	}
+}
+
+// Everything above is free to keep a principal and sort what it carries, so two
+// requests must not be handed the same slice.
+func TestTwoRequestsAreNotHandedTheSameSlice(t *testing.T) {
+	c := cached(t, company(t))
+
+	first := resolved(t, c, "mei")
+	first.Groups.Members[0] = "acme:administrators"
+	first.Unknown = append(first.Unknown, "tampered")
+
+	second := resolved(t, c, "mei")
+	if slices.Contains(second.Groups.Members, "acme:administrators") {
+		t.Fatalf("a write to one caller's group set reached another: %v", second.Groups.Members)
+	}
+	if want := []string{"acme:engineering", "acme:everyone"}; !slices.Equal(second.Groups.Members, want) {
+		t.Errorf("the second caller got %v, want %v", second.Groups.Members, want)
+	}
+}
+
+func TestACancelledRequestDoesNotGetAnAnswer(t *testing.T) {
+	c := cached(t, company(t))
+	resolved(t, c, "mei")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.Expand(ctx, "mei"); !errors.Is(err, context.Canceled) {
+		t.Errorf("a cancelled request was served %v", err)
+	}
+}
+
+func TestTheCacheCarriesTheCountersOfWhatItWraps(t *testing.T) {
+	c := cached(t, company(t))
+	resolved(t, c, "mei")
+	resolved(t, c, "mei")
+
+	// One expansion, because the second request never reached the resolver.
+	if got := c.Counters().Expansions; got != 1 {
+		t.Errorf("the resolver under the cache counted %d expansions, want 1", got)
+	}
+}
+
+func TestACacheNeedsSomethingWithANameToWrap(t *testing.T) {
+	if _, err := directory.NewCache(nil); err == nil {
+		t.Error("a cache over nothing was accepted")
+	}
+	if _, err := directory.NewCache(nameless{}); err == nil {
+		t.Error("a cache over an expander with no name was accepted")
+	}
+}
+
+type nameless struct{}
+
+func (nameless) Name() string { return "" }
+func (nameless) Expand(context.Context, string) (directory.Expansion, error) {
+	return directory.Expansion{}, nil
+}
+
+// The least recently used entry goes, which for this cache means the people who
+// have stopped asking.
+func TestAFullCacheDropsThePeopleWhoStoppedAsking(t *testing.T) {
+	d := directory.NewStatic("acme")
+	d.PutGroup(directory.Group{ID: "everyone"})
+	for i := range 200 {
+		d.Put(directory.Subject{ID: "u" + strconv.Itoa(i), MemberOf: []string{"everyone"}})
+	}
+	c := cached(t, d, directory.WithCapacity(16))
+
+	for i := range 200 {
+		resolved(t, c, "u"+strconv.Itoa(i))
+	}
+	if entries := c.Stats().Entries; entries > 32 {
+		t.Errorf("a cache asked for sixteen entries holds %d", entries)
+	}
+	if c.Stats().Evictions == 0 {
+		t.Error("two hundred people went through a cache of sixteen and nothing was evicted")
+	}
+}
+
+func TestReadingAndWritingTheCacheAtTheSameTimeIsSafe(t *testing.T) {
+	d := company(t)
+	c := cached(t, d)
+
+	var wg sync.WaitGroup
+	for i := range 32 {
+		wg.Go(func() {
+			id := "mei"
+			if i%2 == 0 {
+				id = "sam"
+			}
+			if _, err := c.Expand(context.Background(), id); err != nil {
+				t.Error(err)
+			}
+		})
+		wg.Go(func() {
+			c.Forget("mei")
+			c.Stats()
+		})
+	}
+	wg.Wait()
+}

--- a/directory/expand.go
+++ b/directory/expand.go
@@ -115,10 +115,11 @@ type Counters struct {
 
 // Resolver expands subjects against one directory.
 //
-// It holds no cache. That is deliberate and it is not an oversight: caching a
-// group membership correctly is a harder problem than expanding one, it needs
-// the version this package produces in order to be invalidated, and putting the
-// two in the same type is how the cache ends up with a timeout instead.
+// It holds no cache of its own. That is deliberate and it is not an oversight:
+// caching a group membership correctly is a harder problem than expanding one,
+// it needs the version this produces in order to be invalidated, and putting
+// the two in the same type is how the cache ends up with a timeout instead.
+// [Cache] is the layer, it wraps this, and everything above takes either.
 //
 // A Resolver is safe for concurrent use.
 type Resolver struct {

--- a/docs/alerts.yml
+++ b/docs/alerts.yml
@@ -41,6 +41,11 @@ groups:
 # A document whose permissions did not resolve is held back rather than served, which is the safe outcome, so a growing count is a bug report and not a page.
 # It belongs on the dashboard next to the document count.
 #
+# Directory staleness.
+# genba_directory_staleness_seconds is a constant, so there is nothing in it to alert on.
+# It is published because it is the answer to "how long after I remove somebody from a group does it take effect", and that question gets asked during an incident by somebody who cannot read the deployment's configuration.
+# The layer next to it, genba_cache_hits_total{layer="directory"}, is the one to look at when sign in has become slow.
+#
 # Request duration per endpoint.
 # It is the first thing to look at during an incident and it is too easy to page on: one slow endpoint that nobody uses would fire this every deploy.
 # Search has its own alert above because search is the one endpoint that being slow means the product is down.

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -140,10 +140,45 @@ func TestConformance(t *testing.T) {
 `directory.Static` is the reference implementation the suite runs against, and it is also the directory a small deployment actually uses.
 A company with forty people and six groups has the whole thing in its configuration file, and making them stand up an identity provider to try a search engine is how a search engine does not get tried.
 
+## Remembering the answer
+
+Expanding on every request is not affordable.
+A person in three hundred groups costs three hundred lookups against a service everybody else is also using, and a search box that feels instant cannot start by doing that.
+
+So `directory.Cache` wraps a resolver and holds what it produced, keyed by the subject, for a configured lifetime.
+Concurrent requests for the same person do one expansion between them, which matters here more than in most caches: everybody arrives at nine o'clock, and a cold cache and a thousand people is a thousand walks over the same directory.
+
+There is exactly one layer and that is the interesting decision.
+The obvious second one, remembering what each group is a member of, would help, because real directories converge and the same dozen groups sit above everybody.
+It would also mean an answer could be built out of edges that were themselves already a minute old, so the worst case age of a group set would be the sum of two lifetimes rather than one.
+That is a staleness bound nobody can state without drawing a diagram, and a bound nobody can state is one nobody is holding anyone to.
+One layer, the whole expansion, and the maximum age of any group set is the lifetime.
+`Cache.Staleness` returns it and the metrics publish it, because a promise that only exists in a configuration file is one nobody is checking.
+
+The lifetime and the version are two mechanisms doing two different jobs and they are easy to confuse.
+
+The lifetime bounds how long it takes to notice a membership change.
+Nothing else can, because a directory does not call to say somebody was removed from a group, so noticing means asking again.
+A minute is the default, and it is a minute rather than five because this is a permission input and the hit rate barely moves between the two.
+The traffic that matters is one person making forty requests while they are looking at something.
+
+The version bounds how long anything built on top of a group set outlives it.
+Every bitmap, every filter and every cached result keyed by the group set carries the version, so the moment a refreshed expansion produces a different closure, all of it stops matching at once.
+Without that, a minute of staleness here would be an unbounded amount of staleness in every layer above, and the person removed from a group would keep its documents until something unrelated happened to expire.
+
+`Cache.Forget` drops one person, and it exists because there are moments when waiting for the lifetime is the wrong answer and they are the moments that matter.
+Somebody is taken out of a group during an incident, an account is closed, a provider sends a webhook.
+Those are about one person, and flushing everybody to deal with one person means a sign in storm against the directory at exactly the time nobody wants one.
+
+Errors are never held.
+A directory that was unreachable for a moment is not a fact about a subject, and remembering it would turn a blip into a minute of refusals.
+A refusal the directory meant, a subject it does not hold or has deactivated, still refuses on every request, because that one is an answer rather than a failure.
+
 ## What is not here yet
 
-Caching.
-The resolver holds none, deliberately: caching a group membership correctly is a harder problem than expanding one, it needs the version this package produces in order to be invalidated, and putting the two in the same type is how the cache ends up with a timeout instead.
+Serving a stale answer through a directory outage.
+The cache refuses once an entry has expired and the directory cannot be reached, which is the same direction the resolver fails in, and an operator who would rather serve a slightly old group set than refuse a sign in has no way to say so yet.
+It is a real choice with a real cost on the other side, so it should be a configured window with its own metric rather than a default.
 
 Adapters for the hosted providers.
 The interface is two methods and the suite is what they have to pass, so each is a small amount of code and a fake, in the shape the connectors already use.


### PR DESCRIPTION
Closes #19.

## What changed

`directory.Cache` wraps a resolver and holds what it produced, keyed by the subject.

Expanding on every request is not affordable.
Somebody in three hundred groups costs three hundred lookups against a service everybody else is also using, and a search box that feels instant cannot start by doing that.
Concurrent requests for the same person do one expansion between them, which matters more here than in most caches, because everybody arrives at nine o'clock and a cold cache with a thousand people is a thousand walks over the same directory.

Nothing above it changed shape.
`api.Resolving` now takes a `directory.Expander`, which is `Name` and `Expand`, and both the resolver and the cache satisfy it, so a deployment adds or removes caching without anything else moving.

## There is exactly one layer

This is the decision worth arguing about, so it is worth writing down.

The obvious second layer, remembering what each group is a member of, would help.
Real directories converge hard and the same dozen groups sit above everybody, so caching the edges would cut the lookups a long way.

It would also mean an answer could be built out of edges that were themselves already a minute old.
The worst case age of a group set would then be the sum of two lifetimes rather than one, and that is a staleness bound nobody can state without drawing a diagram.
A bound nobody can state is a bound nobody is holding anyone to, and this is a permission input.

So there is one layer, it is the whole expansion, and the maximum age of any group set this hands out is the lifetime.
`Cache.Staleness` returns it and `genba_directory_staleness_seconds` publishes it.

## The lifetime and the version do two different jobs

They are easy to confuse and it is worth keeping them apart.

The lifetime bounds how long it takes to notice a membership change.
Nothing else can, because a directory does not call to say somebody was removed from a group, so noticing means asking again.

The version bounds how long anything built on top of a group set outlives it.
Every bitmap, every filter and every cached result keyed by `acl.GroupSet` carries the version, so the moment a refreshed expansion produces a different closure, all of it stops matching at once.
Without that, a minute of staleness here would be an unbounded amount of staleness in every layer above, and the person removed from a group would keep its documents until something unrelated happened to expire.

A minute is the default rather than five because this is a permission input and the hit rate barely moves between them.
The traffic that matters is one person making forty requests while they are looking at something, not one person signing in twice a day.

## The rest of the behaviour

`Forget` drops one person, and it exists because there are moments when waiting for the lifetime is the wrong answer and they are the moments that matter.
Somebody is taken out of a group during an incident, an account is closed, a provider sends a webhook.
Those are about one person, and flushing everybody to deal with one person means a sign in storm against the directory at exactly the time nobody wants one.
`Clear` is for a configuration change that invalidates the lot, and it is not what a membership change should reach for.

An error is never held.
A directory that was unreachable for a moment is not a fact about a subject, and remembering it would turn a blip into a minute of refusals.
A refusal the directory meant, a subject it does not hold or has deactivated, still refuses on every request, because that one is an answer rather than a failure.

A cached answer handed to two requests would otherwise be one slice handed to two requests.
Everything above is free to keep a principal and sort what it carries, and this is a permission set, so it is copied on the way out rather than trusted not to be touched.
There is a test that writes into one caller's group set and checks the next caller does not see it.

## What an operator sees

The layer shows up on the stats endpoint and in the metrics as `layer="directory"`, next to the existing search layers.
A deployment resolving without a cache publishes neither the layer nor the gauge, because a hit rate of zero and no cache at all look the same on a dashboard and mean opposite things.

`docs/alerts.yml` gets a note rather than a rule.
The gauge is a constant so there is nothing in it to alert on, and it is published because "how long after I remove somebody does it take effect" gets asked during an incident by somebody who cannot read the deployment's configuration.

## On the checklist

- A membership change is reflected within the bound, with a hand wound clock so the test measures the policy rather than the machine. Both halves are asserted: not seen at 59 seconds, seen at 61.
- The maximum staleness is the configured lifetime, in one place, returned by `Cache.Staleness` and published as a gauge. One layer is what makes that a number rather than an emergent property.
- Hit rate is on the stats endpoint and in the metrics per layer, and the staleness bound is a gauge.
- Forgetting one person leaves everybody else cached, and there is a test that a second person is still served without touching the directory.

## Not in this one

The daemon still builds `api.HeaderAuth` directly, so none of this is reachable from the binary yet.
Wiring it up needs a way to write a small directory down and a couple of flags, and that is #180.

Serving a stale answer through a directory outage is also not here.
The cache refuses once an entry has expired and the directory cannot be reached, which is the same direction the resolver fails in.
An operator who would rather serve a slightly old group set than refuse a sign in has no way to say so, and that is a real choice with a real cost on the other side, so it should be a configured window with its own metric rather than a default.

Refs #19
