### PR TITLE
Resolve group membership from an Okta organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,12 @@ That is a company that acquired another company: two sets of people, two files, 
 A directory that cannot answer refuses the request rather than serving half of somebody's groups, and two files under the same name refuse at startup, since a rule naming one company's `engineering` would otherwise match the other's.
 
 This is the deployment with forty people and six groups in it.
-Adapters for Okta, Entra ID and Google Workspace are the next piece, and they answer the same two lookups the file does.
+
+A company with an identity provider gets an adapter instead, and an adapter answers the same two lookups the file does.
+`directory/okta` is the first one, over the Users and Groups API, and it passes the same conformance suite.
+Okta groups do not contain groups, so an expansion there is one level deep, and the group listing that answers the subject lookup already carries every group object the level below is about to ask for.
+`-directory` does not take an organisation yet, so an adapter is wired up in Go for now.
+Entra ID and Google Workspace are next, and the flag grows a spelling for all three at once.
 
 ## Metrics
 
@@ -424,6 +429,7 @@ func main() {
 | `acl` | principals, groups, permission descriptors, visibility bitmaps |
 | `directory` | a person resolved into the groups they are in, with cycle detection, a version, a union over several providers and one cache layer, [docs/identity.md](docs/identity.md) |
 | `directory/directorytest` | the conformance suite that defines what a directory adapter is |
+| `directory/okta` | group membership from an Okta organisation, over the Users and Groups API |
 | `doc` | the canonical document model every connector normalises into |
 | `store` | the storage interface, plus `storetest`, the conformance suite |
 | `store/memstore` | the reference in memory driver |

--- a/arch_test.go
+++ b/arch_test.go
@@ -37,6 +37,12 @@ var allowed = map[string][]string{
 	"directory":               {"acl", "cache"},
 	"directory/directorytest": {"acl", "directory"},
 
+	// An adapter is the one place in the tree that talks to somebody else's
+	// service, so it gets the transport that knows how to be refused politely
+	// on top of what directory itself is allowed. It is still under acl rather
+	// than beside it: an adapter answers two lookups and decides nothing.
+	"directory/okta": {"acl", "cache", "connector/limit", "directory"},
+
 	// cache is a map with a lock on it and imports nothing of ours, which is
 	// what lets index depend on it without the dependency meaning anything. A
 	// cache that knew about principals would be a second copy of the permission

--- a/connector/limit/transport.go
+++ b/connector/limit/transport.go
@@ -385,18 +385,25 @@ func repeatable(req *http.Request) bool {
 // The headers a service uses to say how much quota is left and when it comes
 // back.
 //
-// There are three conventions and no way to tell which one a service follows
+// There are four conventions and no way to tell which one a service follows
 // except by looking. Retry-After is the standard and is what a refusal carries.
 // The unprefixed RateLimit fields are the newer draft and carry a delta in
 // seconds. The X-RateLimit fields are what most large services shipped years
 // before the draft existed, and their reset is usually a Unix timestamp rather
 // than a delta.
+//
+// The fourth is the same idea with a hyphen in a different place. Okta spells
+// it X-Rate-Limit, which canonicalises to a different header name entirely, so
+// a transport reading only the other three sees an organisation that sends its
+// numbers on every single response as one that sends none at all.
 const (
 	headerRetryAfter    = "Retry-After"
 	headerReset         = "RateLimit-Reset"
 	headerRemaining     = "RateLimit-Remaining"
 	headerLegacyReset   = "X-RateLimit-Reset"
 	headerLegacyRemains = "X-RateLimit-Remaining"
+	headerHyphenReset   = "X-Rate-Limit-Reset"
+	headerHyphenRemains = "X-Rate-Limit-Remaining"
 )
 
 // retryAfter is how long a response says to wait, and zero for one that does
@@ -415,7 +422,7 @@ func retryAfter(resp *http.Response, now time.Time) time.Duration {
 			return at.Sub(now)
 		}
 	}
-	for _, h := range [...]string{headerReset, headerLegacyReset} {
+	for _, h := range [...]string{headerReset, headerLegacyReset, headerHyphenReset} {
 		if d := resetIn(resp.Header.Get(h), now); d > 0 {
 			return d
 		}
@@ -437,6 +444,7 @@ func spent(resp *http.Response, now time.Time) time.Time {
 	for _, pair := range [...][2]string{
 		{headerRemaining, headerReset},
 		{headerLegacyRemains, headerLegacyReset},
+		{headerHyphenRemains, headerHyphenReset},
 	} {
 		v := resp.Header.Get(pair[0])
 		if v == "" {

--- a/connector/limit/transport_test.go
+++ b/connector/limit/transport_test.go
@@ -202,6 +202,9 @@ func TestTheSourcesOwnRetryTimeIsHonoured(t *testing.T) {
 		{"a reset as a delta", header("RateLimit-Reset", "12"), 12 * time.Second},
 		{"a fractional reset", header("RateLimit-Reset", "1.5"), 1500 * time.Millisecond},
 		{"a legacy reset as a timestamp", header("X-RateLimit-Reset", strconv.FormatInt(start.Add(45*time.Second).Unix(), 10)), 45 * time.Second},
+		// Okta's spelling, which is a different header name once it has been
+		// canonicalised and not a variation anything reads by accident.
+		{"a reset with the hyphen in the other place", header("X-Rate-Limit-Reset", strconv.FormatInt(start.Add(60*time.Second).Unix(), 10)), 60 * time.Second},
 		{"a date already gone by", header("Retry-After", start.Add(-time.Hour).Format(http.TimeFormat)), 0},
 		{"a reset too far off to believe", header("RateLimit-Reset", "7200"), 0},
 		{"nonsense", header("Retry-After", "soon"), 0},
@@ -340,6 +343,11 @@ func TestTheQuotaBeingSpentHoldsTheNextRequestBack(t *testing.T) {
 			"the older headers",
 			header("X-RateLimit-Remaining", "0", "X-RateLimit-Reset", strconv.FormatInt(start.Add(90*time.Second).Unix(), 10)),
 			90 * time.Second,
+		},
+		{
+			"the headers with the hyphen in the other place",
+			header("X-Rate-Limit-Remaining", "0", "X-Rate-Limit-Reset", strconv.FormatInt(start.Add(120*time.Second).Unix(), 10)),
+			120 * time.Second,
 		},
 		{"some quota left", header("RateLimit-Remaining", "4", "RateLimit-Reset", "30"), 0},
 		{"no reset to go with it", header("RateLimit-Remaining", "0"), 0},

--- a/directory/directorytest/directorytest.go
+++ b/directory/directorytest/directorytest.go
@@ -25,6 +25,15 @@
 // appear once the graph is walked. An adapter is never used without the
 // resolver, so testing it without one would leave the interesting half untested.
 //
+// # Providers without nesting
+//
+// Some providers have no group graph at all. Okta is the one this was written
+// for: a user is a member of groups, a group is a member of nothing, and there
+// is nothing to walk. A fixture that sets [Fixture.Flat] skips the cases about
+// walking a graph, and the ones that lean on a single level of nesting for
+// their arithmetic count a level fewer. Everything else still runs, because
+// nothing else about what an answer means changes.
+//
 // # Usage
 //
 //	func TestConformance(t *testing.T) {
@@ -74,6 +83,51 @@ type Fixture struct {
 	// It is optional, and a fixture that cannot do it skips the case about an
 	// inconsistent directory rather than failing it.
 	Drop func(t *testing.T, group string)
+
+	// Identity prepares a subject to carry an identity this directory is able
+	// to hold, and returns the identity the expansion is expected to answer
+	// with. It is optional.
+	//
+	// Directories differ in what they can hold. [directory.Static] holds
+	// whatever it is given, which is why the default puts a Slack id on the
+	// subject and expects that back. A hosted provider holds the identities it
+	// knows about and nothing else, so an Okta organisation answers with the
+	// person's Okta id and their email addresses, and no amount of putting a
+	// Slack id on a subject will make one come out.
+	//
+	// What the case is actually about survives either way: an identity the
+	// directory knows reaches the principal, and a rule written in that
+	// vocabulary allows the person it names.
+	Identity func(t *testing.T, s *directory.Subject) acl.Identity
+
+	// Flat says the provider's groups cannot contain groups.
+	//
+	// Okta is the example: a user is a member of groups and a group is a member
+	// of nothing, so there is no graph to walk and every expansion is one level
+	// deep. The cases about walking a graph do not apply to a provider like
+	// that, and an adapter that passed them would be one that had invented a
+	// nesting the provider does not have.
+	//
+	// The default is false, so a provider that does nest runs everything.
+	Flat bool
+}
+
+// above is the membership to give a group the cases nest, which is nothing at
+// all when the provider has no nesting to give it.
+func (f Fixture) above(groups ...string) []string {
+	if f.Flat {
+		return nil
+	}
+	return groups
+}
+
+// nesting skips a case that is about walking a group graph, on a provider that
+// does not have one.
+func (f Fixture) nesting(t *testing.T) {
+	t.Helper()
+	if f.Flat {
+		t.Skip("the provider's groups cannot contain groups, so there is no graph to walk")
+	}
 }
 
 // Factory builds a fresh fixture for one case. Every case gets its own, because
@@ -144,6 +198,7 @@ func testDirect(t *testing.T, f Fixture) {
 }
 
 func testNested(t *testing.T, f Fixture) {
+	f.nesting(t)
 	f.PutGroup(t, directory.Group{ID: "everyone"})
 	f.PutGroup(t, directory.Group{ID: "engineering", MemberOf: []string{"everyone"}})
 	f.PutGroup(t, directory.Group{ID: "storage", MemberOf: []string{"engineering"}})
@@ -164,6 +219,7 @@ func testDiamond(t *testing.T, f Fixture) {
 	// rather than a corner case, and looking the shared group up twice is how
 	// an expansion over a few hundred groups turns into a few thousand
 	// requests.
+	f.nesting(t)
 	f.PutGroup(t, directory.Group{ID: "everyone"})
 	f.PutGroup(t, directory.Group{ID: "engineering", MemberOf: []string{"everyone"}})
 	f.PutGroup(t, directory.Group{ID: "operations", MemberOf: []string{"everyone"}})
@@ -181,6 +237,7 @@ func testDiamond(t *testing.T, f Fixture) {
 }
 
 func testCycle(t *testing.T, f Fixture) {
+	f.nesting(t)
 	f.PutGroup(t, directory.Group{ID: "a", MemberOf: []string{"b"}})
 	f.PutGroup(t, directory.Group{ID: "b", MemberOf: []string{"c"}})
 	f.PutGroup(t, directory.Group{ID: "c", MemberOf: []string{"a"}})
@@ -196,6 +253,7 @@ func testCycle(t *testing.T, f Fixture) {
 }
 
 func testSelfCycle(t *testing.T, f Fixture) {
+	f.nesting(t)
 	f.PutGroup(t, directory.Group{ID: "recursive", MemberOf: []string{"recursive"}})
 	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"recursive"}})
 
@@ -279,7 +337,7 @@ func testVersionMoves(t *testing.T, f Fixture) {
 
 func testVersionStable(t *testing.T, f Fixture) {
 	f.PutGroup(t, directory.Group{ID: "everyone"})
-	f.PutGroup(t, directory.Group{ID: "engineering", MemberOf: []string{"everyone"}})
+	f.PutGroup(t, directory.Group{ID: "engineering", MemberOf: f.above("everyone")})
 	f.Put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
 
 	first := expand(t, f, "mei").Groups.Version
@@ -309,15 +367,13 @@ func testVersionScoped(t *testing.T, f Fixture) {
 
 func testIdentities(t *testing.T, f Fixture) {
 	f.PutGroup(t, directory.Group{ID: "engineering"})
-	f.Put(t, directory.Subject{
-		ID:         "mei",
-		Identities: []acl.Identity{{Source: "slack", Value: "U04AB"}},
-		MemberOf:   []string{"engineering"},
-	})
+	sub := directory.Subject{ID: "mei", MemberOf: []string{"engineering"}}
+	want := f.identity(t, &sub)
+	f.Put(t, sub)
 
 	got := expand(t, f, "mei")
-	if !slices.Contains(got.Subject.Identities, acl.Identity{Source: "slack", Value: "U04AB"}) {
-		t.Fatalf("the identity the directory holds did not survive the expansion: %v", got.Subject.Identities)
+	if !slices.Contains(got.Subject.Identities, want) {
+		t.Fatalf("the identity %v the directory holds did not survive the expansion: %v", want, got.Subject.Identities)
 	}
 
 	// The whole point of an identity is that a rule written in one source's
@@ -326,12 +382,24 @@ func testIdentities(t *testing.T, f Fixture) {
 	got.Apply(p)
 	perm := acl.Permissions{
 		Mode:       acl.ModeACL,
-		Source:     "slack",
-		AllowUsers: []acl.Ref{{Source: "slack", Value: "U04AB"}},
+		Source:     want.Source,
+		AllowUsers: []acl.Ref{{Source: want.Source, Value: want.Value}},
 	}
 	if !perm.Allows(p) {
-		t.Error("a rule naming the subject by their Slack identity did not allow them")
+		t.Errorf("a rule naming the subject by their %s identity did not allow them", want.Source)
 	}
+}
+
+// identity is the identity the case about identities puts and expects, which is
+// a Slack id unless the fixture has something to say about it.
+func (f Fixture) identity(t *testing.T, s *directory.Subject) acl.Identity {
+	t.Helper()
+	if f.Identity != nil {
+		return f.Identity(t, s)
+	}
+	id := acl.Identity{Source: "slack", Value: "U04AB"}
+	s.Identities = append(s.Identities, id)
+	return id
 }
 
 func testBounded(t *testing.T, f Fixture) {
@@ -371,7 +439,7 @@ func testWide(t *testing.T, f Fixture) {
 	in := make([]string, 0, n)
 	for i := range n {
 		id := "g" + strconv.Itoa(i)
-		f.PutGroup(t, directory.Group{ID: id, MemberOf: []string{"everyone"}})
+		f.PutGroup(t, directory.Group{ID: id, MemberOf: f.above("everyone")})
 		in = append(in, id)
 	}
 	f.PutGroup(t, directory.Group{ID: "everyone"})
@@ -381,12 +449,17 @@ func testWide(t *testing.T, f Fixture) {
 	got := expand(t, f, "mei")
 	took := time.Since(start)
 
-	if len(got.Groups.Members) != n+1 {
-		t.Fatalf("a subject in %d groups resolved to %d", n, len(got.Groups.Members))
+	// The subject, the thousand groups, and the one they all point at, which is
+	// not there on a provider whose groups cannot contain groups.
+	members, lookups := n+1, n+2
+	if f.Flat {
+		members, lookups = n, n+1
 	}
-	// The subject, the thousand groups, and the one they all point at.
-	if got.Lookups != n+2 {
-		t.Errorf("a subject in %d groups cost %d lookups, want %d", n, got.Lookups, n+2)
+	if len(got.Groups.Members) != members {
+		t.Fatalf("a subject in %d groups resolved to %d, want %d", n, len(got.Groups.Members), members)
+	}
+	if got.Lookups != lookups {
+		t.Errorf("a subject in %d groups cost %d lookups, want %d", n, got.Lookups, lookups)
 	}
 	if took > 10*time.Second {
 		t.Errorf("a subject in %d groups took %s", n, took.Round(time.Millisecond))

--- a/directory/okta/fake_test.go
+++ b/directory/okta/fake_test.go
@@ -1,0 +1,365 @@
+package okta_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tamnd/genba/directory"
+)
+
+// token is what the fake expects, and it is not a secret in a recording because
+// the recording is of this and not of anybody's organisation.
+const token = "00fakeApiTokenForTests"
+
+// org is a fake Okta organisation.
+//
+// It is enough of one to be wrong against: the three endpoints the adapter
+// reads, the SSWS scheme, the Link header pagination, and the two timestamps
+// Okta keeps on a group. What it is not is a mock. Nothing here asserts that a
+// particular call was made, because the whole point of the conformance suite is
+// that the adapter is judged on its answers.
+type org struct {
+	mu     sync.Mutex
+	users  map[string]*person
+	groups map[string]*team
+
+	// clock stands in for a timestamp and moves whenever anything is written,
+	// so that a revision is a revision and not a wall clock the tests would
+	// have to sleep for.
+	clock int
+
+	// page is how many groups it will put in one page of a listing.
+	page int
+
+	// calls counts requests per route, for the cases that are about how many
+	// requests an expansion costs rather than what it answers.
+	calls map[string]int
+}
+
+type person struct {
+	id, status                string
+	updated                   string
+	login, email, secondEmail string
+	first, last, display      string
+	memberOf                  []string
+}
+
+type team struct {
+	id, name           string
+	updated, memberSet string
+}
+
+// newOrg starts a fake organisation and returns it with its base URL.
+func newOrg(t *testing.T) (fake *org, base string) {
+	t.Helper()
+	o := &org{
+		users:  map[string]*person{},
+		groups: map[string]*team{},
+		page:   200,
+		calls:  map[string]int{},
+	}
+	srv := httptest.NewServer(o.routes())
+	t.Cleanup(srv.Close)
+	return o, srv.URL
+}
+
+func (o *org) routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/users/{id}", o.user)
+	mux.HandleFunc("GET /api/v1/users/{id}/groups", o.memberships)
+	mux.HandleFunc("GET /api/v1/groups/{id}", o.group)
+	return o.authorised(mux)
+}
+
+// authorised is the SSWS scheme. An API token is not a bearer token and Okta
+// refuses it under the other name, so the fake does too, otherwise an adapter
+// that sent the wrong one would pass every test here and work against nobody's
+// organisation.
+func (o *org) authorised(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "SSWS "+token {
+			refuse(w, http.StatusUnauthorized, "E0000011", "Invalid token provided")
+			return
+		}
+		if r.Header.Get("Accept") != "application/json" {
+			refuse(w, http.StatusNotAcceptable, "E0000009", "The request was not acceptable")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (o *org) user(w http.ResponseWriter, r *http.Request) {
+	o.mu.Lock()
+	o.calls["user"]++
+	u, ok := o.users[r.PathValue("id")]
+	body := any(nil)
+	if ok {
+		body = u.json()
+	}
+	o.mu.Unlock()
+
+	if !ok {
+		refuse(w, http.StatusNotFound, "E0000007", "Not found: Resource not found: "+r.PathValue("id")+" (User)")
+		return
+	}
+	send(w, body)
+}
+
+func (o *org) group(w http.ResponseWriter, r *http.Request) {
+	o.mu.Lock()
+	o.calls["group"]++
+	g, ok := o.groups[r.PathValue("id")]
+	body := any(nil)
+	if ok {
+		body = g.json()
+	}
+	o.mu.Unlock()
+
+	if !ok {
+		refuse(w, http.StatusNotFound, "E0000007", "Not found: Resource not found: "+r.PathValue("id")+" (UserGroup)")
+		return
+	}
+	send(w, body)
+}
+
+// memberships is the listing the adapter reads a whole group set out of, one
+// page at a time.
+func (o *org) memberships(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	o.mu.Lock()
+	o.calls["memberships"]++
+	u, ok := o.users[id]
+	var held []*team
+	if ok {
+		// Sorted, because a cursor over an unordered listing is a page boundary
+		// that moves and a group that is served twice or not at all.
+		for _, name := range slices.Sorted(slices.Values(u.memberOf)) {
+			if g, ok := o.groups[name]; ok {
+				held = append(held, g)
+			}
+		}
+	}
+	size := o.page
+	o.mu.Unlock()
+
+	if !ok {
+		refuse(w, http.StatusNotFound, "E0000007", "Not found: Resource not found: "+id+" (User)")
+		return
+	}
+
+	if limit, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && limit > 0 && limit < size {
+		size = limit
+	}
+	after := r.URL.Query().Get("after")
+	if after != "" {
+		held = held[min(cursor(held, after), len(held)):]
+	}
+
+	// The self link carries a filter with a comma in it, which is legal and is
+	// the thing a Link header parser that splits on every comma gets wrong.
+	self := fmt.Sprintf(`<%s?%s>; rel="self"`, o.url(r), url.Values{
+		"filter": {`type eq "OKTA_GROUP", "APP_GROUP"`},
+	}.Encode())
+	w.Header().Add("Link", self)
+
+	if len(held) > size {
+		held = held[:size]
+		next := url.Values{"limit": {strconv.Itoa(size)}, "after": {last(held)}}
+		w.Header().Add("Link", fmt.Sprintf(`<%s?%s>; rel="next"`, o.url(r), next.Encode()))
+	}
+	page := make([]map[string]any, 0, len(held))
+	for _, g := range held {
+		page = append(page, g.json())
+	}
+	send(w, page)
+}
+
+// url is this request without its query, which is what a link back to it is
+// built from.
+func (o *org) url(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host + r.URL.Path
+}
+
+// cursor is where in the listing the page after the given id starts.
+func cursor(held []*team, after string) int {
+	for i, g := range held {
+		if g.id == after {
+			return i + 1
+		}
+	}
+	return len(held)
+}
+
+func last(held []*team) string { return held[len(held)-1].id }
+
+// put adds or replaces one person, in the shape the conformance suite hands
+// them over in.
+func (o *org) put(t *testing.T, s directory.Subject) {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.clock++
+	u := &person{
+		id:       s.ID,
+		status:   "ACTIVE",
+		updated:  o.stamp(),
+		email:    s.Email,
+		display:  s.Name,
+		memberOf: slices.Clone(s.MemberOf),
+	}
+	if s.Disabled {
+		u.status = "SUSPENDED"
+	}
+	if u.email == "" {
+		u.email = s.ID + "@example.test"
+	}
+	u.login = u.email
+
+	// Membership is a fact about the group in Okta rather than about the
+	// person, so joining or leaving one moves the group's membership revision.
+	// The adapter is expected not to build a version out of that, and this is
+	// what makes the case about it mean something.
+	held := map[string]bool{}
+	if was, ok := o.users[s.ID]; ok {
+		for _, g := range was.memberOf {
+			held[g] = true
+		}
+	}
+	for _, g := range s.MemberOf {
+		if held[g] {
+			delete(held, g)
+			continue
+		}
+		o.touch(g)
+	}
+	for g := range held {
+		o.touch(g)
+	}
+	o.users[s.ID] = u
+}
+
+// putGroup adds or replaces one group.
+func (o *org) putGroup(t *testing.T, g directory.Group) {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.clock++
+	name := g.Name
+	if name == "" {
+		name = g.ID
+	}
+	o.groups[g.ID] = &team{id: g.ID, name: name, updated: o.stamp(), memberSet: o.stamp()}
+}
+
+// touch moves a group's membership revision without moving the group itself.
+func (o *org) touch(id string) {
+	if g, ok := o.groups[id]; ok {
+		o.clock++
+		g.memberSet = o.stamp()
+	}
+}
+
+// stamp is a revision in the shape Okta writes one, moving with the counter
+// rather than with a wall clock nothing would want to wait for.
+func (o *org) stamp() string {
+	return fmt.Sprintf("2026-01-01T00:00:00.%03dZ", o.clock)
+}
+
+// count is how many times a route has been asked.
+func (o *org) count(route string) int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.calls[route]
+}
+
+// forget resets the counts, for a case that wants to measure one expansion.
+func (o *org) forget() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	clear(o.calls)
+}
+
+func (u *person) json() map[string]any {
+	return map[string]any{
+		"id":          u.id,
+		"status":      u.status,
+		"created":     "2026-01-01T00:00:00.000Z",
+		"lastUpdated": u.updated,
+		"profile": map[string]any{
+			"login":       u.login,
+			"email":       u.email,
+			"secondEmail": u.secondEmail,
+			"firstName":   u.first,
+			"lastName":    u.last,
+			"displayName": u.display,
+		},
+	}
+}
+
+func (g *team) json() map[string]any {
+	return map[string]any{
+		"id":                    g.id,
+		"created":               "2026-01-01T00:00:00.000Z",
+		"lastUpdated":           g.updated,
+		"lastMembershipUpdated": g.memberSet,
+		"type":                  "OKTA_GROUP",
+		"profile": map[string]any{
+			"name":        g.name,
+			"description": "",
+		},
+	}
+}
+
+func send(w http.ResponseWriter, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	// The numbers Okta puts on every answer, which is what the transport reads
+	// to slow itself down before it is refused rather than after.
+	w.Header().Set("X-Rate-Limit-Limit", "600")
+	w.Header().Set("X-Rate-Limit-Remaining", "599")
+	w.Header().Set("X-Rate-Limit-Reset", "1767225600")
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func refuse(w http.ResponseWriter, status int, code, summary string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"errorCode":    code,
+		"errorSummary": summary,
+		"errorLink":    code,
+		"errorId":      "oaeFakeRequestId",
+		"errorCauses":  []any{},
+	})
+}
+
+// edit changes one person in place, for the account states and profile fields
+// the conformance suite has no vocabulary for.
+func (o *org) edit(t *testing.T, id string, change func(*person)) {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	u, ok := o.users[id]
+	if !ok {
+		t.Fatalf("the fake organisation holds nobody called %q", id)
+	}
+	change(u)
+}
+
+// describe is a group set written the way a failure is easiest to read.
+func describe(members []string) string { return strings.Join(members, " ") }

--- a/directory/okta/okta.go
+++ b/directory/okta/okta.go
@@ -1,0 +1,568 @@
+// Package okta resolves group membership against an Okta organisation.
+//
+// It answers the two lookups [directory.Directory] asks for and nothing else.
+// The closure, the cycle detection, the bound on how much one expansion may
+// cost and the version an answer is stamped with are all in [directory], and
+// they are shared by every provider, because those are exactly the parts that
+// are easy to get subtly wrong and impossible to notice from the outside.
+//
+// # Okta groups do not contain groups
+//
+// This is the one fact about the provider that shapes everything here. Okta's
+// model is flat: a user is a member of groups, and a group is a member of
+// nothing. There is no nesting to walk, so [Directory.Group] always answers
+// with an empty membership and every expansion is one level deep.
+//
+// That has a consequence for cost. The walk asks about each group the user is
+// in, and a person in three hundred groups would be three hundred requests
+// against an organisation that everybody else is signing in to at the same
+// time. So the group listing that answers the subject lookup, which returns the
+// whole group object rather than an id, fills a small buffer that the group
+// lookups then read.
+//
+// It is worth being precise about why that is not a second permission cache,
+// because [directory.Cache] documents at some length why there is only one of
+// those. The fact being held here is "this group exists and is a member of no
+// groups", and for a provider with no nesting that fact cannot become false in
+// a way that changes an answer. A group that was deleted since it was buffered
+// would move into [directory.Expansion] Unknown if it were looked up again, and
+// a group in Unknown is still in the group set, because the directory saying
+// somebody is a member is a statement about them. So the buffer changes how
+// many requests an expansion costs and cannot change what it returns.
+//
+// # What counts as deactivated
+//
+// Okta has eight account states and only some of them are a person who can
+// still be signed in. SUSPENDED and DEPROVISIONED are the two an administrator
+// reaches for when somebody leaves, and STAGED is an account that was created
+// and never activated. All three refuse. LOCKED_OUT and PASSWORD_EXPIRED do
+// not, because both are a live account having a bad morning and neither is a
+// decision anybody made about their access.
+//
+// # Rate limits
+//
+// Okta publishes its own numbers on every response and refuses with a 429 and
+// a reset when they run out, which is what [limit] is for. The retries, the
+// backoff and the circuit breaker are the same ones every adapter in this
+// repository uses.
+//
+// The one thing worth knowing is that Okta spells the headers
+// X-Rate-Limit-Remaining and X-Rate-Limit-Reset, with the hyphen in a different
+// place from everybody else, and that canonicalises to a different header name
+// entirely rather than to a variation something reads by accident. [limit]
+// reads that spelling too, which is what makes holding back before a refusal
+// possible here rather than only after one.
+package okta
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/cache"
+	"github.com/tamnd/genba/connector/limit"
+	"github.com/tamnd/genba/directory"
+)
+
+// DefaultName is the identity source the groups belong to, which is what every
+// group key from this organisation is prefixed with.
+const DefaultName = "okta"
+
+// DefaultPageSize is how many groups are asked for per page. Okta accepts up to
+// a thousand on this endpoint and two hundred is what it suggests.
+const DefaultPageSize = 200
+
+// DefaultBufferTTL is how long the group listing that answered a subject lookup
+// is kept for the group lookups that follow it.
+//
+// It is short because it only has to outlive one expansion, which is one round
+// trip and a handful of lookups. See the package documentation for why holding
+// it for longer would not change an answer either.
+const DefaultBufferTTL = 30 * time.Second
+
+// DefaultBufferSize is how many groups the buffer holds before it starts
+// dropping the ones nobody has asked about recently.
+const DefaultBufferSize = 20000
+
+// Directory resolves subjects and groups against one Okta organisation.
+//
+// It is safe for concurrent use, which it has to be: an expansion looks up a
+// level of the graph in parallel.
+type Directory struct {
+	http  *http.Client
+	base  string
+	token string
+	name  string
+	page  int
+
+	// held is the group listing from a subject lookup, waiting for the group
+	// lookups that are about to ask for the same objects.
+	held *cache.Cache[directory.Group]
+}
+
+var _ directory.Directory = (*Directory)(nil)
+
+// Option configures a [Directory].
+type Option func(*Directory)
+
+// WithName sets the identity source the group ids belong to.
+//
+// A deployment resolving against two organisations needs two names, because
+// "00g1abcd" from one and "00g1abcd" from the other would otherwise be the same
+// group, and they are not.
+func WithName(name string) Option {
+	return func(d *Directory) { d.name = name }
+}
+
+// WithHTTPClient replaces the client entirely, rate limiting included.
+//
+// A caller who passes one is taking on the limits themselves, which is right
+// for a test replaying a recording and wrong for anything talking to Okta.
+func WithHTTPClient(c *http.Client) Option {
+	return func(d *Directory) {
+		if c != nil {
+			d.http = c
+		}
+	}
+}
+
+// WithLimits changes what the organisation is allowed to cost.
+func WithLimits(l limit.Limits) Option {
+	return func(d *Directory) { d.http = throttled(l) }
+}
+
+// WithPageSize sets how many groups are asked for per page. A size below one
+// selects [DefaultPageSize].
+func WithPageSize(n int) Option {
+	return func(d *Directory) { d.page = n }
+}
+
+// WithBuffer sets how long and how much of the group listing is kept for the
+// group lookups that follow it. A size below one selects [DefaultBufferSize].
+//
+// A lifetime below one turns the buffer off, which is a request per group in
+// the set rather than one listing. That is correct and slow, so it is for a
+// test that wants to count the requests rather than for a deployment.
+func WithBuffer(ttl time.Duration, size int) Option {
+	return func(d *Directory) {
+		if ttl < 1 {
+			d.held = nil
+			return
+		}
+		if size < 1 {
+			size = DefaultBufferSize
+		}
+		d.held = cache.New[directory.Group](size, ttl)
+	}
+}
+
+// New returns a directory over an Okta organisation.
+//
+// The org is the URL of the tenant, "https://acme.okta.com", and the token is
+// an API token, which Okta sends as SSWS rather than as a bearer.
+func New(org, token string, opts ...Option) (*Directory, error) {
+	if org == "" {
+		return nil, errors.New("okta: an organisation URL is required")
+	}
+	if token == "" {
+		return nil, errors.New("okta: an API token is required")
+	}
+	u, err := url.Parse(org)
+	if err != nil {
+		return nil, fmt.Errorf("okta: the organisation URL %q: %w", org, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("okta: the organisation URL %q needs a scheme and a host", org)
+	}
+
+	d := &Directory{
+		http:  throttled(limit.Limits{}),
+		base:  strings.TrimSuffix(org, "/"),
+		token: token,
+		name:  DefaultName,
+		page:  DefaultPageSize,
+		held:  cache.New[directory.Group](DefaultBufferSize, DefaultBufferTTL),
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	if d.name == "" {
+		return nil, errors.New("okta: the source name cannot be empty")
+	}
+	if d.page < 1 {
+		d.page = DefaultPageSize
+	}
+	return d, nil
+}
+
+// throttled is the client used when the caller has not supplied one.
+func throttled(l limit.Limits) *http.Client {
+	return &http.Client{Transport: limit.NewTransport(l)}
+}
+
+// Name is the identity source these ids belong to.
+func (d *Directory) Name() string { return d.name }
+
+// Subject returns one person, with the groups they are directly in.
+//
+// It is two requests plus a page of groups: Okta answers a user and their group
+// memberships from separate endpoints and there is no expand parameter that
+// merges them.
+func (d *Directory) Subject(ctx context.Context, id string) (directory.Subject, error) {
+	if id == "" {
+		return directory.Subject{}, fmt.Errorf("okta: %w", directory.ErrNoSubject)
+	}
+
+	var u user
+	if err := d.get(ctx, "/api/v1/users/"+url.PathEscape(id), nil, &u); err != nil {
+		if errors.Is(err, errNotFound) {
+			return directory.Subject{}, fmt.Errorf("okta: %q: %w", id, directory.ErrNoSubject)
+		}
+		return directory.Subject{}, err
+	}
+
+	sub := directory.Subject{
+		ID:         cmp.Or(u.ID, id),
+		Name:       u.Profile.displayName(),
+		Email:      u.Profile.Email,
+		Version:    u.LastUpdated,
+		Identities: d.identities(u),
+		Disabled:   deactivated(u.Status),
+	}
+	// A deactivated account is refused by the resolver, so the group listing it
+	// would have needed is a request nobody is going to read the answer to.
+	if sub.Disabled {
+		return sub, nil
+	}
+
+	groups, err := d.memberships(ctx, u.ID)
+	if err != nil {
+		return directory.Subject{}, err
+	}
+	sub.MemberOf = make([]string, 0, len(groups))
+	for _, g := range groups {
+		sub.MemberOf = append(sub.MemberOf, g.ID)
+		d.buffer(g)
+	}
+	return sub, nil
+}
+
+// buffer keeps a group object for the lookup that is about to ask for it.
+func (d *Directory) buffer(g directory.Group) {
+	if d.held != nil {
+		d.held.Put(g.ID, g)
+	}
+}
+
+// buffered is the group object a listing already went past, if there is one.
+func (d *Directory) buffered(id string) (directory.Group, bool) {
+	if d.held == nil {
+		return directory.Group{}, false
+	}
+	return d.held.Get(id)
+}
+
+// Group returns one group.
+//
+// The membership is always empty, because Okta groups do not contain groups,
+// and the lookup is usually free, because the listing that answered the subject
+// put the object here on its way past. See the package documentation for why
+// that cannot change an answer.
+func (d *Directory) Group(ctx context.Context, id string) (directory.Group, error) {
+	if id == "" {
+		return directory.Group{}, fmt.Errorf("okta: %w", directory.ErrNoGroup)
+	}
+	if g, ok := d.buffered(id); ok {
+		return g, nil
+	}
+
+	var raw group
+	if err := d.get(ctx, "/api/v1/groups/"+url.PathEscape(id), nil, &raw); err != nil {
+		if errors.Is(err, errNotFound) {
+			return directory.Group{}, fmt.Errorf("okta: %q: %w", id, directory.ErrNoGroup)
+		}
+		return directory.Group{}, err
+	}
+	g := raw.directory(id)
+	d.buffer(g)
+	return g, nil
+}
+
+// memberships reads every group a user is in, following the pages.
+func (d *Directory) memberships(ctx context.Context, id string) ([]directory.Group, error) {
+	var (
+		out  []directory.Group
+		path = "/api/v1/users/" + url.PathEscape(id) + "/groups"
+		q    = url.Values{"limit": {strconv.Itoa(d.page)}}
+	)
+	// Bounded because the page after the last one is a link the service sends,
+	// and a service that sent the same link twice would otherwise be an
+	// expansion that never returned. The resolver's own bound is on groups
+	// reached rather than on requests made, so it would not catch this.
+	for range maxPages {
+		var page []group
+		next, err := d.page1(ctx, path, q, &page)
+		if err != nil {
+			return nil, err
+		}
+		for _, raw := range page {
+			if raw.ID == "" {
+				continue
+			}
+			out = append(out, raw.directory(raw.ID))
+		}
+		if next == "" {
+			return out, nil
+		}
+		u, err := url.Parse(next)
+		if err != nil {
+			return nil, fmt.Errorf("okta: the next page link %q: %w", next, err)
+		}
+		path, q = u.Path, u.Query()
+	}
+	return nil, fmt.Errorf("okta: the groups of %q did not stop after %d pages", id, maxPages)
+}
+
+// maxPages bounds a listing. At the default page size it is two hundred
+// thousand groups, which is far past anybody's organisation and well short of
+// forever.
+const maxPages = 1000
+
+// user is what Okta says about one person.
+type user struct {
+	ID          string  `json:"id"`
+	Status      string  `json:"status"`
+	LastUpdated string  `json:"lastUpdated"`
+	Profile     profile `json:"profile"`
+}
+
+type profile struct {
+	Login       string `json:"login"`
+	Email       string `json:"email"`
+	SecondEmail string `json:"secondEmail"`
+	FirstName   string `json:"firstName"`
+	LastName    string `json:"lastName"`
+	DisplayName string `json:"displayName"`
+}
+
+// displayName is what to call somebody, in the order Okta itself falls back.
+func (p profile) displayName() string {
+	if p.DisplayName != "" {
+		return p.DisplayName
+	}
+	if name := strings.TrimSpace(p.FirstName + " " + p.LastName); name != "" {
+		return name
+	}
+	return p.Login
+}
+
+// group is what Okta says about one group.
+type group struct {
+	ID          string       `json:"id"`
+	LastUpdated string       `json:"lastUpdated"`
+	Profile     groupProfile `json:"profile"`
+}
+
+type groupProfile struct {
+	Name string `json:"name"`
+}
+
+// directory turns one into what the resolver walks.
+//
+// The membership is empty and that is not an omission: Okta groups do not
+// contain groups.
+//
+// The version is the group object's own revision, and the interesting part is
+// which revision it is not. Okta also sends lastMembershipUpdated, which is the
+// obvious choice and the wrong one. It moves when anybody at all joins the
+// group, and what this version invalidates is one person's group set, which
+// somebody else joining does not change. At a company of any size something
+// moves every second, so a version derived from it would be correct and
+// useless: nothing cached above it would ever survive to be reused.
+//
+// This person joining or leaving is caught without it, because the group set is
+// fingerprinted over the group ids as well as their versions, and joining or
+// leaving is what changes the ids. For a provider that nests, the group version
+// is also what catches a group being moved under another one. Okta does not
+// nest, so there is nothing else for it to catch.
+func (g group) directory(id string) directory.Group {
+	return directory.Group{
+		ID:      cmp.Or(g.ID, id),
+		Name:    g.Profile.Name,
+		Version: g.LastUpdated,
+	}
+}
+
+// identities is the same person in the systems being indexed.
+//
+// The Okta id is one of them, because a connector that was told about groups by
+// Okta names people the same way. The addresses are the others, because a rule
+// granting to somebody by email is the common shape and an email address is
+// what a person has in every product they use.
+func (d *Directory) identities(u user) []acl.Identity {
+	out := make([]acl.Identity, 0, 4)
+	add := func(source, value string) {
+		if value == "" {
+			return
+		}
+		id := acl.Identity{Source: source, Value: value}
+		if slices.Contains(out, id) {
+			return
+		}
+		out = append(out, id)
+	}
+	add(d.name, u.ID)
+	add("email", u.Profile.Email)
+	// A login is an email address at almost every organisation and is something
+	// else at the few that use a directory of their own, so it is only an email
+	// identity when it looks like one.
+	if strings.Contains(u.Profile.Login, "@") {
+		add("email", u.Profile.Login)
+	}
+	add("email", u.Profile.SecondEmail)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// deactivated says whether an account state is somebody who should stop
+// resolving. See the package documentation for why these three and not the
+// others.
+func deactivated(status string) bool {
+	switch strings.ToUpper(status) {
+	case "SUSPENDED", "DEPROVISIONED", "STAGED", "DELETED":
+		return true
+	default:
+		return false
+	}
+}
+
+// errNotFound is Okta answering rather than failing to answer, and it is what
+// separates a subject the organisation does not hold from an organisation that
+// could not be reached.
+var errNotFound = errors.New("not found")
+
+// get reads one JSON document.
+func (d *Directory) get(ctx context.Context, path string, q url.Values, into any) error {
+	_, err := d.page1(ctx, path, q, into)
+	return err
+}
+
+// page1 reads one response into a value and returns the link to the page after
+// it, if the service sent one.
+func (d *Directory) page1(ctx context.Context, path string, q url.Values, into any) (string, error) {
+	u := d.base + path
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("okta: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	// SSWS rather than Bearer. An API token is not an OAuth token and Okta
+	// refuses it under the other scheme.
+	req.Header.Set("Authorization", "SSWS "+d.token)
+
+	resp, err := d.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("okta: %s: %w", path, err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", d.refusal(path, resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(into); err != nil {
+		return "", fmt.Errorf("okta: %s: reading the answer: %w", path, err)
+	}
+	return nextLink(resp.Header.Values("Link")), nil
+}
+
+// refusal turns a response Okta refused with into an error worth reading.
+//
+// The body carries a code and a summary, and both go in the message: the code
+// is what the operator searches for, and the summary is what tells them whether
+// it is about a token or about a user.
+func (d *Directory) refusal(path string, resp *http.Response) error {
+	var body struct {
+		ErrorCode    string `json:"errorCode"`
+		ErrorSummary string `json:"errorSummary"`
+	}
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_ = json.Unmarshal(raw, &body)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return errNotFound
+	}
+	switch {
+	case body.ErrorCode != "" && body.ErrorSummary != "":
+		return fmt.Errorf("okta: %s: %s: %s (%s)", path, resp.Status, body.ErrorSummary, body.ErrorCode)
+	case body.ErrorSummary != "":
+		return fmt.Errorf("okta: %s: %s: %s", path, resp.Status, body.ErrorSummary)
+	default:
+		return fmt.Errorf("okta: %s: %s", path, resp.Status)
+	}
+}
+
+// nextLink reads the page after this one out of the Link headers.
+//
+// Okta sends several of them, one per relation, and the one that matters is
+// rel="next". A listing that read the first link it saw would follow rel="self"
+// and ask the same question until something stopped it.
+func nextLink(headers []string) string {
+	for _, h := range headers {
+		for _, part := range links(h) {
+			link, params, ok := strings.Cut(part, ";")
+			if !ok {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(params), `rel="next"`) {
+				continue
+			}
+			return strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(link), "<"), ">")
+		}
+	}
+	return ""
+}
+
+// links splits one Link header into its entries.
+//
+// Not by comma, because the URL is inside angle brackets and a filter or a
+// cursor in it may contain one. Splitting on every comma would hand back half a
+// URL, and half a URL that happens to parse is a request to the wrong place.
+func links(h string) []string {
+	var (
+		out   []string
+		depth int
+		start int
+	)
+	for i, r := range h {
+		switch r {
+		case '<':
+			depth++
+		case '>':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, strings.TrimSpace(h[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	return append(out, strings.TrimSpace(h[start:]))
+}

--- a/directory/okta/okta_test.go
+++ b/directory/okta/okta_test.go
@@ -1,0 +1,437 @@
+package okta_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/directorytest"
+	"github.com/tamnd/genba/directory/okta"
+)
+
+// TestConformance is the suite every adapter has to pass, over a fake
+// organisation.
+//
+// Flat, because Okta groups do not contain groups, so the cases about walking a
+// graph are about a provider this is not. No Drop, because a membership in Okta
+// is a fact stored on the group and the organisation cannot get into the state
+// that case describes on its own.
+func TestConformance(t *testing.T) {
+	directorytest.Run(t, func(t *testing.T) directorytest.Fixture {
+		o, base := newOrg(t)
+		return directorytest.Fixture{
+			Directory: dial(t, base),
+			Put:       o.put,
+			PutGroup:  o.putGroup,
+			Flat:      true,
+			Identity: func(t *testing.T, s *directory.Subject) acl.Identity {
+				t.Helper()
+				s.Email = "mei@acme.test"
+				return acl.Identity{Source: "email", Value: "mei@acme.test"}
+			},
+		}
+	})
+}
+
+// dial is the adapter under test, pointed at a fake.
+func dial(t *testing.T, base string, opts ...okta.Option) *okta.Directory {
+	t.Helper()
+	d, err := okta.New(base, token, append([]okta.Option{
+		okta.WithHTTPClient(http.DefaultClient),
+	}, opts...)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// expand resolves one person through the resolver, which is the only way an
+// adapter is ever used.
+func expand(t *testing.T, d directory.Directory, id string, opts ...directory.Option) directory.Expansion {
+	t.Helper()
+	r, err := directory.New(d, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := r.Expand(t.Context(), id)
+	if err != nil {
+		t.Fatalf("expanding %q: %v", id, err)
+	}
+	return got
+}
+
+// joins puts somebody in n groups and hands back the fake and the adapter.
+func joins(t *testing.T, n int, opts ...okta.Option) (*org, *okta.Directory) {
+	t.Helper()
+	o, base := newOrg(t)
+	in := make([]string, 0, n)
+	for i := range n {
+		id := "g" + strconv.Itoa(i)
+		o.putGroup(t, directory.Group{ID: id})
+		in = append(in, id)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: in})
+	return o, dial(t, base, opts...)
+}
+
+// The reason the buffer exists. A person in three hundred groups would be three
+// hundred group lookups against an organisation everybody else is signing in
+// to, and the listing that answered the subject already carried every one of
+// those objects past on its way here.
+func TestTheGroupsAListingAlreadyCarriedAreNotAskedForAgain(t *testing.T) {
+	o, d := joins(t, 300)
+	o.forget()
+
+	got := expand(t, d, "mei")
+	if len(got.Groups.Members) != 300 {
+		t.Fatalf("a person in 300 groups resolved to %d", len(got.Groups.Members))
+	}
+	if n := o.count("group"); n != 0 {
+		t.Errorf("resolving somebody cost %d group lookups on top of the listing that already held them", n)
+	}
+	if n := o.count("user"); n != 1 {
+		t.Errorf("resolving somebody read the user %d times", n)
+	}
+}
+
+// And with it off the same expansion is a request each, which is what says the
+// number above is the buffer working rather than the fake being asked nothing.
+func TestWithTheBufferOffEveryGroupIsARequest(t *testing.T) {
+	o, d := joins(t, 20, okta.WithBuffer(0, 0))
+	o.forget()
+
+	got := expand(t, d, "mei")
+	if len(got.Groups.Members) != 20 {
+		t.Fatalf("a person in 20 groups resolved to %d", len(got.Groups.Members))
+	}
+	if n := o.count("group"); n != 20 {
+		t.Errorf("an unbuffered expansion cost %d group lookups, want 20", n)
+	}
+}
+
+// A listing arrives a page at a time and the pages are followed. An adapter
+// that read the first one and stopped would give somebody a fraction of their
+// groups, which is somebody quietly getting fewer search results.
+//
+// The fake sends a rel="self" link as well, with a comma inside the URL, which
+// is legal and is what a Link header read by splitting on every comma gets
+// wrong. An adapter that followed self would ask the same question until
+// something stopped it.
+func TestAListingIsFollowedAcrossItsPages(t *testing.T) {
+	o, d := joins(t, 25, okta.WithPageSize(4))
+	o.forget()
+
+	got := expand(t, d, "mei")
+	if len(got.Groups.Members) != 25 {
+		t.Fatalf("a person in 25 groups over pages of 4 resolved to %d: %s", len(got.Groups.Members), describe(got.Groups.Members))
+	}
+	// Seven pages, because the last full one is followed by an empty one only
+	// if the service says there is one, and this one does not.
+	if n := o.count("memberships"); n != 7 {
+		t.Errorf("25 groups in pages of 4 took %d requests, want 7", n)
+	}
+}
+
+// A page boundary that moves would serve a group twice or not at all, so the
+// listing is ordered and the cursor is a position in that order.
+func TestNoGroupIsServedTwiceOrMissedAcrossAPageBoundary(t *testing.T) {
+	_, d := joins(t, 9, okta.WithPageSize(2))
+
+	got := expand(t, d, "mei")
+	want := make([]string, 0, 9)
+	for i := range 9 {
+		want = append(want, "okta:g"+strconv.Itoa(i))
+	}
+	slices.Sort(want)
+	if !slices.Equal(got.Groups.Members, want) {
+		t.Errorf("paging gave %s", describe(got.Groups.Members))
+	}
+}
+
+// Okta has eight account states and only some of them are a decision somebody
+// made about access. Refusing on the others would lock people out of search for
+// forgetting a password.
+func TestOnlyTheStatesThatMeanSomebodyLeftAreRefused(t *testing.T) {
+	tests := []struct {
+		status  string
+		refused bool
+	}{
+		{"ACTIVE", false},
+		{"PROVISIONED", false},
+		{"RECOVERY", false},
+		{"LOCKED_OUT", false},
+		{"PASSWORD_EXPIRED", false},
+		{"STAGED", true},
+		{"SUSPENDED", true},
+		{"DEPROVISIONED", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			o, base := newOrg(t)
+			o.putGroup(t, directory.Group{ID: "engineering"})
+			o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+			o.edit(t, "mei", func(u *person) { u.status = tt.status })
+
+			r, err := directory.New(dial(t, base))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := r.Expand(t.Context(), "mei")
+			switch {
+			case tt.refused && !errors.Is(err, directory.ErrDisabled):
+				t.Fatalf("%s resolved with %v, want ErrDisabled", tt.status, err)
+			case tt.refused && len(got.Groups.Members) != 0:
+				t.Errorf("a refused expansion handed back %s", describe(got.Groups.Members))
+			case !tt.refused && err != nil:
+				t.Fatalf("%s was refused with %v", tt.status, err)
+			case !tt.refused && len(got.Groups.Members) != 1:
+				t.Errorf("%s resolved to %s", tt.status, describe(got.Groups.Members))
+			}
+		})
+	}
+}
+
+// A refused account is refused before the group listing, because nobody is
+// going to read the answer to it.
+func TestARefusedAccountDoesNotCostAListing(t *testing.T) {
+	o, base := newOrg(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "lee", MemberOf: []string{"engineering"}, Disabled: true})
+	o.forget()
+
+	r, err := directory.New(dial(t, base))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Expand(t.Context(), "lee"); !errors.Is(err, directory.ErrDisabled) {
+		t.Fatalf("a suspended account gave %v", err)
+	}
+	if n := o.count("memberships"); n != 0 {
+		t.Errorf("a refused account cost %d group listings", n)
+	}
+}
+
+// The whole point of an identity is a rule written where the document lives
+// applying to somebody who signed in through Okta, and the address is what
+// those rules are usually written in.
+func TestBothAddressesAndTheOktaIdBecomeIdentities(t *testing.T) {
+	o, base := newOrg(t)
+	o.put(t, directory.Subject{ID: "00u1mei", Email: "mei@acme.test"})
+	o.edit(t, "00u1mei", func(u *person) { u.secondEmail = "mei@personal.test" })
+
+	got := expand(t, dial(t, base), "00u1mei")
+	for _, want := range []acl.Identity{
+		{Source: "okta", Value: "00u1mei"},
+		{Source: "email", Value: "mei@acme.test"},
+		{Source: "email", Value: "mei@personal.test"},
+	} {
+		if !slices.Contains(got.Subject.Identities, want) {
+			t.Errorf("%v is not among the identities %v", want, got.Subject.Identities)
+		}
+	}
+}
+
+// A login is an email address at almost every organisation and is a username at
+// the few that use a directory of their own. Turning one of those into an email
+// identity would be a rule granting to an address matching somebody who does
+// not have it.
+func TestALoginThatIsNotAnAddressIsNotAnEmailIdentity(t *testing.T) {
+	o, base := newOrg(t)
+	o.put(t, directory.Subject{ID: "00u1mei", Email: "mei@acme.test"})
+	o.edit(t, "00u1mei", func(u *person) { u.login = "mei.nakamura" })
+
+	got := expand(t, dial(t, base), "00u1mei")
+	if slices.Contains(got.Subject.Identities, acl.Identity{Source: "email", Value: "mei.nakamura"}) {
+		t.Errorf("a username became an email address: %v", got.Subject.Identities)
+	}
+}
+
+func TestTheDisplayNameFallsBackTheWayOktaDoes(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*person)
+		want string
+	}{
+		{"the display name when there is one", func(u *person) {
+			u.display, u.first, u.last = "Mei N", "Mei", "Nakamura"
+		}, "Mei N"},
+		{"the two halves of the name otherwise", func(u *person) {
+			u.first, u.last = "Mei", "Nakamura"
+		}, "Mei Nakamura"},
+		{"the login when there is nothing else", func(u *person) {
+			u.login = "mei.nakamura"
+		}, "mei.nakamura"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o, base := newOrg(t)
+			o.put(t, directory.Subject{ID: "mei"})
+			o.edit(t, "mei", func(u *person) {
+				u.display, u.first, u.last = "", "", ""
+				tt.edit(u)
+			})
+
+			if got := expand(t, dial(t, base), "mei").Subject.Name; got != tt.want {
+				t.Errorf("the name is %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The version invalidates one person's group set, and somebody else joining a
+// group they are both in does not change it. Okta sends lastMembershipUpdated,
+// which moves every time anybody joins anything, and a version built on it
+// would be correct and useless at a company of any size.
+func TestTheVersionIgnoresWhoElseJoinedTheGroup(t *testing.T) {
+	o, base := newOrg(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	d := dial(t, base, okta.WithBuffer(0, 0))
+
+	before := expand(t, d, "mei").Groups.Version
+	for i := range 50 {
+		o.put(t, directory.Subject{ID: "other" + strconv.Itoa(i), MemberOf: []string{"engineering"}})
+	}
+	after := expand(t, d, "mei").Groups.Version
+
+	if before != after {
+		t.Errorf("fifty other people joining moved mei's version from %d to %d, so nothing cached above it survives a working day", before, after)
+	}
+}
+
+// And it does move when this person's own membership does, which is the half
+// that is not allowed to be sacrificed for the half above.
+func TestTheVersionMovesWhenThisPersonsMembershipDoes(t *testing.T) {
+	o, base := newOrg(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.putGroup(t, directory.Group{ID: "on-call"})
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering", "on-call"}})
+	d := dial(t, base, okta.WithBuffer(0, 0))
+
+	before := expand(t, d, "mei").Groups.Version
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	after := expand(t, d, "mei").Groups.Version
+
+	if before == after {
+		t.Errorf("coming off the on-call rotation left the version at %d", before)
+	}
+}
+
+// An organisation that refuses the token is not an organisation with nobody in
+// it, and the difference matters: one is an operator with a job to do and the
+// other is everybody silently losing every group they have.
+func TestABadTokenIsAFailureRatherThanAnEmptyDirectory(t *testing.T) {
+	o, base := newOrg(t)
+	o.put(t, directory.Subject{ID: "mei"})
+
+	d, err := okta.New(base, "wrong", okta.WithHTTPClient(http.DefaultClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = r.Expand(t.Context(), "mei")
+	if err == nil {
+		t.Fatal("a refused token resolved")
+	}
+	if errors.Is(err, directory.ErrNoSubject) {
+		t.Fatalf("a refused token looks like a person who is not there: %v", err)
+	}
+	// The operator has to be able to tell which of the two it is from the log.
+	if !strings.Contains(err.Error(), "E0000011") {
+		t.Errorf("the error is %q and does not carry the code to search for", err)
+	}
+}
+
+func TestAGroupTheOrganisationDoesNotHoldIsRefusedAsSuch(t *testing.T) {
+	_, base := newOrg(t)
+
+	_, err := dial(t, base).Group(t.Context(), "00gnope")
+	if !errors.Is(err, directory.ErrNoGroup) {
+		t.Fatalf("an absent group gave %v, want ErrNoGroup", err)
+	}
+}
+
+// Two organisations under one deployment is the acquisition shape, and the ids
+// are opaque strings that do not carry which tenant they came from.
+func TestTwoOrganisationsKeepTheirGroupsApart(t *testing.T) {
+	left, leftBase := newOrg(t)
+	right, rightBase := newOrg(t)
+	for _, o := range []*org{left, right} {
+		o.putGroup(t, directory.Group{ID: "00g1abcd"})
+		o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"00g1abcd"}})
+	}
+
+	a := expand(t, dial(t, leftBase, okta.WithName("acme")), "mei")
+	b := expand(t, dial(t, rightBase, okta.WithName("beta")), "mei")
+
+	if slices.Equal(a.Groups.Members, b.Groups.Members) {
+		t.Fatalf("the same id in two organisations is the same group: %s", describe(a.Groups.Members))
+	}
+	if want := []string{"acme:00g1abcd"}; !slices.Equal(a.Groups.Members, want) {
+		t.Errorf("the first organisation gave %s, want %v", describe(a.Groups.Members), want)
+	}
+}
+
+func TestNewRefusesAnOrganisationItCannotUse(t *testing.T) {
+	tests := []struct {
+		name       string
+		org, token string
+		opts       []okta.Option
+		want       string
+	}{
+		{"no organisation", "", token, nil, "organisation URL is required"},
+		{"no token", "https://acme.okta.com", "", nil, "API token is required"},
+		{"a host and no scheme", "acme.okta.com", token, nil, "scheme and a host"},
+		{"an empty name", "https://acme.okta.com", token, []okta.Option{okta.WithName("")}, "cannot be empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := okta.New(tt.org, tt.token, tt.opts...)
+			if err == nil {
+				t.Fatal("New accepted it")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("the error is %q and does not mention %q", err, tt.want)
+			}
+		})
+	}
+}
+
+// An expansion looks a level up in parallel, so the adapter is used from
+// several goroutines at once whether it wants to be or not.
+func TestResolvingFromOneOrganisationAtOnceIsSafe(t *testing.T) {
+	_, d := joins(t, 40)
+
+	r, err := directory.New(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	done := make(chan error, 16)
+	for range 16 {
+		go func() {
+			got, err := r.Expand(ctx, "mei")
+			if err == nil && len(got.Groups.Members) != 40 {
+				err = errors.New("resolved to " + strconv.Itoa(len(got.Groups.Members)) + " groups")
+			}
+			done <- err
+		}()
+	}
+	for range 16 {
+		if err := <-done; err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/directory/okta/recording_test.go
+++ b/directory/okta/recording_test.go
@@ -1,0 +1,270 @@
+package okta_test
+
+import (
+	"errors"
+	"flag"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/recorded"
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/okta"
+)
+
+// The fixture set is a resolution against a small organisation written down
+// once and read back by the tests below, so that the adapter is exercised
+// against the bytes an Okta organisation actually sends without anybody needing
+// a tenant or an API token to run the tests.
+//
+// The fake next to this file is the other half of the story and neither
+// replaces the other. The fake is where behaviour is written: it can be made to
+// suspend somebody, to page differently, to refuse a token. The recording is
+// where the wire format is pinned: it is the answer to "did we change what we
+// send" and it is the thing that would have to be refreshed if Okta changed a
+// field name.
+const fixtures = "testdata/organisation"
+
+// The organisation the recording is of. It is a real host that nothing reaches,
+// because keying the fixtures on the port a test server happened to be given
+// would make them unreadable and unstable at once.
+const recordedOrg = "https://acme.okta.com"
+
+// The ids the recorded organisation holds. They are written down rather than
+// worked out because a fixture set is a fixed corpus, and a test that derived
+// them from the fake would pass just as happily against a recording of
+// something else entirely.
+const (
+	recordedPerson  = "00u1mei"
+	recordedNobody  = "00u1jo"
+	recordedLeaver  = "00u1lee"
+	recordedGroup   = "00g1sec"
+	recordedMissing = "00g1gone"
+)
+
+var update = flag.Bool("update", false, "record the Okta fixtures in testdata again")
+
+// recordingOrg is the organisation the fixtures are a resolution of.
+//
+// It is small on purpose and every part of it is there for a reason: somebody
+// in three groups so that the listing is more than one page at the size below,
+// somebody in none so that an empty listing is in the recording, somebody
+// suspended so that the refusal is too, and a group looked up on its own so
+// that the endpoint the buffer usually saves is in there as well.
+func recordingOrg(t *testing.T) string {
+	t.Helper()
+	o, base := newOrg(t)
+	o.putGroup(t, directory.Group{ID: "00g1eng", Name: "engineering"})
+	o.putGroup(t, directory.Group{ID: "00g1ops", Name: "operations"})
+	o.putGroup(t, directory.Group{ID: recordedGroup, Name: "security"})
+
+	o.put(t, directory.Subject{
+		ID:       recordedPerson,
+		Name:     "Mei Tanaka",
+		Email:    "mei@acme.test",
+		MemberOf: []string{"00g1eng", "00g1ops", recordedGroup},
+	})
+	o.put(t, directory.Subject{ID: recordedNobody, Email: "jo@acme.test"})
+	o.put(t, directory.Subject{ID: recordedLeaver, Email: "lee@acme.test", Disabled: true})
+	return base
+}
+
+// TestRecordTheFixtures writes the fixture set again. It is skipped unless the
+// flag is given, because a recording that refreshed itself on every run would
+// never fail: the thing it is there to catch is a change to what we send, and a
+// fixture regenerated alongside the change agrees with it by construction.
+func TestRecordTheFixtures(t *testing.T) {
+	if !*update {
+		t.Skip("run with -update to record the fixtures again")
+	}
+
+	base := recordingOrg(t)
+	rec := recorded.Record(http.DefaultTransport, recorded.WithRedactedHeaders("Authorization"))
+
+	resolve(t, func(opts ...okta.Option) *okta.Directory {
+		return dial(t, base, append([]okta.Option{okta.WithHTTPClient(rec.Client())}, opts...)...)
+	})
+
+	// The same question asked twice is one file. A resolution asks for a group
+	// listing once per expansion and the pages repeat across them, and writing
+	// the answer down twice is two files to review and no more coverage.
+	var (
+		seen = map[string]bool{}
+		once []recorded.Exchange
+	)
+	for _, e := range rec.Exchanges() {
+		e = settle(e, base)
+		k := e.Request.Method + " " + e.Request.URL
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		once = append(once, e)
+	}
+
+	if err := recorded.From(once).Save(fixtures); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %d of %d exchanges to %s", len(once), len(rec.Exchanges()), fixtures)
+}
+
+// settle takes the run out of a recorded exchange.
+//
+// Two things in one differ every time it is made: the address the test server
+// was given, and the date the answer came back on. Neither is matched against
+// and neither means anything, and leaving them in would make every refresh of
+// the fixtures a diff on every file with the real change somewhere in it. The
+// host is written as an Okta one for the same reason: a reader opening one of
+// these files should see the request that would have gone to Okta, and that
+// includes the next page link inside the answer.
+func settle(e recorded.Exchange, base string) recorded.Exchange {
+	e.Request.URL = rehost(e.Request.URL)
+	for name, values := range e.Response.Headers {
+		if !strings.EqualFold(name, "Link") {
+			continue
+		}
+		for i, v := range values {
+			values[i] = strings.ReplaceAll(v, base, recordedOrg)
+		}
+	}
+	delete(e.Response.Headers, "Date")
+	delete(e.Response.Headers, "Content-Length")
+	return e
+}
+
+// rehost puts one URL on the organisation the fixtures are written against.
+func rehost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	org, err := url.Parse(recordedOrg)
+	if err != nil {
+		panic(err)
+	}
+	u.Scheme, u.Host = org.Scheme, org.Host
+	return u.String()
+}
+
+// resolve is everything the fixture set has to answer, and it is shared so that
+// what is recorded and what is replayed cannot drift apart.
+func resolve(t *testing.T, dir func(opts ...okta.Option) *okta.Directory) directory.Expansion {
+	t.Helper()
+
+	// Two at a time, so that a listing over pages is in the recording rather
+	// than only in the fake.
+	r, err := directory.New(dir(okta.WithPageSize(2)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := r.Expand(t.Context(), recordedPerson)
+	if err != nil {
+		t.Fatalf("expanding %s: %v", recordedPerson, err)
+	}
+	if _, err := r.Expand(t.Context(), recordedNobody); err != nil {
+		t.Fatalf("expanding %s: %v", recordedNobody, err)
+	}
+	if _, err := r.Expand(t.Context(), recordedLeaver); !errors.Is(err, directory.ErrDisabled) {
+		t.Fatalf("expanding %s gave %v, want ErrDisabled", recordedLeaver, err)
+	}
+
+	// A group asked for on its own, which the buffer would otherwise answer out
+	// of the listing that already went past.
+	alone := dir(okta.WithBuffer(0, 0))
+	if _, err := alone.Group(t.Context(), recordedGroup); err != nil {
+		t.Fatalf("looking up %s: %v", recordedGroup, err)
+	}
+	if _, err := alone.Group(t.Context(), recordedMissing); !errors.Is(err, directory.ErrNoGroup) {
+		t.Fatalf("looking up %s gave %v, want ErrNoGroup", recordedMissing, err)
+	}
+	return got
+}
+
+// TestTheRecordedOrganisationResolvesWithoutATenant is the point of the fixture
+// set: the whole adapter, the real paging and the real decoding, against bytes
+// that came off an organisation and are now a file.
+func TestTheRecordedOrganisationResolvesWithoutATenant(t *testing.T) {
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolve(t, func(opts ...okta.Option) *okta.Directory {
+		d, err := okta.New(recordedOrg, token, append([]okta.Option{okta.WithHTTPClient(rt.Client())}, opts...)...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return d
+	})
+
+	want := []string{"okta:00g1eng", "okta:00g1ops", "okta:" + recordedGroup}
+	if !slices.Equal(got.Groups.Members, want) {
+		t.Fatalf("the recorded organisation resolved to %s, want %v", describe(got.Groups.Members), want)
+	}
+	if got.Subject.Name != "Mei Tanaka" {
+		t.Errorf("the recorded person is called %q", got.Subject.Name)
+	}
+	if want := (acl.Identity{Source: "email", Value: "mei@acme.test"}); !slices.Contains(got.Subject.Identities, want) {
+		t.Errorf("the identities off the recording are %v", got.Subject.Identities)
+	}
+	if got.Depth != 1 {
+		t.Errorf("a provider whose groups cannot contain groups was walked %d levels deep", got.Depth)
+	}
+}
+
+// TestTheRecordingHoldsNothingItIsNotAskedFor keeps the fixture set from
+// growing a tail of responses nothing reads.
+//
+// A recording is a thing people add to and rarely take away from, and one that
+// has drifted is worse than none: a reviewer reading a file next to the test
+// reasonably assumes the test depends on it.
+func TestTheRecordingHoldsNothingItIsNotAskedFor(t *testing.T) {
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolve(t, func(opts ...okta.Option) *okta.Directory {
+		d, err := okta.New(recordedOrg, token, append([]okta.Option{okta.WithHTTPClient(rt.Client())}, opts...)...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return d
+	})
+
+	if left := rt.Unused(); len(left) != 0 {
+		t.Errorf("the fixture set answers %d requests the resolution never makes:\n%s", len(left), strings.Join(left, "\n"))
+	}
+}
+
+// TestTheRecordingCarriesNoCredentials is the reason a fixture set is safe to
+// commit at all. It is a check on the recording rather than on the code, and it
+// is here because the file is here.
+func TestTheRecordingCarriesNoCredentials(t *testing.T) {
+	entries, err := os.ReadDir(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(fixtures, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(raw), token) {
+			t.Errorf("%s holds the token it was recorded with", e.Name())
+		}
+		// The scheme as well as the token, because an API token is whatever
+		// follows it and a reviewer skimming for "SSWS" is how one gets noticed.
+		if strings.Contains(string(raw), "SSWS ") {
+			t.Errorf("%s holds something shaped like an Okta API token", e.Name())
+		}
+	}
+}

--- a/directory/okta/testdata/organisation/0001-get-api-v1-users-00u1mei.json
+++ b/directory/okta/testdata/organisation/0001-get-api-v1-users-00u1mei.json
@@ -1,0 +1,47 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.okta.com/api/v1/users/00u1mei",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ],
+      "X-Rate-Limit-Limit": [
+        "600"
+      ],
+      "X-Rate-Limit-Remaining": [
+        "599"
+      ],
+      "X-Rate-Limit-Reset": [
+        "1767225600"
+      ]
+    },
+    "body": {
+      "json": {
+        "created": "2026-01-01T00:00:00.000Z",
+        "id": "00u1mei",
+        "lastUpdated": "2026-01-01T00:00:00.004Z",
+        "profile": {
+          "displayName": "Mei Tanaka",
+          "email": "mei@acme.test",
+          "firstName": "",
+          "lastName": "",
+          "login": "mei@acme.test",
+          "secondEmail": ""
+        },
+        "status": "ACTIVE"
+      }
+    }
+  }
+}

--- a/directory/okta/testdata/organisation/0002-get-api-v1-users-00u1mei-groups-limit-2.json
+++ b/directory/okta/testdata/organisation/0002-get-api-v1-users-00u1mei-groups-limit-2.json
@@ -1,0 +1,61 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.okta.com/api/v1/users/00u1mei/groups?limit=2",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ],
+      "Link": [
+        "\u003chttps://acme.okta.com/api/v1/users/00u1mei/groups?filter=type+eq+%22OKTA_GROUP%22%2C+%22APP_GROUP%22\u003e; rel=\"self\"",
+        "\u003chttps://acme.okta.com/api/v1/users/00u1mei/groups?after=00g1ops\u0026limit=2\u003e; rel=\"next\""
+      ],
+      "X-Rate-Limit-Limit": [
+        "600"
+      ],
+      "X-Rate-Limit-Remaining": [
+        "599"
+      ],
+      "X-Rate-Limit-Reset": [
+        "1767225600"
+      ]
+    },
+    "body": {
+      "json": [
+        {
+          "created": "2026-01-01T00:00:00.000Z",
+          "id": "00g1eng",
+          "lastMembershipUpdated": "2026-01-01T00:00:00.005Z",
+          "lastUpdated": "2026-01-01T00:00:00.001Z",
+          "profile": {
+            "description": "",
+            "name": "engineering"
+          },
+          "type": "OKTA_GROUP"
+        },
+        {
+          "created": "2026-01-01T00:00:00.000Z",
+          "id": "00g1ops",
+          "lastMembershipUpdated": "2026-01-01T00:00:00.006Z",
+          "lastUpdated": "2026-01-01T00:00:00.002Z",
+          "profile": {
+            "description": "",
+            "name": "operations"
+          },
+          "type": "OKTA_GROUP"
+        }
+      ]
+    }
+  }
+}

--- a/directory/okta/testdata/organisation/0003-get-api-v1-users-00u1mei-groups-after-00g1ops-limit-2.json
+++ b/directory/okta/testdata/organisation/0003-get-api-v1-users-00u1mei-groups-after-00g1ops-limit-2.json
@@ -1,0 +1,49 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.okta.com/api/v1/users/00u1mei/groups?after=00g1ops\u0026limit=2",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ],
+      "Link": [
+        "\u003chttps://acme.okta.com/api/v1/users/00u1mei/groups?filter=type+eq+%22OKTA_GROUP%22%2C+%22APP_GROUP%22\u003e; rel=\"self\""
+      ],
+      "X-Rate-Limit-Limit": [
+        "600"
+      ],
+      "X-Rate-Limit-Remaining": [
+        "599"
+      ],
+      "X-Rate-Limit-Reset": [
+        "1767225600"
+      ]
+    },
+    "body": {
+      "json": [
+        {
+          "created": "2026-01-01T00:00:00.000Z",
+          "id": "00g1sec",
+          "lastMembershipUpdated": "2026-01-01T00:00:00.007Z",
+          "lastUpdated": "2026-01-01T00:00:00.003Z",
+          "profile": {
+            "description": "",
+            "name": "security"
+          },
+          "type": "OKTA_GROUP"
+        }
+      ]
+    }
+  }
+}

--- a/directory/okta/testdata/organisation/0004-get-api-v1-users-00u1jo.json
+++ b/directory/okta/testdata/organisation/0004-get-api-v1-users-00u1jo.json
@@ -1,0 +1,47 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.okta.com/api/v1/users/00u1jo",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ],
+      "X-Rate-Limit-Limit": [
+        "600"
+      ],
+      "X-Rate-Limit-Remaining": [
+        "599"
+      ],
+      "X-Rate-Limit-Reset": [
+        "1767225600"
+      ]
+    },
+    "body": {
+      "json": {
+        "created": "2026-01-01T00:00:00.000Z",
+        "id": "00u1jo",
+        "lastUpdated": "2026-01-01T00:00:00.008Z",
+        "profile": {
+          "displayName": "",
+          "email": "jo@acme.test",
+          "firstName": "",
+          "lastName": "",
+          "login": "jo@acme.test",
+          "secondEmail": ""
+        },
+        "status": "ACTIVE"
+      }
+    }
+  }
+}

--- a/directory/okta/testdata/organisation/0005-get-api-v1-users-00u1jo-groups-limit-2.json
+++ b/directory/okta/testdata/organisation/0005-get-api-v1-users-00u1jo-groups-limit-2.json
@@ -1,0 +1,37 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.okta.com/api/v1/users/00u1jo/groups?limit=2",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ],
+      "Link": [
+        "\u003chttps://acme.okta.com/api/v1/users/00u1jo/groups?filter=type+eq+%22OKTA_GROUP%22%2C+%22APP_GROUP%22\u003e; rel=\"self\""
+      ],
+      "X-Rate-Limit-Limit": [
+        "600"
+      ],
+      "X-Rate-Limit-Remaining": [
+        "599"
+      ],
+      "X-Rate-Limit-Reset": [
+        "1767225600"
+      ]
+    },
+    "body": {
+      "json": []
+    }
+  }
+}

--- a/directory/okta/testdata/organisation/0006-get-api-v1-users-00u1lee.json
+++ b/directory/okta/testdata/organisation/0006-get-api-v1-users-00u1lee.json
@@ -1,0 +1,47 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.okta.com/api/v1/users/00u1lee",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ],
+      "X-Rate-Limit-Limit": [
+        "600"
+      ],
+      "X-Rate-Limit-Remaining": [
+        "599"
+      ],
+      "X-Rate-Limit-Reset": [
+        "1767225600"
+      ]
+    },
+    "body": {
+      "json": {
+        "created": "2026-01-01T00:00:00.000Z",
+        "id": "00u1lee",
+        "lastUpdated": "2026-01-01T00:00:00.009Z",
+        "profile": {
+          "displayName": "",
+          "email": "lee@acme.test",
+          "firstName": "",
+          "lastName": "",
+          "login": "lee@acme.test",
+          "secondEmail": ""
+        },
+        "status": "SUSPENDED"
+      }
+    }
+  }
+}

--- a/directory/okta/testdata/organisation/0007-get-api-v1-groups-00g1sec.json
+++ b/directory/okta/testdata/organisation/0007-get-api-v1-groups-00g1sec.json
@@ -1,0 +1,44 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.okta.com/api/v1/groups/00g1sec",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ],
+      "X-Rate-Limit-Limit": [
+        "600"
+      ],
+      "X-Rate-Limit-Remaining": [
+        "599"
+      ],
+      "X-Rate-Limit-Reset": [
+        "1767225600"
+      ]
+    },
+    "body": {
+      "json": {
+        "created": "2026-01-01T00:00:00.000Z",
+        "id": "00g1sec",
+        "lastMembershipUpdated": "2026-01-01T00:00:00.007Z",
+        "lastUpdated": "2026-01-01T00:00:00.003Z",
+        "profile": {
+          "description": "",
+          "name": "security"
+        },
+        "type": "OKTA_GROUP"
+      }
+    }
+  }
+}

--- a/directory/okta/testdata/organisation/0008-get-api-v1-groups-00g1gone.json
+++ b/directory/okta/testdata/organisation/0008-get-api-v1-groups-00g1gone.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://acme.okta.com/api/v1/groups/00g1gone",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 404,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "errorCauses": [],
+        "errorCode": "E0000007",
+        "errorId": "oaeFakeRequestId",
+        "errorLink": "E0000007",
+        "errorSummary": "Not found: Resource not found: 00g1gone (UserGroup)"
+      }
+    }
+  }
+}

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -137,6 +137,12 @@ func TestConformance(t *testing.T) {
 }
 ```
 
+Two things about a fixture are not the same for every provider and the suite asks rather than assumes.
+
+`Flat` says the provider's groups cannot contain groups, which skips the cases about walking a graph and takes a level off the arithmetic in the two that count lookups.
+`Identity` says which identity the provider can actually be made to hold, because a directory answers in its own vocabulary and no amount of putting a Slack id on an Okta user will make one come out.
+Both default to the shape `directory.Static` has, so nothing that already passes the suite has to say anything, and what the cases are about survives either way.
+
 `directory.Static` is the reference implementation the suite runs against, and it is also the directory a small deployment actually uses.
 A company with forty people and six groups has the whole thing in a file, and making them stand up an identity provider to try a search engine is how a search engine does not get tried.
 
@@ -158,6 +164,43 @@ A change to the directory's own name is refused outright: every group key carrie
 
 A file that does not parse at startup is a different matter and the process exits.
 Nothing is loaded, so there is nothing to keep, and coming up resolving nobody would be a server that answers every request with a refusal.
+
+## Okta
+
+`directory/okta` is the first adapter for a hosted provider, and it is the shape the others take.
+
+It answers the two lookups and nothing else.
+The closure, the cycle detection, the bound on what one expansion may cost and the version an answer is stamped with are all in the shared code, because those are exactly the parts that are easy to get subtly wrong and impossible to notice from the outside.
+
+The one fact about Okta that shapes the rest is that its groups do not contain groups.
+A user is a member of groups and a group is a member of nothing, so there is no graph to walk and every expansion is one level deep.
+That is also why the conformance fixture sets `Flat`, which skips the cases about walking a graph.
+An adapter that passed those would be one that had invented a nesting the provider does not have.
+
+Flat has a cost, though.
+The walk asks about every group the person is in, and a person in three hundred groups would be three hundred requests against an organisation everybody else is signing in to at the same time.
+So the group listing that answers the subject lookup, which returns whole group objects rather than ids, fills a small buffer that the group lookups then read, and the three hundred requests become one listing.
+
+That buffer is worth being careful about, because there is meant to be exactly one cache in this system and it is not this.
+The fact being held here is "this group exists and is a member of no groups", and for a provider with no nesting that fact cannot become false in a way that changes an answer.
+A group deleted since it was buffered would move into the unresolved list if it were looked up again, and an unresolved group is still in the group set, because the directory saying somebody is a member is a statement about them.
+So the buffer changes what an expansion costs and cannot change what it returns.
+
+The version is the other decision worth writing down.
+Okta sends two revisions on a group, `lastUpdated` and `lastMembershipUpdated`, and the second one is the obvious choice and the wrong one.
+It moves whenever anybody at all joins the group, and what this version invalidates is one person's group set, which somebody else joining does not change.
+At a company of any size something moves every second, so a version derived from it would be correct and useless: nothing cached above it would survive a working day.
+This person joining or leaving is caught without it, because the group set is fingerprinted over the group ids as well as their versions, and joining or leaving is what changes the ids.
+
+Deactivation is the third.
+Okta has eight account states and only some of them are a decision somebody made about access.
+`SUSPENDED` and `DEPROVISIONED` are what an administrator reaches for when somebody leaves, and `STAGED` is an account created and never activated, so all three refuse.
+`LOCKED_OUT` and `PASSWORD_EXPIRED` do not, because both are a live account having a bad morning, and refusing on them would take somebody's search away for forgetting a password.
+
+Rate limits are the transport's job rather than the adapter's.
+`connector/limit` is the same one every connector uses, and Okta publishes its numbers on every response.
+It spells the headers `X-Rate-Limit-Remaining` and `X-Rate-Limit-Reset`, with the hyphen in a different place from everybody else, which canonicalises to a different header name entirely.
+A transport that read only the other three spellings would see an organisation sending its numbers on every single response as one sending none at all, and would find the edge of the quota by hitting it.
 
 ## More than one directory
 
@@ -222,5 +265,10 @@ Serving a stale answer through a directory outage.
 The cache refuses once an entry has expired and the directory cannot be reached, which is the same direction the resolver fails in, and an operator who would rather serve a slightly old group set than refuse a sign in has no way to say so yet.
 It is a real choice with a real cost on the other side, so it should be a configured window with its own metric rather than a default.
 
-Adapters for the hosted providers.
-The interface is two methods and the suite is what they have to pass, so each is a small amount of code and a fake, in the shape the connectors already use.
+The rest of the hosted providers.
+Okta is done, and Entra ID and Google Workspace are the two that are not.
+Entra ID expands transitively already, which the walk handles without a special case: it returns the closure it was given and the level above it is empty.
+
+A way to configure an adapter without writing Go.
+`-directory` takes files, and an organisation is not a file.
+All three providers want the same three things, an endpoint, a credential and a name, so the flag should grow one spelling that covers them rather than one per provider.


### PR DESCRIPTION
The first adapter for a hosted provider, over the Users and Groups API, closing the first of the boxes on #179.

It answers the two lookups and nothing else.
The closure, the cycle detection, the bound on what one expansion may cost and the version an answer is stamped with all stay in `directory`, because those are the parts that are easy to get subtly wrong and impossible to notice from the outside.

## Okta groups do not contain groups

This is the one fact about the provider that shapes the rest.
A user is a member of groups and a group is a member of nothing, so there is no graph to walk and every expansion is one level deep.

That makes the level below the whole cost.
The walk asks about every group the person is in, and a person in three hundred groups would be three hundred requests against an organisation everybody else is signing in to at the same time.
So the group listing that answers the subject lookup, which returns whole group objects rather than ids, fills a small buffer the group lookups then read, and the three hundred requests become one listing.

There is meant to be exactly one cache in this system and this is not it, so it is worth saying why.
The fact being held is "this group exists and is a member of no groups", and for a provider with no nesting that fact cannot become false in a way that changes an answer.
A group deleted since it was buffered would move into the unresolved list if it were looked up again, and an unresolved group is still in the group set, because the directory saying somebody is a member is a statement about them.
So the buffer changes what an expansion costs and cannot change what it returns.
`WithBuffer(0, 0)` turns it off, and there is a test that counts the requests both ways.

## The version is not the membership revision

Okta sends two revisions on a group and the second one is the obvious choice and the wrong one.

`lastMembershipUpdated` moves whenever anybody at all joins the group, and what this version invalidates is one person's group set, which somebody else joining does not change.
At a company of any size something moves every second, so a version built on it would be correct and useless: nothing cached above it would survive a working day.
This person joining or leaving is caught without it, because the group set is fingerprinted over the group ids as well as their versions, and joining or leaving is what changes the ids.

The fake bumps `lastMembershipUpdated` the way a real organisation does, so the test where fifty other people join a group and the version does not move is testing something.

## Two new fixture fields on directorytest

`Flat` says the provider's groups cannot contain groups.
It skips the four cases about walking a graph and takes a level off the arithmetic in the two that count lookups.
An adapter that passed those cases would be one that had invented a nesting the provider does not have.

`Identity` says which identity the provider can actually be made to hold.
A directory answers in its own vocabulary, and an Okta organisation answers with the person's Okta id and their email addresses, so no amount of putting a Slack id on a user will make one come out.

Both default to what `directory.Static` does, so `Static` still runs all seventeen cases and nothing already using the suite has to say anything.
Okta runs twelve and skips five.

## Deactivation

Okta has eight account states and only some of them are a decision somebody made about access.
`SUSPENDED`, `DEPROVISIONED` and `STAGED` refuse.
`LOCKED_OUT` and `PASSWORD_EXPIRED` do not, because both are a live account having a bad morning, and refusing on them would take somebody's search away for forgetting a password.
A refused account is refused before the group listing, since nobody is going to read the answer to it.

## The rate limit headers

Okta spells them `X-Rate-Limit-Remaining` and `X-Rate-Limit-Reset`, with the hyphen in a different place from everybody else, and that canonicalises to a different header name entirely rather than to a variation something reads by accident.
`connector/limit` was reading `Retry-After`, `RateLimit-*` and `X-RateLimit-*`, so it saw an organisation sending its numbers on every single response as one sending none at all, and would have found the edge of the quota by hitting it.
It reads the fourth spelling now, with a case in both existing tables.

## Testing

The fake is a real HTTP server over the three endpoints, with the SSWS scheme, Link header pagination and both timestamps on a group.
Its `self` link carries a filter with a comma inside the URL, which is legal and is exactly what a Link header parser that splits on every comma gets wrong, so every listing in the suite exercises that.

The recorded fixtures are eight files in the shape `connector/recorded` already uses, so the whole adapter runs against bytes that came off a service without anybody needing a tenant or a token.
There is a test that the recording holds nothing the resolution does not ask for, and one that it carries no credentials.

Green on the full suite, `-race`, and `golangci-lint` with 0 issues.

## Not in this

`-directory` still takes files, so an adapter is wired up in Go for now.
All three providers want the same three things, an endpoint, a credential and a name, so the flag should grow one spelling that covers them rather than one per provider, and that is worth doing once Entra ID and Google Workspace are in.
