### PR TITLE
Resolve group membership from an Entra ID tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,10 +342,11 @@ A directory that cannot answer refuses the request rather than serving half of s
 This is the deployment with forty people and six groups in it.
 
 A company with an identity provider gets an adapter instead, and an adapter answers the same two lookups the file does.
-`directory/okta` is the first one, over the Users and Groups API, and it passes the same conformance suite.
+`directory/okta` and `directory/entra` are the two that exist, and both pass the same conformance suite the file does.
 Okta groups do not contain groups, so an expansion there is one level deep, and the group listing that answers the subject lookup already carries every group object the level below is about to ask for.
+Entra ID groups do nest and Microsoft Graph will do the nesting for you, so a person eight levels down a tree is one request rather than eight rounds of them, and the expansion is still one level deep for a different reason.
 `-directory` does not take an organisation yet, so an adapter is wired up in Go for now.
-Entra ID and Google Workspace are next, and the flag grows a spelling for all three at once.
+Google Workspace is next, and the flag grows a spelling for all three at once.
 
 ## Metrics
 
@@ -430,6 +431,7 @@ func main() {
 | `directory` | a person resolved into the groups they are in, with cycle detection, a version, a union over several providers and one cache layer, [docs/identity.md](docs/identity.md) |
 | `directory/directorytest` | the conformance suite that defines what a directory adapter is |
 | `directory/okta` | group membership from an Okta organisation, over the Users and Groups API |
+| `directory/entra` | group membership from a Microsoft Entra ID tenant, over the Graph, with the closure resolved by the provider |
 | `doc` | the canonical document model every connector normalises into |
 | `store` | the storage interface, plus `storetest`, the conformance suite |
 | `store/memstore` | the reference in memory driver |

--- a/arch_test.go
+++ b/arch_test.go
@@ -43,6 +43,9 @@ var allowed = map[string][]string{
 	// than beside it: an adapter answers two lookups and decides nothing.
 	"directory/okta": {"acl", "cache", "connector/limit", "directory"},
 
+	// The same place in the layering, for the same reasons.
+	"directory/entra": {"acl", "cache", "connector/limit", "directory"},
+
 	// cache is a map with a lock on it and imports nothing of ours, which is
 	// what lets index depend on it without the dependency meaning anything. A
 	// cache that knew about principals would be a second copy of the permission

--- a/directory/directorytest/directorytest.go
+++ b/directory/directorytest/directorytest.go
@@ -34,6 +34,16 @@
 // their arithmetic count a level fewer. Everything else still runs, because
 // nothing else about what an answer means changes.
 //
+// # Providers that have already walked it
+//
+// The other direction is a provider that nests and hands over the closure
+// itself. Entra ID is the one this was written for: transitiveMemberOf answers
+// with every group a person is in however deeply nested, so the graph arrives
+// walked. A fixture that sets [Fixture.Transitive] runs every case, because the
+// answer is the same set and the lookups are the same count. The one thing that
+// changes is the depth of a nest, which becomes one level, and the suite
+// asserts that rather than allowing it.
+//
 // # Usage
 //
 //	func TestConformance(t *testing.T) {
@@ -110,6 +120,27 @@ type Fixture struct {
 	//
 	// The default is false, so a provider that does nest runs everything.
 	Flat bool
+
+	// Transitive says the provider answers a subject lookup with the whole
+	// closure rather than with the memberships one level up.
+	//
+	// Entra ID is the example: transitiveMemberOf returns every group a person
+	// is in however deeply nested, so the graph arrives already walked. The
+	// answer is the same set as a provider that nests, and every count is the
+	// same too, because the resolver still looks each of those groups up to
+	// learn its name and its version. The one number that differs is the depth,
+	// which is one level for any nest at all.
+	//
+	// That number is asserted rather than tolerated. A provider claiming to
+	// expand transitively and then costing three levels on a three level nest
+	// is one that is not doing what it says, and the difference is the whole
+	// reason to prefer it: a person in a deep directory is one round trip
+	// instead of one per level.
+	//
+	// Flat and Transitive are not the same thing and a provider is at most one
+	// of them. A flat provider has no nesting to expand. A transitive one has
+	// nesting and does the expanding itself.
+	Transitive bool
 }
 
 // above is the membership to give a group the cases nest, which is nothing at
@@ -119,6 +150,16 @@ func (f Fixture) above(groups ...string) []string {
 		return nil
 	}
 	return groups
+}
+
+// levels is how deep a nest of n levels is walked, which is all of them for a
+// provider the resolver has to walk and one for a provider that arrives already
+// walked.
+func (f Fixture) levels(n int) int {
+	if f.Transitive {
+		return 1
+	}
+	return n
 }
 
 // nesting skips a case that is about walking a group graph, on a provider that
@@ -209,8 +250,12 @@ func testNested(t *testing.T, f Fixture) {
 	if !slices.Equal(got.Groups.Members, want) {
 		t.Fatalf("a three level nest resolved to %v, want %v", got.Groups.Members, want)
 	}
-	if got.Depth != 3 {
-		t.Errorf("a three level nest was walked %d levels deep", got.Depth)
+	// A provider that expands transitively hands the whole nest over at once,
+	// so the same three groups cost one level instead of three. That is the
+	// point of such a provider and it is worth failing when it stops being
+	// true.
+	if want := f.levels(3); got.Depth != want {
+		t.Errorf("a three level nest was walked %d levels deep, want %d", got.Depth, want)
 	}
 }
 

--- a/directory/entra/entra.go
+++ b/directory/entra/entra.go
@@ -1,0 +1,565 @@
+// Package entra resolves group membership against a Microsoft Entra ID tenant.
+//
+// It answers the two lookups [directory.Directory] asks for and nothing else.
+// The closure, the cycle detection, the bound on how much one expansion may
+// cost and the version an answer is stamped with are all in [directory], and
+// they are shared by every provider, because those are exactly the parts that
+// are easy to get subtly wrong and impossible to notice from the outside.
+//
+// # The graph arrives already walked
+//
+// Entra groups do nest, and unlike most providers it will do the nesting for
+// you. The transitiveMemberOf collection is every group a person is in however
+// deeply that membership is inherited, so a person eight levels down a nest is
+// one request rather than eight rounds of them.
+//
+// That is why [Directory.Group] answers with an empty membership. It is not
+// that a group here is a member of nothing, it is that whatever it is a member
+// of already came back with the subject. Returning the parents as well would
+// have the resolver walk a graph it has already been handed, which costs the
+// round trips this endpoint exists to avoid and changes no answer.
+//
+// The cost is the same shape as any other provider once the closure is in
+// hand: the walk asks about each group, and a person in three hundred groups
+// would be three hundred requests. So the listing, which returns whole group
+// objects rather than ids, fills a small buffer that the group lookups read.
+// The fact being held there is "this group exists and is a member of nothing
+// this adapter will report", which cannot become false in a way that changes an
+// answer, so the buffer changes what an expansion costs and not what it says.
+//
+// # The cast in the middle of the path
+//
+// The path is transitiveMemberOf/microsoft.graph.group and the cast on the end
+// of it is load bearing. Without it the collection also returns directory roles
+// and administrative units, which are directory objects a person belongs to and
+// are not groups. Their ids would go into the group set beside the real ones,
+// and a rule naming one would then allow everybody who holds that role. The
+// cast asks the service to return only groups rather than filtering after the
+// fact, so the ids that arrive are the ids that belong there.
+//
+// # Two properties that have to be asked for
+//
+// Graph answers a user lookup with a default set of properties, and
+// accountEnabled is not in it. An adapter that reads the user and looks for
+// that field without selecting it gets the zero value, which is false, or gets
+// nothing at all and calls it true, depending on how it is written. Both are
+// wrong in a way nobody notices: the first refuses everybody and the second
+// keeps resolving the groups of people who were deactivated months ago. Every
+// property this adapter reads is named in a $select for that reason.
+//
+// # There is no revision to read
+//
+// The v1.0 Graph exposes no last modified time on a user or on a group, so
+// there is nothing to hand [directory] as a version and copy from the provider.
+//
+// The group version is empty, and for this provider that is complete rather
+// than a gap. A version on a group is there to catch a change that alters
+// somebody's group set without altering the ids in it, which for a provider
+// that nests means a group being moved under another one. Here that move
+// arrives as a different closure, because the closure is what the provider
+// returns. Nothing else a group carries can change a decision, and hashing the
+// display name in would invalidate every member's cached group set for a rename
+// that alters no answer.
+//
+// The subject version is a hash of exactly the fields this adapter reports
+// about the person, because those are not covered by the closure. A new alias
+// or an account being deactivated has to reach the principal, and the group ids
+// do not move when either happens.
+//
+// # Rate limits
+//
+// Graph says nothing about what is left until it refuses, and then answers a
+// 429 or a 503 with a Retry-After. That is the opposite of a provider that
+// publishes its numbers on every response, and it means [limit] can only hold
+// back after a refusal rather than before one. The breaker matters more here
+// for the same reason: a tenant that has started refusing is one that wants to
+// be left alone for a while, and the only way to learn that is to have been
+// told once and remember it.
+package entra
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/cache"
+	"github.com/tamnd/genba/connector/limit"
+	"github.com/tamnd/genba/directory"
+)
+
+// DefaultName is the identity source the groups belong to, which is what every
+// group key from this tenant is prefixed with.
+const DefaultName = "entra"
+
+// DefaultEndpoint is the Graph. A national cloud is a different one.
+const DefaultEndpoint = "https://graph.microsoft.com"
+
+// DefaultPageSize is how many groups are asked for per page, which is the most
+// this collection accepts.
+const DefaultPageSize = 999
+
+// DefaultBufferTTL is how long the group listing that answered a subject lookup
+// is kept for the group lookups that follow it.
+//
+// It is short because it only has to outlive one expansion. See the package
+// documentation for why holding it for longer would not change an answer
+// either.
+const DefaultBufferTTL = 30 * time.Second
+
+// DefaultBufferSize is how many groups the buffer holds before it starts
+// dropping the ones nobody has asked about recently.
+const DefaultBufferSize = 20000
+
+// maxPages bounds a listing. At the default page size it is nearly a million
+// groups, which is past anybody's tenant and well short of forever.
+const maxPages = 1000
+
+// version is the Graph version this speaks. The beta endpoint carries fields
+// that would be useful here and no promise that they will still be there next
+// month, which is the wrong trade for the thing that decides what people can
+// read.
+const version = "/v1.0"
+
+// Directory resolves subjects and groups against one Entra ID tenant.
+//
+// It is safe for concurrent use, which it has to be: an expansion looks up a
+// level of the graph in parallel.
+type Directory struct {
+	http   *http.Client
+	base   string
+	tokens Tokens
+	name   string
+	page   int
+
+	// held is the group listing from a subject lookup, waiting for the group
+	// lookups that are about to ask for the same objects.
+	held *cache.Cache[directory.Group]
+}
+
+var _ directory.Directory = (*Directory)(nil)
+
+// Option configures a [Directory].
+type Option func(*Directory)
+
+// WithName sets the identity source the group ids belong to.
+//
+// A deployment resolving against two tenants needs two names, because a group
+// id from one and the same id from the other would otherwise be the same group,
+// and they are not.
+func WithName(name string) Option {
+	return func(d *Directory) { d.name = name }
+}
+
+// WithEndpoint replaces the Graph, which a national cloud and a test both need.
+func WithEndpoint(base string) Option {
+	return func(d *Directory) { d.base = strings.TrimSuffix(base, "/") }
+}
+
+// WithHTTPClient replaces the client entirely, rate limiting included.
+//
+// A caller who passes one is taking on the limits themselves, which is right
+// for a test replaying a recording and wrong for anything talking to Graph.
+func WithHTTPClient(c *http.Client) Option {
+	return func(d *Directory) {
+		if c != nil {
+			d.http = c
+		}
+	}
+}
+
+// WithLimits changes what the tenant is allowed to cost.
+func WithLimits(l limit.Limits) Option {
+	return func(d *Directory) { d.http = throttled(l) }
+}
+
+// WithPageSize sets how many groups are asked for per page. A size below one
+// selects [DefaultPageSize].
+func WithPageSize(n int) Option {
+	return func(d *Directory) { d.page = n }
+}
+
+// WithBuffer sets how long and how much of the group listing is kept for the
+// group lookups that follow it. A size below one selects [DefaultBufferSize].
+//
+// A lifetime below one turns the buffer off, which is a request per group in
+// the set rather than one listing. That is correct and slow, so it is for a
+// test that wants to count the requests rather than for a deployment.
+func WithBuffer(ttl time.Duration, size int) Option {
+	return func(d *Directory) {
+		if ttl < 1 {
+			d.held = nil
+			return
+		}
+		if size < 1 {
+			size = DefaultBufferSize
+		}
+		d.held = cache.New[directory.Group](size, ttl)
+	}
+}
+
+// New returns a directory over an Entra ID tenant.
+//
+// The tokens are where the bearer comes from. [NewApplication] is the one to
+// reach for in a deployment and [Token] is the one for a test.
+func New(tokens Tokens, opts ...Option) (*Directory, error) {
+	if tokens == nil {
+		return nil, errors.New("entra: a source of tokens is required")
+	}
+
+	d := &Directory{
+		http:   throttled(limit.Limits{}),
+		base:   DefaultEndpoint,
+		tokens: tokens,
+		name:   DefaultName,
+		page:   DefaultPageSize,
+		held:   cache.New[directory.Group](DefaultBufferSize, DefaultBufferTTL),
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	if d.name == "" {
+		return nil, errors.New("entra: the source name cannot be empty")
+	}
+	if d.page < 1 {
+		d.page = DefaultPageSize
+	}
+	u, err := url.Parse(d.base)
+	if err != nil {
+		return nil, fmt.Errorf("entra: the endpoint %q: %w", d.base, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("entra: the endpoint %q needs a scheme and a host", d.base)
+	}
+	return d, nil
+}
+
+// throttled is the client used when the caller has not supplied one.
+func throttled(l limit.Limits) *http.Client {
+	return &http.Client{Transport: limit.NewTransport(l)}
+}
+
+// Name is the identity source these ids belong to.
+func (d *Directory) Name() string { return d.name }
+
+// Subject returns one person, with every group they are in.
+//
+// Every group rather than the ones they are directly in, because that is what
+// the provider answers with and there is nothing to gain by throwing the rest
+// away and asking again. See the package documentation.
+func (d *Directory) Subject(ctx context.Context, id string) (directory.Subject, error) {
+	if id == "" {
+		return directory.Subject{}, fmt.Errorf("entra: %w", directory.ErrNoSubject)
+	}
+
+	q := url.Values{"$select": {"id,displayName,mail,userPrincipalName,otherMails,accountEnabled"}}
+	var u user
+	if err := d.get(ctx, version+"/users/"+url.PathEscape(id), q, &u); err != nil {
+		if errors.Is(err, errNotFound) {
+			return directory.Subject{}, fmt.Errorf("entra: %q: %w", id, directory.ErrNoSubject)
+		}
+		return directory.Subject{}, err
+	}
+
+	sub := directory.Subject{
+		ID:         cmp.Or(u.ID, id),
+		Name:       u.DisplayName,
+		Email:      u.address(),
+		Identities: d.identities(u),
+		Disabled:   u.Enabled != nil && !*u.Enabled,
+	}
+	sub.Version = u.version()
+	// A deactivated account is refused by the resolver, so the group listing it
+	// would have needed is a request nobody is going to read the answer to.
+	if sub.Disabled {
+		return sub, nil
+	}
+
+	groups, err := d.memberships(ctx, sub.ID)
+	if err != nil {
+		return directory.Subject{}, err
+	}
+	sub.MemberOf = make([]string, 0, len(groups))
+	for _, g := range groups {
+		sub.MemberOf = append(sub.MemberOf, g.ID)
+		d.buffer(g)
+	}
+	return sub, nil
+}
+
+// buffer keeps a group object for the lookup that is about to ask for it.
+func (d *Directory) buffer(g directory.Group) {
+	if d.held != nil {
+		d.held.Put(g.ID, g)
+	}
+}
+
+// buffered is the group object a listing already went past, if there is one.
+func (d *Directory) buffered(id string) (directory.Group, bool) {
+	if d.held == nil {
+		return directory.Group{}, false
+	}
+	return d.held.Get(id)
+}
+
+// Group returns one group.
+//
+// The membership is always empty, because whatever this group is a member of
+// arrived with the subject, and the lookup is usually free, because the listing
+// that answered the subject put the object here on its way past. See the
+// package documentation for both.
+func (d *Directory) Group(ctx context.Context, id string) (directory.Group, error) {
+	if id == "" {
+		return directory.Group{}, fmt.Errorf("entra: %w", directory.ErrNoGroup)
+	}
+	if g, ok := d.buffered(id); ok {
+		return g, nil
+	}
+
+	q := url.Values{"$select": {"id,displayName"}}
+	var raw group
+	if err := d.get(ctx, version+"/groups/"+url.PathEscape(id), q, &raw); err != nil {
+		if errors.Is(err, errNotFound) {
+			return directory.Group{}, fmt.Errorf("entra: %q: %w", id, directory.ErrNoGroup)
+		}
+		return directory.Group{}, err
+	}
+	g := raw.directory(id)
+	d.buffer(g)
+	return g, nil
+}
+
+// memberships reads the whole closure, following the pages.
+func (d *Directory) memberships(ctx context.Context, id string) ([]directory.Group, error) {
+	var (
+		out  []directory.Group
+		ref  = version + "/users/" + url.PathEscape(id) + "/transitiveMemberOf/microsoft.graph.group"
+		q    = url.Values{"$select": {"id,displayName"}, "$top": {strconv.Itoa(d.page)}}
+		seen = make(map[string]bool)
+	)
+	// Bounded because the page after the last one is a link the service sends,
+	// and a service that sent the same link twice would otherwise be an
+	// expansion that never returned. The resolver's own bound is on groups
+	// reached rather than on requests made, so it would not catch this.
+	for range maxPages {
+		var page listing[group]
+		if err := d.get(ctx, ref, q, &page); err != nil {
+			return nil, err
+		}
+		for _, raw := range page.Value {
+			// A closure can name the same group twice when two paths reach it,
+			// and the group set is a set.
+			if raw.ID == "" || seen[raw.ID] {
+				continue
+			}
+			seen[raw.ID] = true
+			out = append(out, raw.directory(raw.ID))
+		}
+		if page.Next == "" {
+			return out, nil
+		}
+		// The link is absolute and already carries the skip token, the select
+		// and the page size, so it is followed as it was sent rather than taken
+		// apart and rebuilt.
+		ref, q = page.Next, nil
+	}
+	return nil, fmt.Errorf("entra: the groups of %q did not stop after %d pages", id, maxPages)
+}
+
+// listing is a collection of one kind of thing, and the link to the rest of it.
+type listing[T any] struct {
+	Value []T    `json:"value"`
+	Next  string `json:"@odata.nextLink"`
+}
+
+// user is what Graph says about one person.
+type user struct {
+	ID          string   `json:"id"`
+	DisplayName string   `json:"displayName"`
+	Mail        string   `json:"mail"`
+	UPN         string   `json:"userPrincipalName"`
+	OtherMails  []string `json:"otherMails"`
+
+	// Enabled is a pointer so that the field being absent and the field being
+	// false are two different things. They mean opposite things and the reason
+	// for the first is nearly always a $select somebody forgot.
+	Enabled *bool `json:"accountEnabled"`
+}
+
+// address is the person's mailbox, which is what a rule written by email names.
+//
+// The user principal name is the fallback and not the first choice. It is an
+// address at most tenants and a login that merely looks like one at the rest.
+func (u user) address() string {
+	if u.Mail != "" {
+		return u.Mail
+	}
+	if guest(u.UPN) {
+		return ""
+	}
+	return u.UPN
+}
+
+// version is a fingerprint of what this adapter reports about the person.
+//
+// Graph has no revision to copy, so the alternative to computing one is an
+// empty version, and an empty version means a display name or a new alias never
+// reaches a principal that is already cached. The group set is not in here
+// because [directory] fingerprints the group ids separately and this provider
+// answers with the whole closure, so a membership moving moves those.
+func (u user) version() string {
+	h := fnv.New64a()
+	fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00", u.ID, u.DisplayName, u.Mail, u.UPN)
+	for _, m := range u.OtherMails {
+		fmt.Fprintf(h, "%s\x00", m)
+	}
+	if u.Enabled != nil && !*u.Enabled {
+		fmt.Fprint(h, "disabled\x00")
+	}
+	return strconv.FormatUint(h.Sum64(), 16)
+}
+
+// group is what Graph says about one group.
+type group struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+}
+
+// directory turns one into what the resolver walks.
+//
+// The membership is empty and the version is empty, and neither is an omission.
+// See the package documentation for both.
+func (g group) directory(id string) directory.Group {
+	return directory.Group{ID: cmp.Or(g.ID, id), Name: g.DisplayName}
+}
+
+// identities is the same person in the systems being indexed.
+//
+// The tenant id is one of them, because a connector that was told about groups
+// by Entra names people the same way. The addresses are the others, because a
+// rule granting to somebody by email is the common shape and an email address
+// is what a person has in every product they use.
+func (d *Directory) identities(u user) []acl.Identity {
+	out := make([]acl.Identity, 0, 4)
+	add := func(source, value string) {
+		if value == "" {
+			return
+		}
+		id := acl.Identity{Source: source, Value: value}
+		if slices.Contains(out, id) {
+			return
+		}
+		out = append(out, id)
+	}
+	add(d.name, u.ID)
+	add("email", u.Mail)
+	// A guest's principal name is their address with the at sign replaced and
+	// the host tenant stuck on the end, which is a string that looks enough like
+	// an address to be mistaken for one and is nobody's mailbox. Their real
+	// address is in mail, which is already above.
+	if strings.Contains(u.UPN, "@") && !guest(u.UPN) {
+		add("email", u.UPN)
+	}
+	for _, m := range u.OtherMails {
+		add("email", m)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// guest says whether a principal name belongs to somebody from another tenant.
+func guest(upn string) bool {
+	return strings.Contains(strings.ToUpper(upn), "#EXT#")
+}
+
+// errNotFound is Graph answering rather than failing to answer, and it is what
+// separates a subject the tenant does not hold from a tenant that could not be
+// reached.
+var errNotFound = errors.New("not found")
+
+// get reads one JSON document.
+//
+// The reference is either a path under the endpoint or the absolute link a
+// listing sent for the page after it.
+func (d *Directory) get(ctx context.Context, ref string, q url.Values, into any) error {
+	u := ref
+	if strings.HasPrefix(ref, "/") {
+		u = d.base + ref
+	}
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	token, err := d.tokens.Token(ctx)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("entra: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := d.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("entra: %s: %w", ref, err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return d.refusal(ref, resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(into); err != nil {
+		return fmt.Errorf("entra: %s: reading the answer: %w", ref, err)
+	}
+	return nil
+}
+
+// refusal turns a response Graph refused with into an error worth reading.
+//
+// A 400 is one of these and not a failure, which is worth saying out loud.
+// Graph answers a lookup for an id that could not belong to anybody with a bad
+// request rather than with a not found, so a store holding a username where a
+// principal name belongs would otherwise fail the expansion instead of
+// reporting that nobody by that name is in the tenant. The two mean the same
+// thing to a caller: the tenant does not hold this person.
+func (d *Directory) refusal(ref string, resp *http.Response) error {
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	_ = json.Unmarshal(raw, &body)
+
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		return errNotFound
+	case resp.StatusCode == http.StatusBadRequest && body.Error.Code == "Request_BadRequest":
+		return errNotFound
+	}
+	switch {
+	case body.Error.Code != "" && body.Error.Message != "":
+		return fmt.Errorf("entra: %s: %s: %s (%s)", ref, resp.Status, firstLine(body.Error.Message), body.Error.Code)
+	case body.Error.Message != "":
+		return fmt.Errorf("entra: %s: %s: %s", ref, resp.Status, firstLine(body.Error.Message))
+	default:
+		return fmt.Errorf("entra: %s: %s", ref, resp.Status)
+	}
+}

--- a/directory/entra/entra_test.go
+++ b/directory/entra/entra_test.go
@@ -1,0 +1,423 @@
+package entra_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/directorytest"
+	"github.com/tamnd/genba/directory/entra"
+)
+
+func TestConformance(t *testing.T) {
+	directorytest.Run(t, func(t *testing.T) directorytest.Fixture {
+		o, endpoint := newTenant(t)
+		return directorytest.Fixture{
+			Directory: dial(t, endpoint),
+			Put:       o.put,
+			PutGroup:  o.putGroup,
+
+			// Every group a person is in arrives at once, so a nest of any
+			// depth is one level. See the package documentation.
+			Transitive: true,
+
+			// Drop is deliberately absent. A membership naming a group that is
+			// not there is not a state this provider can be in, because the
+			// collection answers with the group objects rather than with their
+			// ids, and an object that is not there is not in the answer.
+
+			Identity: func(t *testing.T, s *directory.Subject) acl.Identity {
+				t.Helper()
+				s.Email = "mei@acme.test"
+				return acl.Identity{Source: "email", Value: "mei@acme.test"}
+			},
+		}
+	})
+}
+
+// dial is a directory over the fake tenant.
+//
+// Without the rate limiter, because these cases are about the adapter and the
+// limiter is tested where it lives. Leaving it on would make a case about a
+// person in three hundred groups a case about how long five requests a second
+// takes.
+func dial(t *testing.T, endpoint string, opts ...entra.Option) *entra.Directory {
+	t.Helper()
+	d, err := entra.New(entra.Token(bearer), append([]entra.Option{
+		entra.WithEndpoint(endpoint),
+		entra.WithHTTPClient(http.DefaultClient),
+	}, opts...)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// expand is one resolution, which is what every case below is about.
+func expand(t *testing.T, d *entra.Directory, id string, opts ...directory.Option) directory.Expansion {
+	t.Helper()
+	got, err := attempt(t, d, id, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func attempt(t *testing.T, d *entra.Directory, id string, opts ...directory.Option) (directory.Expansion, error) {
+	t.Helper()
+	r, err := directory.New(d, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r.Expand(t.Context(), id)
+}
+
+// members is the group set with the source prefix taken back off, because what
+// these cases are about is which groups came back rather than how a key is
+// spelled.
+func members(t *testing.T, d *entra.Directory, got directory.Expansion) []string {
+	t.Helper()
+	out := make([]string, 0, len(got.Groups.Members))
+	for _, key := range got.Groups.Members {
+		out = append(out, strings.TrimPrefix(key, d.Name()+":"))
+	}
+	return out
+}
+
+func TestTheGroupsAListingAlreadyCarriedAreNotAskedForAgain(t *testing.T) {
+	o, endpoint := newTenant(t)
+	in := make([]string, 0, 300)
+	for i := range 300 {
+		id := "g" + strconv.Itoa(i)
+		o.putGroup(t, directory.Group{ID: id, Name: "Group " + strconv.Itoa(i)})
+		in = append(in, id)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: in})
+
+	got := expand(t, dial(t, endpoint), "mei")
+	if len(got.Groups.Members) != 300 {
+		t.Fatalf("mei resolved to %d groups, want 300", len(got.Groups.Members))
+	}
+	// The whole point of the buffer. Three hundred groups is one listing and
+	// not three hundred and one requests.
+	if n := o.spent("group"); n != 0 {
+		t.Errorf("a person in three hundred groups cost %d group lookups, want none", n)
+	}
+}
+
+func TestWithTheBufferOffEveryGroupIsARequest(t *testing.T) {
+	o, endpoint := newTenant(t)
+	in := make([]string, 0, 20)
+	for i := range 20 {
+		id := "g" + strconv.Itoa(i)
+		o.putGroup(t, directory.Group{ID: id})
+		in = append(in, id)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: in})
+
+	// Saying what the buffer is worth by taking it away. Without this the test
+	// above would pass against an adapter that never looks a group up at all.
+	expand(t, dial(t, endpoint, entra.WithBuffer(0, 0)), "mei")
+	if n := o.spent("group"); n != 20 {
+		t.Errorf("twenty groups cost %d lookups with the buffer off, want 20", n)
+	}
+}
+
+func TestAListingIsFollowedAcrossItsPages(t *testing.T) {
+	o, endpoint := newTenant(t)
+	in := make([]string, 0, 25)
+	for i := range 25 {
+		id := fmt.Sprintf("g%02d", i)
+		o.putGroup(t, directory.Group{ID: id})
+		in = append(in, id)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: in})
+
+	got := expand(t, dial(t, endpoint, entra.WithPageSize(4)), "mei")
+	if n := len(got.Groups.Members); n != 25 {
+		t.Fatalf("mei resolved to %d groups, want 25", n)
+	}
+	if n := o.spent("memberships"); n != 7 {
+		t.Errorf("twenty five groups at four a page cost %d requests, want 7", n)
+	}
+}
+
+func TestNoGroupIsServedTwiceOrMissedAcrossAPageBoundary(t *testing.T) {
+	o, endpoint := newTenant(t)
+	want := make([]string, 0, 13)
+	for i := range 13 {
+		id := fmt.Sprintf("g%02d", i)
+		o.putGroup(t, directory.Group{ID: id})
+		want = append(want, id)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: want})
+
+	d := dial(t, endpoint, entra.WithPageSize(5))
+	got := members(t, d, expand(t, d, "mei"))
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		t.Fatalf("thirteen groups at five a page resolved to [%s], want [%s]", describe(got), describe(want))
+	}
+}
+
+func TestADirectoryRoleIsNotAGroup(t *testing.T) {
+	o, endpoint := newTenant(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	d := dial(t, endpoint)
+	got := members(t, d, expand(t, d, "mei"))
+	// The cast on the end of the path is what keeps this out. Without it the
+	// role is a directory object mei belongs to, its id goes in the group set
+	// beside the real groups, and a rule naming it allows everybody who holds
+	// it.
+	if slices.Contains(got, role) {
+		t.Errorf("mei resolved to [%s], which includes a directory role", describe(got))
+	}
+	if n := o.spent("uncast"); n != 0 {
+		t.Errorf("%d membership requests went without the cast that asks for groups only", n)
+	}
+}
+
+func TestTheClosureCostsOneLevelHoweverDeepTheNestIs(t *testing.T) {
+	o, endpoint := newTenant(t)
+	// Six levels, which against a provider the resolver has to walk is six
+	// rounds of requests one after another.
+	for i := range 6 {
+		g := directory.Group{ID: "level" + strconv.Itoa(i)}
+		if i > 0 {
+			g.MemberOf = []string{"level" + strconv.Itoa(i-1)}
+		}
+		o.putGroup(t, g)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"level5"}})
+
+	got := expand(t, dial(t, endpoint), "mei")
+	if n := len(got.Groups.Members); n != 6 {
+		t.Fatalf("a six level nest resolved to %d groups, want 6", n)
+	}
+	if got.Depth != 1 {
+		t.Errorf("a six level nest was walked %d levels deep, want 1", got.Depth)
+	}
+	if n := o.spent("memberships"); n != 1 {
+		t.Errorf("a six level nest cost %d membership requests, want 1", n)
+	}
+}
+
+func TestAnAnswerWithoutTheAccountStateIsNotTakenAsADeactivation(t *testing.T) {
+	o, endpoint := newTenant(t)
+	o.silent()
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	// A field that is absent and a field that is false mean opposite things.
+	// Reading the second out of the first refuses everybody in the tenant, and
+	// the symptom is a search engine that has stopped finding anything.
+	got, err := attempt(t, dial(t, endpoint), "mei")
+	if err != nil {
+		t.Fatalf("an answer with no accountEnabled in it gave %v, want mei's groups", err)
+	}
+	if len(got.Groups.Members) != 1 {
+		t.Errorf("mei resolved to %v, want one group", got.Groups.Members)
+	}
+}
+
+func TestAGuestPrincipalNameIsNotAnAddress(t *testing.T) {
+	o, endpoint := newTenant(t)
+	o.put(t, directory.Subject{ID: "mei"})
+	o.edit(t, "mei", func(p *person) {
+		p.mail = "mei@partner.test"
+		p.upn = "mei_partner.test#EXT#@acme.onmicrosoft.com"
+	})
+
+	got := expand(t, dial(t, endpoint), "mei")
+	want := acl.Identity{Source: "email", Value: "mei@partner.test"}
+	if !slices.Contains(got.Subject.Identities, want) {
+		t.Errorf("a guest resolved to %v, which does not include their address", got.Subject.Identities)
+	}
+	// It has an at sign in it and it is nobody's mailbox. A rule granting to
+	// that string is not a rule anybody wrote.
+	for _, id := range got.Subject.Identities {
+		if strings.Contains(id.Value, "#EXT#") {
+			t.Errorf("a guest resolved to %v, which includes their principal name as an address", got.Subject.Identities)
+		}
+	}
+}
+
+func TestEveryAddressThePersonHasBecomesAnIdentity(t *testing.T) {
+	o, endpoint := newTenant(t)
+	o.put(t, directory.Subject{ID: "mei", Email: "mei@acme.test"})
+	o.edit(t, "mei", func(p *person) {
+		p.other = []string{"mei.tanaka@acme.test", "m.tanaka@acme.test"}
+	})
+
+	got := expand(t, dial(t, endpoint), "mei")
+	for _, want := range []acl.Identity{
+		{Source: "entra", Value: "mei"},
+		{Source: "email", Value: "mei@acme.test"},
+		{Source: "email", Value: "mei.tanaka@acme.test"},
+		{Source: "email", Value: "m.tanaka@acme.test"},
+	} {
+		if !slices.Contains(got.Subject.Identities, want) {
+			t.Errorf("mei resolved to %v, which does not include %v", got.Subject.Identities, want)
+		}
+	}
+	// The principal name is an address here and the mail is the same one, so
+	// the answer holds it once.
+	if n := len(got.Subject.Identities); n != 4 {
+		t.Errorf("mei resolved to %d identities, want 4 without repeats", n)
+	}
+}
+
+func TestTheVersionMovesWhenTheirAddressDoes(t *testing.T) {
+	o, endpoint := newTenant(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "mei", Email: "mei@acme.test", MemberOf: []string{"engineering"}})
+
+	d := dial(t, endpoint, entra.WithBuffer(0, 0))
+	before := expand(t, d, "mei").Groups.Version
+
+	// The group ids have not moved, so nothing about the closure catches this.
+	// A version that ignored it would leave a cached principal answering with
+	// an address the person no longer has.
+	o.edit(t, "mei", func(p *person) { p.other = []string{"mei.tanaka@acme.test"} })
+	if after := expand(t, d, "mei").Groups.Version; after == before {
+		t.Errorf("a new address left the version at %d", before)
+	}
+}
+
+func TestAnIdThatCouldNotBelongToAnybodyIsNobodyRatherThanAFailure(t *testing.T) {
+	_, endpoint := newTenant(t)
+
+	// Graph refuses a lookup for something that is neither an id nor a
+	// principal name with a bad request rather than with a not found. Both mean
+	// the tenant does not hold this person, and treating the first as a failure
+	// turns one bad row in a store into an expansion that never succeeds.
+	_, err := attempt(t, dial(t, endpoint), "not an id")
+	if !errors.Is(err, directory.ErrNoSubject) {
+		t.Errorf("an id the service refused as malformed gave %v, want ErrNoSubject", err)
+	}
+}
+
+func TestABadTokenIsAFailureRatherThanAnEmptyDirectory(t *testing.T) {
+	_, endpoint := newTenant(t)
+
+	d, err := entra.New(entra.Token("not-the-token"), entra.WithEndpoint(endpoint), entra.WithHTTPClient(http.DefaultClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The important half is that it is not ErrNoSubject. A tenant that refuses
+	// the credential and a tenant that has never heard of somebody have to be
+	// told apart, because the first is an outage and the second is a fact.
+	_, err = attempt(t, d, "mei")
+	switch {
+	case err == nil:
+		t.Fatal("a refused token resolved somebody anyway")
+	case errors.Is(err, directory.ErrNoSubject):
+		t.Fatalf("a refused token gave %v, which reads as a person who is not in the tenant", err)
+	case !strings.Contains(err.Error(), "InvalidAuthenticationToken"):
+		t.Errorf("a refused token gave %v, which does not say why", err)
+	}
+}
+
+func TestAGroupTheTenantDoesNotHoldIsRefusedAsSuch(t *testing.T) {
+	_, endpoint := newTenant(t)
+	_, err := dial(t, endpoint, entra.WithBuffer(0, 0)).Group(t.Context(), "00g1gone")
+	if !errors.Is(err, directory.ErrNoGroup) {
+		t.Errorf("a group nobody holds gave %v, want ErrNoGroup", err)
+	}
+}
+
+func TestTwoTenantsKeepTheirGroupsApart(t *testing.T) {
+	one, first := newTenant(t)
+	two, second := newTenant(t)
+	for _, o := range []*tenant{one, two} {
+		o.putGroup(t, directory.Group{ID: "engineering"})
+		o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	}
+
+	a := expand(t, dial(t, first, entra.WithName("acme")), "mei")
+	b := expand(t, dial(t, second, entra.WithName("globex")), "mei")
+
+	// The same id in two tenants is two groups, and a deployment that indexed
+	// both would otherwise hand one tenant's documents to the other's people.
+	if slices.Equal(a.Groups.Members, b.Groups.Members) {
+		t.Fatalf("two tenants both resolved to %v", a.Groups.Members)
+	}
+	if !slices.Contains(a.Groups.Members, "acme:engineering") {
+		t.Errorf("the first tenant resolved to %v, want acme:engineering", a.Groups.Members)
+	}
+	if !slices.Contains(b.Groups.Members, "globex:engineering") {
+		t.Errorf("the second tenant resolved to %v, want globex:engineering", b.Groups.Members)
+	}
+}
+
+func TestNewRefusesATenantItCannotUse(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		tokens entra.Tokens
+		opts   []entra.Option
+	}{
+		{"no tokens at all", nil, nil},
+		{"an endpoint that is not a URL", entra.Token(bearer), []entra.Option{entra.WithEndpoint("graph.microsoft.com")}},
+		{"an endpoint with no host", entra.Token(bearer), []entra.Option{entra.WithEndpoint("https://")}},
+		{"no source name", entra.Token(bearer), []entra.Option{entra.WithName("")}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := entra.New(c.tokens, c.opts...); err == nil {
+				t.Error("that was accepted, and the failure would arrive at the first lookup instead")
+			}
+		})
+	}
+}
+
+func TestResolvingFromOneTenantAtOnceIsSafe(t *testing.T) {
+	o, endpoint := newTenant(t)
+	for i := range 40 {
+		o.putGroup(t, directory.Group{ID: "g" + strconv.Itoa(i)})
+	}
+	for i := range 8 {
+		id := "u" + strconv.Itoa(i)
+		in := make([]string, 0, 40)
+		for g := range 40 {
+			in = append(in, "g"+strconv.Itoa(g))
+		}
+		o.put(t, directory.Subject{ID: id, MemberOf: in})
+	}
+
+	d := dial(t, endpoint)
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 5 {
+				if _, err := attempt(t, d, "u"+strconv.Itoa(i)); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestALookupThatWasCancelledStops(t *testing.T) {
+	o, endpoint := newTenant(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := dial(t, endpoint).Subject(ctx, "mei"); !errors.Is(err, context.Canceled) {
+		t.Errorf("a cancelled lookup gave %v, want a cancellation", err)
+	}
+}

--- a/directory/entra/fake_test.go
+++ b/directory/entra/fake_test.go
@@ -1,0 +1,382 @@
+package entra_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tamnd/genba/directory"
+)
+
+// A fake tenant, because the alternative is a suite that only runs for whoever
+// has a directory to point it at.
+//
+// It is deliberately more awkward than it needs to be in two places. A user
+// lookup that did not ask for accountEnabled fails the test rather than
+// quietly answering without it, and the membership collection without the cast
+// on the end of it returns a directory role alongside the groups. Both are what
+// Graph does, and both are mistakes an adapter can make without anything above
+// it noticing.
+
+// bearer is the token the fake accepts, and the one its token endpoint hands
+// out.
+const bearer = "eyJ0eXAiOiJKV1QifQ.fakeGraphTokenForTests"
+
+// role is the directory role every person here holds. It exists to be the thing
+// that must not end up in a group set.
+const role = "62e90394-69f5-4237-9190-012177145e10"
+
+type person struct {
+	name     string
+	mail     string
+	upn      string
+	other    []string
+	enabled  bool
+	memberOf []string
+}
+
+type team struct {
+	name     string
+	memberOf []string
+}
+
+type tenant struct {
+	t *testing.T
+
+	mu     sync.Mutex
+	users  map[string]*person
+	groups map[string]*team
+	calls  map[string]int
+	base   string
+
+	// secret is what the token endpoint insists on before it hands one out.
+	secret string
+
+	// quiet leaves accountEnabled out of a user, which is what Graph does when
+	// nobody asked for it.
+	quiet bool
+}
+
+// silent makes the tenant answer a user lookup without the account state, the
+// way the real one answers a lookup that did not name it.
+func (o *tenant) silent() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.quiet = true
+}
+
+// newTenant starts a fake Graph and returns it along with its endpoint.
+func newTenant(t *testing.T) (fake *tenant, endpoint string) {
+	t.Helper()
+	o := &tenant{
+		t:      t,
+		users:  map[string]*person{},
+		groups: map[string]*team{},
+		calls:  map[string]int{},
+		secret: "a-client-secret",
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /{tenant}/oauth2/v2.0/token", o.token)
+	mux.Handle("GET /v1.0/users/{id}", o.authorised(o.user))
+	mux.Handle("GET /v1.0/users/{id}/transitiveMemberOf", o.authorised(o.uncast))
+	mux.Handle("GET /v1.0/users/{id}/transitiveMemberOf/microsoft.graph.group", o.authorised(o.memberships))
+	mux.Handle("GET /v1.0/groups/{id}", o.authorised(o.group))
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	o.base = srv.URL
+	return o, srv.URL
+}
+
+// authorised refuses anything that did not arrive as a bearer, the way Graph
+// does, so a test cannot pass with a token the adapter never sent.
+func (o *tenant) authorised(h http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+bearer {
+			o.refuse(w, http.StatusUnauthorized, "InvalidAuthenticationToken", "Access token is empty or invalid.")
+			return
+		}
+		if !strings.Contains(r.Header.Get("Accept"), "json") {
+			o.refuse(w, http.StatusNotAcceptable, "NotAcceptable", "The request asked for something this endpoint does not produce.")
+			return
+		}
+		h(w, r)
+	})
+}
+
+func (o *tenant) token(w http.ResponseWriter, r *http.Request) {
+	o.count("token")
+	if err := r.ParseForm(); err != nil {
+		o.refuse(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	o.mu.Lock()
+	secret := o.secret
+	o.mu.Unlock()
+
+	if r.PostForm.Get("client_secret") != secret {
+		// The shape of a real refusal, correlation id and all, because the
+		// adapter trims one of these down to the sentence worth reading.
+		o.write(w, http.StatusUnauthorized, map[string]any{
+			"error":             "invalid_client",
+			"error_description": "AADSTS7000215: Invalid client secret provided.\r\nTrace ID: 0000\r\nCorrelation ID: 0000",
+		})
+		return
+	}
+	o.write(w, http.StatusOK, map[string]any{
+		"token_type":   "Bearer",
+		"expires_in":   3599,
+		"access_token": bearer,
+	})
+}
+
+func (o *tenant) user(w http.ResponseWriter, r *http.Request) {
+	o.count("user")
+	id := r.PathValue("id")
+
+	// The whole reason the adapter names its properties. A lookup that did not
+	// ask for accountEnabled gets an answer without it, and an adapter reading
+	// that answer decides whether somebody still works here from a field that
+	// is not in front of it.
+	o.mu.Lock()
+	p, ok := o.users[id]
+	quiet := o.quiet
+	o.mu.Unlock()
+
+	if selected := r.URL.Query().Get("$select"); !quiet && !slices.Contains(strings.Split(selected, ","), "accountEnabled") {
+		o.t.Errorf("a user lookup selected %q, which does not include accountEnabled, so the answer would not say whether the account is live", selected)
+	}
+	if !ok {
+		o.refuse(w, http.StatusNotFound, "Request_ResourceNotFound",
+			fmt.Sprintf("Resource '%s' does not exist or one of its queried reference-property objects are not present.", id))
+		return
+	}
+
+	body := map[string]any{
+		"id":                id,
+		"displayName":       p.name,
+		"mail":              nullable(p.mail),
+		"userPrincipalName": p.upn,
+		"otherMails":        emptyList(p.other),
+		"accountEnabled":    p.enabled,
+	}
+	if quiet {
+		delete(body, "accountEnabled")
+	}
+	o.write(w, http.StatusOK, body)
+}
+
+// uncast is the collection without microsoft.graph.group on the end of it,
+// which answers with the directory roles as well.
+func (o *tenant) uncast(w http.ResponseWriter, r *http.Request) {
+	o.count("uncast")
+	o.list(w, r, true)
+}
+
+func (o *tenant) memberships(w http.ResponseWriter, r *http.Request) {
+	o.count("memberships")
+	o.list(w, r, false)
+}
+
+func (o *tenant) list(w http.ResponseWriter, r *http.Request, roles bool) {
+	id := r.PathValue("id")
+
+	o.mu.Lock()
+	_, ok := o.users[id]
+	held := o.closure(id)
+	o.mu.Unlock()
+	if !ok {
+		o.refuse(w, http.StatusNotFound, "Request_ResourceNotFound",
+			fmt.Sprintf("Resource '%s' does not exist or one of its queried reference-property objects are not present.", id))
+		return
+	}
+
+	value := make([]map[string]any, 0, len(held)+1)
+	if roles {
+		value = append(value, map[string]any{
+			"@odata.type": "#microsoft.graph.directoryRole",
+			"id":          role,
+			"displayName": "Global Reader",
+		})
+	}
+
+	size := len(held)
+	if top := r.URL.Query().Get("$top"); top != "" {
+		n, err := strconv.Atoi(top)
+		if err != nil || n < 1 {
+			o.refuse(w, http.StatusBadRequest, "Request_BadRequest", "Invalid value for $top.")
+			return
+		}
+		size = n
+	}
+	from := 0
+	if skip := r.URL.Query().Get("$skiptoken"); skip != "" {
+		n, err := strconv.Atoi(skip)
+		if err != nil || n < 0 {
+			o.refuse(w, http.StatusBadRequest, "Request_BadRequest", "Invalid skip token.")
+			return
+		}
+		from = min(n, len(held))
+	}
+	to := min(from+size, len(held))
+
+	for _, gid := range held[from:to] {
+		o.mu.Lock()
+		g := o.groups[gid]
+		o.mu.Unlock()
+		value = append(value, map[string]any{
+			"@odata.type": "#microsoft.graph.group",
+			"id":          gid,
+			"displayName": g.name,
+		})
+	}
+
+	body := map[string]any{"value": value}
+	if to < len(held) {
+		// Absolute, and carrying everything the first request carried, which is
+		// what makes following it verbatim the only sensible thing to do.
+		next := *r.URL
+		q := next.Query()
+		q.Set("$skiptoken", strconv.Itoa(to))
+		next.RawQuery = q.Encode()
+		body["@odata.nextLink"] = o.base + next.Path + "?" + next.RawQuery
+	}
+	o.write(w, http.StatusOK, body)
+}
+
+func (o *tenant) group(w http.ResponseWriter, r *http.Request) {
+	o.count("group")
+	id := r.PathValue("id")
+
+	o.mu.Lock()
+	g, ok := o.groups[id]
+	o.mu.Unlock()
+	if !ok {
+		o.refuse(w, http.StatusNotFound, "Request_ResourceNotFound",
+			fmt.Sprintf("Resource '%s' does not exist or one of its queried reference-property objects are not present.", id))
+		return
+	}
+	o.write(w, http.StatusOK, map[string]any{"id": id, "displayName": g.name})
+}
+
+// closure is every group the person is in, however deeply, which is the whole
+// of what this provider does that the others do not. The caller holds the lock.
+func (o *tenant) closure(id string) []string {
+	p, ok := o.users[id]
+	if !ok {
+		return nil
+	}
+	var (
+		out   []string
+		seen  = map[string]bool{}
+		queue = slices.Clone(p.memberOf)
+	)
+	for len(queue) > 0 {
+		g := queue[0]
+		queue = queue[1:]
+		if seen[g] {
+			continue
+		}
+		seen[g] = true
+		// A membership naming a group the tenant does not hold is not something
+		// Graph can answer with, because the collection returns the objects
+		// rather than their ids.
+		team, ok := o.groups[g]
+		if !ok {
+			continue
+		}
+		out = append(out, g)
+		queue = append(queue, team.memberOf...)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// put adds or replaces one person.
+func (o *tenant) put(t *testing.T, s directory.Subject) {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.users[s.ID] = &person{
+		name:     s.Name,
+		mail:     s.Email,
+		upn:      s.ID + "@acme.test",
+		enabled:  !s.Disabled,
+		memberOf: slices.Clone(s.MemberOf),
+	}
+}
+
+// putGroup adds or replaces one group.
+func (o *tenant) putGroup(t *testing.T, g directory.Group) {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.groups[g.ID] = &team{name: g.Name, memberOf: slices.Clone(g.MemberOf)}
+}
+
+// edit changes one person, for the things the conformance suite has no
+// vocabulary for.
+func (o *tenant) edit(t *testing.T, id string, change func(*person)) {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	p, ok := o.users[id]
+	if !ok {
+		t.Fatalf("there is nobody called %q in the tenant", id)
+	}
+	change(p)
+}
+
+// spent is how many requests of one kind arrived.
+func (o *tenant) spent(kind string) int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.calls[kind]
+}
+
+func (o *tenant) count(kind string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.calls[kind]++
+}
+
+func (o *tenant) write(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		o.t.Errorf("writing the answer: %v", err)
+	}
+}
+
+func (o *tenant) refuse(w http.ResponseWriter, status int, code, message string) {
+	o.write(w, status, map[string]any{
+		"error": map[string]any{"code": code, "message": message},
+	})
+}
+
+// nullable is how Graph reports a mailbox somebody does not have.
+func nullable(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// emptyList is how Graph reports a collection with nothing in it, which is not
+// the same as leaving the property out.
+func emptyList(in []string) []string {
+	if in == nil {
+		return []string{}
+	}
+	return in
+}
+
+// describe joins ids for a failure worth reading.
+func describe(in []string) string { return strings.Join(in, " ") }

--- a/directory/entra/recording_test.go
+++ b/directory/entra/recording_test.go
@@ -1,0 +1,294 @@
+package entra_test
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/recorded"
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/entra"
+)
+
+// The fixture set is a resolution against a small tenant written down once and
+// read back by the tests below, so that the adapter is exercised against the
+// bytes Graph actually sends without anybody needing a tenant or an application
+// registration to run the tests.
+//
+// The fake next to this file is the other half of the story and neither
+// replaces the other. The fake is where behaviour is written: it can be made to
+// deactivate somebody, to page differently, to refuse a secret. The recording is
+// where the wire format is pinned: it is the answer to "did we change what we
+// send" and it is the thing that would have to be refreshed if Graph changed a
+// field name.
+//
+// Signing in is not in here on purpose. The fixtures are a description of the
+// Graph and a client credentials grant is a description of the token endpoint,
+// and putting the second in would mean writing a request with a client secret
+// in its body down in a file. What the grant does is covered by the fake.
+const fixtures = "testdata/tenant"
+
+// The tenant the recording is of. It is the real endpoint, which nothing
+// reaches, because keying the fixtures on the port a test server happened to be
+// given would make them unreadable and unstable at once.
+const recordedEndpoint = "https://graph.microsoft.com"
+
+// The ids the recorded tenant holds. They are written down rather than worked
+// out because a fixture set is a fixed corpus, and a test that derived them
+// from the fake would pass just as happily against a recording of something
+// else entirely.
+const (
+	recordedPerson  = "8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60"
+	recordedNobody  = "2b1c4d5e-6f70-4812-93a4-5b6c7d8e9f01"
+	recordedLeaver  = "c3d4e5f6-0718-4923-a4b5-6c7d8e9f0a12"
+	recordedTop     = "11111111-2222-4333-8444-555555555551"
+	recordedMiddle  = "11111111-2222-4333-8444-555555555552"
+	recordedGroup   = "11111111-2222-4333-8444-555555555553"
+	recordedMissing = "99999999-9999-4999-8999-999999999999"
+)
+
+var update = flag.Bool("update", false, "record the Entra fixtures in testdata again")
+
+// recordingTenant is the tenant the fixtures are a resolution of.
+//
+// It is small on purpose and every part of it is there for a reason: somebody
+// three levels down a nest so that the flattening is in the recording rather
+// than only in the fake, and in enough groups for the listing to be more than
+// one page at the size below, somebody in none so that an empty collection is
+// in there, somebody deactivated so that the refusal is too, and a group looked
+// up on its own so that the endpoint the buffer usually saves is there as well.
+func recordingTenant(t *testing.T) string {
+	t.Helper()
+	o, endpoint := newTenant(t)
+	o.putGroup(t, directory.Group{ID: recordedTop, Name: "Everyone"})
+	o.putGroup(t, directory.Group{ID: recordedMiddle, Name: "Engineering", MemberOf: []string{recordedTop}})
+	o.putGroup(t, directory.Group{ID: recordedGroup, Name: "Storage", MemberOf: []string{recordedMiddle}})
+
+	o.put(t, directory.Subject{
+		ID:       recordedPerson,
+		Name:     "Mei Tanaka",
+		Email:    "mei@acme.test",
+		MemberOf: []string{recordedGroup},
+	})
+	o.edit(t, recordedPerson, func(p *person) { p.upn = "mei@acme.test" })
+
+	o.put(t, directory.Subject{ID: recordedNobody, Name: "Jo Okafor", Email: "jo@acme.test"})
+	o.edit(t, recordedNobody, func(p *person) { p.upn = "jo@acme.test" })
+
+	o.put(t, directory.Subject{ID: recordedLeaver, Name: "Lee Byrne", Email: "lee@acme.test", Disabled: true})
+	o.edit(t, recordedLeaver, func(p *person) { p.upn = "lee@acme.test" })
+	return endpoint
+}
+
+// TestRecordTheFixtures writes the fixture set again. It is skipped unless the
+// flag is given, because a recording that refreshed itself on every run would
+// never fail: the thing it is there to catch is a change to what we send, and a
+// fixture regenerated alongside the change agrees with it by construction.
+func TestRecordTheFixtures(t *testing.T) {
+	if !*update {
+		t.Skip("run with -update to record the fixtures again")
+	}
+
+	endpoint := recordingTenant(t)
+	rec := recorded.Record(http.DefaultTransport, recorded.WithRedactedHeaders("Authorization"))
+
+	resolve(t, func(opts ...entra.Option) *entra.Directory {
+		return dial(t, endpoint, append([]entra.Option{entra.WithHTTPClient(rec.Client())}, opts...)...)
+	})
+
+	// The same question asked twice is one file. A resolution asks for a
+	// membership collection once per expansion and the pages repeat across
+	// them, and writing the answer down twice is two files to review and no
+	// more coverage.
+	var (
+		seen = map[string]bool{}
+		once []recorded.Exchange
+	)
+	for _, e := range rec.Exchanges() {
+		e = settle(e, endpoint)
+		k := e.Request.Method + " " + e.Request.URL
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		once = append(once, e)
+	}
+
+	if err := recorded.From(once).Save(fixtures); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %d of %d exchanges to %s", len(once), len(rec.Exchanges()), fixtures)
+}
+
+// settle takes the run out of a recorded exchange.
+//
+// Two things in one differ every time it is made: the address the test server
+// was given, and the date the answer came back on. Neither is matched against
+// and neither means anything, and leaving them in would make every refresh of
+// the fixtures a diff on every file with the real change somewhere in it. The
+// host is written as the Graph for the same reason: a reader opening one of
+// these files should see the request that would have gone to Microsoft, and
+// that includes the next page link, which for this API is inside the answer
+// rather than in a header.
+func settle(e recorded.Exchange, endpoint string) recorded.Exchange {
+	e.Request.URL = rehost(e.Request.URL)
+	if len(e.Response.Body.JSON) > 0 {
+		e.Response.Body.JSON = bytes.ReplaceAll(e.Response.Body.JSON, []byte(endpoint), []byte(recordedEndpoint))
+	}
+	delete(e.Response.Headers, "Date")
+	delete(e.Response.Headers, "Content-Length")
+	return e
+}
+
+// rehost puts one URL on the endpoint the fixtures are written against.
+func rehost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	graph, err := url.Parse(recordedEndpoint)
+	if err != nil {
+		panic(err)
+	}
+	u.Scheme, u.Host = graph.Scheme, graph.Host
+	return u.String()
+}
+
+// resolve is everything the fixture set has to answer, and it is shared so that
+// what is recorded and what is replayed cannot drift apart.
+func resolve(t *testing.T, dir func(opts ...entra.Option) *entra.Directory) directory.Expansion {
+	t.Helper()
+
+	// Two at a time, so that a collection over pages is in the recording rather
+	// than only in the fake.
+	r, err := directory.New(dir(entra.WithPageSize(2)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := r.Expand(t.Context(), recordedPerson)
+	if err != nil {
+		t.Fatalf("expanding %s: %v", recordedPerson, err)
+	}
+	if _, err := r.Expand(t.Context(), recordedNobody); err != nil {
+		t.Fatalf("expanding %s: %v", recordedNobody, err)
+	}
+	if _, err := r.Expand(t.Context(), recordedLeaver); !errors.Is(err, directory.ErrDisabled) {
+		t.Fatalf("expanding %s gave %v, want ErrDisabled", recordedLeaver, err)
+	}
+
+	// A group asked for on its own, which the buffer would otherwise answer out
+	// of the collection that already went past.
+	alone := dir(entra.WithBuffer(0, 0))
+	if _, err := alone.Group(t.Context(), recordedGroup); err != nil {
+		t.Fatalf("looking up %s: %v", recordedGroup, err)
+	}
+	if _, err := alone.Group(t.Context(), recordedMissing); !errors.Is(err, directory.ErrNoGroup) {
+		t.Fatalf("looking up %s gave %v, want ErrNoGroup", recordedMissing, err)
+	}
+	return got
+}
+
+// replayed is the adapter over the fixture set.
+func replayed(t *testing.T, rt *recorded.Transport, opts ...entra.Option) *entra.Directory {
+	t.Helper()
+	d, err := entra.New(entra.Token(bearer), append([]entra.Option{
+		entra.WithEndpoint(recordedEndpoint),
+		entra.WithHTTPClient(rt.Client()),
+	}, opts...)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// TestTheRecordedTenantResolvesWithoutATenant is the point of the fixture set:
+// the whole adapter, the real paging and the real decoding, against bytes that
+// came off the Graph and are now a file.
+func TestTheRecordedTenantResolvesWithoutATenant(t *testing.T) {
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolve(t, func(opts ...entra.Option) *entra.Directory {
+		return replayed(t, rt, opts...)
+	})
+
+	want := []string{"entra:" + recordedTop, "entra:" + recordedMiddle, "entra:" + recordedGroup}
+	slices.Sort(want)
+	if !slices.Equal(got.Groups.Members, want) {
+		t.Fatalf("the recorded tenant resolved to %v, want %v", got.Groups.Members, want)
+	}
+	if got.Subject.Name != "Mei Tanaka" {
+		t.Errorf("the recorded person is called %q", got.Subject.Name)
+	}
+	if want := (acl.Identity{Source: "email", Value: "mei@acme.test"}); !slices.Contains(got.Subject.Identities, want) {
+		t.Errorf("the identities off the recording are %v", got.Subject.Identities)
+	}
+	// Three levels of nesting in the tenant and one level of walking here,
+	// which is the whole reason this provider is worth having.
+	if got.Depth != 1 {
+		t.Errorf("a provider that answers with the closure was walked %d levels deep", got.Depth)
+	}
+}
+
+// TestTheRecordingHoldsNothingItIsNotAskedFor keeps the fixture set from
+// growing a tail of responses nothing reads.
+//
+// A recording is a thing people add to and rarely take away from, and one that
+// has drifted is worse than none: a reviewer reading a file next to the test
+// reasonably assumes the test depends on it.
+func TestTheRecordingHoldsNothingItIsNotAskedFor(t *testing.T) {
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolve(t, func(opts ...entra.Option) *entra.Directory {
+		return replayed(t, rt, opts...)
+	})
+
+	if left := rt.Unused(); len(left) != 0 {
+		t.Errorf("the fixture set answers %d requests the resolution never makes:\n%s", len(left), strings.Join(left, "\n"))
+	}
+}
+
+// TestTheRecordingCarriesNoCredentials is the reason a fixture set is safe to
+// commit at all. It is a check on the recording rather than on the code, and it
+// is here because the file is here.
+func TestTheRecordingCarriesNoCredentials(t *testing.T) {
+	entries, err := os.ReadDir(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(fixtures, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(raw), bearer) {
+			t.Errorf("%s holds the token it was recorded with", e.Name())
+		}
+		// The scheme as well as the token, because a bearer is whatever follows
+		// it and a reviewer skimming for "Bearer" is how one gets noticed.
+		if strings.Contains(string(raw), "Bearer ") {
+			t.Errorf("%s holds something shaped like an access token", e.Name())
+		}
+		// And the secret, which never goes near the Graph and would be a
+		// serious thing to find in a file if it did.
+		if strings.Contains(string(raw), "a-client-secret") {
+			t.Errorf("%s holds a client secret", e.Name())
+		}
+	}
+}

--- a/directory/entra/testdata/tenant/0001-get-v1.0-users-8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60-select-id-displayname-mail.json
+++ b/directory/entra/testdata/tenant/0001-get-v1.0-users-8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60-select-id-displayname-mail.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://graph.microsoft.com/v1.0/users/8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60?%24select=id%2CdisplayName%2Cmail%2CuserPrincipalName%2CotherMails%2CaccountEnabled",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "accountEnabled": true,
+        "displayName": "Mei Tanaka",
+        "id": "8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60",
+        "mail": "mei@acme.test",
+        "otherMails": [],
+        "userPrincipalName": "mei@acme.test"
+      }
+    }
+  }
+}

--- a/directory/entra/testdata/tenant/0002-get-v1.0-users-8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60-transitivememberof.json
+++ b/directory/entra/testdata/tenant/0002-get-v1.0-users-8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60-transitivememberof.json
@@ -1,0 +1,39 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://graph.microsoft.com/v1.0/users/8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60/transitiveMemberOf/microsoft.graph.group?%24select=id%2CdisplayName\u0026%24top=2",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "@odata.nextLink": "https://graph.microsoft.com/v1.0/users/8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60/transitiveMemberOf/microsoft.graph.group?%24select=id%2CdisplayName\u0026%24skiptoken=2\u0026%24top=2",
+        "value": [
+          {
+            "@odata.type": "#microsoft.graph.group",
+            "displayName": "Everyone",
+            "id": "11111111-2222-4333-8444-555555555551"
+          },
+          {
+            "@odata.type": "#microsoft.graph.group",
+            "displayName": "Engineering",
+            "id": "11111111-2222-4333-8444-555555555552"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/directory/entra/testdata/tenant/0003-get-v1.0-users-8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60-transitivememberof.json
+++ b/directory/entra/testdata/tenant/0003-get-v1.0-users-8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60-transitivememberof.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://graph.microsoft.com/v1.0/users/8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60/transitiveMemberOf/microsoft.graph.group?%24select=id%2CdisplayName\u0026%24skiptoken=2\u0026%24top=2",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "value": [
+          {
+            "@odata.type": "#microsoft.graph.group",
+            "displayName": "Storage",
+            "id": "11111111-2222-4333-8444-555555555553"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/directory/entra/testdata/tenant/0004-get-v1.0-users-2b1c4d5e-6f70-4812-93a4-5b6c7d8e9f01-select-id-displayname-mail.json
+++ b/directory/entra/testdata/tenant/0004-get-v1.0-users-2b1c4d5e-6f70-4812-93a4-5b6c7d8e9f01-select-id-displayname-mail.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://graph.microsoft.com/v1.0/users/2b1c4d5e-6f70-4812-93a4-5b6c7d8e9f01?%24select=id%2CdisplayName%2Cmail%2CuserPrincipalName%2CotherMails%2CaccountEnabled",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "accountEnabled": true,
+        "displayName": "Jo Okafor",
+        "id": "2b1c4d5e-6f70-4812-93a4-5b6c7d8e9f01",
+        "mail": "jo@acme.test",
+        "otherMails": [],
+        "userPrincipalName": "jo@acme.test"
+      }
+    }
+  }
+}

