### PR TITLE
directory: read groups from Google Workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,11 +342,11 @@ A directory that cannot answer refuses the request rather than serving half of s
 This is the deployment with forty people and six groups in it.
 
 A company with an identity provider gets an adapter instead, and an adapter answers the same two lookups the file does.
-`directory/okta` and `directory/entra` are the two that exist, and both pass the same conformance suite the file does.
+`directory/okta`, `directory/entra` and `directory/google` are the three that exist, and all of them pass the same conformance suite the file does.
 Okta groups do not contain groups, so an expansion there is one level deep, and the group listing that answers the subject lookup already carries every group object the level below is about to ask for.
 Entra ID groups do nest and Microsoft Graph will do the nesting for you, so a person eight levels down a tree is one request rather than eight rounds of them, and the expansion is still one level deep for a different reason.
-`-directory` does not take an organisation yet, so an adapter is wired up in Go for now.
-Google Workspace is next, and the flag grows a spelling for all three at once.
+Google Workspace groups nest and the Admin SDK will not walk the nesting, so that one is the ordinary case the resolver was written for: one collection answers both lookups, because the endpoint that says which groups a person is in takes a group just as happily as a person.
+`-directory` does not take an organisation yet, so an adapter is wired up in Go for now, and the flag grows a spelling for all three at once.
 
 ## Metrics
 
