### PR TITLE
Union several directories into one group set

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The environment variable is the flag in upper case with a `GENBA_` prefix, and a
 | `GENBA_TENANT` | empty | tenant served by a single tenant deployment |
 | `GENBA_ADMINS` | empty | subjects that hold the administrator role, comma separated |
 | `GENBA_LOG_LEVEL` | `info` | `debug`, `info`, `warn` or `error` |
-| `GENBA_DIRECTORY` | empty | file of subjects and groups to resolve group membership from, empty to believe the request |
+| `GENBA_DIRECTORY` | empty | files of subjects and groups to resolve group membership from, comma separated, empty to believe the request |
 | `GENBA_DIRECTORY_TTL` | `1m` | how long a resolved group set is held |
 | `GENBA_DIRECTORY_REFRESH` | `30s` | how often the file is read again, zero for never |
 | `GENBA_READ_TIMEOUT` | `30s` | request read timeout |
@@ -335,6 +335,10 @@ Renaming the directory is refused rather than applied, because every group key c
 `-directory-ttl` is the longest a membership change can take to have any effect, and it is one number rather than a property that emerges from a stack of caches.
 [docs/identity.md](docs/identity.md) says why there is exactly one layer.
 
+`-directory` takes more than one file, comma separated, and the group sets are unioned.
+That is a company that acquired another company: two sets of people, two files, one search box, and nothing collides because every group key carries the name of the directory it came from.
+A directory that cannot answer refuses the request rather than serving half of somebody's groups, and two files under the same name refuse at startup, since a rule naming one company's `engineering` would otherwise match the other's.
+
 This is the deployment with forty people and six groups in it.
 Adapters for Okta, Entra ID and Google Workspace are the next piece, and they answer the same two lookups the file does.
 
@@ -418,7 +422,7 @@ func main() {
 | Package | What lives there |
 | --- | --- |
 | `acl` | principals, groups, permission descriptors, visibility bitmaps |
-| `directory` | a person resolved into the groups they are in, with cycle detection, a version and one cache layer, [docs/identity.md](docs/identity.md) |
+| `directory` | a person resolved into the groups they are in, with cycle detection, a version, a union over several providers and one cache layer, [docs/identity.md](docs/identity.md) |
 | `directory/directorytest` | the conformance suite that defines what a directory adapter is |
 | `doc` | the canonical document model every connector normalises into |
 | `store` | the storage interface, plus `storetest`, the conformance suite |

--- a/cmd/genbad/directory.go
+++ b/cmd/genbad/directory.go
@@ -27,34 +27,56 @@ import (
 // is a fact about the company that changes without anybody signing in again,
 // and a header carrying it is a copy of an answer somebody else cached.
 //
-// The reload loop, if there is one, runs until the context is done.
+// With more than one, the group sets are unioned. That is a company that
+// acquired another company: two sets of people, two files, one search box, and
+// no collisions because every group key carries the name of the directory it
+// came from.
+//
+// There is one cache and it sits above the union, so the staleness bound is the
+// number in the configuration rather than something that emerges from a stack.
+//
+// The reload loops, if there are any, run until the context is done.
 func authenticator(ctx context.Context, cfg config.Config, log *slog.Logger) (api.Authenticator, error) {
 	header := api.HeaderAuth{Tenant: cfg.Tenant, Admins: cfg.Admins}
-	if cfg.Directory == "" {
+	if len(cfg.Directories) == 0 {
 		return header, nil
 	}
 
-	held := &swap{path: cfg.Directory}
-	if err := held.read(); err != nil {
-		return nil, err
+	var (
+		files = make([]*swap, 0, len(cfg.Directories))
+		parts = make([]directory.Expander, 0, len(cfg.Directories))
+	)
+	for _, path := range cfg.Directories {
+		held := &swap{path: path}
+		if err := held.read(); err != nil {
+			return nil, err
+		}
+		res, err := directory.New(held)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, held)
+		parts = append(parts, res)
 	}
-	res, err := directory.New(held)
+	union, err := directory.NewMulti(parts...)
 	if err != nil {
 		return nil, err
 	}
-	cached, err := directory.NewCache(res, directory.WithTTL(cfg.DirectoryTTL))
+	cached, err := directory.NewCache(union, directory.WithTTL(cfg.DirectoryTTL))
 	if err != nil {
 		return nil, err
 	}
 
 	log.Info("resolving groups from a directory",
-		"path", cfg.Directory,
-		"source", cached.Name(),
+		"paths", cfg.Directories,
+		"sources", union.Directories(),
 		"staleness", cached.Staleness(),
 		"refresh", cfg.DirectoryRefresh,
 	)
 	if cfg.DirectoryRefresh > 0 {
-		go held.reload(ctx, cfg.DirectoryRefresh, cached, log)
+		for _, held := range files {
+			go held.reload(ctx, cfg.DirectoryRefresh, cached, log)
+		}
 	}
 	return api.Resolving{Auth: header, Resolver: cached}, nil
 }

--- a/cmd/genbad/directory_test.go
+++ b/cmd/genbad/directory_test.go
@@ -27,6 +27,19 @@ const smallCompany = `{
   ]
 }`
 
+// The company acme acquired. Mei was given an account on both sides during the
+// integration, which is the case worth having a test for.
+const otherCompany = `{
+  "name": "beta",
+  "groups": [
+    {"id": "payroll"}
+  ],
+  "subjects": [
+    {"id": "mei", "email": "mei@beta.example", "member_of": ["payroll"]},
+    {"id": "jo", "member_of": ["payroll"]}
+  ]
+}`
+
 // write puts a directory in a temporary file and hands back the path.
 func write(t *testing.T, body string) string {
 	t.Helper()
@@ -216,6 +229,48 @@ func TestRenamingTheDirectoryIsRefusedRatherThanApplied(t *testing.T) {
 	}
 	if held.Name() != "acme" {
 		t.Errorf("the directory is now named %q", held.Name())
+	}
+}
+
+// Two files is a company that acquired another company. Nothing collides,
+// because every group key carries the name of the directory it came from.
+func TestTwoDirectoriesAreUnionedIntoOneSession(t *testing.T) {
+	base := serving(t, "-directory", write(t, smallCompany)+","+write(t, otherCompany))
+
+	got := groupsOf(t, base)
+	want := []string{"acme:engineering", "acme:everyone", "beta:payroll"}
+	if !slices.Equal(got, want) {
+		t.Errorf("the session carries %v, want %v", got, want)
+	}
+}
+
+// Two directories under one name would put both companies' groups under the
+// same key, so a rule naming one of them would match the other.
+func TestTwoDirectoriesWithTheSameNameStopTheServerStarting(t *testing.T) {
+	paths := write(t, smallCompany) + "," + write(t, smallCompany)
+
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), []string{"-addr", freeAddr(t), "-directory", paths, "-log-level", "error"}, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("the server started with two directories under one name")
+	}
+	if !strings.Contains(err.Error(), `"acme"`) {
+		t.Errorf("the error is %q and does not say which name is used twice", err)
+	}
+}
+
+// One of two files being unreadable refuses the request rather than serving
+// half of somebody's groups, and the same rule applies at startup.
+func TestOneBadFileOfTwoStopsTheServerStarting(t *testing.T) {
+	paths := write(t, smallCompany) + "," + filepath.Join(t.TempDir(), "absent.json")
+
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), []string{"-addr", freeAddr(t), "-directory", paths, "-log-level", "error"}, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("the server started with one of its two directories missing")
+	}
+	if !strings.Contains(err.Error(), "absent.json") {
+		t.Errorf("the error is %q and does not name the file", err)
 	}
 }
 

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -74,7 +74,11 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	// it and throws away whatever the request claimed. One without believes the
 	// groups it is given, which is right on a laptop and behind a proxy that is
 	// doing the resolution itself, and is not right for a company.
