### PR TITLE
Retry quarantined documents automatically, and put the count on a gauge

### DIFF
--- a/api/metrics.go
+++ b/api/metrics.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"time"
@@ -8,6 +9,15 @@ import (
 	"github.com/tamnd/genba/metric"
 	"github.com/tamnd/genba/store"
 )
+
+// statsBudget is how long a scrape may spend asking the store what it holds.
+//
+// It is a second because that is long enough for the count on any store that is
+// working and short enough that a store that is not does not hold the scrape
+// open. The endpoint that reports the same number to a person is on the request
+// path and has a far tighter budget than this, so a store slow enough to reach
+// this is one somebody already knows about.
+const statsBudget = time.Second
 
 // Metric names. They are constants because the alert in docs/alerts.yml names
 // them, and a rename that only edits the code leaves an alert that will never
@@ -22,6 +32,7 @@ const (
 	MetricCacheEvictions  = "genba_cache_evictions_total"
 	MetricCacheEntries    = "genba_cache_entries"
 	MetricGroupStaleness  = "genba_directory_staleness_seconds"
+	MetricQuarantined     = "genba_quarantined_documents"
 	MetricStoreRows       = "genba_store_rows_total"
 	MetricStoreStatements = "genba_store_statements_total"
 	MetricStoreDecodes    = "genba_store_decodes_total"
@@ -66,8 +77,8 @@ func newMetrics(s *Server) *metrics {
 	// label values come from the scrape rather than from registration. A
 	// deployment with result caching turned off publishes two layers instead of
 	// three, which is the truth and is more useful than a zero.
-	cacheStat := func(pick func(hits, misses, evictions, entries int64) int64) func() map[string]float64 {
-		return func() map[string]float64 {
+	cacheStat := func(pick func(hits, misses, evictions, entries int64) int64) func(context.Context) map[string]float64 {
+		return func(context.Context) map[string]float64 {
 			out := map[string]float64{}
 			for layer, st := range s.cacheStats() {
 				out[layer] = float64(pick(st.Hits, st.Misses, st.Evictions, int64(st.Entries)))
@@ -91,7 +102,7 @@ func newMetrics(s *Server) *metrics {
 	// here, which is the truth: there is no staleness to bound.
 	r.Counters(MetricGroupStaleness,
 		"The most out of date a resolved group set can be, which is the directory cache lifetime.",
-		"", "gauge", func() map[string]float64 {
+		"", "gauge", func(context.Context) map[string]float64 {
 			bounded, ok := s.auth.(interface{ staleness() (float64, bool) })
 			if !ok {
 				return nil
@@ -103,12 +114,42 @@ func newMetrics(s *Server) *metrics {
 			return map[string]float64{"": seconds}
 		})
 
+	// How many documents are being held back because their permissions did not
+	// resolve. It is the one number a held document produces anywhere, by
+	// design, and until now it was only on an endpoint somebody has to go and
+	// look at. A quarantine is normally empty and briefly non zero during a
+	// crawl, so what an operator wants is to be told when that stops being
+	// true, and being told requires a metric.
+	//
+	// A store that cannot answer publishes nothing rather than a zero. A zero
+	// here is the same shape as a healthy index and would silence the alert at
+	// exactly the moment the index stopped being able to say anything about
+	// itself, so the series goes missing instead, which is a thing an alert can
+	// be written against.
+	r.Counters(MetricQuarantined,
+		"Documents held back because their permissions did not resolve, which are invisible to every principal.",
+		"", "gauge", func(ctx context.Context) map[string]float64 {
+			// The scrape's context, bounded again, because a database that has
+			// stopped answering should cost the scrape a second rather than
+			// whatever the scrape timeout happens to be.
+			ctx, cancel := context.WithTimeout(ctx, statsBudget)
+			defer cancel()
+
+			st, err := s.store.Stats(ctx)
+			if err != nil {
+				return nil
+			}
+			return map[string]float64{"": float64(st.Quarantined)}
+		})
+
 	// A driver is not obliged to be measurable. One that is publishes the same
 	// numbers the CI gate asserts on, so a slow deployment can be compared with
 	// a green pull request instead of argued about.
 	if counted, ok := s.store.(store.Counted); ok {
-		single := func(pick func(store.Counters) int64) func() map[string]float64 {
-			return func() map[string]float64 { return map[string]float64{"": float64(pick(counted.Counters()))} }
+		single := func(pick func(store.Counters) int64) func(context.Context) map[string]float64 {
+			return func(context.Context) map[string]float64 {
+				return map[string]float64{"": float64(pick(counted.Counters()))}
+			}
 		}
 		r.Counters(MetricStoreRows, "Rows the storage driver has returned on read paths.", "", "counter",
 			single(func(c store.Counters) int64 { return c.Rows }))
@@ -132,7 +173,7 @@ func (s *Server) Metrics() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-store")
-		_, _ = s.metrics.registry.WriteTo(w)
+		_, _ = s.metrics.registry.Collect(r.Context(), w)
 	})
 }
 

--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -1,6 +1,9 @@
 package api_test
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -8,8 +11,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store"
 	"github.com/tamnd/genba/store/sqlitestore"
 )
 
@@ -155,6 +161,93 @@ func TestTheStoreCountersAreThere(t *testing.T) {
 			t.Errorf("%s is zero after a search that read the store", series)
 		}
 	}
+}
+
+// serving builds a server over a store the caller has filled, which is what the
+// quarantine tests need and the shared helper above does not give them.
+func serving(t *testing.T, st store.Store) *api.Server {
+	t.Helper()
+	searcher := index.New(st, index.WithCache(index.NewCache()))
+	t.Cleanup(func() { _ = searcher.Close() })
+	return api.New(st, searcher, api.HeaderAuth{Tenant: "acme"})
+}
+
+// withHeld returns a store holding the ordinary corpus plus n documents whose
+// permissions did not resolve.
+func withHeld(t *testing.T, n int) *sqlitestore.Store {
+	t.Helper()
+	st, err := sqlitestore.Open(t.Context(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	docs := cacheCorpus()
+	for i := range n {
+		docs = append(docs, doc.Document{
+			ID: fmt.Sprintf("held-%d", i), Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Board pack", Body: "The payments line for the quarter.",
+			Permissions: acl.Permissions{
+				Mode: acl.ModeUnknown, Source: "gdrive",
+				Reason: "the directory was unreachable",
+			},
+		})
+	}
+	if err := st.Put(t.Context(), docs...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	return st
+}
+
+// TestTheQuarantineIsAGaugeAnOperatorCanAlertOn. A held document is invisible to
+// every principal by design, so this number is the only trace it leaves
+// anywhere, and until it was a metric the only way to see it was to go and look
+// at an endpoint.
+func TestTheQuarantineIsAGaugeAnOperatorCanAlertOn(t *testing.T) {
+	s := serving(t, withHeld(t, 2))
+
+	body := scrape(t, s)
+	if got := value(t, body, api.MetricQuarantined); got != 2 {
+		t.Errorf("the quarantine gauge reads %v, want 2", got)
+	}
+	if !strings.Contains(body, "# TYPE "+api.MetricQuarantined+" gauge") {
+		t.Errorf("the quarantine is not published as a gauge:\n%s", body)
+	}
+}
+
+// TestAnEmptyQuarantineStillReportsZero, because a series that only appears once
+// something has gone wrong is one nobody can write a rule against until the
+// night it matters.
+func TestAnEmptyQuarantineStillReportsZero(t *testing.T) {
+	s := serving(t, withHeld(t, 0))
+
+	if got := value(t, scrape(t, s), api.MetricQuarantined); got != 0 {
+		t.Errorf("an index holding nothing back reads %v, want 0", got)
+	}
+}
+
+// TestAStoreThatCannotSayWhatItHoldsPublishesNothing is the difference between
+// no answer and an answer of zero. A zero here is the same shape as a healthy
+// index, so publishing one would silence the alert at exactly the moment the
+// index stopped being able to describe itself.
+func TestAStoreThatCannotSayWhatItHoldsPublishesNothing(t *testing.T) {
+	s := serving(t, silentStore{withHeld(t, 2)})
+
+	body := scrape(t, s)
+	if strings.Contains(body, "\n"+api.MetricQuarantined+" ") {
+		t.Errorf("a store that cannot answer published a count anyway:\n%s", body)
+	}
+	if got := value(t, body, "genba_store_rows_total"); got < 0 {
+		t.Errorf("the rest of the exposition went missing with it: %v", got)
+	}
+}
+
+// silentStore is a store that has stopped being able to say what it holds,
+// which is a database under load rather than an exotic failure.
+type silentStore struct{ *sqlitestore.Store }
+
+func (silentStore) Stats(context.Context) (store.Stats, error) {
+	return store.Stats{}, errors.New("the database is not answering")
 }
 
 // TestAnOpenEventStreamIsNotTimed. It is open for as long as somebody is

--- a/docs/alerts.yml
+++ b/docs/alerts.yml
@@ -38,8 +38,11 @@ groups:
 # It is a number to look at when something else is wrong rather than a reason to wake somebody, because a cold process and a busy crawl both push it down and neither is an incident.
 #
 # Quarantined documents.
-# A document whose permissions did not resolve is held back rather than served, which is the safe outcome, so a growing count is a bug report and not a page.
-# It belongs on the dashboard next to the document count.
+# genba_quarantined_documents is a gauge and it is the only trace a held document leaves anywhere, so it is worth a panel and a threshold somebody looks at during working hours.
+# It is not a page: a document whose permissions did not resolve is held back rather than served, which is the safe outcome, so a growing count is a bug report rather than a reason to wake somebody.
+# The rule to write against it is a ratchet rather than a level, because a crawl of a source with a broken role mapping puts a few thousand in there legitimately and they come back on their own.
+# Something like an increase over an hour on a deployment that is not crawling, or a count that has not fallen after a sweep, which is the retry having run and released nothing.
+# The series disappears rather than reading zero when the store cannot answer, so a rule that has to be right about this pairs the threshold with absent().
 #
 # Directory staleness.
 # genba_directory_staleness_seconds is a constant, so there is nothing in it to alert on.

--- a/ingest/reconcile.go
+++ b/ingest/reconcile.go
@@ -64,8 +64,26 @@ type Reconciliation struct {
 	// the source and is still in the index is still being served.
 	Extra Discrepancies
 
-	// Repaired is how many were refetched and stored.
+	// Held is what the index is holding back because its permissions did not
+	// resolve. It is not drift, and that is why it is not in [Drift]: the index
+	// is right about it, it is right on purpose, and it is right until whatever
+	// failed to resolve is fixed.
+	//
+	// It is refetched anyway, because the fix is at the source. A directory that
+	// was down is up, a token that could not list a channel has been given the
+	// scope, a group that did not exist has been created, and none of those
+	// change the document's revision, so nothing else in this sweep would think
+	// to ask about it again.
+	Held Discrepancies
+
+	// Repaired is how many were refetched and stored, held documents included.
 	Repaired int
+
+	// Released is how many of the held ones came back queryable, which is the
+	// number an operator watching a fix take effect is actually looking for. A
+	// sweep that refetched forty held documents and released none of them means
+	// the cause is still there.
+	Released int
 
 	// Deleted is how many were removed from the index.
 	Deleted int
@@ -101,6 +119,16 @@ func (r Reconciliation) Drift() int {
 // sweep still reports and still deletes, and the missing documents wait for a
 // full sync.
 //
+// # Quarantined documents are retried
+//
+// A document held back because its permissions did not resolve is refetched
+// too, whatever its revision says. That is the automatic retry: the reason a
+// document is held is at the source, so a directory that has come back up, a
+// token that has been given the scope it was missing or a group that has since
+// been created releases it on the next sweep without anybody going and finding
+// the ids. A sweep on an index where nothing is held costs nothing extra, and
+// [Reconciliation.Released] says how many came back.
+//
 // # Nothing is deleted on a partial enumeration
 //
 // If the walk of the source fails halfway, this returns the error and repairs
@@ -134,40 +162,47 @@ func (p *Pipeline) Reconcile(ctx context.Context, tenant genba.TenantID, c conne
 	// million. The alternative is sorting both sides on disk and merging them,
 	// which is the right answer an order of magnitude further up and is not
 	// worth its complexity here.
-	held := make(map[string]string)
+	items := make(map[string]string)
 	if err := enum.Enumerate(ctx, func(it connector.Item) bool {
 		if it.ID != "" {
-			held[it.ID] = it.Version
+			items[it.ID] = it.Version
 		}
 		return true
 	}); err != nil {
 		return rec, fmt.Errorf("ingest: enumerate %s: %w", source, err)
 	}
-	rec.SourceItems = len(held)
+	rec.SourceItems = len(items)
 
-	// Two: what the index holds. Whatever is left in held afterwards is what
+	// Two: what the index holds. Whatever is left in items afterwards is what
 	// the index has never seen.
 	var (
-		stale []string
-		extra []string
+		stale  []string
+		extra  []string
+		quaran []string
 	)
 	if err := p.maint.Inventory(ctx, string(tenant), source, func(it store.Item) bool {
 		rec.IndexItems++
-		version, ok := held[it.ID]
+		version, ok := items[it.ID]
 		switch {
 		case !ok:
 			extra = append(extra, it.ID)
 		case version != "" && version != it.Version:
 			stale = append(stale, it.ID)
+		case it.Held:
+			// Only when the source still holds it and the revision agrees, so a
+			// held document that is also stale is refetched once as stale rather
+			// than twice, and one the source has deleted is deleted rather than
+			// fetched.
+			quaran = append(quaran, it.ID)
 		}
-		delete(held, it.ID)
+		delete(items, it.ID)
 		return true
 	}); err != nil {
 		return rec, fmt.Errorf("ingest: inventory %s: %w", source, err)
 	}
 
-	missing := make([]string, 0, len(held))
-	for id := range held {
+	missing := make([]string, 0, len(items))
+	for id := range items {
 		missing = append(missing, id)
 	}
 	// Sorted so that two sweeps over the same drift report the same sample, and
@@ -176,6 +211,7 @@ func (p *Pipeline) Reconcile(ctx context.Context, tenant genba.TenantID, c conne
 	slices.Sort(missing)
 	slices.Sort(stale)
 	slices.Sort(extra)
+	slices.Sort(quaran)
 
 	for _, id := range missing {
 		rec.Missing.add(id)
@@ -186,8 +222,11 @@ func (p *Pipeline) Reconcile(ctx context.Context, tenant genba.TenantID, c conne
 	for _, id := range extra {
 		rec.Extra.add(id)
 	}
+	for _, id := range quaran {
+		rec.Held.add(id)
+	}
 
-	if err := p.repair(ctx, string(tenant), c, &rec, missing, stale, extra); err != nil {
+	if err := p.repair(ctx, string(tenant), c, &rec, missing, stale, extra, quaran); err != nil {
 		rec.Duration = p.clock().Sub(start)
 		rec.Requests = countersOf(c).Since(before)
 		return rec, err
@@ -204,7 +243,9 @@ func (p *Pipeline) Reconcile(ctx context.Context, tenant genba.TenantID, c conne
 		"missing", rec.Missing.Count,
 		"stale", rec.Stale.Count,
 		"extra", rec.Extra.Count,
+		"held", rec.Held.Count,
 		"repaired", rec.Repaired,
+		"released", rec.Released,
 		"deleted", rec.Deleted,
 		"requests", rec.Requests.Requests(),
 		"duration", rec.Duration,
@@ -220,7 +261,7 @@ func (p *Pipeline) Reconcile(ctx context.Context, tenant genba.TenantID, c conne
 // and source stamping and the same quarantine rule as one that arrived from a
 // change feed. A document that is only correct when it comes in through one of
 // the two doors is a bug waiting for the other door.
-func (p *Pipeline) repair(ctx context.Context, tenant string, c connector.Connector, rec *Reconciliation, missing, stale, extra []string) error {
+func (p *Pipeline) repair(ctx context.Context, tenant string, c connector.Connector, rec *Reconciliation, missing, stale, extra, held []string) error {
 	r := &run{pipeline: p, tenant: tenant, source: c.Source()}
 
 	for _, id := range extra {
@@ -231,12 +272,12 @@ func (p *Pipeline) repair(ctx context.Context, tenant string, c connector.Connec
 
 	fetcher, ok := c.(connector.Fetcher)
 	if !ok {
-		if n := len(missing) + len(stale); n > 0 {
+		if n := len(missing) + len(stale) + len(held); n > 0 {
 			// Said once, loudly, rather than per document. A connector that
 			// cannot fetch by id is not broken, but an operator reading a report
 			// with a missing count in it needs to know why nothing happened
 			// about it.
-			p.log.Warn("documents are missing or stale and this connector cannot fetch by id, so they wait for a full sync",
+			p.log.Warn("documents are missing, stale or held and this connector cannot fetch by id, so they wait for a full sync",
 				"source", c.Source(), "tenant", tenant, "count", n)
 		}
 		if err := r.flush(ctx); err != nil {
@@ -246,25 +287,45 @@ func (p *Pipeline) repair(ctx context.Context, tenant string, c connector.Connec
 		return nil
 	}
 
-	for _, id := range slices.Concat(missing, stale) {
-		d, err := fetcher.Fetch(ctx, id)
-		switch {
-		case errors.Is(err, connector.ErrGone):
-			// The source changed its mind between the enumeration and now,
-			// which is normal on a corpus people are working in. It is not
-			// missing, it is deleted, and it is treated as one.
-			if err := r.emit(ctx, connector.Change{Document: docWithID(id), Deleted: true}); err != nil {
+	refetch := func(ids []string) error {
+		for _, id := range ids {
+			d, err := fetcher.Fetch(ctx, id)
+			switch {
+			case errors.Is(err, connector.ErrGone):
+				// The source changed its mind between the enumeration and now,
+				// which is normal on a corpus people are working in. It is not
+				// missing, it is deleted, and it is treated as one.
+				if err := r.emit(ctx, connector.Change{Document: docWithID(id), Deleted: true}); err != nil {
+					return err
+				}
+				continue
+			case err != nil:
+				return fmt.Errorf("ingest: fetch %s from %s: %w", id, c.Source(), err)
+			}
+			d.ID = id
+			if err := r.emit(ctx, connector.Change{Document: d}); err != nil {
 				return err
 			}
-			continue
-		case err != nil:
-			return fmt.Errorf("ingest: fetch %s from %s: %w", id, c.Source(), err)
 		}
-		d.ID = id
-		if err := r.emit(ctx, connector.Change{Document: d}); err != nil {
-			return err
-		}
+		return nil
 	}
+
+	if err := refetch(slices.Concat(missing, stale)); err != nil {
+		return err
+	}
+
+	// The held ones are fetched second and counted separately, because what
+	// they answer is a different question. Everything above is drift, and a
+	// number that mixed the two would be one an operator cannot use: a sweep
+	// that indexed forty documents says nothing about whether the directory
+	// somebody has just fixed is fixed. The counter moves in emit rather than in
+	// the flush, so this reads the line between the two without writing
+	// anything in the middle of a batch.
+	indexed := r.stats.Indexed
+	if err := refetch(held); err != nil {
+		return err
+	}
+	rec.Released = r.stats.Indexed - indexed
 
 	if err := r.flush(ctx); err != nil {
 		return err

--- a/ingest/reconcile_test.go
+++ b/ingest/reconcile_test.go
@@ -103,6 +103,24 @@ func (s *listedSource) remove(id string) {
 	s.order = slices.DeleteFunc(s.order, func(x string) bool { return x == id })
 }
 
+// unresolved makes the source hand back a document whose permissions did not
+// resolve, which is the document the index stores and holds back. It leaves the
+// revision alone, because that is the whole point: nothing about the document
+// changed, only what the source could say about who may read it.
+func (s *listedSource) unresolved(id, reason string) {
+	d := s.held[id]
+	d.Permissions = connector.Unresolved(s.name, reason)
+	s.held[id] = d
+}
+
+// resolved is the fix, whatever it was: the directory came back up, the token
+// was given the scope it was missing, the group now exists.
+func (s *listedSource) resolved(id string) {
+	d := s.held[id]
+	d.Permissions = acl.Permissions{Mode: acl.ModePublicToTenant, Source: s.name}
+	s.held[id] = d
+}
+
 // corpus builds a source holding n documents at revision one.
 func corpus(name string, n int) *listedSource {
 	s := &listedSource{name: name}
@@ -176,6 +194,120 @@ func TestReconcileIsQuietWhenNothingDrifted(t *testing.T) {
 	}
 	if rec.Requests.Lists != 1 {
 		t.Fatalf("the sweep made %d enumerations, want 1", rec.Requests.Lists)
+	}
+	if rec.Held.Count != 0 || rec.Released != 0 {
+		t.Fatalf("a sweep over an index holding nothing back reported %d held and %d released", rec.Held.Count, rec.Released)
+	}
+}
+
+// TestReconcileReleasesWhatTheSourceCanNowResolve is the automatic retry. A
+// document held back because its permissions did not resolve is refetched
+// whatever its revision says, because the reason it is held is at the source and
+// the fix does not touch the document.
+func TestReconcileReleasesWhatTheSourceCanNowResolve(t *testing.T) {
+	p, st := pipelineOver(t)
+	src := corpus("test", 4)
+	src.unresolved("doc-0001", "the directory was unreachable")
+	reconcile(t, p, src)
+
+	if _, err := st.Get(t.Context(), principal(), "doc-0001"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("a document whose permissions did not resolve is readable: %v", err)
+	}
+
+	src.resolved("doc-0001")
+	src.fetched = nil
+	rec := reconcile(t, p, src)
+
+	if rec.Held.Count != 1 || !slices.Equal(rec.Held.IDs, []string{"doc-0001"}) {
+		t.Fatalf("the sweep reported %d held documents, ids %v, want doc-0001", rec.Held.Count, rec.Held.IDs)
+	}
+	if rec.Drift() != 0 {
+		t.Fatalf("a held document was counted as drift: %d discrepancies", rec.Drift())
+	}
+	if rec.Released != 1 || rec.Repaired != 1 {
+		t.Fatalf("the sweep released %d and repaired %d, want 1 and 1", rec.Released, rec.Repaired)
+	}
+	if !slices.Equal(src.fetched, []string{"doc-0001"}) {
+		t.Fatalf("the sweep fetched %v, want only the held document", src.fetched)
+	}
+	if _, err := st.Get(t.Context(), principal(), "doc-0001"); err != nil {
+		t.Fatalf("a released document is still not readable: %v", err)
+	}
+}
+
+// TestReconcileKeepsHoldingWhatStillDoesNotResolve is the other half, and it is
+// the half that says the retry is safe to run every night. A refetch that comes
+// back unresolved again leaves the document exactly where it was, and the
+// released count says so.
+func TestReconcileKeepsHoldingWhatStillDoesNotResolve(t *testing.T) {
+	p, st := pipelineOver(t)
+	src := corpus("test", 3)
+	src.unresolved("doc-0002", "the group could not be listed")
+	reconcile(t, p, src)
+
+	src.fetched = nil
+	rec := reconcile(t, p, src)
+
+	if rec.Held.Count != 1 {
+		t.Fatalf("the sweep reported %d held documents, want 1", rec.Held.Count)
+	}
+	if rec.Released != 0 {
+		t.Fatalf("the sweep released %d documents whose permissions still do not resolve", rec.Released)
+	}
+	if !slices.Equal(src.fetched, []string{"doc-0002"}) {
+		t.Fatalf("the sweep fetched %v, want the held document retried", src.fetched)
+	}
+	if _, err := st.Get(t.Context(), principal(), "doc-0002"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("a retry that failed made the document readable: %v", err)
+	}
+}
+
+// TestReconcileDeletesAHeldDocumentTheSourceRemoved. A document that is held and
+// has also gone from the source is not a retry, it is a deletion, and fetching
+// it would be a request that can only fail.
+func TestReconcileDeletesAHeldDocumentTheSourceRemoved(t *testing.T) {
+	p, st := pipelineOver(t)
+	src := corpus("test", 3)
+	src.unresolved("doc-0001", "the directory was unreachable")
+	reconcile(t, p, src)
+
+	src.remove("doc-0001")
+	src.fetched = nil
+	rec := reconcile(t, p, src)
+
+	if rec.Held.Count != 0 {
+		t.Fatalf("a document the source no longer holds was reported as held")
+	}
+	if rec.Extra.Count != 1 || rec.Deleted != 1 {
+		t.Fatalf("the sweep reported %d extra and deleted %d, want 1 and 1", rec.Extra.Count, rec.Deleted)
+	}
+	if len(src.fetched) != 0 {
+		t.Fatalf("the sweep fetched %v, want nothing fetched for a deleted document", src.fetched)
+	}
+	if _, err := st.Get(t.Context(), principal(), "doc-0001"); !errors.Is(err, genba.ErrNotFound) {
+		t.Fatalf("a held document deleted at the source is still in the index: %v", err)
+	}
+}
+
+// TestReconcileFetchesAHeldStaleDocumentOnce. Both reasons to refetch apply to
+// the same document, and a sweep that acted on both would spend two requests to
+// store the same bytes twice.
+func TestReconcileFetchesAHeldStaleDocumentOnce(t *testing.T) {
+	p, _ := pipelineOver(t)
+	src := corpus("test", 3)
+	src.unresolved("doc-0001", "the directory was unreachable")
+	reconcile(t, p, src)
+
+	// A new revision, which also carries permissions that resolve.
+	src.put("doc-0001", "v2", "the body, rewritten")
+	src.fetched = nil
+	rec := reconcile(t, p, src)
+
+	if rec.Stale.Count != 1 || rec.Held.Count != 0 {
+		t.Fatalf("the sweep reported %d stale and %d held, want the document counted once as stale", rec.Stale.Count, rec.Held.Count)
+	}
+	if !slices.Equal(src.fetched, []string{"doc-0001"}) {
+		t.Fatalf("the sweep fetched %v, want one fetch of doc-0001", src.fetched)
 	}
 }
 

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -28,6 +28,7 @@
 package metric
 
 import (
+	"context"
 	"io"
 	"maps"
 	"math"
@@ -67,7 +68,13 @@ type family struct {
 	// write appends the series of this family. It runs at scrape time, which is
 	// what lets a counter read a structure that was already counting rather
 	// than requiring every counter in the process to be a metric.
-	write func(*encoder)
+	//
+	// It takes the scrape's context because some of what is read at scrape time
+	// is not a number in memory. A family backed by a database has to be able to
+	// give up when the scrape has, and a monitoring system that holds a
+	// connection open against a store that has stopped answering makes an
+	// incident worse rather than describing it.
+	write func(context.Context, *encoder)
 }
 
 // New returns an empty registry.
@@ -80,7 +87,7 @@ func New() *Registry {
 // A duplicate is a programming error found at startup rather than a scrape that
 // silently reports one of two meanings for the same name, which is the failure
 // that wastes an afternoon during an incident.
-func (r *Registry) register(name, help, kind string, write func(*encoder)) {
+func (r *Registry) register(name, help, kind string, write func(context.Context, *encoder)) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, ok := r.families[name]; ok {
@@ -121,7 +128,7 @@ func (r *Registry) NewHistogram(name, help, label string, buckets []float64) *Hi
 		series:  map[string]*bucketSet{},
 	}
 	slices.Sort(h.buckets)
-	r.register(name, help, "histogram", func(e *encoder) { h.write(e, name) })
+	r.register(name, help, "histogram", func(_ context.Context, e *encoder) { h.write(e, name) })
 	return h
 }
 
@@ -184,9 +191,14 @@ func (h *Histogram) pairs(value string, extra ...string) []string {
 //
 // kind is "counter" for anything that only goes up and "gauge" for anything
 // that can go down, which the format needs and which a reader needs more.
-func (r *Registry) Counters(name, help, label, kind string, read func() map[string]float64) {
-	r.register(name, help, kind, func(e *encoder) {
-		values := read()
+//
+// The read is given the scrape's context, and one that has to go and ask
+// something slower than a mutex should honour it. A read that returns nothing
+// publishes no series at all, which is how a family says it has no answer
+// rather than answering zero.
+func (r *Registry) Counters(name, help, label, kind string, read func(context.Context) map[string]float64) {
+	r.register(name, help, kind, func(ctx context.Context, e *encoder) {
+		values := read(ctx)
 		for _, key := range slices.Sorted(maps.Keys(values)) {
 			if label == "" {
 				e.series(name, nil, values[key])
@@ -197,8 +209,12 @@ func (r *Registry) Counters(name, help, label, kind string, read func() map[stri
 	})
 }
 
-// WriteTo writes an exposition of every family.
-func (r *Registry) WriteTo(w io.Writer) (int64, error) {
+// Collect writes an exposition of every family.
+//
+// The context belongs to the scrape that asked. It is passed to every family
+// that reads something at scrape time, so a scrape the client has given up on
+// stops costing the process anything.
+func (r *Registry) Collect(ctx context.Context, w io.Writer) (int64, error) {
 	r.mu.Lock()
 	names := slices.Clone(r.order)
 	families := maps.Clone(r.families)
@@ -209,16 +225,20 @@ func (r *Registry) WriteTo(w io.Writer) (int64, error) {
 		f := families[name]
 		e.buf.WriteString("# HELP " + name + " " + strings.NewReplacer("\\", `\\`, "\n", `\n`).Replace(f.help) + "\n")
 		e.buf.WriteString("# TYPE " + name + " " + f.kind + "\n")
-		f.write(e)
+		f.write(ctx, e)
 	}
 	n, err := io.WriteString(w, e.buf.String())
 	return int64(n), err
 }
 
-// String returns the exposition, which is what the tests read.
-func (r *Registry) String() string {
+// Text returns the exposition as a string, which is what the tests read.
+//
+// It is not called String, because a String that takes an argument is not the
+// method everything else in Go means by that name and would be called by a
+// print statement that was never meant to scrape anything.
+func (r *Registry) Text(ctx context.Context) string {
 	var sb strings.Builder
-	_, _ = r.WriteTo(&sb)
+	_, _ = r.Collect(ctx, &sb)
 	return sb.String()
 }
 

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -1,6 +1,7 @@
 package metric_test
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"testing"
@@ -19,7 +20,7 @@ func TestAHistogramIsCumulative(t *testing.T) {
 		h.Observe(v, "/search")
 	}
 
-	got := r.String()
+	got := r.Text(t.Context())
 	for _, want := range []string{
 		`genba_test_ms_bucket{endpoint="/search",le="1"} 1`,
 		`genba_test_ms_bucket{endpoint="/search",le="10"} 3`,
@@ -43,7 +44,7 @@ func TestAHistogramWithoutALabelHasNoBraces(t *testing.T) {
 	h := r.NewHistogram("genba_test_size", "how big a thing was", "", []float64{1, 10})
 	h.Observe(5, "")
 
-	got := r.String()
+	got := r.Text(t.Context())
 	if strings.Contains(got, "{}") {
 		t.Errorf("a series carries an empty label set:\n%s", got)
 	}
@@ -62,7 +63,7 @@ func TestALabelValueCannotBreakTheFormat(t *testing.T) {
 	h := r.NewHistogram("genba_test_ms", "how long a thing took", "endpoint", []float64{1})
 	h.Observe(1, "/a\"b\\c\nd")
 
-	got := r.String()
+	got := r.Text(t.Context())
 	if !strings.Contains(got, `endpoint="/a\"b\\c\nd"`) {
 		t.Errorf("the label value was not escaped:\n%s", got)
 	}
@@ -79,21 +80,49 @@ func TestALabelValueCannotBreakTheFormat(t *testing.T) {
 func TestCountersAreReadAtScrapeTime(t *testing.T) {
 	r := metric.New()
 	live := map[string]float64{"results": 1}
-	r.Counters("genba_test_hits_total", "cache hits", "layer", "counter", func() map[string]float64 {
-		return live
-	})
+	r.Counters("genba_test_hits_total", "cache hits", "layer", "counter",
+		func(context.Context) map[string]float64 { return live })
 
-	if got := r.String(); !strings.Contains(got, `genba_test_hits_total{layer="results"} 1`) {
+	if got := r.Text(t.Context()); !strings.Contains(got, `genba_test_hits_total{layer="results"} 1`) {
 		t.Fatalf("the first scrape is wrong:\n%s", got)
 	}
 	live["results"] = 9
 	live["documents"] = 4
-	got := r.String()
+	got := r.Text(t.Context())
 	if !strings.Contains(got, `genba_test_hits_total{layer="results"} 9`) {
 		t.Errorf("the second scrape did not re read the source:\n%s", got)
 	}
 	if !strings.Contains(got, `genba_test_hits_total{layer="documents"} 4`) {
 		t.Errorf("a layer that appeared between scrapes is missing:\n%s", got)
+	}
+}
+
+// TestAFamilyThatCannotAnswerPublishesNoSeries. The read is given the scrape's
+// context so that a family backed by something slower than a mutex can give up,
+// and what it publishes when it does is nothing. A zero would be the same shape
+// as a healthy reading, which is the one thing an alert cannot tell apart.
+func TestAFamilyThatCannotAnswerPublishesNoSeries(t *testing.T) {
+	r := metric.New()
+	r.Counters("genba_test_held", "documents held back", "", "gauge",
+		func(ctx context.Context) map[string]float64 {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return map[string]float64{"": 3}
+		})
+
+	if got := r.Text(t.Context()); !strings.Contains(got, "\ngenba_test_held 3\n") {
+		t.Fatalf("a family that could answer published nothing:\n%s", got)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	got := r.Text(ctx)
+	if strings.Contains(got, "\ngenba_test_held ") {
+		t.Errorf("a family that could not answer published a value anyway:\n%s", got)
+	}
+	if !strings.Contains(got, "# TYPE genba_test_held gauge") {
+		t.Errorf("the family lost its declaration as well as its series:\n%s", got)
 	}
 }
 
@@ -124,13 +153,13 @@ func TestObservingFromEveryGoroutineIsSafe(t *testing.T) {
 			for range 200 {
 				h.Observe(float64(i), "/search")
 			}
-			_ = r.String()
+			_ = r.Text(t.Context())
 		}()
 	}
 	wg.Wait()
 
-	if !strings.Contains(r.String(), `genba_test_ms_count{endpoint="/search"} 1600`) {
-		t.Errorf("observations were lost:\n%s", r.String())
+	if !strings.Contains(r.Text(t.Context()), `genba_test_ms_count{endpoint="/search"} 1600`) {
+		t.Errorf("observations were lost:\n%s", r.Text(t.Context()))
 	}
 }
 

--- a/store/maintain.go
+++ b/store/maintain.go
@@ -21,6 +21,23 @@ type Item struct {
 	// ever compares it to the version the connector reports now, and a
 	// difference means the stored copy is behind.
 	Version string
+
+	// Held is whether the document is being held back because its permissions
+	// did not resolve.
+	//
+	// It is here because a held document is the one kind of drift the version
+	// comparison cannot see. The source and the index agree about the revision,
+	// so nothing above would think to refetch it, and yet the reason it is held
+	// is at the source: a directory that was down, a token that could not list
+	// a channel, a group that has since been created. Without this the retry
+	// would have to be a second pass over the corpus asking each document
+	// whether it resolved, which is the read of the whole corpus this interface
+	// exists to avoid.
+	//
+	// It says nothing about why. That is [Held.Reason], and it is on the
+	// capability that is allowed to say a little about a document rather than
+	// on the one that is only allowed to compare two lists.
+	Held bool
 }
 
 // Maintenance is the capability the ingestion pipeline needs and no query path
@@ -47,10 +64,10 @@ type Maintenance interface {
 	// Inventory calls fn for every document held for one tenant and source, and
 	// stops early if fn returns false. The order is unspecified.
 	//
-	// Quarantined documents are included. A document whose permissions did not
-	// resolve is still a document the source may since have deleted, and
-	// leaving it out would make reconciliation the one path that cannot clean
-	// up the very documents an operator most wants gone.
+	// Quarantined documents are included, with [Item.Held] set. A document
+	// whose permissions did not resolve is still a document the source may
+	// since have deleted, and leaving it out would make reconciliation the one
+	// path that cannot clean up the very documents an operator most wants gone.
 	Inventory(ctx context.Context, tenant, source string, fn func(Item) bool) error
 
 	// SetPermissions replaces the access control list of documents that are

--- a/store/memstore/maintain.go
+++ b/store/memstore/maintain.go
@@ -30,7 +30,7 @@ func (s *Store) Inventory(ctx context.Context, tenant, source string, fn func(st
 		if d.Tenant != tenant || d.Source != source {
 			continue
 		}
-		if !fn(store.Item{ID: d.ID, Version: d.SourceUpdate}) {
+		if !fn(store.Item{ID: d.ID, Version: d.SourceUpdate, Held: !d.Queryable()}) {
 			return nil
 		}
 	}

--- a/store/pgstore/maintain.go
+++ b/store/pgstore/maintain.go
@@ -92,16 +92,18 @@ func (s *Store) Quarantined(ctx context.Context, tenant string, limit int) ([]st
 
 // Inventory calls fn for every document held for one tenant and source.
 //
-// It reads two columns of one table and nothing else. A reconciliation over a
+// It reads three columns of one table and nothing else. A reconciliation over a
 // corpus of a few million documents is a few million ids, and decoding the
 // stored JSON for each of them to reach a field the comparison does not use
-// would turn an index scan into a read of the corpus.
+// would turn an index scan into a read of the corpus. The third column is the
+// flag the query path already filters on, so a held document costs a boolean
+// here rather than a second pass.
 func (s *Store) Inventory(ctx context.Context, tenant, source string, fn func(store.Item) bool) error {
 	if err := s.ready(ctx); err != nil {
 		return err
 	}
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, source_update FROM document WHERE tenant = $1 AND source = $2 ORDER BY id`, tenant, source)
+		`SELECT id, source_update, NOT queryable FROM document WHERE tenant = $1 AND source = $2 ORDER BY id`, tenant, source)
 	if err != nil {
 		return fmt.Errorf("pgstore: inventory: %w", err)
 	}
@@ -109,7 +111,7 @@ func (s *Store) Inventory(ctx context.Context, tenant, source string, fn func(st
 
 	for rows.Next() {
 		var item store.Item
-		if err := rows.Scan(&item.ID, &item.Version); err != nil {
+		if err := rows.Scan(&item.ID, &item.Version, &item.Held); err != nil {
 			return fmt.Errorf("pgstore: inventory: %w", err)
 		}
 		if !fn(item) {

--- a/store/sqlitestore/maintain.go
+++ b/store/sqlitestore/maintain.go
@@ -77,16 +77,18 @@ func (s *Store) Quarantined(ctx context.Context, tenant string, limit int) ([]st
 
 // Inventory calls fn for every document held for one tenant and source.
 //
-// It reads two columns of one table and nothing else. A reconciliation over a
+// It reads three columns of one table and nothing else. A reconciliation over a
 // corpus of a few million documents is a few million ids, and decoding the
 // stored JSON for each of them to reach a field the comparison does not use
-// would turn a scan of an index into a read of the whole corpus.
+// would turn a scan of an index into a read of the whole corpus. The third
+// column is the flag the query path already filters on, so a held document
+// costs a boolean here rather than a second pass.
 func (s *Store) Inventory(ctx context.Context, tenant, source string, fn func(store.Item) bool) error {
 	if err := s.ready(ctx); err != nil {
 		return err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, source_update FROM document WHERE tenant = ? AND source = ?`, tenant, source)
+		`SELECT id, source_update, queryable FROM document WHERE tenant = ? AND source = ?`, tenant, source)
 	if err != nil {
 		return fmt.Errorf("sqlitestore: inventory: %w", err)
 	}
@@ -94,13 +96,14 @@ func (s *Store) Inventory(ctx context.Context, tenant, source string, fn func(st
 
 	for rows.Next() {
 		var (
-			id      string
-			version sql.NullString
+			id        string
+			version   sql.NullString
+			queryable bool
 		)
-		if err := rows.Scan(&id, &version); err != nil {
+		if err := rows.Scan(&id, &version, &queryable); err != nil {
 			return fmt.Errorf("sqlitestore: inventory: %w", err)
 		}
-		if !fn(store.Item{ID: id, Version: version.String}) {
+		if !fn(store.Item{ID: id, Version: version.String, Held: !queryable}) {
 			return nil
 		}
 	}

--- a/store/storetest/maintain.go
+++ b/store/storetest/maintain.go
@@ -47,6 +47,7 @@ var maintainCases = []maintainCase{
 	{"inventory lists one source of one tenant", testInventoryScope},
 	{"inventory reports the stored version", testInventoryVersion},
 	{"inventory includes quarantined documents", testInventoryQuarantined},
+	{"inventory says which documents are held", testInventoryReportsHeld},
 	{"inventory stops when the callback says so", testInventoryEarlyStop},
 	{"a permission change does not rewrite the document", testSetPermissionsKeepsContent},
 	{"a permission change ignores ids of another tenant", testSetPermissionsTenant},
@@ -139,6 +140,39 @@ func testInventoryQuarantined(t *testing.T, s store.Store, m store.Maintenance) 
 
 	if ids := inventoryIDs(t, m, "acme", "gdrive"); !slices.Equal(ids, []string{"d1", "d2"}) {
 		t.Fatalf("Inventory returned %v, want the quarantined document too", ids)
+	}
+}
+
+// testInventoryReportsHeld is what the automatic retry stands on. A held
+// document is the one kind of drift the version comparison cannot see, because
+// the source and the index agree about the revision and the reason it is held is
+// at the source, so a driver that reported nothing here would leave the
+// quarantine to be emptied by hand.
+func testInventoryReportsHeld(t *testing.T, s store.Store, m store.Maintenance) {
+	bad := versioned("d2", "gdrive", "v1")
+	bad.Permissions = acl.Permissions{Mode: acl.ModeUnknown, Source: "gdrive", Reason: "the directory was unreachable"}
+	mustPut(t, s, versioned("d1", "gdrive", "v1"), bad)
+
+	held := map[string]bool{}
+	for _, it := range inventory(t, m, "acme", "gdrive") {
+		held[it.ID] = it.Held
+	}
+	if held["d1"] {
+		t.Error("a queryable document was reported as held, so every sweep would refetch the whole corpus")
+	}
+	if !held["d2"] {
+		t.Error("a quarantined document was not reported as held, so nothing would ever retry it")
+	}
+
+	// And it moves. A document that resolves stops being held, which is the
+	// answer the sweep after a fixed directory has to get.
+	good := versioned("d2", "gdrive", "v1")
+	mustPut(t, s, good)
+
+	for _, it := range inventory(t, m, "acme", "gdrive") {
+		if it.ID == "d2" && it.Held {
+			t.Error("a document whose permissions resolved is still reported as held")
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #20.

A quarantined document is one the pipeline stored and held back because its permissions did not resolve.
It is invisible to every principal, which is the safe answer, and until this change nothing went and looked at it again.

## The retry

The reason a document is held is at the source.
A directory that was unreachable is up again, a token has been given the scope it was missing, a group that did not exist has been created.
None of those touch the document, so its revision is the same on both sides and the version comparison reconciliation already does cannot see it.
The ids only exist in the index.

So the sweep refetches them.
`store.Item` gained a `Held` field, which sqlite and postgres fill from the `queryable` column they already filter every query on, and memstore fills from the document.
`Reconcile` collects the held ids next to the missing and the stale ones, and `repair` fetches them in a second pass.

The second pass is what makes the number worth reading.
`Reconciliation.Released` counts only the held documents that came back queryable, because a sweep that indexed forty documents says nothing about whether the directory somebody has just fixed is fixed, and a sweep that retried forty and released none of them says the cause is still there.
`Held` is reported but is deliberately not part of `Drift()`: the index is right about a held document, it is right on purpose, and it stays right until the source can answer.

Two cases the ordering settles:

- A held document that is also stale is fetched once, as stale, rather than twice.
- A held document the source has deleted is deleted rather than fetched.

Reconciliation already runs after a sync, so this is the automatic retry with no new scheduler and nothing for an operator to run.
A sweep over an index with nothing held costs nothing extra.

## The metric

`genba_quarantined_documents` is a gauge, read from `store.Stats` at scrape time.
It is the only trace a held document leaves anywhere, and before this the only way to see it was to open an admin endpoint and look.

A store that cannot answer publishes no series at all rather than a zero.
A zero here is the same shape as a healthy index, so publishing one would silence the alert at exactly the moment the index stopped being able to describe itself.
`docs/alerts.yml` says how to use it: a panel and a threshold during working hours rather than a page, written as a ratchet rather than a level, paired with `absent()` because the series can go away.

## One thing that had to move

Reading a gauge out of a database at scrape time means the scrape needs a deadline, and the registry had no way to carry one.
`Registry.Collect(ctx, w)` replaces `WriteTo(w)`, and a counter family's read now takes the scrape's context.
Everything already in memory ignores it. The store backed gauge bounds it again at one second, so a database that has stopped answering costs a scrape a second rather than the scrape timeout.

## Testing

- Five cases in `ingest`: released when the source recovers, still held when it does not, deleted when the source removed it, fetched once when it is also stale, and nothing extra fetched when nothing is held.
- The inventory flag is a conformance case in `store/storetest`, so sqlite, postgres and memstore all have to agree about it.
- Three cases in `api` for the gauge, including the empty index reading zero and the store that cannot answer publishing nothing.
- `go test ./...` and `golangci-lint run` are clean.