### PR TITLE
Wait for the whole answer in two watcher tests

### DIFF
--- a/connector/fssource/watch_test.go
+++ b/connector/fssource/watch_test.go
@@ -382,13 +382,25 @@ func TestALostRecordMakesTheNextSyncWalk(t *testing.T) {
 		put(t, root, "docs/"+name, "# "+name+"\n")
 	}
 
-	got, _ := until(t, s, cursor, func(all []connector.Change) bool {
-		return wasRead(all, "repo:docs/a.md") && wasRead(all, "repo:docs/e.md")
-	})
-
 	// Everything is found, which is the point. Losing the record costs a walk
 	// and not a document.
-	for _, name := range []string{"a.md", "b.md", "c.md", "d.md", "e.md"} {
+	//
+	// Waiting for all five rather than for the first and the last of them,
+	// because the walk that finds the overflow is not one sync and there is
+	// nothing that says the two ends of the set arrive last. Stopping as soon
+	// as those two were seen was a test that failed whenever the middle of the
+	// batch happened to land in the sync after them.
+	want := []string{"a.md", "b.md", "c.md", "d.md", "e.md"}
+	got, _ := until(t, s, cursor, func(all []connector.Change) bool {
+		for _, name := range want {
+			if !wasRead(all, "repo:docs/"+name) {
+				return false
+			}
+		}
+		return true
+	})
+
+	for _, name := range want {
 		if !slices.Contains(read(got), "repo:docs/"+name) {
 			t.Fatalf("read %v, which is missing docs/%s", read(got), name)
 		}
@@ -625,8 +637,17 @@ func TestTheWatchedAndWalkedSyncsAgreeOnWhatIsInTheCorpus(t *testing.T) {
 	for rel, body := range files {
 		put(t, root, rel, body+"\n")
 	}
+	// Waiting for the names rather than for the count of them. The two are the
+	// same number here only when the answer is already right, so counting would
+	// have let a run where watching read something else of the same size through
+	// to an assertion that then failed on a set difference.
 	byWatching, _ := until(t, s, cursor, func(all []connector.Change) bool {
-		return len(read(all)) >= len(read(byWalking))
+		for _, id := range read(byWalking) {
+			if !wasRead(all, id) {
+				return false
+			}
+		}
+		return true
 	})
 
 	if !slices.Equal(read(byWatching), read(byWalking)) {


### PR DESCRIPTION
Two tests in `connector/fssource` waited for part of what they then asserted, so they passed or failed on how the syncs happened to be cut up rather than on what the watcher did.

`TestALostRecordMakesTheNextSyncWalk` waited for `docs/a.md` and `docs/e.md` and then asserted all five of a through e. Finding the overflow costs a walk, a walk is not one sync, and nothing says the middle of the batch arrives before the ends of it. That is the failure on `test (ubuntu-latest)` in #184, which reported `read [repo:docs/a.md repo:docs/b.md repo:docs/d.md repo:docs/e.md], which is missing docs/c.md`.

`TestTheWatchedAndWalkedSyncsAgreeOnWhatIsInTheCorpus` waited for a count of read ids and then asserted the names. Those two agree only when the answer is already right, so a run where watching read something else of the same size would get through the wait and fail on the comparison.

Both now wait for exactly what they assert. No production code changed.

Ran the package twenty times over the lost record case and three times over the whole package, all green.
