### PR TITLE
Hold the filesystem cursor back to a second before the sync

### DIFF
--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -21,11 +21,20 @@
 //
 // # Incremental sync
 //
-// The cursor is the highest modification time the last run saw. A later run
-// walks the same tree and skips anything not newer, so the cost of a no change
-// sync is a stat of every file rather than a read of every file. That is the
-// honest limit of what a plain filesystem supports on its own: without a change
-// feed there is no way to avoid the walk, only the read.
+// The cursor is the highest modification time the last run saw, held back to a
+// second before that run started. A later run walks the same tree and skips
+// anything not newer, so the cost of a no change sync is a stat of every file
+// rather than a read of every file. That is the honest limit of what a plain
+// filesystem supports on its own: without a change feed there is no way to
+// avoid the walk, only the read.
+//
+// The second is not slack in the design, it is the design. A file is stamped
+// from a clock that ticks rather than from the one that runs, so a file created
+// a moment after the walk went past its directory carries the same modification
+// time as one the walk read, and a cursor sitting on that time would leave it
+// behind for good. The cost of holding back is that a file written in the
+// second before a sync is read by the next sync as well, which is a document
+// arriving twice rather than a document not arriving at all.
 //
 // A [Watcher] is how the walk goes too. The operating system already knows
 // which files were written, and a source built with [WithWatcher] asks it
@@ -397,13 +406,21 @@ func (s *Source) Close() error { return nil }
 // The returned cursor is the highest modification time seen in the whole tree,
 // including files that were skipped as unchanged, so that a run which finds
 // nothing new still moves the clock forward and a run interrupted halfway does