@@ -432,6 +432,7 @@ func main() {
 | `directory/directorytest` | the conformance suite that defines what a directory adapter is |
 | `directory/okta` | group membership from an Okta organisation, over the Users and Groups API |
 | `directory/entra` | group membership from a Microsoft Entra ID tenant, over the Graph, with the closure resolved by the provider |
+| `directory/google` | group membership from a Google Workspace domain, over the Admin SDK, signed in as a service account acting for an administrator |
 | `doc` | the canonical document model every connector normalises into |
 | `store` | the storage interface, plus `storetest`, the conformance suite |
 | `store/memstore` | the reference in memory driver |

--- a/arch_test.go
+++ b/arch_test.go
@@ -46,6 +46,10 @@ var allowed = map[string][]string{
 	// The same place in the layering, for the same reasons.
 	"directory/entra": {"acl", "cache", "connector/limit", "directory"},
 
+	// And again. This one signs its own grant, so it reaches for crypto and
+	// nothing of ours that the other two do not already have.
+	"directory/google": {"acl", "cache", "connector/limit", "directory"},
+
 	// cache is a map with a lock on it and imports nothing of ours, which is
 	// what lets index depend on it without the dependency meaning anything. A
 	// cache that knew about principals would be a second copy of the permission

--- a/connector/limit/transport.go
+++ b/connector/limit/transport.go
@@ -1,8 +1,10 @@
 package limit
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/rand/v2"
 	"net/http"
@@ -27,12 +29,13 @@ var ErrOpen = errors.New("limit: the circuit is open, the source has been refusi
 // that talks to one service with one set of credentials, because that is the
 // scope a quota has.
 type Transport struct {
-	base    http.RoundTripper
-	limits  Limits
-	limiter *Limiter
-	clock   Clock
-	log     *slog.Logger
-	jitter  func(time.Duration) time.Duration
+	base     http.RoundTripper
+	limits   Limits
+	limiter  *Limiter
+	clock    Clock
+	log      *slog.Logger
+	jitter   func(time.Duration) time.Duration
+	throttle func(*http.Response) bool
 
 	mu        sync.Mutex
 	failures  int
@@ -97,6 +100,30 @@ func WithJitter(f func(time.Duration) time.Duration) Option {
 			t.jitter = f
 		}
 	}
+}
+
+// WithThrottled names the answers from one service that mean "you are going too
+// fast" without arriving as a 429.
+//
+// Most services refuse a request that is over the quota with too many requests,
+// which is what [Transport] retries by default and what nothing needs to be
+// told about. A few say the same thing in a status the specification reserves
+// for something else entirely, and the Admin SDK is the one this was written
+// for: it refuses a caller who is over the rate with a forbidden, and the only
+// thing separating that from an account which genuinely may not read the
+// directory is a reason string in the body.
+//
+// Getting that wrong is expensive in both directions. Retrying every forbidden
+// would hammer a service over permissions that are not going to change, and
+// retrying none of them turns a throttle that would have cleared in two seconds
+// into a sync that failed.
+//
+// The predicate is given the response before anything has read it and may read
+// the body with [Peek], which puts the bytes back for whoever reads it next. It
+// is only consulted for an answer that was refused and is not already worth
+// retrying, so a healthy crawl never calls it.
+func WithThrottled(f func(*http.Response) bool) Option {
+	return func(t *Transport) { t.throttle = f }
 }
 
 // NewTransport returns a transport enforcing l.
@@ -200,7 +227,7 @@ func (t *Transport) verdict(req *http.Request, resp *http.Response, err error, a
 		// and it means nothing at all about the document being read.
 		return t.backoff(attempt, 0), true
 	}
-	if !worthRetrying(resp.StatusCode) {
+	if !worthRetrying(resp.StatusCode) && !t.throttled(resp) {
 		return 0, false
 	}
 	// What the source said beats what we would have guessed. A service that
@@ -312,6 +339,49 @@ func (t *Transport) Stats() TransportStats {
 	return s
 }
 
+// throttled asks the service's own predicate whether a refusal was about the
+// rate rather than about the request.
+//
+// Only a refusal, so that the body of a successful answer is never touched, and
+// only one that is not already being retried, so that a service which sends both
+// shapes pays for the second reading once rather than on every 429.
+func (t *Transport) throttled(resp *http.Response) bool {
+	if t.throttle == nil || resp == nil || resp.StatusCode < 400 {
+		return false
+	}
+	return t.throttle(resp)
+}
+
+// Peek reads up to n bytes of a response body and puts them back.
+//
+// It is here for a [WithThrottled] predicate, which has to look inside a refusal
+// to find out what kind it is and is looking at a response somebody else is
+// about to read. A predicate that consumed the body would leave the connector
+// above it decoding an empty answer, and the failure would be an error message
+// with nothing in it rather than anything that pointed here.
+//
+// The bytes are held in memory, so n is a bound rather than a hint. A refusal is
+// a few hundred bytes and anything claiming to be one and running to megabytes
+// is not something to buffer on the strength of its own say so.
+func Peek(resp *http.Response, n int64) []byte {
+	if resp == nil || resp.Body == nil || n <= 0 {
+		return nil
+	}
+	body := resp.Body
+	raw, err := io.ReadAll(io.LimitReader(body, n))
+	if len(raw) == 0 {
+		// Nothing was taken, so there is nothing to put back. Rewrapping here
+		// would hide the read error from the caller behind an empty body.
+		_ = err
+		return nil
+	}
+	resp.Body = struct {
+		io.Reader
+		io.Closer
+	}{io.MultiReader(bytes.NewReader(raw), body), body}
+	return raw
+}
+
 // worthRetrying reports whether a status is one where the same request might
 // work in a moment.
 //
@@ -320,7 +390,8 @@ func (t *Transport) Stats() TransportStats {
 // on one document says nothing about the next attempt at the same document. A
 // four hundred is not here: a request the service considers malformed is
 // malformed on every attempt, and retrying it burns quota to arrive at the same
-// answer more slowly.
+// answer more slowly. A service that means something else by one of them says so
+// with [WithThrottled].
 func worthRetrying(status int) bool {
 	switch status {
 	case http.StatusTooManyRequests,

--- a/connector/limit/transport_test.go
+++ b/connector/limit/transport_test.go
@@ -21,6 +21,7 @@ import (
 type reply struct {
 	status int
 	header http.Header
+	body   string
 	err    error
 }
 
@@ -62,7 +63,7 @@ func (s *service) RoundTrip(req *http.Request) (*http.Response, error) {
 		StatusCode: r.status,
 		Status:     fmt.Sprintf("%d %s", r.status, http.StatusText(r.status)),
 		Header:     r.header.Clone(),
-		Body:       &countingBody{closes: &s.bodies},
+		Body:       &countingBody{Reader: strings.NewReader(r.body), closes: &s.bodies},
 		Request:    req,
 	}, nil
 }
@@ -75,9 +76,10 @@ func (s *service) calls() int {
 	return len(s.seen)
 }
 
-type countingBody struct{ closes *atomic.Int64 }
-
-func (countingBody) Read([]byte) (int, error) { return 0, io.EOF }
+type countingBody struct {
+	io.Reader
+	closes *atomic.Int64
+}
 
 func (b *countingBody) Close() error {
 	b.closes.Add(1)
@@ -549,5 +551,177 @@ func TestACancelledRequestNeverGoesOut(t *testing.T) {
 	}
 	if got := svc.calls(); got != 0 {
 		t.Errorf("the service was asked %d times, want 0", got)
+	}
+}
+
+// The two shapes a Workspace refusal comes in, which are the same status and
+// mean opposite things. One is a rate that will clear on its own in a moment and
+// the other is a permission that is not going to change today.
+const (
+	overQuota = `{"error":{"code":403,"message":"Quota exceeded for quota metric 'Queries'.",` +
+		`"errors":[{"domain":"usageLimits","reason":"userRateLimitExceeded","message":"Quota exceeded."}]}}`
+	notAllowed = `{"error":{"code":403,"message":"Not Authorized to access this resource/api",` +
+		`"errors":[{"domain":"global","reason":"forbidden","message":"Not Authorized."}]}}`
+)
+
+// quotaish is the sort of predicate a connector supplies: it looks inside the
+// refusal, and it has to put the body back because somebody else is about to
+// read it.
+func quotaish(resp *http.Response) bool {
+	return strings.Contains(string(limit.Peek(resp, 1<<16)), "RateLimitExceeded")
+}
+
+// A source that says slow down in a body rather than in a status is waited out
+// like any other throttle, which is the whole reason the hook is here.
+func TestARefusalTheServiceCallsAThrottleIsTriedAgain(t *testing.T) {
+	svc := newService(
+		reply{status: http.StatusForbidden, body: overQuota},
+		reply{status: http.StatusOK, body: `{"groups":[]}`},
+	)
+	clock := newClock()
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000, MinBackoff: 100 * time.Millisecond},
+		limit.WithBase(svc), limit.WithClock(clock), limit.WithJitter(fullJitter),
+		limit.WithThrottled(quotaish))
+
+	if got := status(t, tr, get(t, "/eighteen")); got != http.StatusOK {
+		t.Fatalf("status = %d, want the answer from the second attempt", got)
+	}
+	if got := svc.calls(); got != 2 {
+		t.Errorf("the service was asked %d times, want 2", got)
+	}
+	if got := tr.Stats().Retries; got != 1 {
+		t.Errorf("retries = %d, want 1", got)
+	}
+	if got := clock.sleeps(); len(got) != 1 || got[0] != 100*time.Millisecond {
+		t.Errorf("waited %v, want one wait of 100ms", got)
+	}
+}
+
+// The other half of it, and the more expensive one to get wrong. Retrying a
+// refusal about permissions hammers a source over something that is not going to
+// change, and the account really may not read that object.
+func TestARefusalThePredicateDoesNotClaimIsNotTriedAgain(t *testing.T) {
+	svc := newService(reply{status: http.StatusForbidden, body: notAllowed})
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000, MinBackoff: time.Millisecond},
+		limit.WithBase(svc), limit.WithClock(newClock()), limit.WithThrottled(quotaish))
+
+	if got := status(t, tr, get(t, "/nineteen")); got != http.StatusForbidden {
+		t.Fatalf("status = %d, want the refusal handed straight back", got)
+	}
+	if got := svc.calls(); got != 1 {
+		t.Errorf("the service was asked %d times, want 1", got)
+	}
+}
+
+// A healthy crawl never calls the predicate, and neither does one being
+// throttled in the ordinary way. Both matter: the first is every request a
+// connector makes, and the second would read the same body twice.
+func TestThePredicateIsOnlyAskedAboutRefusalsNobodyElseWanted(t *testing.T) {
+	var asked atomic.Int64
+	svc := newService(
+		reply{status: http.StatusOK, body: `{"groups":[]}`},
+		reply{status: http.StatusTooManyRequests, header: header("Retry-After", "1")},
+		reply{status: http.StatusOK, body: `{"groups":[]}`},
+	)
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000, MinBackoff: time.Millisecond},
+		limit.WithBase(svc), limit.WithClock(newClock()),
+		limit.WithThrottled(func(*http.Response) bool {
+			asked.Add(1)
+			return false
+		}))
+
+	for range 2 {
+		if got := status(t, tr, get(t, "/twenty")); got != http.StatusOK {
+			t.Fatalf("status = %d", got)
+		}
+	}
+	if got := asked.Load(); got != 0 {
+		t.Errorf("the predicate was asked %d times about answers that needed no opinion, want 0", got)
+	}
+}
+
+// What the predicate reads, the caller still gets. Without this the connector
+// above decodes an empty document and reports a failure with nothing in it.
+func TestThePredicateReadsTheRefusalAndTheCallerStillGetsAllOfIt(t *testing.T) {
+	svc := newService(reply{status: http.StatusForbidden, body: notAllowed})
+	tr := limit.NewTransport(limit.Limits{Rate: 1000, Burst: 1000},
+		limit.WithBase(svc), limit.WithClock(newClock()), limit.WithThrottled(quotaish))
+
+	resp, err := tr.RoundTrip(get(t, "/twentyone"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != notAllowed {
+		t.Errorf("the caller read %q, want the whole refusal", raw)
+	}
+}
+
+func TestPeekPutsBackWhatItTook(t *testing.T) {
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(notAllowed))}
+
+	got := limit.Peek(resp, 24)
+	if len(got) != 24 || !strings.HasPrefix(notAllowed, string(got)) {
+		t.Fatalf("peeked %q, want the first 24 bytes of the refusal", got)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != notAllowed {
+		t.Errorf("what was left to read is %q, want the whole refusal", raw)
+	}
+}
+
+// Closing a body that was peeked at closes the one underneath it. A wrapper that
+// swallowed the close would leak a connection per refusal, which is the worst
+// possible thing to leak on the path that only runs when a source is unhappy.
+func TestClosingAPeekedBodyClosesTheRealOne(t *testing.T) {
+	var closes atomic.Int64
+	resp := &http.Response{Body: &countingBody{Reader: strings.NewReader(overQuota), closes: &closes}}
+
+	limit.Peek(resp, 16)
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := closes.Load(); got != 1 {
+		t.Errorf("the body underneath was closed %d times, want 1", got)
+	}
+}
+
+// Nothing to peek at is not a failure, and it is not a body that turns into an
+// empty one either.
+func TestPeekingAtNothingLeavesEverythingAlone(t *testing.T) {
+	if got := limit.Peek(nil, 16); got != nil {
+		t.Errorf("peeking at no response gave %q", got)
+	}
+	if got := limit.Peek(&http.Response{}, 16); got != nil {
+		t.Errorf("peeking at a response with no body gave %q", got)
+	}
+
+	body := io.NopCloser(strings.NewReader(overQuota))
+	resp := &http.Response{Body: body}
+	if got := limit.Peek(resp, 0); got != nil {
+		t.Errorf("peeking at nothing gave %q", got)
+	}
+	if resp.Body == nil {
+		t.Fatal("a peek of nothing took the body away")
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != overQuota {
+		t.Errorf("what was left to read is %q, want the whole refusal", raw)
+	}
+
+	empty := &http.Response{Body: io.NopCloser(strings.NewReader(""))}
+	if got := limit.Peek(empty, 16); got != nil {
+		t.Errorf("peeking at an empty body gave %q", got)
 	}
 }

--- a/directory/directorytest/budget.go
+++ b/directory/directorytest/budget.go
@@ -1,0 +1,14 @@
+//go:build !race
+
+package directorytest
+
+import "time"
+
+// budget is how long a subject in a thousand groups may take to resolve.
+//
+// It is a bound rather than a benchmark. An adapter that walks a level serially
+// against a fake that answers instantly still passes, and one that is
+// accidentally quadratic does not, which is the only thing this number is asked
+// to tell apart. What the case really asserts is the lookup count, and that one
+// is exact and says the same thing on every machine.
+const budget = 10 * time.Second

--- a/directory/directorytest/budget_race.go
+++ b/directory/directorytest/budget_race.go
@@ -1,0 +1,16 @@
+//go:build race
+
+package directorytest
+
+import "time"
+
+// budget under the race detector, which is the same bound with the cost of
+// running it taken into account.
+//
+// An adapter over a provider that will not expand nesting makes one request per
+// group, so the wide case for that one is a thousand round trips through a test
+// server, and every one of them is instrumented here. The number is four times
+// the ordinary budget because that is roughly what the instrumentation costs on
+// a machine with other work on it, and a bound that failed on a loaded build
+// machine would be turned off inside a week.
+const budget = 40 * time.Second

--- a/directory/directorytest/directorytest.go
+++ b/directory/directorytest/directorytest.go
@@ -477,9 +477,7 @@ func testWide(t *testing.T, f Fixture) {
 		t.Skip("the wide case is about latency and there is nothing to learn from it in a short run")
 	}
 	// The budget in the issue this was written for is a person in a thousand
-	// groups. The number below is not a benchmark, it is a bound: an adapter
-	// that walks the level serially against a fake that answers instantly still
-	// passes, and one that is accidentally quadratic does not.
+	// groups, and what the case costs is next to budget.
 	const n = 1000
 	in := make([]string, 0, n)
 	for i := range n {
@@ -506,7 +504,7 @@ func testWide(t *testing.T, f Fixture) {
 	if got.Lookups != lookups {
 		t.Errorf("a subject in %d groups cost %d lookups, want %d", n, got.Lookups, lookups)
 	}
-	if took > 10*time.Second {
+	if took > budget {
 		t.Errorf("a subject in %d groups took %s", n, took.Round(time.Millisecond))
 	}
 	t.Logf("%d groups in %s over %d lookups", len(got.Groups.Members), took.Round(time.Millisecond), got.Lookups)

--- a/directory/google/fake_test.go
+++ b/directory/google/fake_test.go
@@ -1,0 +1,534 @@
+package google_test
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tamnd/genba/directory"
+)
+
+// A fake domain, because the alternative is a suite that only runs for whoever
+// has a Workspace tenancy to point it at.
+//
+// It is deliberately more awkward than it needs to be in three places. The
+// groups collection refuses a page size above the two hundred the real one
+// accepts, so an adapter that passed a larger number straight through would fail
+// here rather than in production. The token endpoint verifies the signature on
+// the grant and refuses one with nobody to act for, so domain wide delegation is
+// something the tests can be wrong about. And a group listing answers with the
+// group objects and nothing about what those groups are inside, which is the
+// fact the whole walk is shaped around.
+
+// bearer is the token the fake accepts, and the one its token endpoint hands
+// out.
+const bearer = "ya29.fakeAdminSdkTokenForTests"
+
+type person struct {
+	name      string
+	email     string
+	aliases   []string
+	others    []string
+	suspended bool
+	archived  bool
+	memberOf  []string
+}
+
+type team struct {
+	name     string
+	email    string
+	memberOf []string
+}
+
+type domain struct {
+	t *testing.T
+
+	mu     sync.Mutex
+	users  map[string]*person
+	groups map[string]*team
+	calls  map[string]int
+	base   string
+
+	// pub is what the token endpoint checks the grant against, and admin is who
+	// the delegation was granted for. Both are empty until a test arms them,
+	// because most of these cases are about the directory rather than about
+	// signing in.
+	pub   *rsa.PublicKey
+	admin string
+
+	// owed is how many refusals the directory still has to hand out before it
+	// answers anything, and reason is what kind they are.
+	owed   int
+	reason string
+
+	// bare leaves the etag off every object, which is what a Google API that has
+	// stopped sending them looks like.
+	bare bool
+}
+
+// newDomain starts a fake Admin SDK and returns it along with its endpoint.
+func newDomain(t *testing.T) (fake *domain, endpoint string) {
+	t.Helper()
+	o := &domain{
+		t:      t,
+		users:  map[string]*person{},
+		groups: map[string]*team{},
+		calls:  map[string]int{},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /token", o.token)
+	mux.Handle("GET /admin/directory/v1/users/{id}", o.authorised(o.user))
+	mux.Handle("GET /admin/directory/v1/groups", o.authorised(o.list))
+	mux.Handle("GET /admin/directory/v1/groups/{id}", o.authorised(o.group))
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	o.base = srv.URL
+	return o, srv.URL
+}
+
+// authorised refuses anything that did not arrive as a bearer, the way the Admin
+// SDK does, so a test cannot pass with a token the adapter never sent. It is
+// also where an injected refusal is handed out, since a throttle arrives before
+// anything is looked at.
+func (o *domain) authorised(h http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+bearer {
+			o.refuse(w, http.StatusUnauthorized, "authError", "Invalid Credentials")
+			return
+		}
+		if !strings.Contains(r.Header.Get("Accept"), "json") {
+			o.refuse(w, http.StatusNotAcceptable, "notAcceptable", "The request asked for something this endpoint does not produce.")
+			return
+		}
+		o.mu.Lock()
+		owed, reason := o.owed, o.reason
+		if owed > 0 {
+			o.owed--
+		}
+		o.mu.Unlock()
+
+		if owed > 0 {
+			o.count("refused")
+			o.refuse(w, http.StatusForbidden, reason, "Quota exceeded for quota metric 'Queries' and limit 'Queries per minute per user'.")
+			return
+		}
+		h(w, r)
+	})
+}
+
+// throttle makes the next n directory requests refuse with one reason, which is
+// how a rate limit and a permission problem are told apart here.
+func (o *domain) throttle(n int, reason string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.owed, o.reason = n, reason
+}
+
+// forgetEtags is a domain that has stopped sending a revision on anything.
+func (o *domain) forgetEtags() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.bare = true
+}
+
+// trust arms the token endpoint with the key it verifies grants against and the
+// person the delegation was granted for.
+func (o *domain) trust(pub *rsa.PublicKey, admin string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.pub, o.admin = pub, admin
+}
+
+func (o *domain) token(w http.ResponseWriter, r *http.Request) {
+	o.count("token")
+	if err := r.ParseForm(); err != nil {
+		o.deny(w, "invalid_request", err.Error())
+		return
+	}
+	if got := r.PostForm.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+		o.deny(w, "unsupported_grant_type", "The grant type "+got+" is not the one a service account uses.")
+		return
+	}
+
+	o.mu.Lock()
+	pub, admin := o.pub, o.admin
+	o.mu.Unlock()
+	if pub == nil {
+		o.deny(w, "invalid_client", "This domain has no service account registered.")
+		return
+	}
+
+	claims, err := verify(r.PostForm.Get("assertion"), pub, o.base+"/token")
+	if err != nil {
+		o.deny(w, "invalid_grant", err.Error())
+		return
+	}
+	// The refusal domain wide delegation produces when it was never configured,
+	// which is worth having in a test because it is the same one an ungranted
+	// scope produces and neither is guessable from the status.
+	if sub, _ := claims["sub"].(string); sub != admin {
+		o.deny(w, "unauthorized_client",
+			"Client is unauthorized to retrieve access tokens using this method, or client not authorized for any of the scopes requested.")
+		return
+	}
+	o.write(w, http.StatusOK, map[string]any{
+		"token_type":   "Bearer",
+		"expires_in":   3599,
+		"access_token": bearer,
+	})
+}
+
+// verify checks a grant the way the token endpoint does, which is the only way a
+// test can say the assertion was actually signed with the account's key rather
+// than merely well shaped.
+func verify(assertion string, pub *rsa.PublicKey, audience string) (map[string]any, error) {
+	parts := strings.Split(assertion, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("the assertion has %d segments, want 3", len(parts))
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("the signature is not base64: %w", err)
+	}
+	sum := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, sum[:], sig); err != nil {
+		return nil, fmt.Errorf("the assertion was not signed with this account's key: %w", err)
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("the claims are not base64: %w", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return nil, fmt.Errorf("the claims are not JSON: %w", err)
+	}
+	if aud, _ := claims["aud"].(string); aud != audience {
+		return nil, fmt.Errorf("the assertion is addressed to %q rather than to %q", aud, audience)
+	}
+	scope, _ := claims["scope"].(string)
+	if !strings.Contains(scope, "admin.directory.group") {
+		return nil, fmt.Errorf("the grant asks for %q, which cannot read groups", scope)
+	}
+	return claims, nil
+}
+
+func (o *domain) user(w http.ResponseWriter, r *http.Request) {
+	o.count("user")
+	key := r.PathValue("id")
+	if malformed(key) {
+		o.refuse(w, http.StatusBadRequest, "invalid", "Invalid Input: "+key)
+		return
+	}
+
+	o.mu.Lock()
+	id, p := o.person(key)
+	bare := o.bare
+	o.mu.Unlock()
+	if p == nil {
+		o.refuse(w, http.StatusNotFound, "notFound", "Resource Not Found: userKey")
+		return
+	}
+
+	emails := make([]map[string]any, 0, len(p.others)+1)
+	if p.email != "" {
+		emails = append(emails, map[string]any{"address": p.email, "primary": true})
+	}
+	for _, a := range p.others {
+		emails = append(emails, map[string]any{"address": a})
+	}
+	body := map[string]any{
+		"kind":         "admin#directory#user",
+		"id":           id,
+		"primaryEmail": p.email,
+		"name":         map[string]any{"fullName": p.name},
+		"aliases":      emptyList(p.aliases),
+		"emails":       emails,
+		"suspended":    p.suspended,
+		"archived":     p.archived,
+	}
+	if !bare {
+		body["etag"] = revision(id, p.name, p.email, strings.Join(p.aliases, ","), strconv.FormatBool(p.suspended), strconv.FormatBool(p.archived))
+	}
+	o.write(w, http.StatusOK, body)
+}
+
+func (o *domain) group(w http.ResponseWriter, r *http.Request) {
+	o.count("group")
+	key := r.PathValue("id")
+
+	o.mu.Lock()
+	id, g := o.team(key)
+	bare := o.bare
+	o.mu.Unlock()
+	if g == nil {
+		o.refuse(w, http.StatusNotFound, "notFound", "Resource Not Found: groupKey")
+		return
+	}
+	o.write(w, http.StatusOK, o.object(id, g, bare))
+}
+
+// list is the collection that answers both lookups. It takes a userKey which is
+// a person or a group, and it says which groups that key is directly in and
+// nothing about what those are inside.
+func (o *domain) list(w http.ResponseWriter, r *http.Request) {
+	o.count("list")
+	key := r.URL.Query().Get("userKey")
+	switch {
+	case key == "":
+		// The real one wants a customer or a domain instead, and this adapter
+		// has no use for a listing of the whole directory.
+		o.refuse(w, http.StatusBadRequest, "required", "Missing required field: userKey")
+		return
+	case malformed(key):
+		o.refuse(w, http.StatusBadRequest, "invalid", "Invalid Input: "+key)
+		return
+	}
+
+	size := 200
+	if raw := r.URL.Query().Get("maxResults"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		// The ceiling the real endpoint enforces. An adapter that passed a
+		// caller's number straight through would turn a configuration mistake
+		// into an expansion that reports the person is in no groups.
+		if err != nil || n < 1 || n > 200 {
+			o.refuse(w, http.StatusBadRequest, "invalid", "Invalid Input: maxResults")
+			return
+		}
+		size = n
+	}
+
+	o.mu.Lock()
+	held, ok := o.above(key)
+	bare := o.bare
+	o.mu.Unlock()
+	if !ok {
+		o.refuse(w, http.StatusNotFound, "notFound", "Resource Not Found: userKey")
+		return
+	}
+
+	from := 0
+	if token := r.URL.Query().Get("pageToken"); token != "" {
+		n, err := strconv.Atoi(token)
+		if err != nil || n < 0 {
+			o.refuse(w, http.StatusBadRequest, "invalid", "Invalid Input: pageToken")
+			return
+		}
+		from = min(n, len(held))
+	}
+	to := min(from+size, len(held))
+
+	value := make([]map[string]any, 0, to-from)
+	for _, id := range held[from:to] {
+		o.mu.Lock()
+		g := o.groups[id]
+		o.mu.Unlock()
+		value = append(value, o.object(id, g, bare))
+	}
+
+	body := map[string]any{"kind": "admin#directory#groups", "groups": value}
+	if to < len(held) {
+		body["nextPageToken"] = strconv.Itoa(to)
+	}
+	o.write(w, http.StatusOK, body)
+}
+
+// object is one group the way the API sends it, which is what it is and not
+// where it sits.
+func (o *domain) object(id string, g *team, bare bool) map[string]any {
+	body := map[string]any{
+		"kind":  "admin#directory#group",
+		"id":    id,
+		"email": g.email,
+		"name":  g.name,
+	}
+	if !bare {
+		body["etag"] = revision(id, g.name, g.email)
+	}
+	return body
+}
+
+// person finds somebody by id or by any address they answer to. The caller holds
+// the lock.
+func (o *domain) person(key string) (string, *person) {
+	if p, ok := o.users[key]; ok {
+		return key, p
+	}
+	for id, p := range o.users {
+		if p.email == key || slices.Contains(p.aliases, key) || slices.Contains(p.others, key) {
+			return id, p
+		}
+	}
+	return "", nil
+}
+
+// team finds a group by id or by its address. The caller holds the lock.
+func (o *domain) team(key string) (string, *team) {
+	if g, ok := o.groups[key]; ok {
+		return key, g
+	}
+	for id, g := range o.groups {
+		if g.email == key {
+			return id, g
+		}
+	}
+	return "", nil
+}
+
+// above is the groups one key is directly a member of, and whether the domain
+// holds that key at all. The caller holds the lock.
+//
+// A membership naming a group that is not there is simply absent from the
+// answer, because the collection returns the objects rather than their ids and
+// an object that is not there is not in the answer.
+func (o *domain) above(key string) ([]string, bool) {
+	var in []string
+	if _, p := o.person(key); p != nil {
+		in = p.memberOf
+	} else if _, g := o.team(key); g != nil {
+		in = g.memberOf
+	} else {
+		return nil, false
+	}
+
+	out := make([]string, 0, len(in))
+	for _, id := range in {
+		if _, ok := o.groups[id]; ok {
+			out = append(out, id)
+		}
+	}
+	slices.Sort(out)
+	return out, true
+}
+
+// put adds or replaces one person.
+func (o *domain) put(t *testing.T, s directory.Subject) {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	email := s.Email
+	if email == "" {
+		email = s.ID + "@acme.test"
+	}
+	o.users[s.ID] = &person{
+		name:      s.Name,
+		email:     email,
+		suspended: s.Disabled,
+		memberOf:  slices.Clone(s.MemberOf),
+	}
+}
+
+// putGroup adds or replaces one group.
+func (o *domain) putGroup(t *testing.T, g directory.Group) {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.groups[g.ID] = &team{
+		name:     g.Name,
+		email:    g.ID + "@acme.test",
+		memberOf: slices.Clone(g.MemberOf),
+	}
+}
+
+// edit changes one person, for the things the conformance suite has no
+// vocabulary for.
+func (o *domain) edit(t *testing.T, id string, change func(*person)) {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	p, ok := o.users[id]
+	if !ok {
+		t.Fatalf("there is nobody called %q in the domain", id)
+	}
+	change(p)
+}
+
+// editGroup changes one group, for the same reason.
+func (o *domain) editGroup(t *testing.T, id string, change func(*team)) {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	g, ok := o.groups[id]
+	if !ok {
+		t.Fatalf("there is no group called %q in the domain", id)
+	}
+	change(g)
+}
+
+// spent is how many requests of one kind arrived.
+func (o *domain) spent(kind string) int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.calls[kind]
+}
+
+func (o *domain) count(kind string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.calls[kind]++
+}
+
+func (o *domain) write(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		o.t.Errorf("writing the answer: %v", err)
+	}
+}
+
+func (o *domain) refuse(w http.ResponseWriter, status int, reason, message string) {
+	o.write(w, status, map[string]any{
+		"error": map[string]any{
+			"code":    status,
+			"message": message,
+			"errors": []map[string]any{
+				{"domain": "global", "reason": reason, "message": message},
+			},
+		},
+	})
+}
+
+// deny is how the token endpoint refuses, which is a different document from the
+// one the API refuses with.
+func (o *domain) deny(w http.ResponseWriter, code, description string) {
+	o.write(w, http.StatusBadRequest, map[string]any{
+		"error":             code,
+		"error_description": description,
+	})
+}
+
+// revision is a stand in for an etag: a short string that changes when anything
+// it is derived from does.
+func revision(parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return `"` + base64.RawURLEncoding.EncodeToString(sum[:9]) + `"`
+}
+
+// malformed is a key the service will not even look up, which is a real answer
+// and not a failure. A string with a space in it is neither an id nor an
+// address, and the endpoint says so with a bad request.
+func malformed(key string) bool { return strings.ContainsAny(key, " \t") }
+
+// emptyList is how the API reports a collection with nothing in it, which is not
+// the same as leaving the property out.
+func emptyList(in []string) []string {
+	if in == nil {
+		return []string{}
+	}
+	return in
+}
+
+// describe joins ids for a failure worth reading.
+func describe(in []string) string { return strings.Join(in, " ") }