--- a/directory/entra/testdata/tenant/0005-get-v1.0-users-2b1c4d5e-6f70-4812-93a4-5b6c7d8e9f01-transitivememberof.json
+++ b/directory/entra/testdata/tenant/0005-get-v1.0-users-2b1c4d5e-6f70-4812-93a4-5b6c7d8e9f01-transitivememberof.json
@@ -1,0 +1,27 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://graph.microsoft.com/v1.0/users/2b1c4d5e-6f70-4812-93a4-5b6c7d8e9f01/transitiveMemberOf/microsoft.graph.group?%24select=id%2CdisplayName\u0026%24top=2",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "value": []
+      }
+    }
+  }
+}

--- a/directory/entra/testdata/tenant/0006-get-v1.0-users-c3d4e5f6-0718-4923-a4b5-6c7d8e9f0a12-select-id-displayname-mail.json
+++ b/directory/entra/testdata/tenant/0006-get-v1.0-users-c3d4e5f6-0718-4923-a4b5-6c7d8e9f0a12-select-id-displayname-mail.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://graph.microsoft.com/v1.0/users/c3d4e5f6-0718-4923-a4b5-6c7d8e9f0a12?%24select=id%2CdisplayName%2Cmail%2CuserPrincipalName%2CotherMails%2CaccountEnabled",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "accountEnabled": false,
+        "displayName": "Lee Byrne",
+        "id": "c3d4e5f6-0718-4923-a4b5-6c7d8e9f0a12",
+        "mail": "lee@acme.test",
+        "otherMails": [],
+        "userPrincipalName": "lee@acme.test"
+      }
+    }
+  }
+}