-	fs.StringVar(&cfg.Directory, "directory", cfg.Directory, "file of subjects and groups to resolve group membership from, empty to believe the request")
+	//
+	// More than one is a company that acquired another company. The group sets
+	// are unioned, and a file that cannot be read refuses the request rather
+	// than serving half of somebody's groups.
+	directories := fs.String("directory", strings.Join(cfg.Directories, ","), "files of subjects and groups to resolve group membership from, comma separated, empty to believe the request")
 	fs.DurationVar(&cfg.DirectoryTTL, "directory-ttl", cfg.DirectoryTTL, "how long a resolved group set is held, which is the longest a membership change takes to have any effect")
 	fs.DurationVar(&cfg.DirectoryRefresh, "directory-refresh", cfg.DirectoryRefresh, "how often the directory file is read again, zero for never")
 	// A string rather than a repeated flag, because it is a list of a handful of
@@ -127,7 +131,8 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		fmt.Fprintf(stdout, "genbad %s (%s, built %s)\n", genba.Version, genba.Commit, genba.Date)
 		return nil
 	}
-	cfg.Admins = subjects(*admins)
+	cfg.Admins = commas(*admins)
+	cfg.Directories = commas(*directories)
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
@@ -270,7 +275,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		"store", cfg.Store,
 		"interface", web.Enabled(),
 		"cache", cfg.Cache,
-		"directory", cfg.Directory != "",
+		"directories", len(cfg.Directories),
 	)
 
 	errc := make(chan error, len(servers))
@@ -360,13 +365,13 @@ func searchOptions(cfg config.Config) []index.Option {
 	}
 }
 
-// subjects splits a comma separated list of names, dropping the empties.
+// commas splits a comma separated flag, dropping the empties.
 //
 // The empties matter. A flag left at its default is an empty string, and a
 // naive split of that is a list holding one name that is nothing at all, which
 // would make an unauthenticated request an administrator on any deployment
 // where the subject is also empty.