-// not lose the files it already passed.
+// not lose the files it already passed. It is never later than a second before
+// the sync started, for the reason in [settled].
 //
 // A source built with [WithWatcher] reads the paths the watcher recorded and
 // does not walk at all, whenever the watcher can vouch for its record. When it
 // cannot, this is what runs, which is why the two paths have to agree on which
 // files are in the corpus.
 func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(context.Context, connector.Change) error) (connector.Cursor, error) {
+	// Read before anything is looked at, because the cursor this hands back is
+	// bounded by it. Nothing created after this moment can be vouched for by
+	// this sync, whatever modification time it happens to carry. Round drops
+	// the monotonic reading, which means nothing in a cursor that gets written
+	// down and compared against times off a filesystem.
+	started := time.Now().Round(0)
+
 	since, err := parseCursor(from)
 	if err != nil {
 		return connector.Cursor{}, err
@@ -420,7 +437,7 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 
 	changed, gen, watching := s.watched()
 	if watching {
-		return s.syncWatched(ctx, from, since, changed, emit)
+		return s.syncWatched(ctx, from, since, started, changed, emit)
 	}
 
 	var highest time.Time
@@ -479,7 +496,51 @@ func (s *Source) Sync(ctx context.Context, from connector.Cursor, emit func(cont
 	if highest.IsZero() {
 		return from, nil
 	}
-	return connector.Cursor{Value: version(highest), Time: highest}, nil
+	return cursorAt(covered(highest, started, since)), nil
+}
+
+// settled is how far behind the moment a sync started its cursor is allowed to
+// sit, and it is the whole of what keeps a file from being left behind.
+//
+// A cursor says that everything modified at or before that time has been read,
+// and a sync that hands back the newest time it saw is saying more than it
+// knows. A file is stamped from a clock that ticks rather than from the one that
+// runs, so a file created a millisecond after the walk went past its directory
+// carries the same modification time as one the walk read. The next walk emits
+// what is strictly newer than the cursor, so that file is never read, nothing is
+// quarantined and nothing is reported. It is simply not in the index until
+// somebody writes to it again, which is the one failure this connector must not
+// have.
+//
+// One second covers both halves of that. It covers the clock a file is stamped
+// from, which ticks every few milliseconds, and it covers a filesystem that
+// keeps modification times to the second, where a file created at any point
+// during a second carries the start of it.
+//
+// What it costs is that a file written in the second before a sync is read by
+// the next sync as well, and it is paid once: the sync after that starts more
+// than a second later and the cursor moves past it.
+const settled = time.Second
+
+// covered is the newest modification time a sync that started at started can
+// honestly say it has read everything up to.
+//
+// It never goes below the cursor the sync was given, which is a claim an earlier
+// sync already made and this one has no reason to withdraw. Without that a tree
+// written moments ago would drag the cursor backwards on every run.
+func covered(highest, started, since time.Time) time.Time {
+	if safe := started.Add(-settled); safe.Before(highest) {
+		highest = safe
+	}
+	if highest.Before(since) {
+		return since
+	}
+	return highest
+}
+
+// cursorAt is the cursor for one moment.
+func cursorAt(t time.Time) connector.Cursor {
+	return connector.Cursor{Value: version(t), Time: t}
 }
 
 // watched returns the paths the watcher recorded, the generation that record
@@ -519,7 +580,7 @@ func (s *Source) watched() (changed map[string]watchOps, gen int64, ok bool) {
 // restored from a backup with its old time, which is what "cp -p" does, would
 // otherwise drag the cursor into the past and make the next walk re-read
 // everything written since then.
-func (s *Source) syncWatched(ctx context.Context, from connector.Cursor, since time.Time, changed map[string]watchOps, emit func(context.Context, connector.Change) error) (connector.Cursor, error) {
+func (s *Source) syncWatched(ctx context.Context, from connector.Cursor, since, started time.Time, changed map[string]watchOps, emit func(context.Context, connector.Change) error) (connector.Cursor, error) {
 	highest := since
 	// Sorted, so that a sync over the same set of changes does the same work in
 	// the same order twice, which is what makes a failure reproducible.
@@ -623,7 +684,7 @@ func (s *Source) syncWatched(ctx context.Context, from connector.Cursor, since t
 	if highest.IsZero() {
 		return from, nil
 	}
-	return connector.Cursor{Value: version(highest), Time: highest}, nil
+	return cursorAt(covered(highest, started, since)), nil
 }
 
 // refresh emits a permission change for a file whose content did not change but

--- a/connector/fssource/fssource_test.go
+++ b/connector/fssource/fssource_test.go
@@ -20,15 +20,26 @@ import (
 )
 
 // tree writes a directory tree from a map of relative path to contents.
+//
+// The files are dated a minute ago. A corpus that was written in the same
+// millisecond as the sync reading it is not a corpus, and it is not what these
+// tests are about either: a sync will not claim to have covered a moment it is
+// still inside of, so a tree written now leaves a cursor that deliberately sits
+// behind it and the file is read once more on the next sync. Dating the fixture
+// is how the tests ask their own question instead of that one.
 func tree(t *testing.T, files map[string]string) string {
 	t.Helper()
 	root := t.TempDir()
+	ago := time.Now().Add(-time.Minute)
 	for rel, body := range files {
 		full := filepath.Join(root, filepath.FromSlash(rel))
 		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(full, ago, ago); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/connector/fssource/maintain_test.go
+++ b/connector/fssource/maintain_test.go
@@ -295,14 +295,16 @@ func TestAnOwnersEditIsAPermissionChangeAndNotARecrawl(t *testing.T) {
 	}
 	after := s.Counters()
 
-	// One edit at the root, well into the future so the change is unambiguous
-	// on a filesystem with a coarse timestamp.
+	// One edit at the root, dated half a minute ago. It is well clear of the
+	// tree below it, which was written a minute before that, and it is far
+	// enough in the past that a sync will hand back a cursor sitting exactly on
+	// it rather than one that stops short of a change made this second.
 	owners := filepath.Join(root, fssource.OwnersFile)
 	if err := os.WriteFile(owners, []byte("approvers:\n  - alice\n  - bob\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	later := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(owners, later, later); err != nil {
+	edited := time.Now().Add(-30 * time.Second)
+	if err := os.Chtimes(owners, edited, edited); err != nil {
 		t.Fatal(err)
 	}
 

--- a/connector/fssource/osperm_unix_test.go
+++ b/connector/fssource/osperm_unix_test.go
@@ -243,6 +243,14 @@ func TestAChmodIsAPermissionChangeAndNotARecrawl(t *testing.T) {
 	}
 	defer s.Close()
 
+	// A second between writing the tree and reading it, which the rest of these
+	// tests get by dating the files they write. This one cannot: the time that
+	// matters here is the inode change time, which is set when the file is made
+	// and cannot be set to anything else afterwards. Without the wait the first
+	// sync hands back a cursor that stops short of a tree made this second, and
+	// every file in it looks like a rule that just moved.
+	time.Sleep(1100 * time.Millisecond)
+
 	first, cursor := collect(t, s, connector.Cursor{})
 	if len(first) != 3 {
 		t.Fatalf("the first sync read %v, want three documents", ids(first))
@@ -255,10 +263,13 @@ func TestAChmodIsAPermissionChangeAndNotARecrawl(t *testing.T) {
 	}
 	after := s.Counters()
 
-	// The clock again, so that the change time lands unambiguously past a
-	// cursor taken a moment ago.
-	time.Sleep(10 * time.Millisecond)
 	chmod(t, filepath.Join(root, "a.md"), 0o600)
+
+	// The same second again. The chmod has to be unambiguously past the cursor
+	// on a filesystem with a coarse timestamp, and it has to be far enough back
+	// for the sync that finds it to hand back a cursor sitting on it, because
+	// the two syncs below are there to say the change is reported once.
+	time.Sleep(1100 * time.Millisecond)
 
 	var changes []connector.Change
 	next, err := s.Sync(t.Context(), cursor, func(_ context.Context, ch connector.Change) error {

--- a/connector/fssource/watch_test.go
+++ b/connector/fssource/watch_test.go
@@ -153,6 +153,31 @@ func put(t *testing.T, root, rel, body string) {
 	}
 }
 
+// place writes a file outside the tree, gives it a modification time, and moves
+// it in.
+//
+// Two steps rather than a write followed by a utimes, because those are two
+// events on a watcher, and a sync landing between them reads the file with a
+// time it is about to lose. A rename is one event and the file arrives holding
+// the time it is going to keep.
+func place(t *testing.T, root, rel, body string, at time.Time) {
+	t.Helper()
+	staged := filepath.Join(t.TempDir(), "staged")
+	if err := os.WriteFile(staged, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(staged, at, at); err != nil {
+		t.Fatal(err)
+	}
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(staged, full); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestTheFirstWatchedSyncWalksTheWholeTree(t *testing.T) {
 	root := tree(t, map[string]string{
 		"README.md":       "# top\n",
@@ -407,6 +432,40 @@ func TestALostRecordMakesTheNextSyncWalk(t *testing.T) {
 	}
 	if stats := w.Stats(); stats.Walks < 2 {
 		t.Fatalf("the watcher walked %d times, want the first one and at least one more for the overflow", stats.Walks)
+	}
+}
+
+func TestAFileWrittenInTheSameTickAsOneThatWasReadSurvivesALostRecord(t *testing.T) {
+	root := tree(t, map[string]string{"README.md": "# top\n"})
+	w := watch(t, root)
+	s := watched(t, root, w)
+	_, cursor := changes(t, s, connector.Cursor{})
+
+	// One modification time for two files, which is not a contrivance. A file
+	// is stamped from a clock that ticks every few milliseconds rather than
+	// from the one that runs, so anything written in a burst shares a time to
+	// the nanosecond. Setting it rather than racing for it is what makes this
+	// say the same thing on every filesystem. It is ahead of now so that it is
+	// the highest time in the tree whatever the README happens to carry.
+	tick := time.Now().Add(time.Minute)
+	place(t, root, "docs/b.md", "# b\n", tick)
+
+	_, cursor = until(t, s, cursor, func(all []connector.Change) bool {
+		return wasRead(all, "repo:docs/b.md")
+	})
+
+	// The other half of the burst, whose event never reached the record.
+	// Closing the watcher arrives where an overflow arrives and arrives there
+	// on purpose: the next sync has to walk, and a walk has nothing to go on
+	// but the cursor the sync before it handed back.
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	place(t, root, "docs/a.md", "# a\n", tick)
+
+	got, _ := changes(t, s, cursor)
+	if !wasRead(got, "repo:docs/a.md") {
+		t.Fatalf("the walk read %v, so docs/a.md is lost for good: it is not newer than a cursor that landed on its own timestamp", read(got))
 	}
 }
 


### PR DESCRIPTION
A sync handed back the newest modification time it saw.
That says everything at or before that time has been read, and it is a claim no sync is in a position to make about the moment it is still inside of.

A file is stamped from a clock that ticks every few milliseconds rather than from the one that runs, so a file created just after the walk went past its directory carries the same modification time as one the walk read.
The next walk emits what is strictly newer than the cursor, so that file is never read.
Nothing fails, nothing is quarantined and nothing is logged.
The document is simply not in the index until somebody writes to the file again.

The cursor is now the newest time seen or a second before the sync started, whichever is earlier, and never earlier than the cursor the sync was given.
A second covers the clock a file is stamped from and it covers a filesystem that keeps modification times to the second, where a file created at any point during a second carries the start of it.

What it costs is that a change made in the second before a sync is reported by the next sync as well.
That is a document arriving twice rather than a document not arriving at all, and it is paid once: the sync after that starts more than a second later and the cursor moves past it.
An idle corpus pays nothing, because the newest file in it is older than a second and the cursor sits exactly on it.

## Tests

`TestAFileWrittenInTheSameTickAsOneThatWasReadSurvivesALostRecord` places two files with the same modification time, lets one of them be read from the watcher's record, and then forces the walk.
Without the change the second file is missing and the test says so.

The fixtures the walking tests use are now dated a minute ago.
A corpus written in the same millisecond as the sync reading it is not a corpus, and a test that writes one is asking about the settling window rather than about the thing it means to ask about.
The two permission tests wait a second instead, one of them because an inode change time is set when the file is made and cannot be set to anything else afterwards.

## Where it came from

This is what has been failing `TestALostRecordMakesTheNextSyncWalk` on loaded machines, including once on CI for #184.
The five files that test writes land on one or two timestamps there, and the first sync's cursor lands on the same one, so the walk after the record overflowed skipped whichever files shared it.
It looked like a flake because on an idle laptop the writes usually land on separate timestamps.

Six race runs of the package on an eight core machine are clean, where two runs in five failed before.

Fixes #187