--- a/directory/google/google.go
+++ b/directory/google/google.go
@@ -1,0 +1,665 @@
+// Package google resolves group membership against a Google Workspace domain.
+//
+// It answers the two lookups [directory.Directory] asks for and nothing else.
+// The closure, the cycle detection, the bound on how much one expansion may
+// cost and the version an answer is stamped with are all in [directory], and
+// they are shared by every provider, because those are exactly the parts that
+// are easy to get subtly wrong and impossible to notice from the outside.
+//
+// # One endpoint answers both lookups
+//
+// Google Workspace groups nest and the Admin SDK will not walk the nesting for
+// you. The groups collection takes a userKey and returns the groups that key is
+// directly a member of, which is one level and no more.
+//
+// The useful part is what a userKey may be. It is a person, by id or by any of
+// their addresses, and it is also a group, by id or by the group's address. So
+// the same request that answers "which groups is this person in" answers "which
+// groups is this group in", and [Directory.Group] returns a real membership
+// rather than an empty one. The resolver walks from there, which is the shape it
+// was built for.
+//
+// That is worth preferring to the alternative even where the alternative exists.
+// The members collection will report inherited membership if it is asked to, but
+// it answers the question the other way round, from the group towards the
+// people in it, and a company with one group that everybody is in would have to
+// read every employee to find out that one of them is a member. Walking up costs
+// a request per group above somebody and never depends on how many colleagues
+// they have.
+//
+// # What the buffer holds, and what it does not
+//
+// The walk asks about every group, and a person in three hundred groups would be
+// three hundred requests against a domain everybody else is signing in to at the
+// same time. The listing that answers the subject lookup returns whole group
+// objects rather than ids, so those objects fill a small buffer that the group
+// lookups then read, and the three hundred lookups of the object become none.
+//
+// What the buffer cannot hold is what those groups are members of, because the
+// listing does not say. So a group lookup here is one request rather than two:
+// the object comes out of the buffer and the level above it is still asked for.
+// That is the honest limit of what one collection can be made to do, and it is
+// still half of what the walk would otherwise cost.
+//
+// It is worth being precise about why this is not a second permission cache,
+// because [directory.Cache] documents at some length why there is only one of
+// those. The fact being held is "this group exists and is called this", which is
+// not an input to any decision: the membership, which is the part that decides
+// anything, is asked for on every lookup and never held.
+//
+// # Suspended is not the only way to leave
+//
+// An account somebody has suspended is the obvious one and it is not the only
+// one. An archived account is a person who has left, whose mailbox was kept and
+// whose licence was released, and it is a separate field with a separate value.
+// An adapter that reads suspended alone keeps resolving the groups of everybody
+// who left the company and was archived rather than suspended, which is a common
+// way to run a Workspace domain and not a corner case.
+//
+// Neither is a deletion. A deleted user is not returned by this endpoint at all,
+// so they arrive as a subject the domain does not hold, which is what they are.
+//
+// # A forbidden that means slow down
+//
+// The Admin SDK refuses a caller who is over the rate with a 403 rather than
+// with a 429, and the only thing separating that from an account which may not
+// read the directory at all is a reason string in the body. Retrying every
+// forbidden would hammer a service over permissions that are not going to
+// change, and retrying none of them would turn a throttle that clears in two
+// seconds into a sync that failed. So [quota] reads the reason, and [limit] is
+// told about it with [limit.WithThrottled].
+//
+// The daily limit is deliberately not in that set. It is the same shape of
+// answer and it clears at midnight, so waiting for it with a backoff measured in
+// seconds spends the rest of the quota finding out that there is none left.
+package google
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/cache"
+	"github.com/tamnd/genba/connector/limit"
+	"github.com/tamnd/genba/directory"
+)
+
+// DefaultName is the identity source the groups belong to, which is what every
+// group key from this domain is prefixed with.
+const DefaultName = "google"
+
+// DefaultEndpoint is the Admin SDK.
+const DefaultEndpoint = "https://admin.googleapis.com"
+
+// apiPath is the version of the Directory API this speaks, and it is part of
+// the path rather than a header.
+const apiPath = "/admin/directory/v1"
+
+// DefaultPageSize is how many groups are asked for per page, which is the most
+// this collection accepts.
+const DefaultPageSize = 200
+
+// MaxPageSize is the ceiling the endpoint enforces. A larger page is refused
+// with a bad request rather than quietly trimmed, and a bad request on a
+// membership listing is an expansion that fails, so a size above this is capped
+// here instead of being passed on to find out.
+const MaxPageSize = 200
+
+// DefaultBufferTTL is how long the group listing that answered a subject lookup
+// is kept for the group lookups that follow it.
+//
+// It is short because it only has to outlive one expansion. See the package
+// documentation for what is in it and why holding it for longer would not change
+// an answer either.
+const DefaultBufferTTL = 30 * time.Second
+
+// DefaultBufferSize is how many groups the buffer holds before it starts
+// dropping the ones nobody has asked about recently.
+const DefaultBufferSize = 20000
+
+// maxPages bounds a listing. At the default page size it is two hundred
+// thousand groups, which is far past anybody's domain and well short of forever.
+const maxPages = 1000
+
+// Directory resolves subjects and groups against one Google Workspace domain.
+//
+// It is safe for concurrent use, which it has to be: an expansion looks up a
+// level of the graph in parallel.
+type Directory struct {
+	http   *http.Client
+	base   string
+	tokens Tokens
+	name   string
+	page   int
+
+	// held is the group listing from a subject lookup, waiting for the group
+	// lookups that are about to ask for the same objects.
+	held *cache.Cache[group]
+}
+
+var _ directory.Directory = (*Directory)(nil)
+
+// Option configures a [Directory].
+type Option func(*Directory)
+
+// WithName sets the identity source the group ids belong to.
+//
+// A deployment resolving against two domains needs two names, because a group id
+// from one and the same id from the other would otherwise be the same group, and
+// they are not.
+func WithName(name string) Option {
+	return func(d *Directory) { d.name = name }
+}
+
+// WithEndpoint replaces the Admin SDK, which a test needs and nothing else does.
+func WithEndpoint(base string) Option {
+	return func(d *Directory) { d.base = strings.TrimSuffix(base, "/") }
+}
+
+// WithHTTPClient replaces the client entirely, rate limiting included.
+//
+// A caller who passes one is taking on the limits themselves, which is right for
+// a test replaying a recording and wrong for anything talking to Google.
+func WithHTTPClient(c *http.Client) Option {
+	return func(d *Directory) {
+		if c != nil {
+			d.http = c
+		}
+	}
+}
+
+// WithLimits changes what the domain is allowed to cost.
+func WithLimits(l limit.Limits) Option {
+	return func(d *Directory) { d.http = throttled(l) }
+}
+
+// WithPageSize sets how many groups are asked for per page. A size below one
+// selects [DefaultPageSize] and a size above [MaxPageSize] is that.
+func WithPageSize(n int) Option {
+	return func(d *Directory) { d.page = n }
+}
+
+// WithBuffer sets how long and how much of the group listing is kept for the
+// group lookups that follow it. A size below one selects [DefaultBufferSize].
+//
+// A lifetime below one turns the buffer off, which is an extra request per group
+// in the set. That is correct and slow, so it is for a test that wants to count
+// the requests rather than for a deployment.
+func WithBuffer(ttl time.Duration, size int) Option {
+	return func(d *Directory) {
+		if ttl < 1 {
+			d.held = nil
+			return
+		}
+		if size < 1 {
+			size = DefaultBufferSize
+		}
+		d.held = cache.New[group](size, ttl)
+	}
+}
+
+// New returns a directory over a Google Workspace domain.
+//
+// The tokens are where the bearer comes from. [NewServiceAccount] is the one to
+// reach for in a deployment and [Token] is the one for a test.
+func New(tokens Tokens, opts ...Option) (*Directory, error) {
+	if tokens == nil {
+		return nil, errors.New("google: a source of tokens is required")
+	}
+
+	d := &Directory{
+		http:   throttled(limit.Limits{}),
+		base:   DefaultEndpoint,
+		tokens: tokens,
+		name:   DefaultName,
+		page:   DefaultPageSize,
+		held:   cache.New[group](DefaultBufferSize, DefaultBufferTTL),
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	if d.name == "" {
+		return nil, errors.New("google: the source name cannot be empty")
+	}
+	if d.page < 1 {
+		d.page = DefaultPageSize
+	}
+	if d.page > MaxPageSize {
+		d.page = MaxPageSize
+	}
+	u, err := url.Parse(d.base)
+	if err != nil {
+		return nil, fmt.Errorf("google: the endpoint %q: %w", d.base, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("google: the endpoint %q needs a scheme and a host", d.base)
+	}
+	return d, nil
+}
+
+// throttled is the client used when the caller has not supplied one.
+func throttled(l limit.Limits) *http.Client {
+	return &http.Client{Transport: limit.NewTransport(l, limit.WithThrottled(quota))}
+}
+
+// Name is the identity source these ids belong to.
+func (d *Directory) Name() string { return d.name }
+
+// Subject returns one person, with the groups they are directly in.
+func (d *Directory) Subject(ctx context.Context, id string) (directory.Subject, error) {
+	if id == "" {
+		return directory.Subject{}, fmt.Errorf("google: %w", directory.ErrNoSubject)
+	}
+
+	var u user
+	if err := d.get(ctx, apiPath+"/users/"+url.PathEscape(id), nil, &u); err != nil {
+		if errors.Is(err, errNotFound) {
+			return directory.Subject{}, fmt.Errorf("google: %q: %w", id, directory.ErrNoSubject)
+		}
+		return directory.Subject{}, err
+	}
+
+	sub := directory.Subject{
+		ID:         cmp.Or(u.ID, id),
+		Name:       u.display(),
+		Email:      u.PrimaryEmail,
+		Version:    u.version(),
+		Identities: d.identities(u),
+		Disabled:   u.Suspended || u.Archived,
+	}
+	// A deactivated account is refused by the resolver, so the group listing it
+	// would have needed is a request nobody is going to read the answer to.
+	if sub.Disabled {
+		return sub, nil
+	}
+
+	groups, err := d.memberships(ctx, sub.ID)
+	if err != nil {
+		if errors.Is(err, errNotFound) {
+			return directory.Subject{}, fmt.Errorf("google: %q: %w", id, directory.ErrNoSubject)
+		}
+		return directory.Subject{}, err
+	}
+	sub.MemberOf = make([]string, 0, len(groups))
+	for _, g := range groups {
+		sub.MemberOf = append(sub.MemberOf, g.ID)
+		d.buffer(g)
+	}
+	return sub, nil
+}
+
+// buffer keeps a group object for the lookup that is about to ask for it.
+func (d *Directory) buffer(g group) {
+	if d.held != nil && g.ID != "" {
+		d.held.Put(g.ID, g)
+	}
+}
+
+// buffered is the group object a listing already went past, if there is one.
+func (d *Directory) buffered(id string) (group, bool) {
+	if d.held == nil {
+		return group{}, false
+	}
+	return d.held.Get(id)
+}
+
+// Group returns one group, with the groups it is directly inside.
+//
+// The membership is asked for every time and the object usually is not, because
+// the listing that answered the subject put the object here on its way past and
+// said nothing about what it is a member of. See the package documentation.
+func (d *Directory) Group(ctx context.Context, id string) (directory.Group, error) {
+	if id == "" {
+		return directory.Group{}, fmt.Errorf("google: %w", directory.ErrNoGroup)
+	}
+
+	raw, ok := d.buffered(id)
+	if !ok {
+		if err := d.get(ctx, apiPath+"/groups/"+url.PathEscape(id), nil, &raw); err != nil {
+			if errors.Is(err, errNotFound) {
+				return directory.Group{}, fmt.Errorf("google: %q: %w", id, directory.ErrNoGroup)
+			}
+			return directory.Group{}, err
+		}
+		d.buffer(raw)
+	}
+
+	above, err := d.memberships(ctx, cmp.Or(raw.ID, id))
+	if err != nil {
+		if errors.Is(err, errNotFound) {
+			return directory.Group{}, fmt.Errorf("google: %q: %w", id, directory.ErrNoGroup)
+		}
+		return directory.Group{}, err
+	}
+	parents := make([]string, 0, len(above))
+	for _, p := range above {
+		parents = append(parents, p.ID)
+		d.buffer(p)
+	}
+	return raw.directory(id, parents), nil
+}
+
+// memberships reads every group a key is directly in, following the pages.
+//
+// The key is a person or a group, and the request is the same one either way,
+// which is the whole reason this provider is walkable at all.
+func (d *Directory) memberships(ctx context.Context, key string) ([]group, error) {
+	var (
+		out  []group
+		q    = url.Values{"userKey": {key}, "maxResults": {strconv.Itoa(d.page)}}
+		seen = make(map[string]bool)
+	)
+	// Bounded because the page after the last one is a token the service sends,
+	// and a service that sent the same token twice would otherwise be an
+	// expansion that never returned. The resolver's own bound is on groups
+	// reached rather than on requests made, so it would not catch this.
+	for range maxPages {
+		var page listing
+		if err := d.get(ctx, apiPath+"/groups", q, &page); err != nil {
+			return nil, err
+		}
+		for _, raw := range page.Groups {
+			// A key can reach the same group by two paths, and the group set is
+			// a set.
+			if raw.ID == "" || seen[raw.ID] {
+				continue
+			}
+			seen[raw.ID] = true
+			out = append(out, raw)
+		}
+		if page.Next == "" {
+			return out, nil
+		}
+		q.Set("pageToken", page.Next)
+	}
+	return nil, fmt.Errorf("google: the groups of %q did not stop after %d pages", key, maxPages)
+}
+
+// listing is a page of groups, and the token for the page after it.
+type listing struct {
+	Groups []group `json:"groups"`
+	Next   string  `json:"nextPageToken"`
+}
+
+// user is what the Admin SDK says about one person.
+type user struct {
+	ID           string   `json:"id"`
+	PrimaryEmail string   `json:"primaryEmail"`
+	Name         fullName `json:"name"`
+	Aliases      []string `json:"aliases"`
+	Emails       []email  `json:"emails"`
+	ETag         string   `json:"etag"`
+
+	// Suspended and Archived are two different ways to stop working here and
+	// only the first is the obvious one. See the package documentation.
+	Suspended bool `json:"suspended"`
+	Archived  bool `json:"archived"`
+}
+
+type fullName struct {
+	Given  string `json:"givenName"`
+	Family string `json:"familyName"`
+	Full   string `json:"fullName"`
+}
+
+type email struct {
+	Address string `json:"address"`
+	Primary bool   `json:"primary"`
+}
+
+// display is what to call somebody, in the order the provider itself falls back.
+func (u user) display() string {
+	if u.Name.Full != "" {
+		return u.Name.Full
+	}
+	if name := strings.TrimSpace(u.Name.Given + " " + u.Name.Family); name != "" {
+		return name
+	}
+	return u.PrimaryEmail
+}
+
+// version is a fingerprint of what this adapter reports about the person.
+//
+// The etag is the provider's own revision and it is the first thing in here, so
+// for a domain that sends one this is that revision under a different name. The
+// rest is not belt and braces: the Admin SDK has been taking etags off responses
+// across its APIs for years, and an adapter that reads one and finds nothing
+// would stamp every person in the domain with the same version and never
+// invalidate anything built on top of a group set. Hashing the fields as well
+// means a domain that stops sending etags loses nothing.
+//
+// The group ids are not in here because [directory] fingerprints those
+// separately, so somebody joining or leaving a group is caught without them.
+func (u user) version() string {
+	h := fnv.New64a()
+	fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00", u.ETag, u.ID, u.display(), u.PrimaryEmail)
+	for _, a := range u.Aliases {
+		fmt.Fprintf(h, "%s\x00", a)
+	}
+	for _, e := range u.Emails {
+		fmt.Fprintf(h, "%s\x00", e.Address)
+	}
+	if u.Suspended {
+		fmt.Fprint(h, "suspended\x00")
+	}
+	if u.Archived {
+		fmt.Fprint(h, "archived\x00")
+	}
+	return strconv.FormatUint(h.Sum64(), 16)
+}
+
+// group is what the Admin SDK says about one group.
+type group struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+	ETag  string `json:"etag"`
+}
+
+// directory turns one into what the resolver walks.
+func (g group) directory(id string, above []string) directory.Group {
+	return directory.Group{
+		ID:       cmp.Or(g.ID, id),
+		Name:     cmp.Or(g.Name, g.Email),
+		Version:  g.version(above),
+		MemberOf: above,
+	}
+}
+
+// version is a fingerprint of the group and of where it sits.
+//
+// The groups above it are in here and that is the part worth explaining. A
+// version on a group exists to catch a change that alters somebody's group set
+// without altering the ids already in it, and for a provider that nests, that
+// change is a group being put inside another one. The etag does not move when
+// that happens, because being a member of something is a fact the provider keeps
+// on the other end of the edge. So a version that was the etag alone would leave
+// every member of that group with a cached set that is missing whatever the
+// group was just put underneath, until an unrelated change moved something else.
+func (g group) version(above []string) string {
+	h := fnv.New64a()
+	fmt.Fprintf(h, "%s\x00%s\x00%s\x00", g.ETag, g.Name, g.Email)
+	for _, id := range above {
+		fmt.Fprintf(h, "%s\x00", id)
+	}
+	return strconv.FormatUint(h.Sum64(), 16)
+}
+
+// identities is the same person in the systems being indexed.
+//
+// The Google id is one of them, because a connector that was told about groups
+// by Workspace names people the same way. The addresses are the others, because
+// a rule granting to somebody by email is the common shape and an email address
+// is what a person has in every product they use.
+//
+// The non editable aliases are not in here. Those are generated for the domain
+// rather than chosen for the person: a company with three domain aliases gets
+// three more addresses for every employee, none of which anybody has ever
+// written down, and putting them all in the principal makes every expansion
+// carry a list nothing will ever match.
+func (d *Directory) identities(u user) []acl.Identity {
+	out := make([]acl.Identity, 0, 4)
+	add := func(source, value string) {
+		if value == "" {
+			return
+		}
+		id := acl.Identity{Source: source, Value: value}
+		if slices.Contains(out, id) {
+			return
+		}
+		out = append(out, id)
+	}
+	add(d.name, u.ID)
+	add("email", u.PrimaryEmail)
+	for _, a := range u.Aliases {
+		add("email", a)
+	}
+	for _, e := range u.Emails {
+		add("email", e.Address)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// errNotFound is the service answering rather than failing to answer, and it is
+// what separates a subject the domain does not hold from a domain that could not
+// be reached.
+var errNotFound = errors.New("not found")
+
+// get reads one JSON document.
+func (d *Directory) get(ctx context.Context, path string, q url.Values, into any) error {
+	u := d.base + path
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	token, err := d.tokens.Token(ctx)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("google: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := d.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("google: %s: %w", path, err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return d.refusal(path, resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(into); err != nil {
+		return fmt.Errorf("google: %s: reading the answer: %w", path, err)
+	}
+	return nil
+}
+
+// failure is the error document every Google API answers a refusal with.
+type failure struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Errors  []struct {
+			Domain  string `json:"domain"`
+			Reason  string `json:"reason"`
+			Message string `json:"message"`
+		} `json:"errors"`
+	} `json:"error"`
+}
+
+// reason is what the service says this refusal was about, which is the field
+// worth branching on and the one worth putting in a message.
+func (f failure) reason() string {
+	if len(f.Error.Errors) == 0 {
+		return ""
+	}
+	return f.Error.Errors[0].Reason
+}
+
+// refusal turns a response the service refused with into an error worth reading.
+//
+// A bad request is one of these and not a failure, which is worth saying out
+// loud. The endpoint refuses a userKey that could not belong to anybody with an
+// invalid rather than with a not found, so a store holding a username where an
+// address belongs would otherwise fail the expansion instead of reporting that
+// nobody by that name is in the domain. The two mean the same thing to a caller:
+// the domain does not hold this person.
+//
+// That mapping is only safe because nothing else this adapter sends can be
+// invalid. The one parameter with a range on it is the page size, and it is
+// capped at [MaxPageSize] on the way in rather than sent to find out.
+func (d *Directory) refusal(path string, resp *http.Response) error {
+	var body failure
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	_ = json.Unmarshal(raw, &body)
+	reason := body.reason()
+
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		return errNotFound
+	case resp.StatusCode == http.StatusBadRequest && (reason == "invalid" || reason == "invalidInput"):
+		return errNotFound
+	}
+
+	message := firstLine(body.Error.Message)
+	switch {
+	case reason != "" && message != "":
+		return fmt.Errorf("google: %s: %s: %s (%s)", path, resp.Status, message, reason)
+	case message != "":
+		return fmt.Errorf("google: %s: %s: %s", path, resp.Status, message)
+	default:
+		return fmt.Errorf("google: %s: %s", path, resp.Status)
+	}
+}
+
+// quota reports whether a refusal is the service saying the requests are
+// arriving too fast, rather than saying this account may not read the directory.
+//
+// Both are a 403 and the reason is the only thing that tells them apart. See the
+// package documentation for why the daily limit is not in here.
+func quota(resp *http.Response) bool {
+	if resp.StatusCode != http.StatusForbidden {
+		return false
+	}
+	var body failure
+	if err := json.Unmarshal(limit.Peek(resp, 1<<16), &body); err != nil {
+		return false
+	}
+	for _, e := range body.Error.Errors {
+		switch e.Reason {
+		case "quotaExceeded", "rateLimitExceeded", "userRateLimitExceeded":
+			return true
+		}
+	}
+	return false
+}
+
+// firstLine trims a message down to the sentence worth reading. The rest of it
+// is usually a link to a console page, which belongs in a support ticket rather
+// than in a log line.
+func firstLine(s string) string {
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}