-func subjects(v string) []string {
+func commas(v string) []string {
 	var out []string
 	for _, s := range strings.Split(v, ",") {
 		if s = strings.TrimSpace(s); s != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -78,12 +78,18 @@ type Config struct {
 	// which is the property that makes a cache safe to have in the first place.
 	Cache bool
 
-	// Directory is the path to a directory of subjects and groups, and it is
-	// empty by default. A deployment with one resolves the groups on every
-	// request out of it and throws away whatever the request claimed. A
-	// deployment without one believes the groups it is given, which is right for
-	// a laptop and behind a proxy that is doing the resolution itself.
-	Directory string
+	// Directories are the files of subjects and groups to resolve group
+	// membership from, and it is empty by default. A deployment with one
+	// resolves the groups on every request out of it and throws away whatever
+	// the request claimed. A deployment without one believes the groups it is
+	// given, which is right for a laptop and behind a proxy that is doing the
+	// resolution itself.
+	//
+	// More than one is a company that acquired another company: the group sets
+	// are unioned, nothing collides because every group key carries the name of
+	// the directory it came from, and a file that cannot be read refuses the
+	// request rather than serving half of somebody's groups.
+	Directories []string
 
 	// DirectoryTTL is how long a resolved group set is held for, and therefore
 	// the longest a membership change can take to have any effect.
@@ -143,7 +149,9 @@ func Load(getenv func(string) string) (Config, error) {
 	str(getenv, "GENBA_DSN", &c.DSN)
 	str(getenv, "GENBA_TENANT", &c.Tenant)
 	str(getenv, "GENBA_LOG_LEVEL", &c.LogLevel)
-	str(getenv, "GENBA_DIRECTORY", &c.Directory)
+	if v := getenv("GENBA_DIRECTORY"); v != "" {
+		c.Directories = list(v)
+	}
 	if v := getenv("GENBA_ADMINS"); v != "" {
 		c.Admins = list(v)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +48,24 @@ func TestLoadAppliesTheEnvironment(t *testing.T) {
 	}
 	if c.WriteTimeout != config.Default().WriteTimeout {
 		t.Errorf("an unset variable overwrote the default: WriteTimeout = %v", c.WriteTimeout)
+	}
+}
+
+// One variable holding several paths, because a company that acquired another
+// company has a file per side and one unit file.
+func TestSeveralDirectoriesComeFromOneVariable(t *testing.T) {
+	c, err := config.Load(env(map[string]string{
+		"GENBA_DIRECTORY": "/etc/genba/acme.json, /etc/genba/beta.json",
+	}))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{"/etc/genba/acme.json", "/etc/genba/beta.json"}
+	if !slices.Equal(c.Directories, want) {
+		t.Errorf("Directories = %v, want %v", c.Directories, want)
+	}
+	if len(config.Default().Directories) != 0 {
+		t.Error("the default resolves groups from a directory nobody configured")
 	}
 }
 

--- a/directory/multi.go
+++ b/directory/multi.go
@@ -1,0 +1,246 @@
+package directory
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// Multi expands one subject against several directories and unions the answers.
+//
+// The shape it exists for is a company that acquired another company. There are
+// two identity providers, nobody is going to merge them this quarter, and there
+// is one search box. Half the people are in one directory, half are in the
+// other, and a few are in both because they were given an account on the other
+// side during the integration.
+//
+// Nothing collides, because a group key already carries the name of the
+// directory it came from. "engineering" at one company and "engineering" at the
+// other are two different groups here for the same reason they are two
+// different groups in real life.
+//
+// # A partial answer is the one thing it will not return
+//
+// If any directory fails, the expansion fails. This is the same rule the walk
+// inside one directory follows and it matters more here, not less: with several
+// providers there are several things that can be having a bad day, and a person
+// whose second directory timed out looks exactly like a person who is only in
+// the first one. Serving them the groups that did answer would silently take
+// away half of what they can read, with nothing anywhere to say why.
+//
+// A directory that does not hold the subject at all is not a failure. That is
+// the ordinary case, since most people are in one of them, and it contributes
+// nothing to the union. A subject every directory refuses is [ErrNoSubject].
+//
+// A subject one directory holds and has deactivated refuses the whole
+// expansion, even if another directory still has them active. Deactivating an
+// account is a statement somebody made on purpose, and the alternative is that
+// closing an account on Friday does nothing because a directory nobody has
+// tidied up still says yes. During a migration, take the old directory out of
+// the list rather than leaving deactivated accounts in it.
+//
+// # Where the cache goes
+//
+// Above this, not below it. Wrapping a [Multi] in one [Cache] gives one entry
+// per person and one lifetime to reason about. Wrapping each directory
+// separately gives the same staleness bound and several times the entries, and
+// it makes an expansion a hit only when every part of it is.
+//
+// A Multi is safe for concurrent use.
+type Multi struct {
+	parts []Expander
+	name  string
+}
+
+// NewMulti returns a directory that unions the ones it is given.
+//
+// The order matters for one thing only: where the display name and the email
+// come from when more than one directory holds the same person. It is the first
+// one that answers.
+func NewMulti(parts ...Expander) (*Multi, error) {
+	if len(parts) == 0 {
+		return nil, errors.New("directory: a union needs at least one directory")
+	}
+	names := make([]string, 0, len(parts))
+	for i, p := range parts {
+		if p == nil {
+			return nil, fmt.Errorf("directory: directory %d of %d is nil", i+1, len(parts))
+		}
+		name := p.Name()
+		if name == "" {
+			return nil, fmt.Errorf("directory: directory %d of %d has no name", i+1, len(parts))
+		}
+		// Two directories under one name would put both companies' groups under
+		// the same key, so a rule naming one of them would match the other. That
+		// is the whole thing this type is built not to do.
+		if slices.Contains(names, name) {
+			return nil, fmt.Errorf("directory: two of these directories are named %q, so their groups would be the same groups", name)
+		}
+		names = append(names, name)
+	}
+	return &Multi{parts: slices.Clone(parts), name: strings.Join(names, "+")}, nil
+}
+
+// Name is every directory in the union, joined, which is what ends up in a log
+// line and in the startup message. It is not an identity source: the sources
+// are the individual directories, and they are what the group keys carry.
+func (m *Multi) Name() string { return m.name }
+
+// Directories names the directories in the union, in order.
+func (m *Multi) Directories() []string {
+	out := make([]string, len(m.parts))
+	for i, p := range m.parts {
+		out[i] = p.Name()
+	}
+	return out
+}
+
+// Counters adds up the numbers of whichever directories keep them.
+//
+// They are the directories' own counts rather than this one's, so a person in
+// two of them is two expansions here and one sign in. That is the number worth
+// having, because what these bound is the load on the providers.
+func (m *Multi) Counters() Counters {
+	var out Counters
+	for _, p := range m.parts {
+		c, ok := p.(interface{ Counters() Counters })
+		if !ok {
+			continue
+		}
+		n := c.Counters()
+		out.Expansions += n.Expansions
+		out.Failures += n.Failures
+		out.Lookups += n.Lookups
+		out.Missing += n.Missing
+		out.Disabled += n.Disabled
+		out.Unresolved += n.Unresolved
+	}
+	return out
+}
+
+// Expand resolves one subject against every directory at once.
+//
+// Together rather than one after another, because these are separate services
+// over separate networks and doing them in turn makes a sign in cost the sum of
+// two round trips for no reason. The first real failure cancels the rest, since
+// their answers are about to be thrown away.
+func (m *Multi) Expand(ctx context.Context, id string) (Expansion, error) {
+	if err := ctx.Err(); err != nil {
+		return Expansion{}, fmt.Errorf("directory %s: %q: %w", m.name, id, err)
+	}
+
+	type answer struct {
+		got  Expansion
+		err  error
+		held bool
+	}
+	out := make([]answer, len(m.parts))
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for i, p := range m.parts {
+		wg.Go(func() {
+			got, err := p.Expand(ctx, id)
+			switch {
+			case errors.Is(err, ErrNoSubject):
+				// Not a failure. Most people are in one directory of several, so
+				// the ones who are not in this one are the ordinary case rather
+				// than something to report.
+			case err != nil:
+				out[i].err = err
+				cancel()
+			default:
+				out[i].got, out[i].held = got, true
+			}
+		})
+	}
+	wg.Wait()
+
+	// In order, and a real failure ahead of a cancellation, so that the same two
+	// directories in the same state produce the same message twice running and
+	// the message names what went wrong rather than what it caused. The error is
+	// returned as the directory wrote it, because that one already says which
+	// provider and which subject.
+	for _, a := range out {
+		if a.err != nil && !errors.Is(a.err, context.Canceled) {
+			return Expansion{}, a.err
+		}
+	}
+	for _, a := range out {
+		if a.err != nil {
+			return Expansion{}, a.err
+		}
+	}
+
+	var (
+		merged   Expansion
+		members  []string
+		unknown  []string
+		sources  []string
+		versions = make(map[string]string, len(m.parts))
+		answered bool
+	)
+	for i, a := range out {
+		if !a.held {
+			continue
+		}
+		source := m.parts[i].Name()
+		sources = append(sources, source)
+
+		// The part's version is already a fingerprint of its own closure, so
+		// hashing the versions is hashing the answer. A directory that stops
+		// holding this person drops out of the list, which moves the number too.
+		versions[source] = strconv.FormatUint(a.got.Groups.Version, 10)
+
+		members = append(members, a.got.Groups.Members...)
+		for _, g := range a.got.Unknown {
+			// Qualified, unlike the single directory case, because two providers
+			// can each be missing a group called "engineering" and an operator
+			// reading the list has to know which one to go and look at.
+			unknown = append(unknown, acl.Ref{Source: source, Value: g}.GroupKey())
+		}
+		merged.Lookups += a.got.Lookups
+		merged.Depth = max(merged.Depth, a.got.Depth)
+
+		if !answered {
+			answered = true
+			merged.Subject.ID = cmp.Or(a.got.Subject.ID, id)
+			merged.Subject.Name = a.got.Subject.Name
+			merged.Subject.Email = a.got.Subject.Email
+		}
+		// Identities are unioned across all of them rather than taken from the
+		// first, because the rule that matters may name a Slack member id that
+		// only the other directory knows about.
+		for _, ident := range a.got.Subject.Identities {
+			if !slices.Contains(merged.Subject.Identities, ident) {
+				merged.Subject.Identities = append(merged.Subject.Identities, ident)
+			}
+		}
+	}
+	if !answered {
+		return Expansion{}, fmt.Errorf("directory %s: %q: %w", m.name, id, ErrNoSubject)
+	}
+
+	// Subject.MemberOf is deliberately left empty. It is a list of ids in one
+	// directory's own naming, and there is no naming here that several of them
+	// share. Everything it would have said is in Groups, with the source on it.
+
+	sort.Strings(members)
+	sort.Strings(unknown)
+	merged.Groups = acl.GroupSet{
+		Version: fingerprint(m.name, "", sources, versions),
+		Members: slices.Compact(members),
+	}
+	merged.Unknown = slices.Compact(unknown)
+	return merged, nil
+}

--- a/directory/multi_test.go
+++ b/directory/multi_test.go
@@ -1,0 +1,424 @@
+package directory_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/directory"
+)
+
+// The two companies. Mei was given an account on both sides during the
+// integration, Ravi only exists at the acquirer, and Jo only exists at the
+// company that was bought.
+func acquirer(t *testing.T) *directory.Static {
+	t.Helper()
+	d := directory.NewStatic("acme")
+	d.PutGroup(directory.Group{ID: "everyone"})
+	d.PutGroup(directory.Group{ID: "engineering", MemberOf: []string{"everyone"}})
+	d.Put(directory.Subject{
+		ID:         "mei",
+		Name:       "Mei",
+		Email:      "mei@acme.com",
+		Identities: []acl.Identity{{Source: "slack", Value: "U04AB"}},
+		MemberOf:   []string{"engineering"},
+	})
+	d.Put(directory.Subject{ID: "ravi", MemberOf: []string{"everyone"}})
+	return d
+}
+
+func acquired(t *testing.T) *directory.Static {
+	t.Helper()
+	d := directory.NewStatic("beta")
+	d.PutGroup(directory.Group{ID: "payroll"})
+	d.Put(directory.Subject{
+		ID:         "mei",
+		Name:       "Mei Tan",
+		Email:      "mei@beta.example",
+		Identities: []acl.Identity{{Source: "jira", Value: "5f1"}},
+		MemberOf:   []string{"payroll"},
+	})
+	d.Put(directory.Subject{ID: "jo", MemberOf: []string{"payroll"}})
+	return d
+}
+
+// union builds the thing under test over whatever directories a case wants.
+func union(t *testing.T, dirs ...directory.Directory) *directory.Multi {
+	t.Helper()
+	parts := make([]directory.Expander, len(dirs))
+	for i, d := range dirs {
+		parts[i] = mustResolve(t, d)
+	}
+	m, err := directory.NewMulti(parts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+// both is the union the ordinary cases resolve against.
+func both(t *testing.T) *directory.Multi {
+	t.Helper()
+	return union(t, acquirer(t), acquired(t))
+}
+
+func expandOne(t *testing.T, e directory.Expander, id string) directory.Expansion {
+	t.Helper()
+	got, err := e.Expand(t.Context(), id)
+	if err != nil {
+		t.Fatalf("expanding %s: %v", id, err)
+	}
+	return got
+}
+
+func TestSomebodyInBothDirectoriesCarriesTheGroupsOfBoth(t *testing.T) {
+	got := expandOne(t, both(t), "mei")
+
+	want := []string{"acme:engineering", "acme:everyone", "beta:payroll"}
+	if !slices.Equal(got.Groups.Members, want) {
+		t.Errorf("mei resolved to %v, want %v", got.Groups.Members, want)
+	}
+}
+
+// Most people are in one directory of several, so a directory that has never
+// heard of somebody is the ordinary case rather than something to report.
+func TestSomebodyInOnlyOneDirectoryResolvesFine(t *testing.T) {
+	m := both(t)
+
+	for _, c := range []struct {
+		id   string
+		want []string
+	}{
+		{"ravi", []string{"acme:everyone"}},
+		{"jo", []string{"beta:payroll"}},
+	} {
+		if got := expandOne(t, m, c.id).Groups.Members; !slices.Equal(got, c.want) {
+			t.Errorf("%s resolved to %v, want %v", c.id, got, c.want)
+		}
+	}
+}
+
+func TestSomebodyInNoneOfThemIsStillNoSuchSubject(t *testing.T) {
+	_, err := both(t).Expand(t.Context(), "nobody")
+	if !errors.Is(err, directory.ErrNoSubject) {
+		t.Errorf("the error is %v, want it to be ErrNoSubject", err)
+	}
+}
+
+// The reason this type is written the way it is. A person whose second
+// directory timed out looks exactly like a person who is only in the first one,
+// and serving them half their groups takes away what they can read with nothing
+// anywhere to say why.
+func TestADirectoryThatCannotAnswerRefusesRatherThanReturningHalfTheGroups(t *testing.T) {
+	down := &broken{Static: acquired(t)}
+	down.down.Store(true)
+	m := union(t, acquirer(t), down)
+
+	_, err := m.Expand(t.Context(), "mei")
+	if err == nil {
+		t.Fatal("a union with one directory down answered anyway")
+	}
+	if !errors.Is(err, errDirectoryDown) {
+		t.Errorf("the error is %v, want the directory's own", err)
+	}
+	// And the message names the directory that failed rather than the union,
+	// because that is the one somebody has to go and look at.
+	if !strings.Contains(err.Error(), "beta") {
+		t.Errorf("the error is %q and does not name the directory that failed", err)
+	}
+}
+
+// A directory that has been asked to stop speaking for somebody is a statement
+// somebody made on purpose, and it holds even where another directory has not
+// caught up yet.
+func TestADeactivatedAccountInEitherDirectoryRefuses(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		in   func(*testing.T) *directory.Multi
+	}{
+		{"the first", func(t *testing.T) *directory.Multi {
+			d := acquirer(t)
+			d.Put(directory.Subject{ID: "mei", Disabled: true})
+			return union(t, d, acquired(t))
+		}},
+		{"the second", func(t *testing.T) *directory.Multi {
+			d := acquired(t)
+			d.Put(directory.Subject{ID: "mei", Disabled: true})
+			return union(t, acquirer(t), d)
+		}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := c.in(t).Expand(t.Context(), "mei")
+			if !errors.Is(err, directory.ErrDisabled) {
+				t.Errorf("the error is %v, want it to be ErrDisabled", err)
+			}
+		})
+	}
+}
+
+// The version has to move when either side does, because the thing it
+// invalidates is the whole session and not one directory's part of it.
+func TestTheVersionMovesWhenEitherDirectoryDoes(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		change func(a, b *directory.Static)
+	}{
+		{"the first", func(a, _ *directory.Static) {
+			a.Put(directory.Subject{ID: "mei", MemberOf: []string{"everyone"}})
+		}},
+		{"the second", func(_, b *directory.Static) {
+			b.Put(directory.Subject{ID: "mei"})
+		}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			a, b := acquirer(t), acquired(t)
+			m := union(t, a, b)
+
+			was := expandOne(t, m, "mei").Groups.Version
+			c.change(a, b)
+			now := expandOne(t, m, "mei").Groups.Version
+			if was == now {
+				t.Errorf("the version is still %d after a membership changed", now)
+			}
+		})
+	}
+}
+
+// And it does not move when nothing did, or every session would be thrown away
+// on every request.
+func TestTheVersionIsTheSameTwiceRunning(t *testing.T) {
+	m := both(t)
+	if was, now := expandOne(t, m, "mei").Groups.Version, expandOne(t, m, "mei").Groups.Version; was != now {
+		t.Errorf("two expansions of an unchanged directory gave %d and %d", was, now)
+	}
+}
+
+// A rule may name a Slack member id that only one of the two directories knows
+// about, so taking the identities from the first one to answer would drop it.
+func TestIdentitiesAreUnionedAcrossTheDirectories(t *testing.T) {
+	got := expandOne(t, both(t), "mei")
+
+	for _, want := range []acl.Identity{
+		{Source: "slack", Value: "U04AB"},
+		{Source: "jira", Value: "5f1"},
+	} {
+		if !slices.Contains(got.Subject.Identities, want) {
+			t.Errorf("the identities are %v, want %v in them", got.Subject.Identities, want)
+		}
+	}
+}
+
+// Somebody has to win, and the first directory given is the one an operator can
+// reorder.
+func TestTheDisplayNameComesFromTheFirstDirectoryThatHasThem(t *testing.T) {
+	if got := expandOne(t, both(t), "mei").Subject.Email; got != "mei@acme.com" {
+		t.Errorf("the email is %q, want the first directory's", got)
+	}
+	if got := expandOne(t, union(t, acquired(t), acquirer(t)), "mei").Subject.Email; got != "mei@beta.example" {
+		t.Errorf("the email is %q, want the first directory's", got)
+	}
+}
+
+// MemberOf is a list of ids in one directory's own naming and there is no
+// naming here that both of them share, so it is left empty rather than
+// concatenated into something that reads like a single directory's answer.
+func TestTheRawMembershipListIsNotConcatenated(t *testing.T) {
+	if got := expandOne(t, both(t), "mei").Subject.MemberOf; len(got) != 0 {
+		t.Errorf("the subject carries MemberOf %v, which belongs to no single directory", got)
+	}
+}
+
+// Two providers can each be missing a group called the same thing, and an
+// operator reading the list has to know which one to go and look at.
+func TestAnUnknownGroupSaysWhichDirectoryItIsMissingFrom(t *testing.T) {
+	a, b := acquirer(t), acquired(t)
+	a.Put(directory.Subject{ID: "mei", MemberOf: []string{"engineering", "ghosts"}})
+	b.Put(directory.Subject{ID: "mei", MemberOf: []string{"payroll", "ghosts"}})
+
+	got := expandOne(t, union(t, a, b), "mei")
+	if want := []string{"acme:ghosts", "beta:ghosts"}; !slices.Equal(got.Unknown, want) {
+		t.Errorf("the unknown groups are %v, want %v", got.Unknown, want)
+	}
+	// They are still in the group set, because the directory saying somebody is
+	// a member is a statement about them whatever else it has lost.
+	for _, want := range []string{"acme:ghosts", "beta:ghosts"} {
+		if !slices.Contains(got.Groups.Members, want) {
+			t.Errorf("the groups are %v, want %v in them", got.Groups.Members, want)
+		}
+	}
+}
+
+// Two separate services over two separate networks, so asking them in turn
+// makes a sign in cost the sum of two round trips for no reason.
+func TestBothDirectoriesAreAskedAtTheSameTime(t *testing.T) {
+	var (
+		arrived = make(chan struct{}, 2)
+		release = make(chan struct{})
+	)
+	slow := func(d *directory.Static) directory.Directory {
+		return &gated{Static: d, arrived: arrived, release: release}
+	}
+	m, err := directory.NewMulti(
+		mustResolve(t, slow(acquirer(t))),
+		mustResolve(t, slow(acquired(t))),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := m.Expand(t.Context(), "mei"); err != nil {
+			t.Errorf("expanding mei: %v", err)
+		}
+	}()
+
+	for i := range 2 {
+		select {
+		case <-arrived:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d of the two directories had been asked, so they are being asked in turn", i)
+		}
+	}
+	close(release)
+	<-done
+}
+
+// gated is a directory that says when it has been asked and then waits.
+type gated struct {
+	*directory.Static
+	arrived chan<- struct{}
+	release <-chan struct{}
+}
+
+func (g *gated) Subject(ctx context.Context, id string) (directory.Subject, error) {
+	g.arrived <- struct{}{}
+	select {
+	case <-g.release:
+	case <-ctx.Done():
+		return directory.Subject{}, ctx.Err()
+	}
+	return g.Static.Subject(ctx, id)
+}
+
+func TestTheCountersAreTheDirectoriesOwn(t *testing.T) {
+	m := both(t)
+	expandOne(t, m, "mei")
+
+	got := m.Counters()
+	if got.Expansions != 2 {
+		t.Errorf("one sign in against two directories counted %d expansions, want 2", got.Expansions)
+	}
+	// Mei is looked up twice, engineering and everyone once each on one side and
+	// payroll once on the other.
+	if got.Lookups != 5 {
+		t.Errorf("the union made %d lookups, want 5", got.Lookups)
+	}
+}
+
+func TestACancelledRequestIsNotSentToAnyDirectory(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	if _, err := both(t).Expand(ctx, "mei"); !errors.Is(err, context.Canceled) {
+		t.Errorf("the error is %v, want it to be a cancellation", err)
+	}
+}
+
+func TestAUnionNeedsDirectoriesThatCanBeToldApart(t *testing.T) {
+	one := mustResolve(t, acquirer(t))
+	for _, c := range []struct {
+		name string
+		in   []directory.Expander
+		says string
+	}{
+		{"nothing at all", nil, "at least one"},
+		{"a nil directory", []directory.Expander{one, nil}, "is nil"},
+		{"a directory with no name", []directory.Expander{one, nameless{}}, "no name"},
+		{"the same name twice", []directory.Expander{one, mustResolve(t, acquirer(t))}, `"acme"`},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := directory.NewMulti(c.in...)
+			if err == nil {
+				t.Fatal("the union was built")
+			}
+			if !strings.Contains(err.Error(), c.says) {
+				t.Errorf("the error is %q, and %q is not in it", err, c.says)
+			}
+		})
+	}
+}
+
+// A union of one is a supported shape, because it is what a deployment that was
+// given a list of directories with one entry in it ends up with.
+func TestAUnionOfOneAnswersLikeTheDirectory(t *testing.T) {
+	m := union(t, acquirer(t))
+	if got := m.Name(); got != "acme" {
+		t.Errorf("the union is named %q", got)
+	}
+	got := expandOne(t, m, "mei").Groups.Members
+	if want := []string{"acme:engineering", "acme:everyone"}; !slices.Equal(got, want) {
+		t.Errorf("mei resolved to %v, want %v", got, want)
+	}
+}
+
+func TestTheNameSaysWhichDirectoriesAreInIt(t *testing.T) {
+	m := both(t)
+	if got := m.Name(); got != "acme+beta" {
+		t.Errorf("the union is named %q, want acme+beta", got)
+	}
+	if want := []string{"acme", "beta"}; !slices.Equal(m.Directories(), want) {
+		t.Errorf("the union holds %v, want %v", m.Directories(), want)
+	}
+}
+
+// One cache over the union rather than one over each directory, which is the
+// arrangement the documentation asks for and the one the daemon builds.
+func TestOneCacheOverTheUnionHoldsOnePersonPerEntry(t *testing.T) {
+	c, err := directory.NewCache(both(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Expand(t.Context(), "mei"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Expand(t.Context(), "mei"); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Stats(); got.Entries != 1 || got.Hits != 1 {
+		t.Errorf("the cache holds %d entries with %d hits, want one of each", got.Entries, got.Hits)
+	}
+	if got := c.Name(); got != "acme+beta" {
+		t.Errorf("the cache is named %q", got)
+	}
+}
+
+func TestTwoAnswersFromAUnionAreNotTheSameSlice(t *testing.T) {
+	m := both(t)
+	first := expandOne(t, m, "mei")
+	first.Groups.Members[0] = "acme:administrators"
+
+	if got := expandOne(t, m, "mei").Groups.Members[0]; got != "acme:engineering" {
+		t.Errorf("an edit to one answer reached the next one, which now starts with %q", got)
+	}
+}
+
+func TestResolvingFromSeveralDirectoriesAtOnceIsSafe(t *testing.T) {
+	m := both(t)
+	var wg sync.WaitGroup
+	for i := range 64 {
+		wg.Go(func() {
+			id := []string{"mei", "ravi", "jo"}[i%3]
+			if _, err := m.Expand(t.Context(), id); err != nil {
+				t.Errorf("expanding %s: %v", id, err)
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -159,6 +159,29 @@ A change to the directory's own name is refused outright: every group key carrie
 A file that does not parse at startup is a different matter and the process exits.
 Nothing is loaded, so there is nothing to keep, and coming up resolving nobody would be a server that answers every request with a refusal.
 
+## More than one directory
+
+`directory.Multi` unions several of them into one group set, and `genbad -directory` takes a list of files.
+
+The shape it exists for is a company that acquired another company.
+There are two identity providers, nobody is going to merge them this quarter, and there is one search box.
+Half the people are in one directory, half are in the other, and a few are in both because they were given an account on the other side during the integration.
+Nothing collides, because a group key already carries the name of the directory it came from, and `engineering` at one company and `engineering` at the other are two different groups here for the same reason they are two different groups in real life.
+Two directories under one name are refused when the union is built, since that is the one arrangement where a rule naming one of them would match the other.
+
+If any directory fails, the expansion fails.
+This is the same rule the walk inside one directory follows and it matters more here, not less.
+With several providers there are several things that can be having a bad day, and a person whose second directory timed out looks exactly like a person who is only in the first one.
+Serving them the groups that did answer would take away half of what they can read with nothing anywhere to say why.
+
+A directory that does not hold the subject at all is not a failure, because most people are in one directory of several, and a subject every directory refuses is `ErrNoSubject`.
+A subject one directory holds and has deactivated refuses the whole expansion even where another directory still has them active, because deactivating an account is a statement somebody made on purpose.
+During a migration, take the old directory out of the list rather than leaving deactivated accounts in it.
+
+The cache goes above the union rather than under it.
+One cache over a `Multi` is one entry per person and one lifetime to reason about.
+One cache per directory is the same staleness bound, several times the entries, and an expansion that is a hit only when every part of it is.
+
 ## Remembering the answer
 
 Expanding on every request is not affordable.


### PR DESCRIPTION
## What this is

`directory.Multi` unions several directories into one group set, which is the fifth box on #179.

The shape it exists for is a company that acquired another company.
There are two identity providers, nobody is going to merge them this quarter, and there is one search box.
Half the people are in one directory, half are in the other, and a few are in both because they were given an account on the other side during the integration.

Nothing collides, because a group key already carries the name of the directory it came from.
`engineering` at one company and `engineering` at the other are two different groups here for the same reason they are two different groups in real life.
Two directories under one name are refused when the union is built, since that is the one arrangement where a rule naming one of them would match the other.

## A partial answer is the one thing it will not return

If any directory fails, the expansion fails.
This is the same rule the walk inside one directory follows and it matters more here, not less: with several providers there are several things that can be having a bad day, and a person whose second directory timed out looks exactly like a person who is only in the first one.
Serving them the groups that did answer would take away half of what they can read with nothing anywhere to say why.

A directory that does not hold the subject at all is not a failure.
That is the ordinary case, since most people are in one directory of several, and a subject every directory refuses is `ErrNoSubject`.

A subject one directory holds and has deactivated refuses the whole expansion, even where another directory still has them active.
Deactivating an account is a statement somebody made on purpose, and the alternative is that closing an account on Friday does nothing because a directory nobody has tidied up still says yes.
During a migration, take the old directory out of the list rather than leaving deactivated accounts in it.

## The smaller decisions

The version is a hash of the parts' versions, and each of those is already a fingerprint of its own closure, so it moves when either side moves and stays put when neither does.
A directory that stops holding somebody drops out of the list, which moves the number too.

Identities are unioned rather than taken from the first directory to answer, because the rule that matters may name a Slack member id that only the other one knows about.
The display name and the email do come from the first one, which is the order an operator can change.

`Subject.MemberOf` is left empty.
It is a list of ids in one directory's own naming and there is no naming here that several of them share, so concatenating them would read like a single directory's answer and would not be one.
Everything it would have said is in `Groups`, with the source attached.

`Unknown` is qualified with the directory name, unlike the single directory case, because two providers can each be missing a group called `engineering` and an operator reading the list has to know which one to go and look at.

The cache goes above the union rather than under it.
One cache over a `Multi` is one entry per person and one lifetime to reason about.
One cache per directory is the same staleness bound, several times the entries, and an expansion that is a hit only when every part of it is.

## Reachable without writing any Go

`-directory` now takes a list of files and `GENBA_DIRECTORY` a comma separated one, so a deployment builds the union from a unit file.
Each file gets its own reload ticker and they all flush the one cache.

```
genbad -directory /etc/genba/acme.json,/etc/genba/beta.json
```

`mei`, who is in both, ends up carrying `acme:engineering`, `acme:everyone` and `beta:payroll`.

## Tests

`directory/multi_test.go` covers the union, somebody in only one of them, somebody in none of them, a directory that is down, a deactivated account on either side, the version moving and not moving, the identity union, the unknown groups being qualified, both directories being asked at the same time rather than in turn, the counters, cancellation, the four ways a union is refused, a union of one, one cache over the union, the answers not sharing a slice, and sixty four concurrent expansions under the race detector.

`cmd/genbad/directory_test.go` covers the end to end case over HTTP: two files, one `/api/v1/me`, groups from both, plus two files under one name and one file of two missing, both of which stop the server starting.

Closes nothing on its own, ticks one box on #179.
