### PR TITLE
Give the daemon a directory it can be given

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ The environment variable is the flag in upper case with a `GENBA_` prefix, and a
 | `GENBA_TENANT` | empty | tenant served by a single tenant deployment |
 | `GENBA_ADMINS` | empty | subjects that hold the administrator role, comma separated |
 | `GENBA_LOG_LEVEL` | `info` | `debug`, `info`, `warn` or `error` |
+| `GENBA_DIRECTORY` | empty | file of subjects and groups to resolve group membership from, empty to believe the request |
+| `GENBA_DIRECTORY_TTL` | `1m` | how long a resolved group set is held |
+| `GENBA_DIRECTORY_REFRESH` | `30s` | how often the file is read again, zero for never |
 | `GENBA_READ_TIMEOUT` | `30s` | request read timeout |
 | `GENBA_WRITE_TIMEOUT` | `60s` | request write timeout |
 | `GENBA_SHUTDOWN_GRACE` | `15s` | how long a shutdown waits for in flight requests |
@@ -290,6 +293,51 @@ Anybody who knows their quota can set a rate high enough that it never binds, wh
 A refusal that says to come back later is waited out rather than failed, with the wait doubling up to half a minute and the source's own `Retry-After` honoured over anything computed, and a source that has been refusing everything stops the sync rather than being retried all afternoon.
 The `bucket synced` line carries `retries`, `throttled`, `throttled_for` and `quota_pauses`, because a crawl that is being throttled looks exactly like a crawl that is slow and the difference decides whether you go looking at the network or ask for more quota.
 
+## Who somebody is, and what they are a member of
+
+Those are two questions and the server answers them from two places.
+
+Who is a credential, and by default it is a header from a proxy that has already checked one.
+What they are a member of is a fact about the company that changes without anybody signing in again, so a header carrying it is a copy of an answer somebody else cached, and the day somebody is taken out of a group is the day the copy is wrong.
+
+Without `-directory` the server believes the groups on the request.
+That is right on a laptop and right behind a proxy that is doing the resolution itself, and it is not right for a company.
+
+With `-directory` the groups on the request are thrown away and the file is asked instead.
+It holds subjects and groups, groups can be members of groups, and the transitive closure is what a request ends up carrying.
+
+```json
+{
+  "name": "acme",
+  "groups": [
+    {"id": "everyone"},
+    {"id": "engineering", "member_of": ["everyone"]},
+    {"id": "storage", "member_of": ["engineering"]}
+  ],
+  "subjects": [
+    {"id": "mei", "email": "mei@acme.com", "identities": ["slack:U04AB"], "member_of": ["storage"]},
+    {"id": "lee", "member_of": ["everyone"], "disabled": true}
+  ]
+}
+```
+
+`mei` resolves to `acme:engineering`, `acme:everyone` and `acme:storage`, and `lee` does not resolve at all, because an account closed on Friday should stop working on Friday.
+The `identities` list is how a rule that names a Slack member id applies to somebody who signed in as themselves.
+
+The file is strict on purpose.
+An unknown field is a typo, a group named in a membership and not defined is a typo, and both refuse at startup rather than turning into somebody mysteriously missing a group at nine o'clock.
+That is the whole advantage a file has over an identity provider: its mistakes can be caught before anybody signs in.
+
+`-directory-refresh` rereads it, because editing a group and then bouncing the server is how somebody ends up not editing the group.
+An edit that does not parse leaves the last good one in place and logs, since an operator halfway through a change should not take everybody's groups away.
+Renaming the directory is refused rather than applied, because every group key carries the name and changing it renames every group in every rule at once.
+
+`-directory-ttl` is the longest a membership change can take to have any effect, and it is one number rather than a property that emerges from a stack of caches.
+[docs/identity.md](docs/identity.md) says why there is exactly one layer.
+
+This is the deployment with forty people and six groups in it.
+Adapters for Okta, Entra ID and Google Workspace are the next piece, and they answer the same two lookups the file does.
+
 ## Metrics
 
 Set `GENBA_METRICS_ADDR` and the process opens a second listener that serves the Prometheus text format at any path on it.
@@ -311,6 +359,7 @@ The deployment that gets this right binds it somewhere the outside cannot reach,
 | `genba_search_matches` | how many matched, before paging |
 | `genba_cache_hits_total` | per layer, alongside misses, evictions and the entry count |
 | `genba_store_rows_total` | rows the driver returned, alongside statements and decodes |
+| `genba_directory_staleness_seconds` | the longest a membership change can take to have any effect, on a deployment with a directory |
 
 The buckets are 1, 2, 5, 10, 25, 50, 100, 250 and 500 milliseconds, which are tighter at the bottom than a default histogram because the question here is what fraction of requests came back in under ten milliseconds.
 