--- a/directory/entra/testdata/tenant/0007-get-v1.0-groups-11111111-2222-4333-8444-555555555553-select-id-displayname.json
+++ b/directory/entra/testdata/tenant/0007-get-v1.0-groups-11111111-2222-4333-8444-555555555553-select-id-displayname.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://graph.microsoft.com/v1.0/groups/11111111-2222-4333-8444-555555555553?%24select=id%2CdisplayName",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "displayName": "Storage",
+        "id": "11111111-2222-4333-8444-555555555553"
+      }
+    }
+  }
+}

--- a/directory/entra/testdata/tenant/0008-get-v1.0-groups-99999999-9999-4999-8999-999999999999-select-id-displayname.json
+++ b/directory/entra/testdata/tenant/0008-get-v1.0-groups-99999999-9999-4999-8999-999999999999-select-id-displayname.json
@@ -1,0 +1,30 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://graph.microsoft.com/v1.0/groups/99999999-9999-4999-8999-999999999999?%24select=id%2CdisplayName",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 404,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "error": {
+          "code": "Request_ResourceNotFound",
+          "message": "Resource '99999999-9999-4999-8999-999999999999' does not exist or one of its queried reference-property objects are not present."
+        }
+      }
+    }
+  }
+}

--- a/directory/entra/token.go
+++ b/directory/entra/token.go
@@ -1,0 +1,256 @@
+package entra
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tamnd/genba/connector/limit"
+)
+
+// Tokens hands out a bearer token for the Graph.
+//
+// It is an interface because a Graph token lives for about an hour, which makes
+// a fixed string the wrong shape for anything that runs longer than that. An
+// adapter built on one would work all afternoon and start refusing every lookup
+// at some point in the evening, and the symptom above it is not an error that
+// says the token expired, it is everybody losing their groups at once.
+type Tokens interface {
+	// Token returns a token that is valid now.
+	Token(ctx context.Context) (string, error)
+}
+
+// Token is a bearer token somebody else obtained.
+//
+// It is for a test, for a script, and for a deployment where something outside
+// this process is already responsible for keeping a token fresh. It is not for
+// a daemon holding one it acquired at startup, for the reason in [Tokens].
+type Token string
+
+// Token returns the token, which is the whole of what this type does.
+func (t Token) Token(context.Context) (string, error) {
+	if t == "" {
+		return "", errors.New("entra: the token is empty")
+	}
+	return string(t), nil
+}
+
+// Credentials is an application in the tenant signing in as itself.
+//
+// The application needs User.Read.All and GroupMember.Read.All as application
+// permissions, granted by an administrator. Delegated permissions are the wrong
+// kind here: they resolve the groups of whoever is signed in, and this resolves
+// the groups of whoever was asked about.
+type Credentials struct {
+	// Tenant is the directory to sign in to, either the tenant id or a domain
+	// such as acme.onmicrosoft.com.
+	Tenant string
+
+	// ID is the application, which Entra calls the client id.
+	ID string
+
+	// Secret is the client secret.
+	Secret string
+}
+
+// DefaultAuthority is where a token comes from.
+const DefaultAuthority = "https://login.microsoftonline.com"
+
+// DefaultScope is what the token is asked to be good for. The .default suffix
+// means the application permissions an administrator already granted, rather
+// than a list this process gets to name for itself.
+const DefaultScope = "https://graph.microsoft.com/.default"
+
+// DefaultEarly is how long before a token expires it is replaced.
+//
+// It is not tuning. A token that is checked, found to have four seconds left
+// and then used is a request that arrives after it expired, and the failure is
+// indistinguishable from a credential that was revoked. Five minutes is far
+// longer than any request here takes and far shorter than a token lives.
+const DefaultEarly = 5 * time.Minute
+
+// Application signs in with the client credentials grant and holds the token it
+// gets until shortly before it expires.
+//
+// It is safe for concurrent use and it acquires one token at a time. Holding
+// the lock across the request is deliberate: an expansion looks up a level of
+// the graph in parallel, so the moment a token expires is the moment several
+// goroutines notice at once, and letting each of them go and get one would turn
+// every expiry into a small burst against the endpoint most likely to throttle.
+type Application struct {
+	creds     Credentials
+	http      *http.Client
+	authority string
+	scope     string
+	early     time.Duration
+	now       func() time.Time
+
+	mu    sync.Mutex
+	token string
+	until time.Time
+}
+
+var _ Tokens = (*Application)(nil)
+
+// ApplicationOption configures an [Application].
+type ApplicationOption func(*Application)
+
+// WithAuthority replaces where tokens are asked for, which a national cloud and
+// a test both need.
+func WithAuthority(base string) ApplicationOption {
+	return func(a *Application) { a.authority = strings.TrimSuffix(base, "/") }
+}
+
+// WithScope replaces what the token is asked to be good for.
+func WithScope(scope string) ApplicationOption {
+	return func(a *Application) { a.scope = scope }
+}
+
+// WithTokenClient replaces the client the token is fetched with.
+func WithTokenClient(c *http.Client) ApplicationOption {
+	return func(a *Application) {
+		if c != nil {
+			a.http = c
+		}
+	}
+}
+
+// WithEarly sets how long before expiry a token is replaced. A duration below
+// zero selects [DefaultEarly].
+func WithEarly(d time.Duration) ApplicationOption {
+	return func(a *Application) { a.early = d }
+}
+
+// WithTokenClock replaces the clock, for a test that needs a token to expire
+// without waiting an hour for it.
+func WithTokenClock(now func() time.Time) ApplicationOption {
+	return func(a *Application) {
+		if now != nil {
+			a.now = now
+		}
+	}
+}
+
+// NewApplication returns a [Tokens] that signs in as an application.
+func NewApplication(c Credentials, opts ...ApplicationOption) (*Application, error) {
+	switch {
+	case c.Tenant == "":
+		return nil, errors.New("entra: a tenant is required")
+	case c.ID == "":
+		return nil, errors.New("entra: an application id is required")
+	case c.Secret == "":
+		return nil, errors.New("entra: a client secret is required")
+	}
+
+	a := &Application{
+		creds:     c,
+		http:      &http.Client{Transport: limit.NewTransport(limit.Limits{})},
+		authority: DefaultAuthority,
+		scope:     DefaultScope,
+		early:     DefaultEarly,
+		now:       time.Now,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	if a.early < 0 {
+		a.early = DefaultEarly
+	}
+	if a.authority == "" {
+		return nil, errors.New("entra: the authority cannot be empty")
+	}
+	return a, nil
+}
+
+// Token returns a token that is valid now, signing in again if the one being
+// held is close enough to expiring to be worth replacing.
+func (a *Application) Token(ctx context.Context) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.token != "" && a.now().Before(a.until.Add(-a.early)) {
+		return a.token, nil
+	}
+	token, lasts, err := a.acquire(ctx)
+	if err != nil {
+		// Leaving the old token where it is. It is either expired, in which
+		// case the next caller tries again and gets the same error, or it has a
+		// few minutes left, in which case a token endpoint having a bad moment
+		// costs nothing at all.
+		return "", err
+	}
+	a.token, a.until = token, a.now().Add(lasts)
+	return a.token, nil
+}
+
+// acquire is one client credentials grant.
+func (a *Application) acquire(ctx context.Context) (token string, lasts time.Duration, err error) {
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {a.creds.ID},
+		"client_secret": {a.creds.Secret},
+		"scope":         {a.scope},
+	}
+	endpoint := a.authority + "/" + url.PathEscape(a.creds.Tenant) + "/oauth2/v2.0/token"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", 0, fmt.Errorf("entra: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("entra: signing in as %q: %w", a.creds.ID, err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	var body struct {
+		Token       string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		Error       string `json:"error"`
+		Description string `json:"error_description"`
+	}
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	_ = json.Unmarshal(raw, &body)
+
+	if resp.StatusCode != http.StatusOK {
+		// The description is where the reason lives, and the reason is nearly
+		// always one an operator can act on: a secret that expired, a tenant
+		// spelled wrong, a consent nobody granted.
+		if body.Description != "" {
+			return "", 0, fmt.Errorf("entra: signing in as %q: %s: %s", a.creds.ID, resp.Status, firstLine(body.Description))
+		}
+		return "", 0, fmt.Errorf("entra: signing in as %q: %s", a.creds.ID, resp.Status)
+	}
+	if body.Token == "" {
+		return "", 0, fmt.Errorf("entra: signing in as %q: the answer carried no token", a.creds.ID)
+	}
+	lasts = time.Duration(body.ExpiresIn) * time.Second
+	if lasts <= 0 {
+		// A grant with no lifetime on it is one this holds for as long as it
+		// dares rather than one it holds forever.
+		lasts = a.early + time.Minute
+	}
+	return body.Token, lasts, nil
+}
+
+// firstLine trims a token endpoint error down to the sentence worth reading.
+// The rest of it is a correlation id, a timestamp and a stack of trace ids,
+// which belong in a support ticket rather than in a log line.
+func firstLine(s string) string {
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}