--- a/directory/google/google_test.go
+++ b/directory/google/google_test.go
@@ -1,0 +1,509 @@
+package google_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/limit"
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/directorytest"
+	"github.com/tamnd/genba/directory/google"
+)
+
+func TestConformance(t *testing.T) {
+	directorytest.Run(t, func(t *testing.T) directorytest.Fixture {
+		o, endpoint := newDomain(t)
+		return directorytest.Fixture{
+			Directory: dial(t, endpoint),
+			Put:       o.put,
+			PutGroup:  o.putGroup,
+
+			// Neither Flat nor Transitive. Workspace groups nest and the
+			// provider will not walk the nesting, so this is the ordinary case
+			// the resolver was built for and every case in the suite applies.
+
+			// Drop is deliberately absent. A membership naming a group that is
+			// not there is not a state this provider can be in, because the
+			// collection answers with the group objects rather than with their
+			// ids, and an object that is not there is not in the answer.
+
+			Identity: func(t *testing.T, s *directory.Subject) acl.Identity {
+				t.Helper()
+				s.Email = "mei@acme.test"
+				return acl.Identity{Source: "email", Value: "mei@acme.test"}
+			},
+		}
+	})
+}
+
+// dial is a directory over the fake domain.
+//
+// Without the rate limiter, because these cases are about the adapter and the
+// limiter is tested where it lives. Leaving it on would make a case about a
+// person in three hundred groups a case about how long five requests a second
+// takes.
+func dial(t *testing.T, endpoint string, opts ...google.Option) *google.Directory {
+	t.Helper()
+	d, err := google.New(google.Token(bearer), append([]google.Option{
+		google.WithEndpoint(endpoint),
+		google.WithHTTPClient(http.DefaultClient),
+	}, opts...)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// expand is one resolution, which is what every case below is about.
+func expand(t *testing.T, d *google.Directory, id string, opts ...directory.Option) directory.Expansion {
+	t.Helper()
+	got, err := attempt(t, d, id, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func attempt(t *testing.T, d *google.Directory, id string, opts ...directory.Option) (directory.Expansion, error) {
+	t.Helper()
+	r, err := directory.New(d, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r.Expand(t.Context(), id)
+}
+
+// members is the group set with the source prefix taken back off, because what
+// these cases are about is which groups came back rather than how a key is
+// spelled.
+func members(t *testing.T, d *google.Directory, got directory.Expansion) []string {
+	t.Helper()
+	out := make([]string, 0, len(got.Groups.Members))
+	for _, key := range got.Groups.Members {
+		out = append(out, strings.TrimPrefix(key, d.Name()+":"))
+	}
+	return out
+}
+
+func TestTheGroupObjectsAListingCarriedAreNotAskedForAgain(t *testing.T) {
+	o, endpoint := newDomain(t)
+	in := make([]string, 0, 300)
+	for i := range 300 {
+		id := "g" + strconv.Itoa(i)
+		o.putGroup(t, directory.Group{ID: id, Name: "Group " + strconv.Itoa(i)})
+		in = append(in, id)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: in})
+
+	got := expand(t, dial(t, endpoint), "mei")
+	if len(got.Groups.Members) != 300 {
+		t.Fatalf("mei resolved to %d groups, want 300", len(got.Groups.Members))
+	}
+	// The whole point of the buffer. Three hundred groups is one listing and
+	// not three hundred requests for objects the listing already carried.
+	if n := o.spent("group"); n != 0 {
+		t.Errorf("a person in three hundred groups cost %d object lookups, want none", n)
+	}
+	// What the buffer cannot save is the membership of each of those groups,
+	// because the listing says nothing about it. Two pages for mei at the
+	// default size and one listing for each group above her.
+	if n := o.spent("list"); n != 302 {
+		t.Errorf("a person in three hundred groups cost %d listings, want 302", n)
+	}
+}
+
+func TestWithTheBufferOffEveryGroupIsAnExtraRequest(t *testing.T) {
+	o, endpoint := newDomain(t)
+	in := make([]string, 0, 20)
+	for i := range 20 {
+		id := "g" + strconv.Itoa(i)
+		o.putGroup(t, directory.Group{ID: id})
+		in = append(in, id)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: in})
+
+	// Saying what the buffer is worth by taking it away. Without this the case
+	// above would pass against an adapter that never looks a group up at all.
+	expand(t, dial(t, endpoint, google.WithBuffer(0, 0)), "mei")
+	if n := o.spent("group"); n != 20 {
+		t.Errorf("twenty groups cost %d object lookups with the buffer off, want 20", n)
+	}
+}
+
+func TestAListingIsFollowedAcrossItsPages(t *testing.T) {
+	o, endpoint := newDomain(t)
+	in := make([]string, 0, 25)
+	for i := range 25 {
+		id := fmt.Sprintf("g%02d", i)
+		o.putGroup(t, directory.Group{ID: id})
+		in = append(in, id)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: in})
+
+	got := expand(t, dial(t, endpoint, google.WithPageSize(4)), "mei")
+	if n := len(got.Groups.Members); n != 25 {
+		t.Fatalf("mei resolved to %d groups, want 25", n)
+	}
+	// Seven pages for mei, and one empty listing for each of the twenty five
+	// groups nothing is above.
+	if n := o.spent("list"); n != 32 {
+		t.Errorf("twenty five groups at four a page cost %d requests, want 32", n)
+	}
+}
+
+func TestNoGroupIsServedTwiceOrMissedAcrossAPageBoundary(t *testing.T) {
+	o, endpoint := newDomain(t)
+	want := make([]string, 0, 13)
+	for i := range 13 {
+		id := fmt.Sprintf("g%02d", i)
+		o.putGroup(t, directory.Group{ID: id})
+		want = append(want, id)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: want})
+
+	d := dial(t, endpoint, google.WithPageSize(5))
+	got := members(t, d, expand(t, d, "mei"))
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		t.Fatalf("thirteen groups at five a page resolved to [%s], want [%s]", describe(got), describe(want))
+	}
+}
+
+// TestAPageSizeTheEndpointWouldRefuseIsCapped is about a mistake in a
+// configuration file rather than in the code, and about what it costs.
+func TestAPageSizeTheEndpointWouldRefuseIsCapped(t *testing.T) {
+	o, endpoint := newDomain(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	// The endpoint refuses a page above two hundred with a bad request, and this
+	// adapter reads a bad request on a lookup as a person the domain does not
+	// hold. So passing the number straight through would not fail loudly, it
+	// would quietly report that mei is in no groups.
+	got := expand(t, dial(t, endpoint, google.WithPageSize(5000)), "mei")
+	if n := len(got.Groups.Members); n != 1 {
+		t.Fatalf("with an oversized page mei resolved to %d groups, want 1", n)
+	}
+	if n := o.spent("refused"); n != 0 {
+		t.Errorf("%d requests were refused, so the page size went out as it was given", n)
+	}
+}
+
+// TestAGroupInsideAnotherIsWalkedFromTheSameCollection is the fact the whole
+// adapter is shaped around: one endpoint answers both lookups.
+func TestAGroupInsideAnotherIsWalkedFromTheSameCollection(t *testing.T) {
+	o, endpoint := newDomain(t)
+	for i := range 4 {
+		g := directory.Group{ID: "level" + strconv.Itoa(i)}
+		if i > 0 {
+			g.MemberOf = []string{"level" + strconv.Itoa(i-1)}
+		}
+		o.putGroup(t, g)
+	}
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"level3"}})
+
+	d := dial(t, endpoint)
+	got := expand(t, d, "mei")
+	want := []string{"level0", "level1", "level2", "level3"}
+	in := members(t, d, got)
+	slices.Sort(in)
+	if !slices.Equal(in, want) {
+		t.Fatalf("a four level nest resolved to [%s], want [%s]", describe(in), describe(want))
+	}
+	// One level per level, which is what a provider that does not expand
+	// transitively costs and what the resolver is for.
+	if got.Depth != 4 {
+		t.Errorf("a four level nest was walked %d levels deep, want 4", got.Depth)
+	}
+}
+
+// TestAnArchivedAccountIsRefusedTheSameWayASuspendedOneIs is the one fact about
+// this provider that an adapter can get wrong without anything noticing.
+func TestAnArchivedAccountIsRefusedTheSameWayASuspendedOneIs(t *testing.T) {
+	o, endpoint := newDomain(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "lee", MemberOf: []string{"engineering"}})
+	o.edit(t, "lee", func(p *person) { p.archived = true })
+
+	// Archiving is how a lot of companies handle somebody leaving: the mailbox
+	// is kept and the licence is released, and suspended stays false. An adapter
+	// reading that field alone keeps resolving the groups of everybody who has
+	// left.
+	got, err := attempt(t, dial(t, endpoint), "lee")
+	if !errors.Is(err, directory.ErrDisabled) {
+		t.Fatalf("an archived account gave %v, want ErrDisabled", err)
+	}
+	if len(got.Groups.Members) != 0 {
+		t.Errorf("a refused expansion still handed back the groups %v", got.Groups.Members)
+	}
+	// And it costs one request. There is nobody to resolve, so the listing is a
+	// question nobody is going to read the answer to.
+	if n := o.spent("list"); n != 0 {
+		t.Errorf("a refused account still cost %d membership listings", n)
+	}
+}
+
+func TestEveryAddressThePersonHasBecomesAnIdentity(t *testing.T) {
+	o, endpoint := newDomain(t)
+	o.put(t, directory.Subject{ID: "mei", Email: "mei@acme.test"})
+	o.edit(t, "mei", func(p *person) {
+		p.aliases = []string{"mei.tanaka@acme.test"}
+		p.others = []string{"m.tanaka@acme.test"}
+	})
+
+	got := expand(t, dial(t, endpoint), "mei")
+	for _, want := range []acl.Identity{
+		{Source: "google", Value: "mei"},
+		{Source: "email", Value: "mei@acme.test"},
+		{Source: "email", Value: "mei.tanaka@acme.test"},
+		{Source: "email", Value: "m.tanaka@acme.test"},
+	} {
+		if !slices.Contains(got.Subject.Identities, want) {
+			t.Errorf("mei resolved to %v, which does not include %v", got.Subject.Identities, want)
+		}
+	}
+	// The primary address arrives twice, once on its own and once inside the
+	// list of addresses, and the answer holds it once.
+	if n := len(got.Subject.Identities); n != 4 {
+		t.Errorf("mei resolved to %d identities, want 4 without repeats", n)
+	}
+}
+
+// TestTheVersionMovesWhenAGroupIsPutInsideAnother is what the group version is
+// for on a provider that nests, and it is the case a version taken straight off
+// the etag would fail.
+func TestTheVersionMovesWhenAGroupIsPutInsideAnother(t *testing.T) {
+	o, endpoint := newDomain(t)
+	o.putGroup(t, directory.Group{ID: "everyone"})
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	d := dial(t, endpoint, google.WithBuffer(0, 0))
+	before := expand(t, d, "mei").Groups.Version
+
+	// Nothing about the engineering group object changed, so its etag has not
+	// moved. What changed is where it sits, and mei can now read everything
+	// granted to everyone.
+	o.editGroup(t, "engineering", func(g *team) { g.memberOf = []string{"everyone"} })
+
+	got := expand(t, d, "mei")
+	if len(got.Groups.Members) != 2 {
+		t.Fatalf("after the move mei resolved to %v, want two groups", got.Groups.Members)
+	}
+	if got.Groups.Version == before {
+		t.Errorf("a group being put inside another left the version at %d", before)
+	}
+}
+
+// TestADomainThatSendsNoEtagsStillHasVersionsThatMove is about a provider that
+// takes something away rather than about one that never had it. Google has been
+// dropping etags across its APIs for years.
+func TestADomainThatSendsNoEtagsStillHasVersionsThatMove(t *testing.T) {
+	o, endpoint := newDomain(t)
+	o.forgetEtags()
+	o.putGroup(t, directory.Group{ID: "engineering", Name: "Engineering"})
+	o.put(t, directory.Subject{ID: "mei", Email: "mei@acme.test", MemberOf: []string{"engineering"}})
+
+	d := dial(t, endpoint, google.WithBuffer(0, 0))
+	before := expand(t, d, "mei").Groups.Version
+
+	// The group ids have not moved, so nothing about the membership catches
+	// this. A version that was the etag alone would be empty here and this
+	// change would never reach anything holding a cached group set.
+	o.edit(t, "mei", func(p *person) { p.aliases = []string{"mei.tanaka@acme.test"} })
+	if after := expand(t, d, "mei").Groups.Version; after == before {
+		t.Errorf("with no etags to copy, a new address left the version at %d", before)
+	}
+}
+
+// TestAQuotaRefusalIsWaitedOutRatherThanReported is the reason this adapter
+// tells the transport what a throttle looks like here.
+func TestAQuotaRefusalIsWaitedOutRatherThanReported(t *testing.T) {
+	o, endpoint := newDomain(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	// Two refusals and then the answer. The service says this with a forbidden
+	// rather than with a 429, and a transport that read the status alone would
+	// give up on a wait of a few milliseconds.
+	o.throttle(2, "quotaExceeded")
+
+	d := dial(t, endpoint, google.WithLimits(limit.Limits{
+		Rate:       1000,
+		Burst:      1000,
+		MinBackoff: time.Millisecond,
+		MaxBackoff: 5 * time.Millisecond,
+	}))
+	got := expand(t, d, "mei")
+	if len(got.Groups.Members) != 1 {
+		t.Fatalf("mei resolved to %v after two throttles, want one group", got.Groups.Members)
+	}
+	if n := o.spent("refused"); n != 2 {
+		t.Errorf("the domain refused %d times, want 2", n)
+	}
+}
+
+// TestAForbiddenThatIsNotAQuotaIsReportedAtOnce is the other half. Retrying a
+// permission that is not going to change spends the rest of the quota arriving
+// at the same answer more slowly.
+func TestAForbiddenThatIsNotAQuotaIsReportedAtOnce(t *testing.T) {
+	o, endpoint := newDomain(t)
+	o.put(t, directory.Subject{ID: "mei"})
+	o.throttle(20, "forbidden")
+
+	d := dial(t, endpoint, google.WithLimits(limit.Limits{
+		Rate:       1000,
+		Burst:      1000,
+		MinBackoff: time.Millisecond,
+		MaxBackoff: 5 * time.Millisecond,
+	}))
+	_, err := attempt(t, d, "mei")
+	switch {
+	case err == nil:
+		t.Fatal("a forbidden resolved somebody anyway")
+	case errors.Is(err, directory.ErrNoSubject):
+		t.Fatalf("a forbidden gave %v, which reads as a person who is not in the domain", err)
+	case !strings.Contains(err.Error(), "forbidden"):
+		t.Errorf("a forbidden gave %v, which does not say why", err)
+	}
+	if n := o.spent("refused"); n != 1 {
+		t.Errorf("a refusal that was never going to clear was tried %d times, want once", n)
+	}
+}
+
+func TestAnIdThatCouldNotBelongToAnybodyIsNobodyRatherThanAFailure(t *testing.T) {
+	_, endpoint := newDomain(t)
+
+	// The endpoint refuses a userKey that is neither an id nor an address with a
+	// bad request rather than with a not found. Both mean the domain does not
+	// hold this person, and treating the first as a failure turns one bad row in
+	// a store into an expansion that never succeeds.
+	_, err := attempt(t, dial(t, endpoint), "not an id")
+	if !errors.Is(err, directory.ErrNoSubject) {
+		t.Errorf("an id the service refused as malformed gave %v, want ErrNoSubject", err)
+	}
+}
+
+func TestABadTokenIsAFailureRatherThanAnEmptyDirectory(t *testing.T) {
+	_, endpoint := newDomain(t)
+
+	d, err := google.New(google.Token("not-the-token"), google.WithEndpoint(endpoint), google.WithHTTPClient(http.DefaultClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The important half is that it is not ErrNoSubject. A domain that refuses
+	// the credential and a domain that has never heard of somebody have to be
+	// told apart, because the first is an outage and the second is a fact.
+	_, err = attempt(t, d, "mei")
+	switch {
+	case err == nil:
+		t.Fatal("a refused token resolved somebody anyway")
+	case errors.Is(err, directory.ErrNoSubject):
+		t.Fatalf("a refused token gave %v, which reads as a person who is not in the domain", err)
+	case !strings.Contains(err.Error(), "authError"):
+		t.Errorf("a refused token gave %v, which does not say why", err)
+	}
+}
+
+func TestAGroupTheDomainDoesNotHoldIsRefusedAsSuch(t *testing.T) {
+	_, endpoint := newDomain(t)
+	_, err := dial(t, endpoint, google.WithBuffer(0, 0)).Group(t.Context(), "01abcdefgone")
+	if !errors.Is(err, directory.ErrNoGroup) {
+		t.Errorf("a group nobody holds gave %v, want ErrNoGroup", err)
+	}
+}
+
+func TestTwoDomainsKeepTheirGroupsApart(t *testing.T) {
+	one, first := newDomain(t)
+	two, second := newDomain(t)
+	for _, o := range []*domain{one, two} {
+		o.putGroup(t, directory.Group{ID: "engineering"})
+		o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+	}
+
+	a := expand(t, dial(t, first, google.WithName("acme")), "mei")
+	b := expand(t, dial(t, second, google.WithName("globex")), "mei")
+
+	// The same id in two domains is two groups, and a deployment that indexed
+	// both would otherwise hand one company's documents to the other's people.
+	if slices.Equal(a.Groups.Members, b.Groups.Members) {
+		t.Fatalf("two domains both resolved to %v", a.Groups.Members)
+	}
+	if !slices.Contains(a.Groups.Members, "acme:engineering") {
+		t.Errorf("the first domain resolved to %v, want acme:engineering", a.Groups.Members)
+	}
+	if !slices.Contains(b.Groups.Members, "globex:engineering") {
+		t.Errorf("the second domain resolved to %v, want globex:engineering", b.Groups.Members)
+	}
+}
+
+func TestNewRefusesADomainItCannotUse(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		tokens google.Tokens
+		opts   []google.Option
+	}{
+		{"no tokens at all", nil, nil},
+		{"an endpoint that is not a URL", google.Token(bearer), []google.Option{google.WithEndpoint("admin.googleapis.com")}},
+		{"an endpoint with no host", google.Token(bearer), []google.Option{google.WithEndpoint("https://")}},
+		{"no source name", google.Token(bearer), []google.Option{google.WithName("")}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := google.New(c.tokens, c.opts...); err == nil {
+				t.Error("that was accepted, and the failure would arrive at the first lookup instead")
+			}
+		})
+	}
+}
+
+func TestResolvingFromOneDomainAtOnceIsSafe(t *testing.T) {
+	o, endpoint := newDomain(t)
+	for i := range 40 {
+		o.putGroup(t, directory.Group{ID: "g" + strconv.Itoa(i)})
+	}
+	for i := range 8 {
+		id := "u" + strconv.Itoa(i)
+		in := make([]string, 0, 40)
+		for g := range 40 {
+			in = append(in, "g"+strconv.Itoa(g))
+		}
+		o.put(t, directory.Subject{ID: id, MemberOf: in})
+	}
+
+	d := dial(t, endpoint)
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 5 {
+				if _, err := attempt(t, d, "u"+strconv.Itoa(i)); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestALookupThatWasCancelledStops(t *testing.T) {
+	o, endpoint := newDomain(t)
+	o.putGroup(t, directory.Group{ID: "engineering"})
+	o.put(t, directory.Subject{ID: "mei", MemberOf: []string{"engineering"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := dial(t, endpoint).Subject(ctx, "mei"); !errors.Is(err, context.Canceled) {
+		t.Errorf("a cancelled lookup gave %v, want a cancellation", err)
+	}
+}

--- a/directory/google/recording_test.go
+++ b/directory/google/recording_test.go
@@ -1,0 +1,315 @@
+package google_test
+
+import (
+	"errors"
+	"flag"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/recorded"
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/google"
+)
+
+// The fixture set is a resolution against a small domain written down once and
+// read back by the tests below, so that the adapter is exercised against the
+// bytes the Admin SDK actually sends without anybody needing a Workspace domain
+// and a service account to run the tests.
+//
+// The fake next to this file is the other half of the story and neither
+// replaces the other. The fake is where behaviour is written: it can be made to
+// suspend somebody, to page differently, to refuse with a quota. The recording
+// is where the wire format is pinned: it is the answer to "did we change what we
+// send" and it is the thing that would have to be refreshed if the Admin SDK
+// changed a field name.
+//
+// Signing in is not in here on purpose. The fixtures are a description of the
+// directory endpoints and a JWT bearer grant is a description of the token
+// endpoint, and putting the second in would mean writing an assertion signed
+// with a private key down in a file. What the grant does is covered by the fake.
+const fixtures = "testdata/domain"
+
+// The domain the recording is of. It is the real endpoint, which nothing
+// reaches, because keying the fixtures on the port a test server happened to be
+// given would make them unreadable and unstable at once.
+const recordedEndpoint = "https://admin.googleapis.com"
+
+// The ids the recorded domain holds, in the two shapes this API uses: a person
+// is a long number and a group is a short string of letters and digits. They are
+// written down rather than worked out because a fixture set is a fixed corpus,
+// and a test that derived them from the fake would pass just as happily against
+// a recording of something else entirely.
+const (
+	recordedPerson  = "104325091920138142876"
+	recordedNobody  = "117234598712345098761"
+	recordedLeaver  = "112938475610293847561"
+	recordedTop     = "03dy6vkm2gh4kso"
+	recordedMiddle  = "01opuj5n3f8k9ac"
+	recordedGroup   = "02lwamvv4c1pzs7"
+	recordedOncall  = "04hjm7q8w2r5vbz"
+	recordedPanel   = "05t9zc3x6n1kfdy"
+	recordedMissing = "00meukdy0v9x1nq"
+)
+
+var update = flag.Bool("update", false, "record the Google Workspace fixtures in testdata again")
+
+// recordingDomain is the domain the fixtures are a resolution of.
+//
+// It is small on purpose and every part of it is there for a reason: somebody
+// three levels down a nest so that the walk is in the recording rather than only
+// in the fake, and in enough groups directly for their listing to be more than
+// one page at the size below, somebody in none so that an empty collection is in
+// there, somebody suspended so that the refusal is too, and a group looked up on
+// its own so that the endpoint the buffer usually saves is there as well.
+func recordingDomain(t *testing.T) string {
+	t.Helper()
+	o, endpoint := newDomain(t)
+
+	for _, g := range []struct {
+		id, name, email string
+		in              []string
+	}{
+		{recordedTop, "Everyone", "everyone@acme.test", nil},
+		{recordedMiddle, "Engineering", "engineering@acme.test", []string{recordedTop}},
+		{recordedGroup, "Storage", "storage@acme.test", []string{recordedMiddle}},
+		{recordedOncall, "Storage Oncall", "storage-oncall@acme.test", nil},
+		{recordedPanel, "Interviewers", "interviewers@acme.test", nil},
+	} {
+		o.putGroup(t, directory.Group{ID: g.id, Name: g.name, MemberOf: g.in})
+		o.editGroup(t, g.id, func(team *team) { team.email = g.email })
+	}
+
+	o.put(t, directory.Subject{
+		ID:       recordedPerson,
+		Name:     "Mei Tanaka",
+		Email:    "mei@acme.test",
+		MemberOf: []string{recordedGroup, recordedOncall, recordedPanel},
+	})
+	o.edit(t, recordedPerson, func(p *person) { p.aliases = []string{"m.tanaka@acme.test"} })
+
+	o.put(t, directory.Subject{ID: recordedNobody, Name: "Jo Okafor", Email: "jo@acme.test"})
+	o.put(t, directory.Subject{ID: recordedLeaver, Name: "Lee Byrne", Email: "lee@acme.test", Disabled: true})
+	return endpoint
+}
+
+// TestRecordTheFixtures writes the fixture set again. It is skipped unless the
+// flag is given, because a recording that refreshed itself on every run would
+// never fail: the thing it is there to catch is a change to what we send, and a
+// fixture regenerated alongside the change agrees with it by construction.
+func TestRecordTheFixtures(t *testing.T) {
+	if !*update {
+		t.Skip("run with -update to record the fixtures again")
+	}
+
+	endpoint := recordingDomain(t)
+	rec := recorded.Record(http.DefaultTransport, recorded.WithRedactedHeaders("Authorization"))
+
+	resolve(t, func(opts ...google.Option) *google.Directory {
+		return dial(t, endpoint, append([]google.Option{google.WithHTTPClient(rec.Client())}, opts...)...)
+	})
+
+	// The same question asked twice is one file. A resolution asks for the
+	// groups above one key once per expansion and the pages repeat across them,
+	// and writing the answer down twice is two files to review and no more
+	// coverage.
+	var (
+		seen = map[string]bool{}
+		once []recorded.Exchange
+	)
+	for _, e := range rec.Exchanges() {
+		e = settle(e)
+		k := e.Request.Method + " " + e.Request.URL
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		once = append(once, e)
+	}
+
+	if err := recorded.From(once).Save(fixtures); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %d of %d exchanges to %s", len(once), len(rec.Exchanges()), fixtures)
+}
+
+// settle takes the run out of a recorded exchange.
+//
+// Two things in one differ every time it is made: the address the test server
+// was given, and the date the answer came back on. Neither is matched against
+// and neither means anything, and leaving them in would make every refresh of
+// the fixtures a diff on every file with the real change somewhere in it. The
+// host is written as the Admin SDK for the same reason: a reader opening one of
+// these files should see the request that would have gone to Google.
+func settle(e recorded.Exchange) recorded.Exchange {
+	e.Request.URL = rehost(e.Request.URL)
+	delete(e.Response.Headers, "Date")
+	delete(e.Response.Headers, "Content-Length")
+	return e
+}
+
+// rehost puts one URL on the endpoint the fixtures are written against.
+func rehost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	admin, err := url.Parse(recordedEndpoint)
+	if err != nil {
+		panic(err)
+	}
+	u.Scheme, u.Host = admin.Scheme, admin.Host
+	return u.String()
+}
+
+// resolve is everything the fixture set has to answer, and it is shared so that
+// what is recorded and what is replayed cannot drift apart.
+func resolve(t *testing.T, dir func(opts ...google.Option) *google.Directory) directory.Expansion {
+	t.Helper()
+
+	// Two at a time, so that a listing over pages is in the recording rather
+	// than only in the fake.
+	r, err := directory.New(dir(google.WithPageSize(2)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := r.Expand(t.Context(), recordedPerson)
+	if err != nil {
+		t.Fatalf("expanding %s: %v", recordedPerson, err)
+	}
+	if _, err := r.Expand(t.Context(), recordedNobody); err != nil {
+		t.Fatalf("expanding %s: %v", recordedNobody, err)
+	}
+	if _, err := r.Expand(t.Context(), recordedLeaver); !errors.Is(err, directory.ErrDisabled) {
+		t.Fatalf("expanding %s gave %v, want ErrDisabled", recordedLeaver, err)
+	}
+
+	// A group asked for on its own, which the buffer would otherwise answer out
+	// of the listing that already went past.
+	alone := dir(google.WithBuffer(0, 0))
+	if _, err := alone.Group(t.Context(), recordedGroup); err != nil {
+		t.Fatalf("looking up %s: %v", recordedGroup, err)
+	}
+	if _, err := alone.Group(t.Context(), recordedMissing); !errors.Is(err, directory.ErrNoGroup) {
+		t.Fatalf("looking up %s gave %v, want ErrNoGroup", recordedMissing, err)
+	}
+	return got
+}
+
+// replayed is the adapter over the fixture set.
+func replayed(t *testing.T, rt *recorded.Transport, opts ...google.Option) *google.Directory {
+	t.Helper()
+	d, err := google.New(google.Token(bearer), append([]google.Option{
+		google.WithEndpoint(recordedEndpoint),
+		google.WithHTTPClient(rt.Client()),
+	}, opts...)...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// TestTheRecordedDomainResolvesWithoutADomain is the point of the fixture set:
+// the whole adapter, the real paging and the real decoding, against bytes that
+// came off the Admin SDK and are now a file.
+func TestTheRecordedDomainResolvesWithoutADomain(t *testing.T) {
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolve(t, func(opts ...google.Option) *google.Directory {
+		return replayed(t, rt, opts...)
+	})
+
+	want := []string{
+		"google:" + recordedTop,
+		"google:" + recordedMiddle,
+		"google:" + recordedGroup,
+		"google:" + recordedOncall,
+		"google:" + recordedPanel,
+	}
+	slices.Sort(want)
+	if !slices.Equal(got.Groups.Members, want) {
+		t.Fatalf("the recorded domain resolved to %v, want %v", got.Groups.Members, want)
+	}
+	if got.Subject.Name != "Mei Tanaka" {
+		t.Errorf("the recorded person is called %q", got.Subject.Name)
+	}
+	for _, want := range []acl.Identity{
+		{Source: "email", Value: "mei@acme.test"},
+		{Source: "email", Value: "m.tanaka@acme.test"},
+	} {
+		if !slices.Contains(got.Subject.Identities, want) {
+			t.Errorf("the identities off the recording are %v, and %v is not among them", got.Subject.Identities, want)
+		}
+	}
+	// Three levels of nesting in the domain and three levels of walking here,
+	// because this provider answers with direct memberships and nothing else.
+	if got.Depth != 3 {
+		t.Errorf("a domain three levels deep was walked %d levels", got.Depth)
+	}
+}
+
+// TestTheRecordingHoldsNothingItIsNotAskedFor keeps the fixture set from
+// growing a tail of responses nothing reads.
+//
+// A recording is a thing people add to and rarely take away from, and one that
+// has drifted is worse than none: a reviewer reading a file next to the test
+// reasonably assumes the test depends on it.
+func TestTheRecordingHoldsNothingItIsNotAskedFor(t *testing.T) {
+	rt, err := recorded.Replay(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolve(t, func(opts ...google.Option) *google.Directory {
+		return replayed(t, rt, opts...)
+	})
+
+	if left := rt.Unused(); len(left) != 0 {
+		t.Errorf("the fixture set answers %d requests the resolution never makes:\n%s", len(left), strings.Join(left, "\n"))
+	}
+}
+
+// TestTheRecordingCarriesNoCredentials is the reason a fixture set is safe to
+// commit at all. It is a check on the recording rather than on the code, and it
+// is here because the file is here.
+func TestTheRecordingCarriesNoCredentials(t *testing.T) {
+	entries, err := os.ReadDir(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(fixtures, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, bad := range []struct{ what, needle string }{
+			{"the token it was recorded with", bearer},
+			// The scheme as well as the token, because a bearer is whatever
+			// follows it and a reviewer skimming for "Bearer" is how one gets
+			// noticed.
+			{"something shaped like an access token", "Bearer "},
+			// And the key, which never goes near these endpoints and would be
+			// the most serious thing on this list to find in a file.
+			{"something shaped like a private key", "PRIVATE KEY"},
+			// A signed assertion is not a credential for long, but it is one,
+			// and the only way one reaches this directory is by somebody
+			// recording the token endpoint into the wrong fixture set.
+			{"a token grant", "grant_type"},
+		} {
+			if strings.Contains(string(raw), bad.needle) {
+				t.Errorf("%s holds %s", e.Name(), bad.what)
+			}
+		}
+	}
+}

--- a/directory/google/testdata/domain/0001-get-admin-directory-v1-users-104325091920138142876.json
+++ b/directory/google/testdata/domain/0001-get-admin-directory-v1-users-104325091920138142876.json
@@ -1,0 +1,44 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/users/104325091920138142876",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "aliases": [
+          "m.tanaka@acme.test"
+        ],
+        "archived": false,
+        "emails": [
+          {
+            "address": "mei@acme.test",
+            "primary": true
+          }
+        ],
+        "etag": "\"cp6A8mtJj2ET\"",
+        "id": "104325091920138142876",
+        "kind": "admin#directory#user",
+        "name": {
+          "fullName": "Mei Tanaka"
+        },
+        "primaryEmail": "mei@acme.test",
+        "suspended": false
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0002-get-admin-directory-v1-groups-maxresults-2-userkey-104325091920138142876.json
+++ b/directory/google/testdata/domain/0002-get-admin-directory-v1-groups-maxresults-2-userkey-104325091920138142876.json
@@ -1,0 +1,44 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups?maxResults=2\u0026userKey=104325091920138142876",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "groups": [
+          {
+            "email": "storage@acme.test",
+            "etag": "\"iYhpv-_o4LQX\"",
+            "id": "02lwamvv4c1pzs7",
+            "kind": "admin#directory#group",
+            "name": "Storage"
+          },
+          {
+            "email": "storage-oncall@acme.test",
+            "etag": "\"xIOys7bXVv9Y\"",
+            "id": "04hjm7q8w2r5vbz",
+            "kind": "admin#directory#group",
+            "name": "Storage Oncall"
+          }
+        ],
+        "kind": "admin#directory#groups",
+        "nextPageToken": "2"
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0003-get-admin-directory-v1-groups-maxresults-2-pagetoken-2-userkey.json
+++ b/directory/google/testdata/domain/0003-get-admin-directory-v1-groups-maxresults-2-pagetoken-2-userkey.json
@@ -1,0 +1,36 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups?maxResults=2\u0026pageToken=2\u0026userKey=104325091920138142876",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "groups": [
+          {
+            "email": "interviewers@acme.test",
+            "etag": "\"Y3mrPqschmaX\"",
+            "id": "05t9zc3x6n1kfdy",
+            "kind": "admin#directory#group",
+            "name": "Interviewers"
+          }
+        ],
+        "kind": "admin#directory#groups"
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0004-get-admin-directory-v1-groups-maxresults-2-userkey-05t9zc3x6n1kfdy.json
+++ b/directory/google/testdata/domain/0004-get-admin-directory-v1-groups-maxresults-2-userkey-05t9zc3x6n1kfdy.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups?maxResults=2\u0026userKey=05t9zc3x6n1kfdy",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "groups": [],
+        "kind": "admin#directory#groups"
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0005-get-admin-directory-v1-groups-maxresults-2-userkey-02lwamvv4c1pzs7.json
+++ b/directory/google/testdata/domain/0005-get-admin-directory-v1-groups-maxresults-2-userkey-02lwamvv4c1pzs7.json
@@ -1,0 +1,36 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups?maxResults=2\u0026userKey=02lwamvv4c1pzs7",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "groups": [
+          {
+            "email": "engineering@acme.test",
+            "etag": "\"W88AeXDHuoUA\"",
+            "id": "01opuj5n3f8k9ac",
+            "kind": "admin#directory#group",
+            "name": "Engineering"
+          }
+        ],
+        "kind": "admin#directory#groups"
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0006-get-admin-directory-v1-groups-maxresults-2-userkey-04hjm7q8w2r5vbz.json
+++ b/directory/google/testdata/domain/0006-get-admin-directory-v1-groups-maxresults-2-userkey-04hjm7q8w2r5vbz.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups?maxResults=2\u0026userKey=04hjm7q8w2r5vbz",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "groups": [],
+        "kind": "admin#directory#groups"
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0007-get-admin-directory-v1-groups-maxresults-2-userkey-01opuj5n3f8k9ac.json
+++ b/directory/google/testdata/domain/0007-get-admin-directory-v1-groups-maxresults-2-userkey-01opuj5n3f8k9ac.json
@@ -1,0 +1,36 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups?maxResults=2\u0026userKey=01opuj5n3f8k9ac",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "groups": [
+          {
+            "email": "everyone@acme.test",
+            "etag": "\"aBAZnlujjMhm\"",
+            "id": "03dy6vkm2gh4kso",
+            "kind": "admin#directory#group",
+            "name": "Everyone"
+          }
+        ],
+        "kind": "admin#directory#groups"
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0008-get-admin-directory-v1-groups-maxresults-2-userkey-03dy6vkm2gh4kso.json
+++ b/directory/google/testdata/domain/0008-get-admin-directory-v1-groups-maxresults-2-userkey-03dy6vkm2gh4kso.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups?maxResults=2\u0026userKey=03dy6vkm2gh4kso",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "groups": [],
+        "kind": "admin#directory#groups"
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0009-get-admin-directory-v1-users-117234598712345098761.json
+++ b/directory/google/testdata/domain/0009-get-admin-directory-v1-users-117234598712345098761.json
@@ -1,0 +1,42 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/users/117234598712345098761",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "aliases": [],
+        "archived": false,
+        "emails": [
+          {
+            "address": "jo@acme.test",
+            "primary": true
+          }
+        ],
+        "etag": "\"edkSaAZO5Ddc\"",
+        "id": "117234598712345098761",
+        "kind": "admin#directory#user",
+        "name": {
+          "fullName": "Jo Okafor"
+        },
+        "primaryEmail": "jo@acme.test",
+        "suspended": false
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0010-get-admin-directory-v1-groups-maxresults-2-userkey-117234598712345098761.json
+++ b/directory/google/testdata/domain/0010-get-admin-directory-v1-groups-maxresults-2-userkey-117234598712345098761.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups?maxResults=2\u0026userKey=117234598712345098761",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "groups": [],
+        "kind": "admin#directory#groups"
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0011-get-admin-directory-v1-users-112938475610293847561.json
+++ b/directory/google/testdata/domain/0011-get-admin-directory-v1-users-112938475610293847561.json
@@ -1,0 +1,42 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/users/112938475610293847561",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "aliases": [],
+        "archived": false,
+        "emails": [
+          {
+            "address": "lee@acme.test",
+            "primary": true
+          }
+        ],
+        "etag": "\"DOa79gRU7LvA\"",
+        "id": "112938475610293847561",
+        "kind": "admin#directory#user",
+        "name": {
+          "fullName": "Lee Byrne"
+        },
+        "primaryEmail": "lee@acme.test",
+        "suspended": true
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0012-get-admin-directory-v1-groups-02lwamvv4c1pzs7.json
+++ b/directory/google/testdata/domain/0012-get-admin-directory-v1-groups-02lwamvv4c1pzs7.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups/02lwamvv4c1pzs7",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "email": "storage@acme.test",
+        "etag": "\"iYhpv-_o4LQX\"",
+        "id": "02lwamvv4c1pzs7",
+        "kind": "admin#directory#group",
+        "name": "Storage"
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0013-get-admin-directory-v1-groups-maxresults-200-userkey-02lwamvv4c1pzs7.json
+++ b/directory/google/testdata/domain/0013-get-admin-directory-v1-groups-maxresults-200-userkey-02lwamvv4c1pzs7.json
@@ -1,0 +1,36 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups?maxResults=200\u0026userKey=02lwamvv4c1pzs7",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "groups": [
+          {
+            "email": "engineering@acme.test",
+            "etag": "\"W88AeXDHuoUA\"",
+            "id": "01opuj5n3f8k9ac",
+            "kind": "admin#directory#group",
+            "name": "Engineering"
+          }
+        ],
+        "kind": "admin#directory#groups"
+      }
+    }
+  }
+}

--- a/directory/google/testdata/domain/0014-get-admin-directory-v1-groups-00meukdy0v9x1nq.json
+++ b/directory/google/testdata/domain/0014-get-admin-directory-v1-groups-00meukdy0v9x1nq.json
@@ -1,0 +1,37 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://admin.googleapis.com/admin/directory/v1/groups/00meukdy0v9x1nq",
+    "headers": {
+      "Accept": [
+        "application/json"
+      ],
+      "Authorization": [
+        "REDACTED"
+      ]
+    }
+  },
+  "response": {
+    "status": 404,
+    "headers": {
+      "Content-Type": [
+        "application/json"
+      ]
+    },
+    "body": {
+      "json": {
+        "error": {
+          "code": 404,
+          "errors": [
+            {
+              "domain": "global",
+              "message": "Resource Not Found: groupKey",
+              "reason": "notFound"
+            }
+          ],
+          "message": "Resource Not Found: groupKey"
+        }
+      }
+    }
+  }
+}