--- a/arch_test.go
+++ b/arch_test.go
@@ -227,7 +227,7 @@ var allowed = map[string][]string{
 	"benchcorpus/gen": {"benchcorpus", "store/sqlitestore"},
 
 	"cmd/genba":  {""},
-	"cmd/genbad": {"", "api", "config", "connector", "connector/aclmap", "connector/fssource", "connector/limit", "connector/objectsource", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
+	"cmd/genbad": {"", "api", "config", "connector", "connector/aclmap", "connector/fssource", "connector/limit", "connector/objectsource", "directory", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
 }
 
 func TestDependencyDirection(t *testing.T) {

--- a/cmd/genbad/directory.go
+++ b/cmd/genbad/directory.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/config"
+	"github.com/tamnd/genba/directory"
+)
+
+// authenticator is what the server authenticates with, and which of the two it
+// is depends on whether the deployment was given a directory.
+//
+// Without one, the groups on a request are believed. That is the right shape
+// behind a proxy that has already done the resolution and on a laptop somebody
+// is trying the binary on, and it is not a shape to leave a company in.
+//
+// With one, the groups on a request are thrown away and the directory is asked
+// instead. Who somebody is comes from a credential. What they are a member of
+// is a fact about the company that changes without anybody signing in again,
+// and a header carrying it is a copy of an answer somebody else cached.
+//
+// The reload loop, if there is one, runs until the context is done.
+func authenticator(ctx context.Context, cfg config.Config, log *slog.Logger) (api.Authenticator, error) {
+	header := api.HeaderAuth{Tenant: cfg.Tenant, Admins: cfg.Admins}
+	if cfg.Directory == "" {
+		return header, nil
+	}
+
+	held := &swap{path: cfg.Directory}
+	if err := held.read(); err != nil {
+		return nil, err
+	}
+	res, err := directory.New(held)
+	if err != nil {
+		return nil, err
+	}
+	cached, err := directory.NewCache(res, directory.WithTTL(cfg.DirectoryTTL))
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("resolving groups from a directory",
+		"path", cfg.Directory,
+		"source", cached.Name(),
+		"staleness", cached.Staleness(),
+		"refresh", cfg.DirectoryRefresh,
+	)
+	if cfg.DirectoryRefresh > 0 {
+		go held.reload(ctx, cfg.DirectoryRefresh, cached, log)
+	}
+	return api.Resolving{Auth: header, Resolver: cached}, nil
+}
+
+// swap is a directory that can be replaced under the readers.
+//
+// The pointer is read on every lookup and written by the reload, which is a
+// whole file at a time. Reading a directory that is half of the old file and
+// half of the new one would be a person resolving to a group set that never
+// existed, so nothing is ever edited in place.
+type swap struct {
+	path string
+
+	held atomic.Pointer[directory.Static]
+
+	// sum is the file as it was last read, so that a reload that changes
+	// nothing costs a hash rather than a parse and a cache flush.
+	sum atomic.Pointer[[32]byte]
+}
+
+// read parses the file and installs it, and reports whether the contents
+// differed from what was already held.
+func (s *swap) read() error {
+	_, err := s.reread()
+	return err
+}
+
+func (s *swap) reread() (bool, error) {
+	raw, err := os.ReadFile(s.path)
+	if err != nil {
+		return false, fmt.Errorf("directory: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	if held := s.sum.Load(); held != nil && *held == sum {
+		return false, nil
+	}
+
+	// Parsed from the bytes already read rather than from the file again,
+	// because a file that changes between the hash and the parse would leave
+	// the two describing different things.
+	d, err := directory.ReadStatic(bytes.NewReader(raw))
+	if err != nil {
+		return false, fmt.Errorf("directory %s: %w", s.path, err)
+	}
+	if held := s.held.Load(); held != nil && held.Name() != d.Name() {
+		// Every group key carries the directory's name, so renaming it renames
+		// every group in every rule at once. That is a different directory
+		// rather than an edit to this one, and it is a restart.
+		return false, fmt.Errorf("directory %s: the name changed from %q to %q, which renames every group", s.path, held.Name(), d.Name())
+	}
+	s.held.Store(d)
+	s.sum.Store(&sum)
+	return true, nil
+}
+
+// reload rereads the file on a ticker.
+//
+// A file that has been deleted or has stopped parsing leaves the last good one
+// in place and logs. An operator halfway through an edit should not take
+// everybody's groups away, and the alternative, refusing every request until
+// the file is valid again, turns a typo into an outage.
+func (s *swap) reload(ctx context.Context, every time.Duration, cached *directory.Cache, log *slog.Logger) {
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			changed, err := s.reread()
+			switch {
+			case err != nil:
+				log.Error("rereading the directory, keeping the one already loaded",
+					"path", s.path, "error", err)
+			case changed:
+				// Everybody, rather than one person, because the file changed
+				// and nothing in it says who was affected. This is the
+				// deployment with forty people in it, so a flush is forty
+				// expansions against a file already in the page cache.
+				cached.Clear()
+				log.Info("the directory changed and was reloaded", "path", s.path)
+			}
+		}
+	}
+}
+
+// Name is the identity source the groups belong to.
+func (s *swap) Name() string {
+	if d := s.held.Load(); d != nil {
+		return d.Name()
+	}
+	return ""
+}
+
+// Subject looks one up in whatever is currently held.
+func (s *swap) Subject(ctx context.Context, id string) (directory.Subject, error) {
+	d := s.held.Load()
+	if d == nil {
+		return directory.Subject{}, directory.ErrNoSubject
+	}
+	return d.Subject(ctx, id)
+}
+
+// Group looks one up in whatever is currently held.
+func (s *swap) Group(ctx context.Context, id string) (directory.Group, error) {
+	d := s.held.Load()
+	if d == nil {
+		return directory.Group{}, directory.ErrNoGroup
+	}
+	return d.Group(ctx, id)
+}

--- a/cmd/genbad/directory_test.go
+++ b/cmd/genbad/directory_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/api"
+)
+
+const smallCompany = `{
+  "name": "acme",
+  "groups": [
+    {"id": "everyone"},
+    {"id": "engineering", "member_of": ["everyone"]}
+  ],
+  "subjects": [
+    {"id": "mei", "email": "mei@acme.com", "member_of": ["engineering"]}
+  ]
+}`
+
+// write puts a directory in a temporary file and hands back the path.
+func write(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "directory.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// serving starts a server with these flags and stops it when the test ends.
+func serving(t *testing.T, args ...string) string {
+	t.Helper()
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, append([]string{"-addr", addr, "-tenant", "acme", "-log-level", "error"}, args...), env(nil), &out, &errOut)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("run returned %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("the server did not shut down after its context was cancelled")
+		}
+	})
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+	return "http://" + addr
+}
+
+// groupsOf asks who the server thinks somebody is.
+func groupsOf(t *testing.T, base string, header ...string) []string {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/api/v1/me", http.NoBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set(api.HeaderSubject, "mei")
+	for i := 0; i+1 < len(header); i += 2 {
+		req.Header.Set(header[i], header[i+1])
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/api/v1/me answered %d: %s", resp.StatusCode, body)
+	}
+	var out struct {
+		Groups []string `json:"groups"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out.Groups
+}
+
+// The reason all of this exists. A group list on a request is a copy of an
+// answer somebody else cached, and a copy somebody can edit is a way in.
+func TestAGroupsHeaderIsThrownAwayWhenThereIsADirectory(t *testing.T) {
+	base := serving(t, "-directory", write(t, smallCompany))
+
+	got := groupsOf(t, base, api.HeaderGroups, "acme:administrators,acme:finance")
+	if slices.Contains(got, "acme:administrators") {
+		t.Fatalf("a group from the request reached the session: %v", got)
+	}
+	if want := []string{"acme:engineering", "acme:everyone"}; !slices.Equal(got, want) {
+		t.Errorf("the session carries %v, want %v", got, want)
+	}
+}
+
+// And a deployment without one behaves exactly as it did, because a search
+// engine somebody is trying out on a laptop should not need an identity
+// provider, and a proxy that has already done the resolution is a real shape.
+func TestWithoutADirectoryTheRequestIsStillBelieved(t *testing.T) {
+	base := serving(t)
+
+	got := groupsOf(t, base, api.HeaderGroups, "acme:engineering")
+	if want := []string{"acme:engineering"}; !slices.Equal(got, want) {
+		t.Errorf("the session carries %v, want %v", got, want)
+	}
+}
+
+// Editing a group and then bouncing the server is how somebody ends up not
+// editing the group.
+func TestEditingTheDirectoryTakesEffectWithoutARestart(t *testing.T) {
+	path := write(t, smallCompany)
+	base := serving(t, "-directory", path, "-directory-refresh", "20ms")
+
+	if want := []string{"acme:engineering", "acme:everyone"}; !slices.Equal(groupsOf(t, base), want) {
+		t.Fatalf("the session started as %v, want %v", groupsOf(t, base), want)
+	}
+
+	edited := strings.Replace(smallCompany,
+		`{"id": "everyone"},`,
+		`{"id": "everyone"},
+    {"id": "on-call"},`, 1)
+	edited = strings.Replace(edited, `"member_of": ["engineering"]`, `"member_of": ["engineering", "on-call"]`, 1)
+	if err := os.WriteFile(path, []byte(edited), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"acme:engineering", "acme:everyone", "acme:on-call"}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if slices.Equal(groupsOf(t, base), want) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("the edit never took effect, the session still carries %v", groupsOf(t, base))
+}
+
+// An operator halfway through an edit should not take everybody's groups away,
+// and refusing every request until the file parses again turns a typo into an
+// outage.
+func TestAnEditThatDoesNotParseKeepsWhatWasAlreadyLoaded(t *testing.T) {
+	path := write(t, smallCompany)
+	base := serving(t, "-directory", path, "-directory-refresh", "20ms")
+
+	if err := os.WriteFile(path, []byte(`{"name": "acme", "groups": [`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	if want := []string{"acme:engineering", "acme:everyone"}; !slices.Equal(groupsOf(t, base), want) {
+		t.Errorf("a broken edit changed the session to %v, want %v", groupsOf(t, base), want)
+	}
+}
+
+// A file that does not parse at startup is a different matter. Nothing is
+// loaded, so there is nothing to keep, and coming up resolving nobody would be
+// a server that answers every request with a refusal.
+func TestADirectoryThatDoesNotParseStopsTheServerStarting(t *testing.T) {
+	path := write(t, `{"name": "acme", "subjects": [{"id": "mei", "member_of": ["enginering"]}]}`)
+
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), []string{"-addr", freeAddr(t), "-directory", path, "-log-level", "error"}, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("the server started with a directory that does not parse")
+	}
+	if !strings.Contains(err.Error(), "enginering") {
+		t.Errorf("the error is %q and does not say what is wrong with the file", err)
+	}
+}
+
+func TestADirectoryThatIsNotThereStopsTheServerStarting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.json")
+
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), []string{"-addr", freeAddr(t), "-directory", path, "-log-level", "error"}, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("the server started with a directory that is not there")
+	}
+	if !strings.Contains(err.Error(), "absent.json") {
+		t.Errorf("the error is %q and does not name the file", err)
+	}
+}
+
+// Every group key carries the directory's name, so renaming it renames every
+// group in every rule at once. That is a different directory rather than an
+// edit to this one.
+func TestRenamingTheDirectoryIsRefusedRatherThanApplied(t *testing.T) {
+	path := write(t, smallCompany)
+	held := &swap{path: path}
+	if err := held.read(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(path, []byte(strings.Replace(smallCompany, `"name": "acme"`, `"name": "other"`, 1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := held.reread(); err == nil {
+		t.Fatal("a renamed directory was swapped in")
+	}
+	if held.Name() != "acme" {
+		t.Errorf("the directory is now named %q", held.Name())
+	}
+}
+
+// A reread that finds the same bytes costs a hash rather than a parse and a
+// cache flush, which is what makes a twenty second ticker affordable.
+func TestARereadThatChangesNothingSaysSo(t *testing.T) {
+	held := &swap{path: write(t, smallCompany)}
+	if err := held.read(); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := held.reread()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("rereading an unchanged file reported a change, so every tick would flush the cache")
+	}
+}

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -70,6 +70,13 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	fs.StringVar(&cfg.DSN, "dsn", cfg.DSN, "storage data source")
 	fs.StringVar(&cfg.Tenant, "tenant", cfg.Tenant, "tenant served by a single tenant deployment")
 	fs.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "debug, info, warn or error")
+	// A deployment with a directory resolves the groups on every request out of
+	// it and throws away whatever the request claimed. One without believes the
+	// groups it is given, which is right on a laptop and behind a proxy that is
+	// doing the resolution itself, and is not right for a company.
+	fs.StringVar(&cfg.Directory, "directory", cfg.Directory, "file of subjects and groups to resolve group membership from, empty to believe the request")
+	fs.DurationVar(&cfg.DirectoryTTL, "directory-ttl", cfg.DirectoryTTL, "how long a resolved group set is held, which is the longest a membership change takes to have any effect")
+	fs.DurationVar(&cfg.DirectoryRefresh, "directory-refresh", cfg.DirectoryRefresh, "how often the directory file is read again, zero for never")
 	// A string rather than a repeated flag, because it is a list of a handful of
 	// names that is written once in a unit file. Empty means nobody is an
 	// administrator, which is the right default for a deployment that has not
@@ -188,7 +195,12 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	// listens for the store's writes and the first sync is a write like any
 	// other. Building it afterwards left it reporting that nothing had been
 	// indexed since it came up while sitting on a corpus it had just loaded.
-	srv := api.New(st, searcher, api.HeaderAuth{Tenant: cfg.Tenant, Admins: cfg.Admins}, opts...)
+	auth, err := authenticator(ctx, cfg, log)
+	if err != nil {
+		return err
+	}
+
+	srv := api.New(st, searcher, auth, opts...)
 
 	// Each source starts syncing here and keeps going behind the listener. What
 	// is built here and not in the background is everything that can be wrong
@@ -258,6 +270,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		"store", cfg.Store,
 		"interface", web.Enabled(),
 		"cache", cfg.Cache,
+		"directory", cfg.Directory != "",
 	)
 
 	errc := make(chan error, len(servers))

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,22 @@ type Config struct {
 	// which is the property that makes a cache safe to have in the first place.
 	Cache bool
 
+	// Directory is the path to a directory of subjects and groups, and it is
+	// empty by default. A deployment with one resolves the groups on every
+	// request out of it and throws away whatever the request claimed. A
+	// deployment without one believes the groups it is given, which is right for
+	// a laptop and behind a proxy that is doing the resolution itself.
+	Directory string
+
+	// DirectoryTTL is how long a resolved group set is held for, and therefore
+	// the longest a membership change can take to have any effect.
+	DirectoryTTL time.Duration
+
+	// DirectoryRefresh is how often the file is read again, and zero means
+	// never. It exists because editing a group and then bouncing the server is
+	// how somebody ends up not editing the group.
+	DirectoryRefresh time.Duration
+
 	// CacheResultExpiry is the backstop on how long a ranked ordering may be
 	// reused. A write to the tenant drops its orderings whatever this says, so
 	// this is what bounds a driver that cannot report its writes.
@@ -104,6 +120,10 @@ func Default() Config {
 		// again rather than imported because configuration sits below everything
 		// and importing the query layer to read one constant would invert that.
 		CacheResultExpiry: 30 * time.Second,
+		// The same minute as directory.DefaultTTL, written again rather than
+		// imported for the same reason as the line above.
+		DirectoryTTL:     time.Minute,
+		DirectoryRefresh: 30 * time.Second,
 	}
 }
 
@@ -123,6 +143,7 @@ func Load(getenv func(string) string) (Config, error) {
 	str(getenv, "GENBA_DSN", &c.DSN)
 	str(getenv, "GENBA_TENANT", &c.Tenant)
 	str(getenv, "GENBA_LOG_LEVEL", &c.LogLevel)
+	str(getenv, "GENBA_DIRECTORY", &c.Directory)
 	if v := getenv("GENBA_ADMINS"); v != "" {
 		c.Admins = list(v)
 	}
@@ -135,6 +156,8 @@ func Load(getenv func(string) string) (Config, error) {
 		dur(getenv, "GENBA_WRITE_TIMEOUT", &c.WriteTimeout),
 		dur(getenv, "GENBA_SHUTDOWN_GRACE", &c.ShutdownGrace),
 		dur(getenv, "GENBA_CACHE_RESULT_EXPIRY", &c.CacheResultExpiry),
+		dur(getenv, "GENBA_DIRECTORY_TTL", &c.DirectoryTTL),
+		dur(getenv, "GENBA_DIRECTORY_REFRESH", &c.DirectoryRefresh),
 		boolean(getenv, "GENBA_CACHE", &c.Cache),
 	)
 	if err != nil {
@@ -181,6 +204,8 @@ func (c Config) Validate() error {
 		{"write timeout", c.WriteTimeout},
 		{"shutdown grace", c.ShutdownGrace},
 		{"cache result expiry", c.CacheResultExpiry},
+		{"directory ttl", c.DirectoryTTL},
+		{"directory refresh", c.DirectoryRefresh},
 	} {
 		if d.value < 0 {
 			errs = append(errs, fmt.Errorf("config: %s is negative", d.name))

--- a/directory/file.go
+++ b/directory/file.go
@@ -1,0 +1,170 @@
+package directory
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// A directory written down.
+//
+// The shape is meant to be typed by hand rather than generated, because the
+// deployment this is for is the one with forty people and six groups, and
+// making them stand up an identity provider in order to try a search engine is
+// how a search engine does not get tried.
+//
+//	{
+//	  "name": "acme",
+//	  "groups": [
+//	    {"id": "everyone"},
+//	    {"id": "engineering", "member_of": ["everyone"]}
+//	  ],
+//	  "subjects": [
+//	    {"id": "mei", "email": "mei@acme.com", "identities": ["slack:U04AB"], "member_of": ["engineering"]}
+//	  ]
+//	}
+//
+// Identities are "source:value" because that is the convention everywhere else,
+// and a pair of nested objects to say the same thing is three lines of typing
+// for no more meaning.
+type file struct {
+	Name     string        `json:"name"`
+	Groups   []fileGroup   `json:"groups"`
+	Subjects []fileSubject `json:"subjects"`
+}
+
+type fileGroup struct {
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	Version  string   `json:"version"`
+	MemberOf []string `json:"member_of"`
+}
+
+type fileSubject struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	Email      string   `json:"email"`
+	Version    string   `json:"version"`
+	Identities []string `json:"identities"`
+	MemberOf   []string `json:"member_of"`
+	Disabled   bool     `json:"disabled"`
+}
+
+// OpenStatic reads a directory out of a file.
+//
+// The error names the path, because the person who gets it is looking at a unit
+// file and a directory they wrote by hand, and "unexpected end of JSON input"
+// on its own tells them nothing about which of the two is wrong.
+func OpenStatic(path string) (*Static, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("directory: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	d, err := ReadStatic(f)
+	if err != nil {
+		return nil, fmt.Errorf("directory %s: %w", path, err)
+	}
+	return d, nil
+}
+
+// ReadStatic reads a directory out of JSON.
+//
+// It is strict on purpose. An unknown field is a typo rather than a future
+// version of the format, a group named in a membership and not defined is a
+// typo too, and both of them fail at startup rather than turning into somebody
+// mysteriously missing a group at nine o'clock. This is a file somebody wrote,
+// and the whole advantage a file has over an identity provider is that its
+// mistakes can be caught before anybody signs in.
+func ReadStatic(r io.Reader) (*Static, error) {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+
+	var in file
+	if err := dec.Decode(&in); err != nil {
+		return nil, err
+	}
+	// Anything after the object is a second document pasted in by accident, and
+	// silently reading the first half of a file is worse than refusing it.
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		return nil, errors.New("more than one directory in the file")
+	}
+	if in.Name == "" {
+		return nil, errors.New("no name, and a directory without one cannot have its groups told apart from another's")
+	}
+
+	d := NewStatic(in.Name)
+	defined := make(map[string]bool, len(in.Groups))
+	for _, g := range in.Groups {
+		if g.ID == "" {
+			return nil, errors.New("a group with no id")
+		}
+		if defined[g.ID] {
+			return nil, fmt.Errorf("group %q appears twice", g.ID)
+		}
+		defined[g.ID] = true
+		d.PutGroup(Group{ID: g.ID, Name: g.Name, Version: g.Version, MemberOf: slices.Clone(g.MemberOf)})
+	}
+
+	// The membership check happens after every group is defined, so the order
+	// they are written in is not something anybody has to think about.
+	for _, g := range in.Groups {
+		for _, of := range g.MemberOf {
+			if !defined[of] {
+				return nil, fmt.Errorf("group %q is a member of %q, which is not defined here", g.ID, of)
+			}
+		}
+	}
+
+	seen := make(map[string]bool, len(in.Subjects))
+	for _, s := range in.Subjects {
+		if s.ID == "" {
+			return nil, errors.New("a subject with no id")
+		}
+		if seen[s.ID] {
+			return nil, fmt.Errorf("subject %q appears twice", s.ID)
+		}
+		seen[s.ID] = true
+
+		ids := make([]acl.Identity, 0, len(s.Identities))
+		for _, raw := range s.Identities {
+			id, err := identity(raw)
+			if err != nil {
+				return nil, fmt.Errorf("subject %q: %w", s.ID, err)
+			}
+			ids = append(ids, id)
+		}
+		for _, of := range s.MemberOf {
+			if !defined[of] {
+				return nil, fmt.Errorf("subject %q is a member of %q, which is not defined here", s.ID, of)
+			}
+		}
+
+		d.Put(Subject{
+			ID:         s.ID,
+			Name:       s.Name,
+			Email:      s.Email,
+			Version:    s.Version,
+			Identities: ids,
+			MemberOf:   slices.Clone(s.MemberOf),
+			Disabled:   s.Disabled,
+		})
+	}
+	return d, nil
+}
+
+// identity splits "slack:U04AB" the way the rest of the system writes one.
+func identity(raw string) (acl.Identity, error) {
+	source, value, ok := strings.Cut(raw, ":")
+	if !ok || source == "" || value == "" {
+		return acl.Identity{}, fmt.Errorf("identity %q is not source:value", raw)
+	}
+	return acl.Identity{Source: source, Value: value}, nil
+}

--- a/directory/file_test.go
+++ b/directory/file_test.go
@@ -1,0 +1,188 @@
+package directory_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/directory"
+)
+
+const acme = `{
+  "name": "acme",
+  "groups": [
+    {"id": "everyone"},
+    {"id": "engineering", "name": "Engineering", "member_of": ["everyone"]},
+    {"id": "storage", "member_of": ["engineering"]}
+  ],
+  "subjects": [
+    {"id": "mei", "name": "Mei", "email": "mei@acme.com", "identities": ["slack:U04AB"], "member_of": ["storage"]},
+    {"id": "lee", "member_of": ["everyone"], "disabled": true},
+    {"id": "sam"}
+  ]
+}`
+
+func read(t *testing.T, in string) (*directory.Static, error) {
+	t.Helper()
+	return directory.ReadStatic(strings.NewReader(in))
+}
+
+func good(t *testing.T, in string) *directory.Static {
+	t.Helper()
+	d, err := read(t, in)
+	if err != nil {
+		t.Fatalf("reading the directory: %v", err)
+	}
+	return d
+}
+
+func TestAWrittenDirectoryResolvesTheSameAsAnyOther(t *testing.T) {
+	c, err := directory.NewCache(mustResolve(t, good(t, acme)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolved(t, c, "mei")
+	want := []string{"acme:engineering", "acme:everyone", "acme:storage"}
+	if !slices.Equal(got.Groups.Members, want) {
+		t.Errorf("mei resolved to %v, want %v", got.Groups.Members, want)
+	}
+	if got.Subject.Email != "mei@acme.com" {
+		t.Errorf("the email did not survive the file: %q", got.Subject.Email)
+	}
+	if want := (acl.Identity{Source: "slack", Value: "U04AB"}); !slices.Contains(got.Subject.Identities, want) {
+		t.Errorf("the identities are %v, want %v in them", got.Subject.Identities, want)
+	}
+}
+
+func TestSomebodyInNoGroupsIsOneLine(t *testing.T) {
+	c, err := directory.NewCache(mustResolve(t, good(t, acme)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := resolved(t, c, "sam"); len(got.Groups.Members) != 0 {
+		t.Errorf("sam resolved to %v, want nothing", got.Groups.Members)
+	}
+}
+
+func TestADeactivatedAccountInTheFileIsStillDeactivated(t *testing.T) {
+	if _, err := good(t, acme).Subject(t.Context(), "lee"); err != nil {
+		t.Fatalf("the directory does not hold lee at all: %v", err)
+	}
+	c, err := directory.NewCache(mustResolve(t, good(t, acme)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Expand(t.Context(), "lee"); err == nil {
+		t.Error("a deactivated account in the file resolved anyway")
+	}
+}
+
+// The whole advantage a file has over an identity provider is that its mistakes
+// can be caught before anybody signs in, so it is strict.
+func TestABadFileIsRefusedWithSomethingToActOn(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		in   string
+		says string
+	}{
+		{"no name", `{"subjects": [{"id": "mei"}]}`, "name"},
+		{"not json", `nonsense`, "invalid character"},
+		{"an unknown field", `{"name": "acme", "membors": []}`, "membors"},
+		{"a group with no id", `{"name": "acme", "groups": [{"name": "Engineering"}]}`, "no id"},
+		{"a subject with no id", `{"name": "acme", "subjects": [{"name": "Mei"}]}`, "no id"},
+		{"the same group twice", `{"name": "acme", "groups": [{"id": "a"}, {"id": "a"}]}`, "twice"},
+		{"the same subject twice", `{"name": "acme", "subjects": [{"id": "mei"}, {"id": "mei"}]}`, "twice"},
+		{
+			"a subject in a group that is not defined",
+			`{"name": "acme", "subjects": [{"id": "mei", "member_of": ["enginering"]}]}`,
+			"enginering",
+		},
+		{
+			"a group in a group that is not defined",
+			`{"name": "acme", "groups": [{"id": "a", "member_of": ["b"]}]}`,
+			`"b"`,
+		},
+		{
+			"an identity that is not source and value",
+			`{"name": "acme", "subjects": [{"id": "mei", "identities": ["U04AB"]}]}`,
+			"source:value",
+		},
+		{"two documents", `{"name": "acme"}{"name": "other"}`, "more than one"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := read(t, c.in)
+			if err == nil {
+				t.Fatal("the file was accepted")
+			}
+			if !strings.Contains(err.Error(), c.says) {
+				t.Errorf("the error is %q, and %q is not in it", err, c.says)
+			}
+		})
+	}
+}
+
+// The order groups are written in is not something anybody should have to think
+// about.
+func TestAGroupMayBeWrittenAfterTheOneItIsIn(t *testing.T) {
+	good(t, `{
+	  "name": "acme",
+	  "groups": [
+	    {"id": "storage", "member_of": ["engineering"]},
+	    {"id": "engineering"}
+	  ]
+	}`)
+}
+
+func TestOpeningAFileThatIsNotThereSaysWhichFile(t *testing.T) {
+	_, err := directory.OpenStatic(filepath.Join(t.TempDir(), "absent.json"))
+	if err == nil {
+		t.Fatal("a directory that is not there was opened")
+	}
+	if !strings.Contains(err.Error(), "absent.json") {
+		t.Errorf("the error is %q and does not name the file", err)
+	}
+}
+
+func TestOpeningAFileThatDoesNotParseSaysWhichFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "acme.json")
+	if err := os.WriteFile(path, []byte(`{"name": "acme", "groups": [`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := directory.OpenStatic(path)
+	if err == nil {
+		t.Fatal("a truncated directory was accepted")
+	}
+	if !strings.Contains(err.Error(), "acme.json") {
+		t.Errorf("the error is %q and does not name the file", err)
+	}
+}
+
+func TestAWrittenDirectoryReadsBackFromDisk(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "acme.json")
+	if err := os.WriteFile(path, []byte(acme), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d, err := directory.OpenStatic(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Name() != "acme" {
+		t.Errorf("the directory is named %q", d.Name())
+	}
+	if _, err := d.Subject(t.Context(), "mei"); err != nil {
+		t.Errorf("mei is not in the directory that was read: %v", err)
+	}
+}
+
+func mustResolve(t *testing.T, d directory.Directory) *directory.Resolver {
+	t.Helper()
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -138,7 +138,26 @@ func TestConformance(t *testing.T) {
 ```
 
 `directory.Static` is the reference implementation the suite runs against, and it is also the directory a small deployment actually uses.
-A company with forty people and six groups has the whole thing in its configuration file, and making them stand up an identity provider to try a search engine is how a search engine does not get tried.
+A company with forty people and six groups has the whole thing in a file, and making them stand up an identity provider to try a search engine is how a search engine does not get tried.
+
+## The file
+
+`genbad -directory` points at it, `directory.OpenStatic` reads it, and the README has the shape.
+
+It is strict, and that is the point of it being a file.
+An unknown field is a typo rather than a future version of the format, a group named in a membership and not defined is a typo too, and both refuse at startup rather than turning into somebody mysteriously missing a group at nine o'clock.
+An identity provider cannot offer that, because its mistakes are in somebody else's data.
+
+`-directory-refresh` reads it again on a ticker and swaps the whole thing in at once, so nothing ever reads a directory that is half of the old file and half of the new one.
+A reread that finds the same bytes costs a hash rather than a parse, which is what makes a short interval affordable.
+A reread that finds a change flushes the cache, everybody rather than one person, because the file changed and nothing in it says who was affected.
+
+Two things fail rather than apply.
+An edit that does not parse leaves the last good directory in place and logs, because an operator halfway through a change should not take everybody's groups away, and refusing every request until the file is valid again turns a typo into an outage.
+A change to the directory's own name is refused outright: every group key carries the name, so renaming it renames every group in every rule at once, and that is a different directory rather than an edit to this one.
+
+A file that does not parse at startup is a different matter and the process exits.
+Nothing is loaded, so there is nothing to keep, and coming up resolving nobody would be a server that answers every request with a refusal.
 
 ## Remembering the answer
 


### PR DESCRIPTION
Closes #180.

## What changed

The daemon can be given a directory, and when it has one it resolves group membership out of it instead of believing the request.

#18 put the interface and the graph walk in `directory`, #19 put a cache in front of it, and neither was reachable from the binary.
`genbad` still built `api.HeaderAuth` on its own, so all of it was written, tested, documented and used by nobody.
`docs/identity.md` claimed a company with forty people and six groups has the whole directory in a file, and there was no file to put it in.

## The file

```json
{
  "name": "acme",
  "groups": [
    {"id": "everyone"},
    {"id": "engineering", "member_of": ["everyone"]},
    {"id": "storage", "member_of": ["engineering"]}
  ],
  "subjects": [
    {"id": "mei", "email": "mei@acme.com", "identities": ["slack:U04AB"], "member_of": ["storage"]},
    {"id": "lee", "member_of": ["everyone"], "disabled": true}
  ]
}
```

`mei` resolves to `acme:engineering`, `acme:everyone` and `acme:storage`.
`lee` does not resolve at all, because an account closed on Friday should stop working on Friday.

The shape is meant to be typed by hand rather than generated, since the deployment this is for is the one that does not have an identity provider to point at.
Identities are `source:value` because that is the convention everywhere else, and a pair of nested objects to say the same thing is three lines of typing for no more meaning.
A group that is a member of nothing is one line.

It is strict, and that is the whole advantage a file has over a provider.
An unknown field is a typo rather than a future version of the format, a group named in a membership and not defined is a typo too, and both refuse at startup rather than turning into somebody mysteriously missing a group at nine o'clock.
A provider cannot offer that, because its mistakes are in somebody else's data.
The order things are written in does not matter, so a group can be declared after the one it is inside.

## The flags

| Flag | Default | What it does |
| --- | --- | --- |
| `-directory` | empty | the file, empty to believe the request |
| `-directory-ttl` | `1m` | how long a resolved group set is held |
| `-directory-refresh` | `30s` | how often the file is read again, zero for never |

All three have the usual `GENBA_` environment variables, because unlike a corpus to index this is a property of a deployment rather than something typed once while trying the binary out.

Without `-directory` nothing changes.
The groups on a request are still believed, which is right on a laptop and right behind a proxy that has already done the resolution.
There is a test for that, because "a deployment with no directory behaves exactly as it does today" is the kind of promise that quietly stops being true.

## Reloading

Editing a group and then bouncing the server is how somebody ends up not editing the group, so `-directory-refresh` rereads the file.

The whole thing is swapped in at once, so nothing ever reads a directory that is half of the old file and half of the new one, which would be a person resolving to a group set that never existed.
A reread that finds the same bytes costs a hash rather than a parse and a cache flush, which is what makes a short interval affordable.
A reread that finds a change flushes the cache, everybody rather than one person, because the file changed and nothing in it says who was affected.
This is the deployment with forty people in it, so a flush is forty expansions against a file already in the page cache.

Two things fail rather than apply.

An edit that does not parse leaves the last good directory in place and logs.
An operator halfway through a change should not take everybody's groups away, and refusing every request until the file is valid again turns a typo into an outage.

A change to the directory's own name is refused outright.
Every group key carries the name, so renaming it renames every group in every rule at once, and that is a different directory rather than an edit to this one.

A file that does not parse at startup is a different matter and the process exits.
Nothing is loaded, so there is nothing to keep, and coming up resolving nobody would be a server that answers every request with a refusal.
The error names the file, because the person reading it is looking at a unit file and a directory they wrote by hand and "unexpected end of JSON input" tells them nothing about which of the two is wrong.

## Tests

The interesting ones go through a real server on a real port and read `/api/v1/me`, because that is the endpoint that says what the session ended up carrying.

- A request claiming `acme:administrators` against a deployment with a directory comes back with `acme:engineering` and `acme:everyone`, and the claim is gone.
- The same request against a deployment without one comes back with what it claimed.
- Editing the file adds a group to a live session without a restart.
- Breaking the file leaves the session exactly as it was.
- A file that does not parse, and a file that is not there, both stop the server starting and both say which file.

The rest are unit tests on the swap and on the reader, including the eleven ways a file can be wrong and what each of them says.

## Notes

`docs/identity.md` gets a section on the file and the README gets one on the two questions and why they are answered from two places.
The next piece is #179, the adapters for Okta, Entra ID and Google Workspace, which answer the same two lookups this file does.

Refs #180
