### PR TITLE
Point a deployment at an identity provider without writing Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The environment variable is the flag in upper case with a `GENBA_` prefix, and a
 | `GENBA_TENANT` | empty | tenant served by a single tenant deployment |
 | `GENBA_ADMINS` | empty | subjects that hold the administrator role, comma separated |
 | `GENBA_LOG_LEVEL` | `info` | `debug`, `info`, `warn` or `error` |
-| `GENBA_DIRECTORY` | empty | files of subjects and groups to resolve group membership from, comma separated, empty to believe the request |
+| `GENBA_DIRECTORY` | empty | files to resolve group membership from, each either subjects and groups written out or a description of a hosted provider, comma separated, empty to believe the request |
 | `GENBA_DIRECTORY_TTL` | `1m` | how long a resolved group set is held |
 | `GENBA_DIRECTORY_REFRESH` | `30s` | how often the file is read again, zero for never |
 | `GENBA_READ_TIMEOUT` | `30s` | request read timeout |
@@ -346,7 +346,61 @@ A company with an identity provider gets an adapter instead, and an adapter answ
 Okta groups do not contain groups, so an expansion there is one level deep, and the group listing that answers the subject lookup already carries every group object the level below is about to ask for.
 Entra ID groups do nest and Microsoft Graph will do the nesting for you, so a person eight levels down a tree is one request rather than eight rounds of them, and the expansion is still one level deep for a different reason.
 Google Workspace groups nest and the Admin SDK will not walk the nesting, so that one is the ordinary case the resolver was written for: one collection answers both lookups, because the endpoint that says which groups a person is in takes a group just as happily as a person.
-`-directory` does not take an organisation yet, so an adapter is wired up in Go for now, and the flag grows a spelling for all three at once.
+### Pointing a deployment at an identity provider
+
+`-directory` still takes files, and a file is now either a directory written out in full or a description of a hosted one.
+The two are told apart by reading them, so a mixed list works the way two files already do: the forty contractors somebody keeps in a JSON file and everybody else in an Okta organisation is one flag value and one search box.
+
+```json
+{
+  "provider": "okta",
+  "name": "acme",
+  "endpoint": "https://acme.okta.com",
+  "credential_file": "/etc/genba/okta-token"
+}
+```
+
+`name` is the identity source the group keys carry, so `mei` above resolves to `acme:engineering` whether that group came from a file or from the organisation.
+It has no default for the same reason it has none in a directory file: it is what a rule is written against.
+`endpoint` for Okta is the organisation URL, and the credential is an API token.
+
+```json
+{
+  "provider": "entra",
+  "name": "acme",
+  "tenant": "8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60",
+  "client_id": "c3d4e5f6-0718-4923-a4b5-6c7d8e9f0a12",
+  "credential_env": "ACME_ENTRA_SECRET"
+}
+```
+
+`tenant` is the directory id and `client_id` is the application registration this signs in as, and the credential is that application's client secret.
+The registration needs `GroupMember.Read.All` and `User.Read.All` as application permissions, granted by an administrator, since there is nobody signing in to consent to them.
+`authority` moves the token endpoint, which a national cloud needs.
+
+```json
+{
+  "provider": "google",
+  "name": "acme",
+  "subject": "admin@acme.test",
+  "credential_file": "/etc/genba/service-account.json"
+}
+```
+
+For Google Workspace the credential is the whole service account key file the console hands over, rather than one field out of it, so the file that arrived is the file that gets mounted and nobody has to copy a private key from one place to another.
+`subject` is the administrator the service account acts as, and domain wide delegation has to be configured for the account's client id with `admin.directory.group.readonly` and `admin.directory.user.readonly`.
+Without that the grant is refused with a message saying so, which is worth knowing because the failure is otherwise a bad request that names none of the four things that can be wrong.
+
+The credential is never in the description itself.
+A file like the ones above is the sort of thing that gets pasted into a ticket and committed to a repository of manifests, and none of that is true of the file it names.
+`credential_file` is a path whose contents are the credential, which is what a mounted secret looks like, and `credential_env` names an environment variable instead, which is what a container that was handed one looks like.
+It is not a flag either, because argv is readable by every process on the machine.
+A description that carries the credential inline is refused with a message saying which of the two to use.
+
+The server asks each provider one question on the way up, about somebody who does not exist, and a credential the provider will not accept stops it starting.
+A server that comes up and then refuses every sign in looks like an outage in the search engine rather than a token somebody forgot to rotate, and it is worth one request to tell those apart.
+There is no reload loop on a description, because it names a service rather than a set of people, and the people behind it change without the file changing.
+`-directory-ttl` is what bounds that, exactly as it does for a file.
 
 ## Metrics
 