--- a/directory/google/token.go
+++ b/directory/google/token.go
@@ -1,0 +1,406 @@
+package google
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tamnd/genba/connector/limit"
+)
+
+// Tokens hands out a bearer token for the Admin SDK.
+//
+// It is an interface because a Google access token lives for about an hour,
+// which makes a fixed string the wrong shape for anything that runs longer than
+// that. An adapter built on one would work all afternoon and start refusing
+// every lookup at some point in the evening, and the symptom above it is not an
+// error saying the token expired, it is everybody losing their groups at once.
+type Tokens interface {
+	// Token returns a token that is valid now.
+	Token(ctx context.Context) (string, error)
+}
+
+// Token is a bearer token somebody else obtained.
+//
+// It is for a test, for a script, and for a deployment where something outside
+// this process is already responsible for keeping a token fresh. It is not for a
+// daemon holding one it acquired at startup, for the reason in [Tokens].
+type Token string
+
+// Token returns the token, which is the whole of what this type does.
+func (t Token) Token(context.Context) (string, error) {
+	if t == "" {
+		return "", errors.New("google: the token is empty")
+	}
+	return string(t), nil
+}
+
+// The scopes this adapter needs, which are the read only halves of the two
+// collections it reads and nothing else.
+//
+// They are separate constants because they are granted separately. Domain wide
+// delegation is configured by pasting a list of scopes into an admin console
+// next to a client id, and an operator who pasted one of these and not the other
+// gets a directory that resolves people and finds them in no groups.
+const (
+	ScopeUsers  = "https://www.googleapis.com/auth/admin.directory.user.readonly"
+	ScopeGroups = "https://www.googleapis.com/auth/admin.directory.group.readonly"
+)
+
+// DefaultTokenEndpoint is where a token comes from.
+const DefaultTokenEndpoint = "https://oauth2.googleapis.com/token"
+
+// DefaultEarly is how long before a token expires it is replaced.
+//
+// It is not tuning. A token that is checked, found to have four seconds left and
+// then used is a request that arrives after it expired, and the failure is
+// indistinguishable from a credential that was revoked. Five minutes is far
+// longer than any request here takes and far shorter than a token lives.
+const DefaultEarly = 5 * time.Minute
+
+// assertionLife is how long the signed statement asking for a token is good
+// for, and it is the longest the service accepts. It has nothing to do with how
+// long the token that comes back lives.
+const assertionLife = time.Hour
+
+// Credentials is a service account and the administrator it acts as.
+//
+// The service account is an identity with no directory of its own, so on its own
+// it resolves nothing: every lookup is refused or answers about a domain with
+// nobody in it. What makes it work is domain wide delegation, where an
+// administrator grants the account's client id a list of scopes and the account
+// then asks for a token on behalf of a named person. That person is [Subject],
+// and they have to be somebody in the domain who can read the directory.
+//
+// The three fields before it come out of the JSON key file the console hands
+// over when the account is created, and [CredentialsFromJSON] reads one.
+type Credentials struct {
+	// Email is the service account, which the key file calls client_email.
+	Email string
+
+	// PrivateKey is the account's key, in PEM, which the key file calls
+	// private_key.
+	PrivateKey string
+
+	// KeyID is which of the account's keys this is, which the key file calls
+	// private_key_id. It is optional and it goes in the header of the assertion
+	// so that a service account with two keys can have one of them rotated.
+	KeyID string
+
+	// Subject is the administrator to act as. Without one the token is refused,
+	// and the refusal is the same one an ungranted scope produces.
+	Subject string
+}
+
+// keyFile is the JSON a service account key is handed over as.
+type keyFile struct {
+	Type       string `json:"type"`
+	Email      string `json:"client_email"`
+	PrivateKey string `json:"private_key"`
+	KeyID      string `json:"private_key_id"`
+}
+
+// CredentialsFromJSON reads a service account key file and pairs it with the
+// administrator to act as.
+//
+// It exists so that the key stays in a file. A private key is the one thing here
+// that must not arrive on a command line, where it is in the process listing for
+// everybody on the host and in the shell history of whoever started it.
+func CredentialsFromJSON(raw []byte, subject string) (Credentials, error) {
+	var f keyFile
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return Credentials{}, fmt.Errorf("google: reading the service account key: %w", err)
+	}
+	// A user credential file has the same extension, lives in the same place and
+	// is a different thing entirely, and the failure it causes without this is a
+	// missing private key three steps later.
+	if f.Type != "" && f.Type != "service_account" {
+		return Credentials{}, fmt.Errorf("google: the key is for a %q rather than a service account", f.Type)
+	}
+	return Credentials{
+		Email:      f.Email,
+		PrivateKey: f.PrivateKey,
+		KeyID:      f.KeyID,
+		Subject:    subject,
+	}, nil
+}
+
+// ServiceAccount signs in with the JWT bearer grant and holds the token it gets
+// until shortly before it expires.
+//
+// It is safe for concurrent use and it acquires one token at a time. Holding the
+// lock across the request is deliberate: an expansion looks up a level of the
+// graph in parallel, so the moment a token expires is the moment several
+// goroutines notice at once, and letting each of them go and get one would turn
+// every expiry into a small burst against the endpoint most likely to throttle.
+type ServiceAccount struct {
+	creds    Credentials
+	key      *rsa.PrivateKey
+	http     *http.Client
+	endpoint string
+	scopes   []string
+	early    time.Duration
+	now      func() time.Time
+
+	mu    sync.Mutex
+	token string
+	until time.Time
+}
+
+var _ Tokens = (*ServiceAccount)(nil)
+
+// ServiceAccountOption configures a [ServiceAccount].
+type ServiceAccountOption func(*ServiceAccount)
+
+// WithTokenEndpoint replaces where tokens are asked for, which a test needs.
+//
+// It is also what the assertion is addressed to, because the audience of a
+// signed statement is whoever it is being presented to. Changing one without the
+// other would produce an assertion the endpoint refuses to look at.
+func WithTokenEndpoint(endpoint string) ServiceAccountOption {
+	return func(a *ServiceAccount) { a.endpoint = endpoint }
+}
+
+// WithScopes replaces what the token is asked to be good for.
+func WithScopes(scopes ...string) ServiceAccountOption {
+	return func(a *ServiceAccount) { a.scopes = scopes }
+}
+
+// WithTokenClient replaces the client the token is fetched with.
+func WithTokenClient(c *http.Client) ServiceAccountOption {
+	return func(a *ServiceAccount) {
+		if c != nil {
+			a.http = c
+		}
+	}
+}
+
+// WithEarly sets how long before expiry a token is replaced. A duration below
+// zero selects [DefaultEarly].
+func WithEarly(d time.Duration) ServiceAccountOption {
+	return func(a *ServiceAccount) { a.early = d }
+}
+
+// WithTokenClock replaces the clock, for a test that needs a token to expire
+// without waiting an hour for it.
+func WithTokenClock(now func() time.Time) ServiceAccountOption {
+	return func(a *ServiceAccount) {
+		if now != nil {
+			a.now = now
+		}
+	}
+}
+
+// NewServiceAccount returns a [Tokens] that signs in as a service account acting
+// for an administrator.
+//
+// The key is parsed here rather than at the first lookup, so a key file that is
+// truncated, encrypted or of the wrong kind stops a deployment from starting
+// instead of turning into a directory outage the first time somebody searches.
+func NewServiceAccount(c Credentials, opts ...ServiceAccountOption) (*ServiceAccount, error) {
+	switch {
+	case c.Email == "":
+		return nil, errors.New("google: a service account address is required")
+	case c.PrivateKey == "":
+		return nil, errors.New("google: a private key is required")
+	case c.Subject == "":
+		// Refused rather than defaulted, because there is nothing to default to
+		// and the alternative is the least readable failure this adapter has: a
+		// token endpoint refusing an unauthorized_client, which is the same
+		// answer an ungranted scope gives.
+		return nil, errors.New("google: an administrator to act as is required, since a service account has no directory of its own")
+	}
+	key, err := parseKey(c.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	a := &ServiceAccount{
+		creds:    c,
+		key:      key,
+		http:     &http.Client{Transport: limit.NewTransport(limit.Limits{})},
+		endpoint: DefaultTokenEndpoint,
+		scopes:   []string{ScopeUsers, ScopeGroups},
+		early:    DefaultEarly,
+		now:      time.Now,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	if a.early < 0 {
+		a.early = DefaultEarly
+	}
+	if a.endpoint == "" {
+		return nil, errors.New("google: the token endpoint cannot be empty")
+	}
+	if len(a.scopes) == 0 {
+		return nil, errors.New("google: a token with no scopes on it is good for nothing")
+	}
+	return a, nil
+}
+
+// parseKey reads the PEM a service account key file carries.
+//
+// Both encodings are accepted because both turn up. The console writes PKCS 8
+// and a key that has been through a conversion tool at some point is often
+// PKCS 1, and the difference is invisible to whoever pasted it into a secret
+// store.
+func parseKey(key string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(key))
+	if block == nil {
+		return nil, errors.New("google: the private key is not PEM, so it is probably a path or a truncated copy of one")
+	}
+	if parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		rsaKey, ok := parsed.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("google: the private key is a %T, and the grant is signed with RSA", parsed)
+		}
+		return rsaKey, nil
+	}
+	parsed, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("google: reading the private key: %w", err)
+	}
+	return parsed, nil
+}
+
+// Token returns a token that is valid now, signing in again if the one being
+// held is close enough to expiring to be worth replacing.
+func (a *ServiceAccount) Token(ctx context.Context) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.token != "" && a.now().Before(a.until.Add(-a.early)) {
+		return a.token, nil
+	}
+	token, lasts, err := a.acquire(ctx)
+	if err != nil {
+		// Leaving the old token where it is. It is either expired, in which case
+		// the next caller tries again and gets the same error, or it has a few
+		// minutes left, in which case a token endpoint having a bad moment costs
+		// nothing at all.
+		return "", err
+	}
+	a.token, a.until = token, a.now().Add(lasts)
+	return a.token, nil
+}
+
+// acquire is one JWT bearer grant.
+func (a *ServiceAccount) acquire(ctx context.Context) (token string, lasts time.Duration, err error) {
+	assertion, err := a.assertion(a.now())
+	if err != nil {
+		return "", 0, err
+	}
+	form := url.Values{
+		"grant_type": {"urn:ietf:params:oauth:grant-type:jwt-bearer"},
+		"assertion":  {assertion},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", 0, fmt.Errorf("google: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("google: signing in as %q: %w", a.creds.Email, err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	var body struct {
+		Token       string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		Error       string `json:"error"`
+		Description string `json:"error_description"`
+	}
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	_ = json.Unmarshal(raw, &body)
+
+	if resp.StatusCode != http.StatusOK {
+		// The description is where the reason lives, and here it is nearly
+		// always the same one: the account's client id has not been granted
+		// these scopes in the admin console, or the person it is acting for
+		// cannot read the directory. Both arrive as unauthorized_client and
+		// neither is guessable from the status alone.
+		if body.Description != "" {
+			return "", 0, fmt.Errorf("google: signing in as %q for %q: %s: %s",
+				a.creds.Email, a.creds.Subject, resp.Status, firstLine(body.Description))
+		}
+		return "", 0, fmt.Errorf("google: signing in as %q for %q: %s", a.creds.Email, a.creds.Subject, resp.Status)
+	}
+	if body.Token == "" {
+		return "", 0, fmt.Errorf("google: signing in as %q: the answer carried no token", a.creds.Email)
+	}
+	lasts = time.Duration(body.ExpiresIn) * time.Second
+	if lasts <= 0 {
+		// A grant with no lifetime on it is one this holds for as long as it
+		// dares rather than one it holds forever.
+		lasts = a.early + time.Minute
+	}
+	return body.Token, lasts, nil
+}
+
+// assertion is the signed statement the grant is made with.
+//
+// The subject claim is what turns a service account into an administrator, and
+// it is the whole of domain wide delegation as far as this process is concerned.
+// Without it the account asks about its own directory, which is empty, and the
+// answers are a domain where nobody exists rather than an error saying the
+// delegation was never configured.
+func (a *ServiceAccount) assertion(now time.Time) (string, error) {
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	if a.creds.KeyID != "" {
+		header["kid"] = a.creds.KeyID
+	}
+	claims := map[string]any{
+		"iss":   a.creds.Email,
+		"sub":   a.creds.Subject,
+		"scope": strings.Join(a.scopes, " "),
+		"aud":   a.endpoint,
+		"iat":   now.Unix(),
+		"exp":   now.Add(assertionLife).Unix(),
+	}
+
+	encoded, err := segments(header, claims)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(encoded))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, a.key, crypto.SHA256, sum[:])
+	if err != nil {
+		return "", fmt.Errorf("google: signing the grant: %w", err)
+	}
+	return encoded + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// segments is the part of a JWT that gets signed, which is the two documents
+// base64 encoded and joined with a dot.
+func segments(parts ...any) (string, error) {
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		raw, err := json.Marshal(part)
+		if err != nil {
+			return "", fmt.Errorf("google: building the grant: %w", err)
+		}
+		out = append(out, base64.RawURLEncoding.EncodeToString(raw))
+	}
+	return strings.Join(out, "."), nil
+}