--- a/directory/entra/token_test.go
+++ b/directory/entra/token_test.go
@@ -1,0 +1,181 @@
+package entra_test
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/entra"
+)
+
+func TestTheApplicationSignsInOnceAndTheTokenIsUsedAfterThat(t *testing.T) {
+	o, endpoint := newTenant(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	d, err := entra.New(application(t, endpoint), entra.WithEndpoint(endpoint), entra.WithBuffer(0, 0), entra.WithHTTPClient(http.DefaultClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 5 {
+		expand(t, d, "mei")
+	}
+	// A token lasts an hour and this took a moment, so signing in more than
+	// once here would be a token endpoint asked for something it already gave.
+	if n := o.spent("token"); n != 1 {
+		t.Errorf("five expansions signed in %d times, want once", n)
+	}
+}
+
+func TestATokenIsReplacedBeforeItExpiresRatherThanAfter(t *testing.T) {
+	o, endpoint := newTenant(t)
+	o.put(t, directory.Subject{ID: "mei"})
+
+	// The fake hands out a token good for 3599 seconds and the application
+	// replaces one with less than five minutes left on it, so this clock moves
+	// to a point where the token is still valid and not valid for long.
+	var elapsed atomic.Int64
+	now := func() time.Time {
+		return time.Unix(1<<30, 0).Add(time.Duration(elapsed.Load()))
+	}
+	tokens, err := entra.NewApplication(
+		entra.Credentials{Tenant: "acme.onmicrosoft.com", ID: "an-application", Secret: "a-client-secret"},
+		entra.WithAuthority(endpoint),
+		entra.WithTokenClock(now),
+		entra.WithTokenClient(http.DefaultClient),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := entra.New(tokens, entra.WithEndpoint(endpoint), entra.WithHTTPClient(http.DefaultClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expand(t, d, "mei")
+	if n := o.spent("token"); n != 1 {
+		t.Fatalf("the first expansion signed in %d times, want once", n)
+	}
+
+	// Fifty six minutes in, which is four minutes before it expires and a
+	// minute past the point where it is worth replacing.
+	elapsed.Store(int64(56 * time.Minute))
+	expand(t, d, "mei")
+	if n := o.spent("token"); n != 2 {
+		t.Errorf("a token with four minutes left was used for a request instead of being replaced, after %d sign ins", n)
+	}
+
+	// And having replaced it, the fresh one is used rather than replaced again.
+	expand(t, d, "mei")
+	if n := o.spent("token"); n != 2 {
+		t.Errorf("a token acquired a moment ago was replaced anyway, after %d sign ins", n)
+	}
+}
+
+func TestASecretTheTenantRefusesSaysWhatIsWrongWithIt(t *testing.T) {
+	_, endpoint := newTenant(t)
+	tokens, err := entra.NewApplication(
+		entra.Credentials{Tenant: "acme.onmicrosoft.com", ID: "an-application", Secret: "the-old-secret"},
+		entra.WithAuthority(endpoint),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := entra.New(tokens, entra.WithEndpoint(endpoint), entra.WithHTTPClient(http.DefaultClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = attempt(t, d, "mei")
+	if err == nil {
+		t.Fatal("a refused secret resolved somebody anyway")
+	}
+	// The code is what an operator searches for, and this one means the secret
+	// expired, which is the single most common reason an Entra integration
+	// stops working.
+	if !strings.Contains(err.Error(), "AADSTS7000215") {
+		t.Errorf("a refused secret gave %v, which does not say why", err)
+	}
+	// And the trace ids are not in it. They belong in a support ticket rather
+	// than in every line of a log.
+	if strings.Contains(err.Error(), "Trace ID") {
+		t.Errorf("a refused secret gave %v, which is three lines of correlation ids", err)
+	}
+	if !strings.Contains(err.Error(), "an-application") {
+		t.Errorf("a refused secret gave %v, which does not say which application it was", err)
+	}
+}
+
+func TestSigningInHappensOnceWhenSeveralLookupsNoticeAtTheSameTime(t *testing.T) {
+	o, endpoint := newTenant(t)
+	for i := range 20 {
+		o.putGroup(t, directory.Group{ID: "g" + string(rune('a'+i%26))})
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"ga", "gb", "gc"}})
+
+	d, err := entra.New(application(t, endpoint), entra.WithEndpoint(endpoint), entra.WithBuffer(0, 0), entra.WithHTTPClient(http.DefaultClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// An expansion looks a level up in parallel, so the moment a token is
+	// needed is a moment several goroutines need one. Each of them going to get
+	// their own would turn every expiry into a small burst against the endpoint
+	// most likely to throttle.
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := attempt(t, d, "mei"); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if n := o.spent("token"); n != 1 {
+		t.Errorf("eight expansions at once signed in %d times, want once", n)
+	}
+}
+
+func TestNewApplicationRefusesCredentialsItCannotSignInWith(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		creds entra.Credentials
+	}{
+		{"no tenant", entra.Credentials{ID: "an-application", Secret: "a-client-secret"}},
+		{"no application", entra.Credentials{Tenant: "acme.onmicrosoft.com", Secret: "a-client-secret"}},
+		{"no secret", entra.Credentials{Tenant: "acme.onmicrosoft.com", ID: "an-application"}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := entra.NewApplication(c.creds); err == nil {
+				t.Error("that was accepted, and the failure would arrive at the first lookup instead")
+			}
+		})
+	}
+}
+
+func TestAnEmptyTokenIsRefusedRatherThanSent(t *testing.T) {
+	if _, err := entra.Token("").Token(t.Context()); err == nil {
+		t.Error("an empty token was handed out, and the tenant would answer every lookup with a refusal")
+	}
+}
+
+// application is the client credentials grant against the fake tenant.
+func application(t *testing.T, endpoint string) *entra.Application {
+	t.Helper()
+	a, err := entra.NewApplication(
+		entra.Credentials{Tenant: "acme.onmicrosoft.com", ID: "an-application", Secret: "a-client-secret"},
+		entra.WithAuthority(endpoint),
+		entra.WithTokenClient(http.DefaultClient),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a
+}

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -137,11 +137,13 @@ func TestConformance(t *testing.T) {
 }
 ```
 
-Two things about a fixture are not the same for every provider and the suite asks rather than assumes.
+Three things about a fixture are not the same for every provider and the suite asks rather than assumes.
 
 `Flat` says the provider's groups cannot contain groups, which skips the cases about walking a graph and takes a level off the arithmetic in the two that count lookups.
+`Transitive` says the opposite thing, that the provider nests and hands over the whole closure itself, which runs every case and changes one number: a nest of any depth is walked one level.
+That number is asserted rather than tolerated, because a provider claiming to expand transitively and then costing three levels on a three level nest is one that is not doing what it says.
 `Identity` says which identity the provider can actually be made to hold, because a directory answers in its own vocabulary and no amount of putting a Slack id on an Okta user will make one come out.
-Both default to the shape `directory.Static` has, so nothing that already passes the suite has to say anything, and what the cases are about survives either way.
+All three default to the shape `directory.Static` has, so nothing that already passes the suite has to say anything, and what the cases are about survives either way.
 
 `directory.Static` is the reference implementation the suite runs against, and it is also the directory a small deployment actually uses.
 A company with forty people and six groups has the whole thing in a file, and making them stand up an identity provider to try a search engine is how a search engine does not get tried.
@@ -201,6 +203,44 @@ Rate limits are the transport's job rather than the adapter's.
 `connector/limit` is the same one every connector uses, and Okta publishes its numbers on every response.
 It spells the headers `X-Rate-Limit-Remaining` and `X-Rate-Limit-Reset`, with the hyphen in a different place from everybody else, which canonicalises to a different header name entirely.
 A transport that read only the other three spellings would see an organisation sending its numbers on every single response as one sending none at all, and would find the edge of the quota by hitting it.
+
+## Entra ID
+
+`directory/entra` is the second adapter, and it is the interesting one because the provider does half the work.
+
+Entra groups nest, and unlike most providers Microsoft Graph will walk the nesting for you.
+The `transitiveMemberOf` collection is every group a person is in however deeply that membership is inherited, so somebody eight levels down a tree is one request rather than eight rounds of them.
+That is why the conformance fixture sets `Transitive` and why `Group` answers with an empty membership.
+It is not that a group here is a member of nothing, it is that whatever it is a member of already came back with the subject, and returning the parents again would have the resolver walk a graph it has already been handed.
+
+The cast on the end of the path is load bearing.
+Without `microsoft.graph.group` the collection also returns directory roles and administrative units, which are directory objects a person belongs to and are not groups.
+Their ids would land in the group set beside the real ones, and a rule naming one would then allow everybody who holds that role.
+The cast asks the service for groups only rather than filtering after the fact, so the ids that arrive are the ids that belong there.
+
+Every property the adapter reads is named in a `$select`, and one of them is the reason.
+Graph answers a user lookup with a default set of properties and `accountEnabled` is not in it.
+An adapter that reads the answer without having asked for that field gets the zero value, which is false, or gets nothing at all and calls it true, depending on how it is written.
+The first refuses everybody in the tenant and the second keeps resolving the groups of people who were deactivated months ago, and neither looks like a bug in the place it happens.
+The fake next to the adapter fails the test when a user lookup arrives without that field named, so the whole suite enforces it rather than one case.
+
+The version is where this provider differs from Okta most.
+The v1.0 Graph exposes no last modified time on a user or on a group, so there is no revision to copy.
+The group version is empty, and here that is complete rather than a gap: a version on a group exists to catch a change that alters somebody's group set without altering the ids in it, which for a nesting provider means a group being moved under another one, and that move arrives as a different closure because the closure is what the provider returns.
+Hashing the display name in instead would invalidate every member's cached group set for a rename that alters no answer.
+The subject version is a hash of exactly the fields the adapter reports about the person, because those are the ones the closure does not cover: a new alias has to reach the principal and the group ids do not move when one is added.
+
+Two smaller decisions.
+A guest's principal name is their address with the at sign replaced and the host tenant stuck on the end, which looks enough like an address to be mistaken for one and is nobody's mailbox, so it is not an email identity and their `mail` is.
+And a lookup for something that is neither an id nor a principal name is refused with a bad request rather than a not found, so both are read as a person the tenant does not hold, since treating the first as a failure would turn one bad row in a store into an expansion that never succeeds.
+
+Rate limits work the other way round from Okta.
+Graph says nothing about what is left until it refuses, and then answers a 429 or a 503 with a `Retry-After`.
+So the transport can only hold back after a refusal rather than before one, and the circuit breaker matters more for the same reason: a tenant that has started refusing wants to be left alone for a while, and the only way to learn that is to have been told once and remember it.
+
+Signing in is part of the adapter because a Graph token lives about an hour.
+`entra.Token` is a string somebody else keeps fresh and `entra.NewApplication` is the client credentials grant, which holds a token until five minutes before it expires and then replaces it.
+It acquires one at a time on purpose: an expansion looks a level up in parallel, so the moment a token expires is the moment several goroutines notice at once, and letting each of them go and get their own would turn every expiry into a small burst against the endpoint most likely to throttle.
 
 ## More than one directory
 
@@ -266,9 +306,9 @@ The cache refuses once an entry has expired and the directory cannot be reached,
 It is a real choice with a real cost on the other side, so it should be a configured window with its own metric rather than a default.
 
 The rest of the hosted providers.
-Okta is done, and Entra ID and Google Workspace are the two that are not.
-Entra ID expands transitively already, which the walk handles without a special case: it returns the closure it was given and the level above it is empty.
+Okta and Entra ID are done, and Google Workspace is the one that is not.
 
 A way to configure an adapter without writing Go.
 `-directory` takes files, and an organisation is not a file.
 All three providers want the same three things, an endpoint, a credential and a name, so the flag should grow one spelling that covers them rather than one per provider.
+Entra ID wants a fourth, since a client credentials grant is a tenant, an application and a secret rather than one token, and a secret is the one thing that must not arrive on a command line.


### PR DESCRIPTION
The second directory provider, after Okta.
It answers the same three questions the interface asks and it passes the same conformance suite, so a deployment picks one in configuration and nothing above it changes.

## The graph arrives already walked

Entra ID is not another Okta with different field names.
The Graph has a `transitiveMemberOf` collection that returns every group somebody is in however deeply the nesting goes, so the closure comes back in one listing and the resolver has nothing left to expand.
A three level nest costs one level here where it costs three against a provider that answers with one level at a time.

That is a difference the conformance suite has to know about rather than tolerate, so `directorytest` grew a `Transitive` flag next to `Flat`.
A provider is at most one of them.
A flat provider has no nesting to expand and a transitive one has nesting and does the expanding itself.
The nested case now asserts the depth it should cost instead of asserting three.

The collection carries the display name of every group with it, so the groups a listing already described are put in a small buffer and the resolver's follow up lookups are answered without a request.
A person in three hundred groups is one request rather than three hundred and one.

## The parts that are Graph specific

The path is cast to `microsoft.graph.group`, because the uncast collection also returns directory roles and administrative units, and neither of those is a group anybody should be granted access by.

`accountEnabled` is not in the default property set, so it has to be asked for by name.
An answer without it is not a deactivation, and the fake refuses any user lookup that leaves it out of the `$select` so the whole suite enforces it rather than one test.

There is no revision to read on a user or a group in v1.0, so the version is a hash of exactly the fields this adapter reports.
A group carries no version at all, which is correct for a provider that answers with the closure: a group that moves in the tree arrives as a different set of ids.

A guest principal name has `#EXT#` in it and is not an address, so it does not become an identity.
An id that could not belong to anybody comes back as 400 rather than 404, and that is read as nobody rather than as a failure.

## Signing in

An application signs in with the client credentials grant and holds the token until shortly before it expires.
It acquires one at a time on purpose, because an expansion looks up a level of the graph in parallel, so the moment a token expires is the moment several goroutines notice at once.

A fixed token is still accepted, for a script and for a deployment where something outside the process keeps one fresh.
It is not what a daemon should use and the documentation says so.

## Tests

Sixteen conformance cases pass and one skips, the one that needs a provider able to drop a group.
There is a fake tenant with paging, nesting, a directory role, a deactivated person, a guest and two tenants that must not see each other, and a recorded fixture set so the adapter is exercised against bytes that came off the wire.

The grant is deliberately not in the recording.
Its request body carries a client secret and redaction covers the query string rather than the form, so a fixture of it would be a secret in a file.
A test reads every fixture and fails if a bearer token or a secret is in one.

Part of #179