@@ -430,6 +484,7 @@ func main() {
 | `acl` | principals, groups, permission descriptors, visibility bitmaps |
 | `directory` | a person resolved into the groups they are in, with cycle detection, a version, a union over several providers and one cache layer, [docs/identity.md](docs/identity.md) |
 | `directory/directorytest` | the conformance suite that defines what a directory adapter is |
+| `directory/provider` | a hosted directory built from a description of one, so a deployment names a provider in a file instead of importing it |
 | `directory/okta` | group membership from an Okta organisation, over the Users and Groups API |
 | `directory/entra` | group membership from a Microsoft Entra ID tenant, over the Graph, with the closure resolved by the provider |
 | `directory/google` | group membership from a Google Workspace domain, over the Admin SDK, signed in as a service account acting for an administrator |

--- a/arch_test.go
+++ b/arch_test.go
@@ -50,6 +50,12 @@ var allowed = map[string][]string{
 	// nothing of ours that the other two do not already have.
 	"directory/google": {"acl", "cache", "connector/limit", "directory"},
 
+	// provider sits above all three, which is the only place in the tree that
+	// does. It exists so that a deployment can name one in a file instead of
+	// importing it, so it has to know all of them and nothing else may know it
+	// except the command that reads the flag.
+	"directory/provider": {"directory", "directory/entra", "directory/google", "directory/okta"},
+
 	// cache is a map with a lock on it and imports nothing of ours, which is
 	// what lets index depend on it without the dependency meaning anything. A
 	// cache that knew about principals would be a second copy of the permission
@@ -240,7 +246,7 @@ var allowed = map[string][]string{
 	"benchcorpus/gen": {"benchcorpus", "store/sqlitestore"},
 
 	"cmd/genba":  {""},
-	"cmd/genbad": {"", "api", "config", "connector", "connector/aclmap", "connector/fssource", "connector/limit", "connector/objectsource", "directory", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
+	"cmd/genbad": {"", "api", "config", "connector", "connector/aclmap", "connector/fssource", "connector/limit", "connector/objectsource", "directory", "directory/provider", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
 }
 
 func TestDependencyDirection(t *testing.T) {

--- a/cmd/genbad/directory.go
+++ b/cmd/genbad/directory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tamnd/genba/api"
 	"github.com/tamnd/genba/config"
 	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/provider"
 )
 
 // authenticator is what the server authenticates with, and which of the two it
@@ -32,11 +33,17 @@ import (
 // no collisions because every group key carries the name of the directory it
 // came from.
 //
+// A file is either a directory written out in full or a description of a hosted
+// one, see [github.com/tamnd/genba/directory/provider], and a list can hold both
+// because it was always a list of files. The two are told apart by reading them,
+// rather than by a second flag, so that the deployment with forty contractors in
+// a file and an Okta organisation for everybody else is one flag value.
+//
 // There is one cache and it sits above the union, so the staleness bound is the
 // number in the configuration rather than something that emerges from a stack.
 //
 // The reload loops, if there are any, run until the context is done.
-func authenticator(ctx context.Context, cfg config.Config, log *slog.Logger) (api.Authenticator, error) {
+func authenticator(ctx context.Context, cfg config.Config, getenv func(string) string, log *slog.Logger) (api.Authenticator, error) {
 	header := api.HeaderAuth{Tenant: cfg.Tenant, Admins: cfg.Admins}
 	if len(cfg.Directories) == 0 {
 		return header, nil
@@ -47,15 +54,32 @@ func authenticator(ctx context.Context, cfg config.Config, log *slog.Logger) (ap
 		parts = make([]directory.Expander, 0, len(cfg.Directories))
 	)
 	for _, path := range cfg.Directories {
-		held := &swap{path: path}
-		if err := held.read(); err != nil {
-			return nil, err
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("directory: %w", err)
 		}
-		res, err := directory.New(held)
+
+		var d directory.Directory
+		if provider.Describes(raw) {
+			d, err = hosted(ctx, raw, getenv, log)
+		} else {
+			// The bytes already read rather than the path, because the file
+			// would otherwise be read twice and the second read is the one that
+			// gets installed.
+			held := &swap{path: path}
+			if _, err = held.install(raw); err == nil {
+				files = append(files, held)
+				d = held
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("directory %s: %w", path, err)
+		}
+
+		res, err := directory.New(d)
 		if err != nil {
 			return nil, err
 		}
-		files = append(files, held)
 		parts = append(parts, res)
 	}
 	union, err := directory.NewMulti(parts...)
@@ -81,6 +105,37 @@ func authenticator(ctx context.Context, cfg config.Config, log *slog.Logger) (ap
 	return api.Resolving{Auth: header, Resolver: cached}, nil
 }
 
+// credentialCheck is how long the one question at startup gets.
+//
+// It is generous because it is paid once and because the first request to a
+// provider is the slow one: a TLS handshake, and for two of the three a token
+// grant before the lookup it was for. It is bounded at all because a tenant that
+// accepts a connection and then says nothing would otherwise hang the server on
+// the way up, which looks exactly like a server that is running.
+const credentialCheck = 20 * time.Second
+
+// hosted builds a directory out of a description of one and asks it a question
+// before letting the server come up.
+//
+// There is no reload loop. A description names a service rather than a set of
+// people, and the people behind it change without the file changing, which is
+// what the cache above the union is for.
+func hosted(ctx context.Context, raw []byte, getenv func(string) string, log *slog.Logger) (directory.Directory, error) {
+	d, err := provider.Open(raw, getenv)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, credentialCheck)
+	defer cancel()
+	if err := provider.Reachable(ctx, d); err != nil {
+		return nil, fmt.Errorf("the credential was refused: %w", err)
+	}
+
+	log.Info("the credential for a hosted directory was accepted", "source", d.Name())
+	return d, nil
+}
+
 // swap is a directory that can be replaced under the readers.
 //
 // The pointer is read on every lookup and written by the reload, which is a
@@ -97,35 +152,37 @@ type swap struct {
 	sum atomic.Pointer[[32]byte]
 }
 
-// read parses the file and installs it, and reports whether the contents
-// differed from what was already held.
-func (s *swap) read() error {
-	_, err := s.reread()
-	return err
-}
-
+// reread reads the file and installs it.
 func (s *swap) reread() (bool, error) {
 	raw, err := os.ReadFile(s.path)
 	if err != nil {
-		return false, fmt.Errorf("directory: %w", err)
+		return false, err
 	}
+	return s.install(raw)
+}
+
+// install parses a file that has already been read and puts it in place, and
+// reports whether the contents differed from what was already held.
+//
+// It takes the bytes rather than the path because the caller at startup has
+// already read them to work out what sort of file this is, and because a file
+// that changes between one read and the next would otherwise leave the hash and
+// the parse describing different things.
+func (s *swap) install(raw []byte) (bool, error) {
 	sum := sha256.Sum256(raw)
 	if held := s.sum.Load(); held != nil && *held == sum {
 		return false, nil
 	}
 
-	// Parsed from the bytes already read rather than from the file again,
-	// because a file that changes between the hash and the parse would leave
-	// the two describing different things.
 	d, err := directory.ReadStatic(bytes.NewReader(raw))
 	if err != nil {
-		return false, fmt.Errorf("directory %s: %w", s.path, err)
+		return false, err
 	}
 	if held := s.held.Load(); held != nil && held.Name() != d.Name() {
 		// Every group key carries the directory's name, so renaming it renames
 		// every group in every rule at once. That is a different directory
 		// rather than an edit to this one, and it is a restart.
-		return false, fmt.Errorf("directory %s: the name changed from %q to %q, which renames every group", s.path, held.Name(), d.Name())
+		return false, fmt.Errorf("the name changed from %q to %q, which renames every group", held.Name(), d.Name())
 	}
 	s.held.Store(d)
 	s.sum.Store(&sum)

--- a/cmd/genbad/directory_test.go
+++ b/cmd/genbad/directory_test.go
@@ -53,13 +53,20 @@ func write(t *testing.T, body string) string {
 // serving starts a server with these flags and stops it when the test ends.
 func serving(t *testing.T, args ...string) string {
 	t.Helper()
+	return servingWith(t, env(nil), args...)
+}
+
+// servingWith is the same with an environment, for the flags whose value names
+// something in one rather than carrying it.
+func servingWith(t *testing.T, getenv func(string) string, args ...string) string {
+	t.Helper()
 	addr := freeAddr(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
 		var out, errOut bytes.Buffer
-		done <- run(ctx, append([]string{"-addr", addr, "-tenant", "acme", "-log-level", "error"}, args...), env(nil), &out, &errOut)
+		done <- run(ctx, append([]string{"-addr", addr, "-tenant", "acme", "-log-level", "error"}, args...), getenv, &out, &errOut)
 	}()
 	t.Cleanup(func() {
 		cancel()
@@ -217,7 +224,7 @@ func TestADirectoryThatIsNotThereStopsTheServerStarting(t *testing.T) {
 func TestRenamingTheDirectoryIsRefusedRatherThanApplied(t *testing.T) {
 	path := write(t, smallCompany)
 	held := &swap{path: path}
-	if err := held.read(); err != nil {
+	if _, err := held.reread(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -278,7 +285,7 @@ func TestOneBadFileOfTwoStopsTheServerStarting(t *testing.T) {
 // cache flush, which is what makes a twenty second ticker affordable.
 func TestARereadThatChangesNothingSaysSo(t *testing.T) {
 	held := &swap{path: write(t, smallCompany)}
-	if err := held.read(); err != nil {
+	if _, err := held.reread(); err != nil {
 		t.Fatal(err)
 	}
 	changed, err := held.reread()

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -78,7 +78,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	// More than one is a company that acquired another company. The group sets
 	// are unioned, and a file that cannot be read refuses the request rather
 	// than serving half of somebody's groups.
-	directories := fs.String("directory", strings.Join(cfg.Directories, ","), "files of subjects and groups to resolve group membership from, comma separated, empty to believe the request")
+	directories := fs.String("directory", strings.Join(cfg.Directories, ","), "files to resolve group membership from, each either subjects and groups written out or a description of a hosted provider, comma separated, empty to believe the request")
 	fs.DurationVar(&cfg.DirectoryTTL, "directory-ttl", cfg.DirectoryTTL, "how long a resolved group set is held, which is the longest a membership change takes to have any effect")
 	fs.DurationVar(&cfg.DirectoryRefresh, "directory-refresh", cfg.DirectoryRefresh, "how often the directory file is read again, zero for never")
 	// A string rather than a repeated flag, because it is a list of a handful of
@@ -200,7 +200,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	// listens for the store's writes and the first sync is a write like any
 	// other. Building it afterwards left it reporting that nothing had been
 	// indexed since it came up while sitting on a corpus it had just loaded.
-	auth, err := authenticator(ctx, cfg, log)
+	auth, err := authenticator(ctx, cfg, getenv, log)
 	if err != nil {
 		return err
 	}

--- a/cmd/genbad/provider_test.go
+++ b/cmd/genbad/provider_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// An organisation with one person in it, which is as much of a provider as
+// these cases need. What is being tested here is the flag and the startup, and
+// the adapter itself is tested against a fake and a recording next to it.
+func fakeOrg(t *testing.T) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users/mei", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, `{
+			"id": "mei",
+			"status": "ACTIVE",
+			"lastUpdated": "2026-02-11T09:14:22.000Z",
+			"profile": {"login": "mei@cloud.example", "email": "mei@cloud.example", "firstName": "Mei", "lastName": "Tanaka"}
+		}`)
+	})
+	mux.HandleFunc("/api/v1/users/mei/groups", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, `[
+			{"id": "sales", "lastUpdated": "2026-01-04T11:02:00.000Z", "profile": {"name": "Sales"}}
+		]`)
+	})
+	// Everybody else, which includes the id the startup check asks about. A
+	// lookup that finds nothing is the cheapest answer there is and it takes a
+	// credential the organisation accepted, which is the whole of what that
+	// check is asking.
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusNotFound, `{"errorCode":"E0000007","errorSummary":"Not found: Resource not found"}`)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func writeJSON(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
+}
+
+// describe writes a description of a hosted directory and hands back the path,
+// alongside the credential file it names.
+func describe(t *testing.T, org, credential string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	secret := filepath.Join(dir, "token")
+	if err := os.WriteFile(secret, []byte(credential), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "cloud.json")
+	body := fmt.Sprintf(`{
+  "provider": "okta",
+  "name": "cloud",
+  "endpoint": %q,
+  "credential_file": %q
+}`, org, secret)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestAFileAndAnOrganisationAreUnionedIntoOneSession is why the description is
+// a file rather than a spelling on the flag. The company that acquired another
+// company keeps forty contractors in a JSON file and everybody else in an Okta
+// organisation, and that is one flag value and one search box.
+func TestAFileAndAnOrganisationAreUnionedIntoOneSession(t *testing.T) {
+	paths := write(t, smallCompany) + "," + describe(t, fakeOrg(t), "00AnApiToken\n")
+	base := serving(t, "-directory", paths)
+
+	got := groupsOf(t, base)
+	want := []string{"acme:engineering", "acme:everyone", "cloud:sales"}
+	if !slices.Equal(got, want) {
+		t.Errorf("the session carries %v, want %v", got, want)
+	}
+}
+
+// TestTheCredentialCanComeFromTheEnvironment is the other half of it, and the
+// reason neither half is a flag: a secret is the one thing that must not arrive
+// on a command line, because argv is readable by every process on the machine.
+func TestTheCredentialCanComeFromTheEnvironment(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cloud.json")
+	body := fmt.Sprintf(`{
+  "provider": "okta",
+  "name": "cloud",
+  "endpoint": %q,
+  "credential_env": "CLOUD_OKTA_TOKEN"
+}`, fakeOrg(t))
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	base := servingWith(t, env(map[string]string{"CLOUD_OKTA_TOKEN": "00AnApiToken"}), "-directory", path)
+	got := groupsOf(t, base)
+	if want := []string{"cloud:sales"}; !slices.Equal(got, want) {
+		t.Errorf("the session carries %v, want %v", got, want)
+	}
+}
+
+// TestACredentialTheOrganisationRefusesStopsTheServerStarting is the failure
+// worth catching at startup rather than at the first search. A server that
+// comes up and then resolves everybody into nothing looks like a bug in the
+// search engine, and this looks like what it is.
+func TestACredentialTheOrganisationRefusesStopsTheServerStarting(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusUnauthorized, `{"errorCode":"E0000011","errorSummary":"Invalid token provided"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	path := describe(t, srv.URL, "00NotAToken")
+
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), []string{"-addr", freeAddr(t), "-directory", path, "-log-level", "error"}, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("the server started with a credential the organisation will not accept")
+	}
+	// Which file, because a deployment with three of these gets one line in a
+	// unit file to work out which one is wrong.
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("the error is %q and does not name the file", err)
+	}
+	if !strings.Contains(err.Error(), "Invalid token provided") {
+		t.Errorf("the error is %q and does not carry what the organisation said", err)
+	}
+}
+
+// A description that names an environment variable nobody set is the same sort
+// of failure as a directory file that is not there, and it is refused in the
+// same place rather than at the first search.
+func TestASecretThatDidNotArriveStopsTheServerStarting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cloud.json")
+	body := fmt.Sprintf(`{
+  "provider": "okta",
+  "name": "cloud",
+  "endpoint": %q,
+  "credential_env": "CLOUD_OKTA_TOKEN"
+}`, fakeOrg(t))
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), []string{"-addr", freeAddr(t), "-directory", path, "-log-level", "error"}, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("the server started with no credential at all")
+	}
+	if !strings.Contains(err.Error(), "CLOUD_OKTA_TOKEN") {
+		t.Errorf("the error is %q and does not say where the credential was to come from", err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -78,8 +78,10 @@ type Config struct {
 	// which is the property that makes a cache safe to have in the first place.
 	Cache bool
 
-	// Directories are the files of subjects and groups to resolve group
-	// membership from, and it is empty by default. A deployment with one
+	// Directories are the files to resolve group membership from, and it is
+	// empty by default. Each is either subjects and groups written out in full
+	// or a description of a hosted provider, and which one it is comes from
+	// reading it rather than from a second flag. A deployment with one
 	// resolves the groups on every request out of it and throws away whatever
 	// the request claimed. A deployment without one believes the groups it is
 	// given, which is right for a laptop and behind a proxy that is doing the

--- a/directory/provider/provider.go
+++ b/directory/provider/provider.go
@@ -1,0 +1,340 @@
+// Package provider builds a directory out of a description of one.
+//
+// The adapters in the packages next to this one are reachable from Go and
+// nothing else, which is fine while there is one of them and it is being
+// written, and is not fine once there are three. A deployment that wants its
+// groups from Okta should not have to import a package and build its own
+// binary.
+//
+// # Why a file
+//
+// `-directory` already takes a comma separated list of files, unioned by
+// [directory.Multi], and that is the whole of the spelling. A file here is
+// either a directory written out in full, which is the deployment with forty
+// people in it, or a description of a hosted one, which is this package. A
+// mixed list works because it was always a list of files, so a company that
+// acquired another company can point at their own Okta organisation and at the
+// forty contractors somebody keeps in a JSON file and get one search box.
+//
+// The alternative was a spelling on the flag itself, "okta:acme.okta.com", and
+// it loses twice. A credential cannot go in it, because argv is readable by
+// every process on the machine, so the secret would have to arrive from an
+// environment variable named after the source, and now there are two places to
+// look. And a national cloud, a page size or a second organisation turns one
+// flag value into a query string nobody can read.
+//
+// # Where the credential comes from
+//
+//	{
+//	  "provider": "okta",
+//	  "name": "acme",
+//	  "endpoint": "https://acme.okta.com",
+//	  "credential_file": "/etc/genba/okta-token"
+//	}
+//
+// Never from the description itself. A file like the one above is the sort of
+// thing that gets pasted into a ticket, committed to a repository of manifests
+// and read by everybody who can list a directory, and none of that is true of
+// the file it names. `credential_file` is a path whose contents are the
+// credential, which is what a mounted secret looks like, and `credential_env`
+// names an environment variable instead, which is what a container that was
+// handed one looks like. A description that carries the credential inline is
+// refused with a message saying which of the two to use, because that is the
+// mistake somebody is going to make and "unknown field" is not an answer to it.
+//
+// # What is checked at startup
+//
+// A credential the provider will not accept stops the server coming up, see
+// [Reachable]. A server that starts and then refuses every sign in looks like
+// an outage in the search engine rather than a token somebody forgot to
+// rotate, and it is worth one request at startup to tell those apart.
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/entra"
+	"github.com/tamnd/genba/directory/google"
+	"github.com/tamnd/genba/directory/okta"
+)
+
+// The providers a description can name.
+const (
+	Okta   = "okta"
+	Entra  = "entra"
+	Google = "google"
+)
+
+// spec is a description of a hosted directory.
+//
+// It is not exported. Somebody writing Go has the adapters themselves, which
+// take their own options and are better at it, and an exported struct here
+// would be a second way to do the same thing that has to keep up with all three
+// of them.
+type spec struct {
+	// Provider is which of the three this is, and its presence is what
+	// separates a description from a directory written out in full.
+	Provider string `json:"provider"`
+
+	// Name is the identity source the group keys carry. It is required for the
+	// same reason it is required in a directory file: it is what a rule is
+	// written against, so it cannot be something that got picked by default.
+	Name string `json:"name"`
+
+	// Endpoint is the organisation URL for Okta, which has no default, and an
+	// override of the service for the other two, which do.
+	Endpoint string `json:"endpoint"`
+
+	// Tenant and ClientID are the halves of an Entra ID application that are
+	// not the secret.
+	Tenant   string `json:"tenant"`
+	ClientID string `json:"client_id"`
+
+	// Authority is where tokens are asked for, which a national cloud and a
+	// test both need. Okta has no such thing, since its API token is the
+	// credential rather than something a credential is exchanged for.
+	Authority string `json:"authority"`
+
+	// Subject is the administrator a Google Workspace service account acts as.
+	Subject string `json:"subject"`
+
+	// CredentialFile is a path whose contents are the credential, and
+	// CredentialEnv names an environment variable holding it instead. Exactly
+	// one of them.
+	CredentialFile string `json:"credential_file"`
+	CredentialEnv  string `json:"credential_env"`
+
+	// Credential is here to be refused. It is where somebody will put the
+	// secret, and a field that exists produces a better error than an unknown
+	// one does.
+	Credential string `json:"credential"`
+}
+
+// Describes reports whether a document is a description of a hosted provider
+// rather than a directory written out in full.
+//
+// It looks at one field and ignores everything else, including whether the rest
+// of the document makes sense, because the caller has a file it has to decide
+// what to do with and a description that is wrong should be reported by the
+// thing that understands descriptions.
+func Describes(raw []byte) bool {
+	var in struct {
+		Provider string `json:"provider"`
+	}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return false
+	}
+	return in.Provider != ""
+}
+
+// Open builds the directory a description names.
+//
+// getenv is where `credential_env` is looked up, and nil means the process
+// environment.
+func Open(raw []byte, getenv func(string) string) (directory.Directory, error) {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	// Strict for the same reason the directory file is: an unknown field here
+	// is a typo, and a typo in the name of a credential is a deployment that
+	// comes up against the wrong tenant or does not come up at all, which are
+	// both better found now.
+	dec.DisallowUnknownFields()
+
+	var s spec
+	if err := dec.Decode(&s); err != nil {
+		return nil, fmt.Errorf("provider: %w", err)
+	}
+	// Anything after the object is a second description pasted in by accident,
+	// and silently reading the first half of a file is worse than refusing it.
+	if err := dec.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		return nil, errors.New("provider: more than one description in the file")
+	}
+	if s.Name == "" {
+		return nil, errors.New("provider: no name, and a directory without one cannot have its groups told apart from another's")
+	}
+
+	credential, err := s.credential(getenv)
+	if err != nil {
+		return nil, fmt.Errorf("provider %s: %w", s.Name, err)
+	}
+
+	var d directory.Directory
+	switch s.Provider {
+	case Okta:
+		d, err = s.okta(credential)
+	case Entra:
+		d, err = s.entra(credential)
+	case Google:
+		d, err = s.google(credential)
+	default:
+		return nil, fmt.Errorf("provider %s: %q is not a provider this knows, which are %s, %s and %s",
+			s.Name, s.Provider, Okta, Entra, Google)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("provider %s: %w", s.Name, err)
+	}
+	return d, nil
+}
+
+func (s spec) okta(token string) (directory.Directory, error) {
+	if s.Endpoint == "" {
+		return nil, errors.New("no endpoint, which for this provider is the organisation URL, https://acme.okta.com")
+	}
+	if err := s.unused(Okta, "tenant", "client_id", "authority", "subject"); err != nil {
+		return nil, err
+	}
+	return okta.New(s.Endpoint, token, okta.WithName(s.Name))
+}
+
+func (s spec) entra(secret string) (directory.Directory, error) {
+	switch {
+	case s.Tenant == "":
+		return nil, errors.New("no tenant, which is the directory id of the Entra ID tenant")
+	case s.ClientID == "":
+		return nil, errors.New("no client_id, which is the application registration this signs in as")
+	}
+	if err := s.unused(Entra, "subject"); err != nil {
+		return nil, err
+	}
+
+	var opts []entra.ApplicationOption
+	if s.Authority != "" {
+		opts = append(opts, entra.WithAuthority(s.Authority))
+	}
+	app, err := entra.NewApplication(entra.Credentials{
+		Tenant: s.Tenant,
+		ID:     s.ClientID,
+		Secret: secret,
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	dir := []entra.Option{entra.WithName(s.Name)}
+	if s.Endpoint != "" {
+		dir = append(dir, entra.WithEndpoint(s.Endpoint))
+	}
+	return entra.New(app, dir...)
+}
+
+func (s spec) google(key string) (directory.Directory, error) {
+	if s.Subject == "" {
+		return nil, errors.New("no subject, and a service account with no administrator to act for has no directory of its own")
+	}
+	if err := s.unused(Google, "tenant", "client_id"); err != nil {
+		return nil, err
+	}
+
+	// The credential here is the whole key file the console hands over rather
+	// than one field out of it, so that the file it arrived in is the file that
+	// gets mounted and nobody has to copy a private key from one place to
+	// another to deploy this.
+	creds, err := google.CredentialsFromJSON([]byte(key), s.Subject)
+	if err != nil {
+		return nil, err
+	}
+
+	var opts []google.ServiceAccountOption
+	if s.Authority != "" {
+		opts = append(opts, google.WithTokenEndpoint(s.Authority))
+	}
+	account, err := google.NewServiceAccount(creds, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	dir := []google.Option{google.WithName(s.Name)}
+	if s.Endpoint != "" {
+		dir = append(dir, google.WithEndpoint(s.Endpoint))
+	}
+	return google.New(account, dir...)
+}
+
+// credential reads the one thing that is never in the description.
+func (s spec) credential(getenv func(string) string) (string, error) {
+	switch {
+	case s.Credential != "":
+		return "", errors.New(`the credential itself does not belong in this file, name the file or the environment variable that holds it with "credential_file" or "credential_env"`)
+	case s.CredentialFile != "" && s.CredentialEnv != "":
+		return "", errors.New("both credential_file and credential_env are set, and there is no rule about which of them wins")
+	case s.CredentialFile != "":
+		raw, err := os.ReadFile(s.CredentialFile)
+		if err != nil {
+			return "", fmt.Errorf("reading the credential: %w", err)
+		}
+		// Trimmed because a token in a file put there by a person has a newline
+		// on the end of it, and a token with a newline on the end is refused by
+		// the provider with something that does not mention the newline.
+		got := strings.TrimSpace(string(raw))
+		if got == "" {
+			return "", fmt.Errorf("the credential in %s is empty", s.CredentialFile)
+		}
+		return got, nil
+	case s.CredentialEnv != "":
+		got := strings.TrimSpace(getenv(s.CredentialEnv))
+		if got == "" {
+			return "", fmt.Errorf("%s is not set, and it is where the credential was to come from", s.CredentialEnv)
+		}
+		return got, nil
+	}
+	return "", errors.New(`no credential, so name the file or the environment variable that holds it with "credential_file" or "credential_env"`)
+}
+
+// unused refuses a field that means nothing to the provider named.
+//
+// A tenant on an Okta description is somebody who copied one of these from the
+// other and changed half of it. Ignoring it would leave them with a deployment
+// pointed at the organisation in the other half of the file.
+func (s spec) unused(kind string, named ...string) error {
+	set := map[string]string{
+		"endpoint":  s.Endpoint,
+		"tenant":    s.Tenant,
+		"client_id": s.ClientID,
+		"authority": s.Authority,
+		"subject":   s.Subject,
+	}
+	for _, field := range named {
+		if set[field] != "" {
+			return fmt.Errorf("%q means nothing to %s and this description sets it", field, kind)
+		}
+	}
+	return nil
+}
+
+// probe is the id [Reachable] asks about. It is not a person anywhere and it
+// says what it is, so an administrator reading a log of lookups against their
+// own tenant can see why one arrived from us at startup.
+const probe = "genba-startup-credential-check"
+
+// Reachable asks a directory one question, so that a credential it will not
+// accept stops the server starting.
+//
+// The question is about somebody who does not exist, and the answer that means
+// everything is working is that they do not exist. Anything a provider will
+// answer at all takes a credential it accepted, and there is no lookup in any
+// of these APIs that costs less than one that finds nothing.
+//
+// A subject the provider does hold is fine too, in the unlikely event somebody
+// is named after this, and so is one it has deactivated. Both are answers, and
+// the only thing being asked here is whether the provider is answering.
+func Reachable(ctx context.Context, d directory.Directory) error {
+	_, err := d.Subject(ctx, probe)
+	switch {
+	case err == nil,
+		errors.Is(err, directory.ErrNoSubject),
+		errors.Is(err, directory.ErrDisabled):
+		return nil
+	}
+	return fmt.Errorf("%s: %w", d.Name(), err)
+}

--- a/directory/provider/provider_test.go
+++ b/directory/provider/provider_test.go
@@ -1,0 +1,372 @@
+package provider_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tamnd/genba/directory"
+	"github.com/tamnd/genba/directory/provider"
+)
+
+// A service account key file, which is the one credential of the three that has
+// to be a real one: the Google adapter parses the key at construction, on
+// purpose, so a description naming a key file that is not a key is refused here
+// rather than at the first search.
+//
+// One key for the whole package, because generating an RSA key is the slowest
+// thing in this file by a long way and none of these cases is about which key it
+// is.
+var keyFile = sync.OnceValue(func() string {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		panic(err)
+	}
+	raw, err := json.Marshal(map[string]string{
+		"type":           "service_account",
+		"project_id":     "acme-search",
+		"private_key_id": "0123456789abcdef",
+		"private_key":    string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})),
+		"client_email":   "genba@acme.iam.gserviceaccount.com",
+		"token_uri":      "https://oauth2.googleapis.com/token",
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(raw)
+})
+
+// held writes a credential to a file and hands back the path, which is the
+// shape a mounted secret arrives in.
+func held(t *testing.T, credential string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "credential")
+	if err := os.WriteFile(path, []byte(credential), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// open builds a directory out of a description, with nothing in the
+// environment unless a case says otherwise.
+func open(t *testing.T, description string, env ...string) (directory.Directory, error) {
+	t.Helper()
+	set := map[string]string{}
+	for i := 0; i+1 < len(env); i += 2 {
+		set[env[i]] = env[i+1]
+	}
+	return provider.Open([]byte(description), func(k string) string { return set[k] })
+}
+
+// TestADescriptionIsToldFromADirectory is the whole of how one flag reaches
+// both, so it is worth stating on its own.
+func TestADescriptionIsToldFromADirectory(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"a description", `{"provider": "okta", "name": "acme"}`, true},
+		{"a directory written out in full", `{"name": "acme", "groups": [{"id": "everyone"}]}`, false},
+		{"a directory with somebody called provider in it", `{"name": "acme", "subjects": [{"id": "provider"}]}`, false},
+		{"an empty object", `{}`, false},
+		{"something that is not JSON at all", `not a file anybody meant to write`, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := provider.Describes([]byte(c.raw)); got != c.want {
+				t.Errorf("Describes = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestEachProviderIsBuiltFromItsOwnDescription is the point of the package:
+// three providers, one spelling, and the name a rule is written against is the
+// one in the file.
+func TestEachProviderIsBuiltFromItsOwnDescription(t *testing.T) {
+	for _, c := range []struct {
+		name        string
+		description string
+	}{
+		{"okta", fmt.Sprintf(`{
+			"provider": "okta",
+			"name": "acme",
+			"endpoint": "https://acme.okta.com",
+			"credential_file": %q
+		}`, held(t, "00AnApiToken\n"))},
+
+		{"entra", fmt.Sprintf(`{
+			"provider": "entra",
+			"name": "acme",
+			"tenant": "8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60",
+			"client_id": "c3d4e5f6-0718-4923-a4b5-6c7d8e9f0a12",
+			"credential_file": %q
+		}`, held(t, "a-client-secret"))},
+
+		{"google", fmt.Sprintf(`{
+			"provider": "google",
+			"name": "acme",
+			"subject": "admin@acme.test",
+			"credential_file": %q
+		}`, held(t, keyFile()))},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			d, err := open(t, c.description)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if d.Name() != "acme" {
+				t.Errorf("the source is called %q, and every group key carries that", d.Name())
+			}
+		})
+	}
+}
+
+// TestTheCredentialComesFromTheEnvironmentToo is the other half of it, which is
+// what a container that was handed a secret looks like.
+func TestTheCredentialComesFromTheEnvironmentToo(t *testing.T) {
+	d, err := open(t, `{
+		"provider": "okta",
+		"name": "acme",
+		"endpoint": "https://acme.okta.com",
+		"credential_env": "ACME_OKTA_TOKEN"
+	}`, "ACME_OKTA_TOKEN", "00AnApiToken")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Name() != "acme" {
+		t.Errorf("the source is called %q", d.Name())
+	}
+}
+
+// TestADescriptionThatCannotBeUsedIsRefused is one case rather than fifteen
+// because every one of these is the same statement: whatever is wrong with a
+// description is wrong at startup, and the message says which file and what.
+func TestADescriptionThatCannotBeUsedIsRefused(t *testing.T) {
+	token := held(t, "00AnApiToken")
+	key := held(t, keyFile())
+
+	for _, c := range []struct {
+		name        string
+		description string
+		says        string
+	}{
+		{
+			"a provider nobody has written an adapter for",
+			fmt.Sprintf(`{"provider": "ldap", "name": "acme", "credential_file": %q}`, token),
+			"is not a provider this knows",
+		},
+		{
+			"no name, so nothing could tell its groups from another source's",
+			fmt.Sprintf(`{"provider": "okta", "endpoint": "https://acme.okta.com", "credential_file": %q}`, token),
+			"no name",
+		},
+		{
+			"an Okta organisation with no organisation",
+			fmt.Sprintf(`{"provider": "okta", "name": "acme", "credential_file": %q}`, token),
+			"no endpoint",
+		},
+		{
+			"an Entra ID application with no tenant",
+			fmt.Sprintf(`{"provider": "entra", "name": "acme", "client_id": "c3d4e5f6-0718-4923-a4b5-6c7d8e9f0a12", "credential_file": %q}`, token),
+			"no tenant",
+		},
+		{
+			"an Entra ID tenant with no application",
+			fmt.Sprintf(`{"provider": "entra", "name": "acme", "tenant": "8f7c1a2b-3d4e-4f50-9a6b-1c2d3e4f5a60", "credential_file": %q}`, token),
+			"no client_id",
+		},
+		{
+			"a service account with nobody to act for",
+			fmt.Sprintf(`{"provider": "google", "name": "acme", "credential_file": %q}`, key),
+			"no subject",
+		},
+		{
+			"half of one description and half of another",
+			fmt.Sprintf(`{"provider": "okta", "name": "acme", "endpoint": "https://acme.okta.com", "tenant": "8f7c1a2b", "credential_file": %q}`, token),
+			`"tenant" means nothing to okta`,
+		},
+		{
+			"the credential itself, which is the mistake worth a real message",
+			`{"provider": "okta", "name": "acme", "endpoint": "https://acme.okta.com", "credential": "00AnApiToken"}`,
+			"does not belong in this file",
+		},
+		{
+			"no credential at all",
+			`{"provider": "okta", "name": "acme", "endpoint": "https://acme.okta.com"}`,
+			"no credential",
+		},
+		{
+			"both of them, which is a merge somebody did not finish",
+			fmt.Sprintf(`{"provider": "okta", "name": "acme", "endpoint": "https://acme.okta.com", "credential_file": %q, "credential_env": "ACME_OKTA_TOKEN"}`, token),
+			"both credential_file and credential_env",
+		},
+		{
+			"a credential file that is not there",
+			`{"provider": "okta", "name": "acme", "endpoint": "https://acme.okta.com", "credential_file": "/etc/genba/gone"}`,
+			"reading the credential",
+		},
+		{
+			"an empty credential file, which is a secret that failed to mount",
+			fmt.Sprintf(`{"provider": "okta", "name": "acme", "endpoint": "https://acme.okta.com", "credential_file": %q}`, held(t, "\n")),
+			"is empty",
+		},
+		{
+			"an environment variable nobody set",
+			`{"provider": "okta", "name": "acme", "endpoint": "https://acme.okta.com", "credential_env": "ACME_OKTA_TOKEN"}`,
+			"is not set",
+		},
+		{
+			"a key file that is a user credential rather than a service account",
+			fmt.Sprintf(`{"provider": "google", "name": "acme", "subject": "admin@acme.test", "credential_file": %q}`,
+				held(t, `{"type":"authorized_user","client_id":"x","client_secret":"y","refresh_token":"z"}`)),
+			"rather than a service account",
+		},
+		{
+			"a key file that is not a key",
+			fmt.Sprintf(`{"provider": "google", "name": "acme", "subject": "admin@acme.test", "credential_file": %q}`,
+				held(t, `{"type":"service_account","client_email":"genba@acme.iam.gserviceaccount.com","private_key":"/etc/genba/key.pem"}`)),
+			"not PEM",
+		},
+		{
+			"a field nobody has ever heard of",
+			fmt.Sprintf(`{"provider": "okta", "name": "acme", "endpoint": "https://acme.okta.com", "credentials_file": %q}`, token),
+			"unknown field",
+		},
+		{
+			"two descriptions in one file",
+			fmt.Sprintf(`{"provider": "okta", "name": "acme", "endpoint": "https://acme.okta.com", "credential_file": %q}{"provider": "okta"}`, token),
+			"more than one description",
+		},
+		{
+			"something that is not a description at all",
+			`name = acme`,
+			"provider:",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := open(t, c.description)
+			if err == nil {
+				t.Fatal("that was accepted, and it would have failed at the first search instead")
+			}
+			if !strings.Contains(err.Error(), c.says) {
+				t.Errorf("the refusal is %q, which does not say %q", err, c.says)
+			}
+		})
+	}
+}
+
+// TestACredentialTheProviderRefusesIsFoundAtStartup is what [provider.Reachable]
+// is for. A server that comes up and then refuses every sign in looks like an
+// outage in the search engine rather than a token somebody forgot to rotate.
+func TestACredentialTheProviderRefusesIsFoundAtStartup(t *testing.T) {
+	org := refusing(t, http.StatusUnauthorized, `{"errorCode":"E0000011","errorSummary":"Invalid token provided"}`)
+
+	d, err := open(t, fmt.Sprintf(`{
+		"provider": "okta",
+		"name": "acme",
+		"endpoint": %q,
+		"credential_file": %q
+	}`, org, held(t, "00NotAToken")))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = provider.Reachable(t.Context(), d)
+	if err == nil {
+		t.Fatal("a token the organisation will not accept was let through")
+	}
+	// Which source, because a deployment with three of them gets one line in a
+	// unit file to work out which one is wrong.
+	if !strings.Contains(err.Error(), "acme") {
+		t.Errorf("the refusal is %q, which does not say which source it is about", err)
+	}
+	if !strings.Contains(err.Error(), "Invalid token provided") {
+		t.Errorf("the refusal is %q, which does not carry what the provider said", err)
+	}
+}
+
+// And the other way round: a credential that works produces nothing, and the
+// question it asks is about nobody.
+func TestACredentialThatWorksSaysNothing(t *testing.T) {
+	org := refusing(t, http.StatusNotFound, `{"errorCode":"E0000007","errorSummary":"Not found: Resource not found"}`)
+
+	d, err := open(t, fmt.Sprintf(`{
+		"provider": "okta",
+		"name": "acme",
+		"endpoint": %q,
+		"credential_file": %q
+	}`, org, held(t, "00AnApiToken")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := provider.Reachable(t.Context(), d); err != nil {
+		t.Errorf("a working credential was reported as %v", err)
+	}
+}
+
+// TestReachableTakesAnAnswerHoweverItComes covers the two answers that are not
+// a lookup that found nothing, without standing up three fake providers to get
+// at them.
+func TestReachableTakesAnAnswerHoweverItComes(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nobody by that name", directory.ErrNoSubject, true},
+		{"somebody by that name, deactivated", directory.ErrDisabled, true},
+		{"somebody by that name", nil, true},
+		{"a tenant that is not answering", errors.New("dial tcp: connection refused"), false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			err := provider.Reachable(t.Context(), stub{err: c.err})
+			if (err == nil) != c.want {
+				t.Errorf("Reachable = %v", err)
+			}
+		})
+	}
+}
+
+// refusing is a service that answers everything the same way, which is all a
+// credential check ever sees.
+func refusing(t *testing.T, status int, body string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// stub is a directory that answers one way, for the cases above that are about
+// what an answer means rather than about how it was obtained.
+type stub struct{ err error }
+
+func (stub) Name() string { return "acme" }
+
+func (s stub) Subject(context.Context, string) (directory.Subject, error) {
+	return directory.Subject{ID: "nobody"}, s.err
+}
+
+func (s stub) Group(context.Context, string) (directory.Group, error) {
+	return directory.Group{}, s.err
+}

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -347,6 +347,30 @@ Errors are never held.
 A directory that was unreachable for a moment is not a fact about a subject, and remembering it would turn a blip into a minute of refusals.
 A refusal the directory meant, a subject it does not hold or has deactivated, still refuses on every request, because that one is an answer rather than a failure.
 
+## Naming a provider in a file
+
+All three adapters are reachable from Go and that is fine while there is one of them and it is being written.
+It is not fine once there are three, because a deployment that wants its groups from Okta should not have to import a package and build its own binary.
+
+`-directory` keeps its spelling exactly, because it already means a comma separated list of files unioned by `Multi`.
+A file is either a directory written out in full or a description of a hosted one, and the two are told apart by reading them.
+That is what makes a mixed list work: a company with an Okta organisation and forty contractors in a JSON file gets one flag value, and it works because it was always a list of files rather than because anything was added for the case.
+
+The alternative was a spelling on the flag itself, `okta:acme.okta.com`, and it loses twice.
+A credential cannot go in it, since argv is readable by every process on the machine, so the secret would have to arrive from an environment variable named after the source and now there are two places to look.
+And a national cloud, a page size or a second organisation turns one flag value into a query string nobody can read.
+
+The description never carries the credential.
+`credential_file` is a path whose contents are the credential and `credential_env` names an environment variable holding it, and a description that carries one inline is refused with a message saying which of the two to use.
+That last part is a field that exists only to be refused, because it is the mistake somebody is going to make and `unknown field` is not an answer to it.
+
+A description is checked at startup by asking the provider about a subject who does not exist.
+The answer that means everything is working is that they do not exist, which is the cheapest lookup any of these APIs has, and anything a provider will answer at all took a credential it accepted.
+A credential the provider refuses stops the server coming up, because a server that starts and then refuses every sign in looks like an outage in the search engine rather than a token somebody forgot to rotate.
+
+There is no reload loop on a description, unlike a file.
+It names a service rather than a set of people, and the people behind it change without it changing, which is what the cache above the union is for.
+
 ## What is not here yet
 
 Serving a stale answer through a directory outage.
@@ -356,8 +380,6 @@ It is a real choice with a real cost on the other side, so it should be a config
 The rest of the hosted providers.
 Okta, Entra ID and Google Workspace are done, and LDAP is the one that is not.
 
-A way to configure an adapter without writing Go.
-`-directory` takes files, and an organisation is not a file.
-All three providers want the same three things, an endpoint, a credential and a name, so the flag should grow one spelling that covers them rather than one per provider.
-Entra ID wants a fourth, since a client credentials grant is a tenant, an application and a secret rather than one token, and a secret is the one thing that must not arrive on a command line.
-Google Workspace wants the same treatment for a different shape, since a service account is a key file and the administrator to act for, and the key belongs in the file it arrived in rather than in a flag.
+A description that names more than one thing.
+One file is one provider, so a company with two Okta organisations writes two files, which is fine, and a provider that wanted a list of domains rather than one would not fit at all.
+Nothing wants that yet and the shape it should take depends on which provider asks for it first.


### PR DESCRIPTION
Closes #185.

All three adapters were reachable from Go and nothing else, so the only way to run a deployment against Okta was to import the package and build your own binary.

`-directory` keeps its exact spelling, because it already means a comma separated list of files unioned by `directory.Multi`.
A file is now either a directory written out in full or a description of a hosted one, and the two are told apart by reading them rather than by a second flag.

```json
{
  "provider": "okta",
  "name": "acme",
  "endpoint": "https://acme.okta.com",
  "credential_file": "/etc/genba/okta-token"
}
```

Entra ID takes `tenant` and `client_id` instead of an endpoint, Google Workspace takes the administrator to act for in `subject`, and `authority` moves the token endpoint for the two that have one.
A mixed list works because it was always a list of files, so the company with an Okta organisation and forty contractors in a JSON file gets one flag value and one search box.

The alternative was a spelling on the flag itself, `okta:acme.okta.com`, and it loses twice.
A credential cannot go in it, so the secret would have to arrive from an environment variable named after the source and now there are two places to look.
And a national cloud, a page size or a second organisation turns one flag value into a query string nobody can read.

The description never carries the credential.
`credential_file` is a path whose contents are the credential, which is what a mounted secret looks like, and `credential_env` names an environment variable instead, which is what a container that was handed one looks like.
For Google Workspace the credential is the whole service account key file the console hands over rather than one field out of it, so the file that arrived is the file that gets mounted and nobody has to copy a private key from one place to another.
A description that carries the credential inline is refused with a message naming the two alternatives, which is a field that exists only to be refused, because that is the mistake somebody is going to make and `unknown field` is not an answer to it.

Each provider is asked one question on the way up, about somebody who does not exist, and a credential it will not accept stops the server starting.
The answer that means everything is working is that they do not exist, which is the cheapest lookup any of these APIs has, and anything a provider will answer at all took a credential it accepted.
There is no reload loop on a description, unlike a file, because it names a service rather than a set of people and the people behind it change without the file changing.
`-directory-ttl` bounds that, exactly as it does for a file.

## What is here

`directory/provider` is the new package and it is the only place in the tree that knows all three adapters.
Nothing else may import it except the command that reads the flag, which `arch_test.go` now says.

`cmd/genbad` reads each entry once and branches on what it read, so the file is not read twice, and the credential check is bounded at twenty seconds because a tenant that accepts a connection and then says nothing would otherwise hang the server on the way up.

## Tests

The package covers a description being told from a directory and from garbage, each provider built from its own description, the credential from a file and from the environment, and a table of fifteen descriptions that cannot be used, including the inline credential, both sources, neither, a file that is not there, an empty file, a variable nobody set, a key file that is a user credential rather than a service account, and a field that means nothing to the provider named.

End to end in `cmd/genbad`, against a fake organisation: a file and an organisation unioned into one session, a credential read from the environment, a credential the organisation refuses stopping the server with an error that names the file and carries what the organisation said, and a secret that did not arrive doing the same.

The README has a section on pointing a deployment at each of the three, and `docs/identity.md` says why the description is a file rather than a spelling on the flag.