--- a/directory/google/token_test.go
+++ b/directory/google/token_test.go
@@ -1,0 +1,282 @@
+package google_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/google"
+)
+
+// account is the service account key these cases sign with.
+//
+// One key for the whole package, because generating an RSA key is the slowest
+// thing in this file by a wide margin and none of these cases is about which key
+// it is. A failure here is a machine that cannot make a key at all, which is not
+// something a test can report usefully, so it panics rather than pretending to
+// be a case that failed.
+var account = sync.OnceValue(func() signer {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		panic(err)
+	}
+	return signer{
+		key:     key,
+		encoded: string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})),
+	}
+})
+
+type signer struct {
+	key     *rsa.PrivateKey
+	encoded string
+}
+
+// theAdmin is the person the delegation in these cases was granted for.
+const theAdmin = "admin@acme.test"
+
+// delegated is a domain whose token endpoint trusts the package key, and the
+// credentials that go with it.
+func delegated(t *testing.T) (fake *domain, endpoint string, creds google.Credentials) {
+	t.Helper()
+	o, endpoint := newDomain(t)
+	o.trust(&account().key.PublicKey, theAdmin)
+	return o, endpoint, google.Credentials{
+		Email:      "genba@acme.iam.gserviceaccount.com",
+		PrivateKey: account().encoded,
+		KeyID:      "0123456789abcdef",
+		Subject:    theAdmin,
+	}
+}
+
+// TestAServiceAccountSignsInAndResolvesSomebody is the whole grant end to end:
+// a JWT this package built and signed, checked by something that has only the
+// public key, and then a directory lookup with the token that came back.
+func TestAServiceAccountSignsInAndResolvesSomebody(t *testing.T) {
+	o, endpoint, creds := delegated(t)
+	o.putGroup(t, directory.Group{ID: "engineering", Name: "Engineering"})
+	o.put(t, directory.Subject{ID: "mei", Name: "Mei", MemberOf: []string{"engineering"}})
+
+	tokens, err := google.NewServiceAccount(creds,
+		google.WithTokenEndpoint(endpoint+"/token"),
+		google.WithTokenClient(http.DefaultClient),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := google.New(tokens, google.WithEndpoint(endpoint), google.WithHTTPClient(http.DefaultClient))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := expand(t, d, "mei")
+	if len(got.Groups.Members) != 1 {
+		t.Fatalf("mei resolved to %v, want one group", got.Groups.Members)
+	}
+	if n := o.spent("token"); n != 1 {
+		t.Errorf("one expansion cost %d grants, want 1", n)
+	}
+}
+
+// TestAGrantForSomebodyTheDelegationDoesNotCoverSaysWhy is the failure an
+// operator actually hits, and the one that is impossible to diagnose from the
+// status alone.
+func TestAGrantForSomebodyTheDelegationDoesNotCoverSaysWhy(t *testing.T) {
+	_, endpoint, creds := delegated(t)
+	creds.Subject = "somebody.else@acme.test"
+
+	tokens, err := google.NewServiceAccount(creds,
+		google.WithTokenEndpoint(endpoint+"/token"),
+		google.WithTokenClient(http.DefaultClient),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tokens.Token(t.Context())
+	if err == nil {
+		t.Fatal("a grant for somebody the delegation does not cover was accepted")
+	}
+	// The description is the whole of what there is to go on. Without it this is
+	// a bad request against an endpoint that will not say which of the four
+	// things that can be wrong is wrong.
+	if !strings.Contains(err.Error(), "unauthorized to retrieve access tokens") {
+		t.Errorf("the refusal came back as %v, which does not carry the reason", err)
+	}
+	// And it names both halves, because the account and the person it is acting
+	// for are configured in different places by different people.
+	for _, want := range []string{creds.Email, creds.Subject} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal came back as %v, which does not mention %q", err, want)
+		}
+	}
+}
+
+// TestATokenIsHeldUntilItIsNearlyExpired is what makes this worth having at all.
+// A grant per lookup would be a request to the endpoint most likely to throttle
+// in front of every request to the one being read.
+func TestATokenIsHeldUntilItIsNearlyExpired(t *testing.T) {
+	o, endpoint, creds := delegated(t)
+
+	now := time.Now()
+	tokens, err := google.NewServiceAccount(creds,
+		google.WithTokenEndpoint(endpoint+"/token"),
+		google.WithTokenClient(http.DefaultClient),
+		google.WithTokenClock(func() time.Time { return now }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for range 5 {
+		if _, err := tokens.Token(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if n := o.spent("token"); n != 1 {
+		t.Fatalf("five lookups cost %d grants, want 1", n)
+	}
+
+	// The fake hands out a token good for an hour, so this is inside it and
+	// inside the five minutes before it expires. A token with four seconds left
+	// is a request that arrives after it expired, and that failure is
+	// indistinguishable from a credential somebody revoked.
+	now = now.Add(56 * time.Minute)
+	if _, err := tokens.Token(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if n := o.spent("token"); n != 2 {
+		t.Errorf("a token close to expiring was asked for again %d times, want 2 grants in all", n)
+	}
+}
+
+// TestOneTokenIsAcquiredWhenEverybodyNoticesAtOnce is the case the lock is
+// there for. An expansion looks a level up in parallel, so the moment a token
+// expires is the moment several goroutines find out together.
+func TestOneTokenIsAcquiredWhenEverybodyNoticesAtOnce(t *testing.T) {
+	o, endpoint, creds := delegated(t)
+	tokens, err := google.NewServiceAccount(creds,
+		google.WithTokenEndpoint(endpoint+"/token"),
+		google.WithTokenClient(http.DefaultClient),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := tokens.Token(t.Context()); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if n := o.spent("token"); n != 1 {
+		t.Errorf("sixteen goroutines noticing at once cost %d grants, want 1", n)
+	}
+}
+
+func TestCredentialsFromJSONReadsAServiceAccountKey(t *testing.T) {
+	raw, err := json.Marshal(map[string]any{
+		"type":           "service_account",
+		"project_id":     "acme-search",
+		"private_key_id": "0123456789abcdef",
+		"private_key":    account().encoded,
+		"client_email":   "genba@acme.iam.gserviceaccount.com",
+		"client_id":      "112233445566778899",
+		"token_uri":      "https://oauth2.googleapis.com/token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := google.CredentialsFromJSON(raw, theAdmin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if creds.Email != "genba@acme.iam.gserviceaccount.com" {
+		t.Errorf("the account came out as %q", creds.Email)
+	}
+	if creds.KeyID != "0123456789abcdef" {
+		t.Errorf("the key id came out as %q, so a rotation would sign with a key the console cannot name", creds.KeyID)
+	}
+	if creds.Subject != theAdmin {
+		t.Errorf("the administrator came out as %q", creds.Subject)
+	}
+	if _, err := google.NewServiceAccount(creds); err != nil {
+		t.Errorf("the credentials off a real key file were refused: %v", err)
+	}
+}
+
+// TestAKeyFileThatIsNotAServiceAccountIsRefused is about the mistake rather than
+// about the format. A user credential file has the same extension, lives in the
+// same directory and is a different thing entirely.
+func TestAKeyFileThatIsNotAServiceAccountIsRefused(t *testing.T) {
+	raw := []byte(`{"type":"authorized_user","client_id":"x","client_secret":"y","refresh_token":"z"}`)
+	if _, err := google.CredentialsFromJSON(raw, theAdmin); err == nil {
+		t.Error("a user credential file was accepted as a service account key")
+	}
+}
+
+// TestNewServiceAccountRefusesWhatWouldFailLater is the whole reason the key is
+// parsed at construction. Every one of these produces a directory that comes up
+// fine and refuses every lookup once somebody searches.
+func TestNewServiceAccountRefusesWhatWouldFailLater(t *testing.T) {
+	good := google.Credentials{
+		Email:      "genba@acme.iam.gserviceaccount.com",
+		PrivateKey: account().encoded,
+		Subject:    theAdmin,
+	}
+	for _, c := range []struct {
+		name  string
+		creds google.Credentials
+		opts  []google.ServiceAccountOption
+	}{
+		{"no service account", google.Credentials{PrivateKey: good.PrivateKey, Subject: theAdmin}, nil},
+		{"no private key", google.Credentials{Email: good.Email, Subject: theAdmin}, nil},
+		{"nobody to act for", google.Credentials{Email: good.Email, PrivateKey: good.PrivateKey}, nil},
+		{"a path where the key should be", google.Credentials{Email: good.Email, PrivateKey: "/etc/genba/key.pem", Subject: theAdmin}, nil},
+		{"a key that is not a key", google.Credentials{Email: good.Email, Subject: theAdmin,
+			PrivateKey: "-----BEGIN PRIVATE KEY-----\nbm90IGEga2V5\n-----END PRIVATE KEY-----\n"}, nil},
+		{"no token endpoint", good, []google.ServiceAccountOption{google.WithTokenEndpoint("")}},
+		{"no scopes", good, []google.ServiceAccountOption{google.WithScopes()}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := google.NewServiceAccount(c.creds, c.opts...); err == nil {
+				t.Error("that was accepted, and the failure would arrive at the first search instead")
+			}
+		})
+	}
+}
+
+// TestAGrantAskingForNothingUsefulIsRefusedByTheEndpoint says that the scopes
+// actually travel. Domain wide delegation is configured by pasting a list of
+// them next to a client id, and the two halves have to agree.
+func TestAGrantAskingForNothingUsefulIsRefusedByTheEndpoint(t *testing.T) {
+	_, endpoint, creds := delegated(t)
+	tokens, err := google.NewServiceAccount(creds,
+		google.WithTokenEndpoint(endpoint+"/token"),
+		google.WithTokenClient(http.DefaultClient),
+		google.WithScopes(google.ScopeUsers),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tokens.Token(t.Context()); err == nil {
+		t.Error("a grant that cannot read groups was accepted, so a directory would come up resolving everybody into nothing")
+	}
+}

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -242,6 +242,54 @@ Signing in is part of the adapter because a Graph token lives about an hour.
 `entra.Token` is a string somebody else keeps fresh and `entra.NewApplication` is the client credentials grant, which holds a token until five minutes before it expires and then replaces it.
 It acquires one at a time on purpose: an expansion looks a level up in parallel, so the moment a token expires is the moment several goroutines notice at once, and letting each of them go and get their own would turn every expiry into a small burst against the endpoint most likely to throttle.
 
+## Google Workspace
+
+`directory/google` is the third adapter, and it is the first one where the provider does none of the walking.
+
+Google groups nest and the Admin SDK will not expand the nesting, so this is the ordinary case the resolver was written for: the adapter answers what one key is directly a member of and the resolver goes up a level at a time.
+That is why the conformance fixture here sets neither `Flat` nor `Transitive`, which the other two adapters each set one of.
+
+One collection answers both lookups.
+`GET /groups?userKey=` returns the groups a key is directly in, and the key is allowed to be a group as well as a person, which is the fact the whole adapter is built on.
+Without it a nesting provider would need a second collection with different paging and different failure modes to answer the group lookup, and the two would disagree about something eventually.
+
+The other direction was the obvious way to do it and it is the wrong one.
+The members collection takes `includeDerivedMembership` and will happily hand back the closure, but it answers from a group towards its people rather than from a person towards their groups.
+Expanding one person that way means reading the membership of every group they might be in, so a company wide group turns one sign in into a walk over every employee.
+
+The buffer holds less here than it does in the other two adapters, and it is worth being precise about what it holds.
+A listing carries the full group objects, so the group lookups that are about to arrive for those ids are already answered and cost nothing.
+It says nothing about what those groups are inside, which is exactly the thing the next level of the walk needs, so a person in twenty groups is one listing plus twenty listings and not one plus forty requests.
+Two tests state that in both directions, with the buffer on and with it off.
+
+The version is a hash of the etag and of the fields the adapter reports, and both halves are load bearing.
+Google has been dropping etags across its APIs, and an adapter that hashed only the etag would go quiet on a domain that stopped sending them, which is a version that never moves and a cache above it that never invalidates.
+The group version also folds in the ids of the groups that group is inside, because the etag on a group does not move when somebody puts it under another one, and for a nesting provider that move changes the group set of everybody underneath it.
+
+Deactivation has two spellings.
+A suspended account is the obvious one and an archived account is the one that is easy to miss, since archiving is what an administrator reaches for when somebody leaves and the licence is being reclaimed.
+Either one refuses, and a refused subject is refused before their groups are read rather than after.
+
+Identities are the id, the primary address, the aliases and every address in `emails`.
+`nonEditableAliases` is deliberately not among them: those are the automatic ones the domain generates, they are addresses nobody was given, and a rule written against one would be a rule about the domain's naming rather than about a person.
+
+A key the service will not even look at comes back as a bad request with a reason of `invalid`, and that is read as nobody rather than as a failure, for the same reason it is in the Entra adapter.
+One malformed row in a store should cost that row and not the whole expansion.
+
+Rate limits are the one place this provider made the shared transport grow something.
+The Admin SDK refuses a caller who is over the rate with a 403 rather than a 429, and the only thing separating that from an account which genuinely may not read the directory is a reason string in the body.
+Retrying every 403 would hammer a service over permissions that are not going to change, and retrying none of them turns a throttle that would have cleared in two seconds into a sync that failed.
+So `connector/limit` gained `WithThrottled`, a predicate the transport consults only for a refusal it was not already going to retry, and `limit.Peek`, which reads the first few kilobytes of a body and puts them back so the connector above still gets the whole answer.
+The adapter treats `quotaExceeded`, `rateLimitExceeded` and `userRateLimitExceeded` as throttles.
+`dailyLimitExceeded` is not among them, because the window that clears it is tomorrow and no backoff this transport is willing to wait is going to reach it.
+
+Signing in is a service account acting for an administrator.
+The account has no directory of its own, so on its own it resolves nothing, and what makes it work is domain wide delegation: an administrator grants the account's client id a list of scopes, and the account then asks for a token on behalf of a named person.
+That name is the `sub` claim in the signed assertion and it is the whole of the delegation as far as this process is concerned.
+`NewServiceAccount` refuses an empty one at construction rather than defaulting it, because the failure it produces otherwise is an `unauthorized_client` from the token endpoint, which is the same answer an ungranted scope gives and is not guessable from the status.
+The private key is parsed at construction for the same reason, so a truncated or encrypted key file stops a deployment from starting instead of becoming a directory outage the first time somebody searches.
+`CredentialsFromJSON` reads the key file the console hands over, and it exists so that the key stays in a file, since a private key is the one thing here that must not arrive on a command line where it is in the process listing for everybody on the host.
+
 ## More than one directory
 
 `directory.Multi` unions several of them into one group set, and `genbad -directory` takes a list of files.
@@ -306,9 +354,10 @@ The cache refuses once an entry has expired and the directory cannot be reached,
 It is a real choice with a real cost on the other side, so it should be a configured window with its own metric rather than a default.
 
 The rest of the hosted providers.
-Okta and Entra ID are done, and Google Workspace is the one that is not.
+Okta, Entra ID and Google Workspace are done, and LDAP is the one that is not.
 
 A way to configure an adapter without writing Go.
 `-directory` takes files, and an organisation is not a file.
 All three providers want the same three things, an endpoint, a credential and a name, so the flag should grow one spelling that covers them rather than one per provider.
 Entra ID wants a fourth, since a client credentials grant is a tenant, an application and a secret rather than one token, and a secret is the one thing that must not arrive on a command line.
+Google Workspace wants the same treatment for a different shape, since a service account is a key file and the administrator to act for, and the key belongs in the file it arrived in rather than in a flag.


### PR DESCRIPTION
Third directory adapter, over the Google Workspace Admin SDK, and the first one where the provider does none of the walking.

Okta groups do not nest and Entra ID expands the nesting for you. Google groups nest and the Admin SDK will not expand them, so this is the ordinary case the resolver was written for: the adapter answers what one key is directly a member of and the resolver goes up a level at a time. The conformance fixture sets neither `Flat` nor `Transitive`, which the other two adapters each set one of, and the whole suite applies unchanged.

## One collection answers both lookups

`GET /groups?userKey=` returns the groups a key is directly in, and the key is allowed to be a group as well as a person. That is the fact the adapter is built on. Without it a nesting provider needs a second collection with different paging and different failure modes to answer the group lookup, and the two disagree about something eventually.

The members collection with `includeDerivedMembership` was the obvious alternative and it is the wrong one. It answers from a group towards its people rather than from a person towards their groups, so expanding one person means reading the membership of every group they might be in, and a company wide group turns one sign in into a walk over every employee.

## What the buffer can hold

Less than in the other two adapters, and it is worth being precise. A listing carries the full group objects, so the group lookups that are about to arrive for those ids are already answered. It says nothing about what those groups are inside, which is exactly what the next level of the walk needs. A person in twenty groups is one listing plus twenty listings, not one plus forty requests. Two tests state that in both directions, with the buffer on and with it off.

## Versions

The version hashes the etag and the fields the adapter reports. Google has been dropping etags across its APIs, and an adapter that hashed only the etag would go quiet on a domain that stopped sending them, which is a version that never moves and a cache above it that never invalidates.

The group version also folds in the ids of the groups that group is inside. The etag on a group does not move when somebody puts it under another one, and for a nesting provider that move changes the group set of everybody underneath it. Both properties have their own case.

## A forbidden that means slow down

The Admin SDK refuses a caller who is over the rate with a 403 rather than a 429, and the only thing separating that from an account which genuinely may not read the directory is a reason string in the body. Retrying every 403 would hammer a service over permissions that are not going to change, and retrying none of them turns a throttle that would have cleared in two seconds into a sync that failed.

So `connector/limit` grows two exported things:

- `WithThrottled` takes a predicate the transport consults only for a refusal it was not already going to retry, so a healthy crawl never calls it and a service that sends both shapes pays for the second reading once.
- `Peek` reads the front of a response body and puts it back, because a predicate that consumed the body would leave the connector above it decoding an empty answer, and that failure is an error message with nothing in it rather than anything that points at the cause.

The adapter treats `quotaExceeded`, `rateLimitExceeded` and `userRateLimitExceeded` as throttles. `dailyLimitExceeded` is not among them, because the window that clears it is tomorrow.

## Signing in

A service account acting for an administrator, over the JWT bearer grant. The account has no directory of its own, so what makes it work is domain wide delegation: an administrator grants the account's client id a list of scopes and the account then asks for a token on behalf of a named person. That name is the `sub` claim.

`NewServiceAccount` refuses an empty subject at construction rather than defaulting it, because the failure it produces otherwise is an `unauthorized_client` from the token endpoint, which is the same answer an ungranted scope gives and is not guessable from the status. The private key is parsed at construction for the same reason, so a truncated or encrypted key file stops a deployment from starting instead of becoming a directory outage the first time somebody searches. `CredentialsFromJSON` reads the key file the console hands over, and it exists so that the key stays in a file rather than arriving on a command line where it is in the process listing for everybody on the host.

## Tests

The conformance suite, a fake domain and a recorded fixture set, the same three the other two adapters have.

The fake is deliberately more awkward than it needs to be in three places. The groups collection refuses a page size above the two hundred the real one accepts. The token endpoint verifies the signature on the grant with the account's public key and refuses one with the wrong person to act for. And a listing answers with the group objects and nothing about what those groups are inside, which is the fact the whole walk is shaped around.

The fixtures under `testdata/domain` are a resolution against a small domain: somebody three levels down a nest and in enough groups directly for their listing to page, somebody in none, somebody suspended, and a group looked up on its own. Signing in is deliberately not recorded, since that would mean writing a signed assertion down in a file, and one case checks every fixture for a token, a key and a grant.

## The wide case and the race detector

This is the first adapter whose wide conformance case makes a thousand real round trips, since every group above the subject is its own listing. Under the race detector on a loaded build machine that goes past the ten second bound, so the budget moved into a pair of build tagged files and is four times as long when the detector is on. What the case really asserts is the lookup count, which is exact and says the same thing on every machine, and the time is there to catch a walk that turned quadratic.

## Checks

`go test -race`, `gofmt`, `go vet` and `golangci-lint run` are clean.
