### PR TITLE
Add an audit log for content access

### DIFF
--- a/arch_test.go
+++ b/arch_test.go
@@ -68,6 +68,13 @@ var allowed = map[string][]string{
 	// deliberately not behind the permission check.
 	"metric": nil,
 
+	// audit imports nothing of ours for the same reason again, and with more at
+	// stake. A record is plain strings, so the package that writes the trail
+	// cannot pull a document or a principal into a file that is deliberately
+	// easier to ship off the machine than the index is. Mapping a principal onto
+	// a record is the job of the package that already has one.
+	"audit": nil,
+
 	"store": {"acl", "doc"},
 
 	// segment is the on disk format and imports nothing of ours, not even doc.

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -1,0 +1,413 @@
+// Package audit records who saw what.
+//
+// Any company that would run a search engine over its own documents has to be
+// able to answer that question, and answer it months after the fact, usually to
+// somebody who is not going to accept "the logs have rolled". So this is not a
+// feature of the interface, it is a property of the system: every path that
+// returns content writes a record, there is no configuration that turns it off,
+// and the only thing a deployment chooses is where the records go and how long
+// they are kept.
+//
+// # What is in a record
+//
+// A record says who asked, what they asked, which documents came back and
+// through which surface. It does not say what was in them. A title is content
+// and a snippet is more of it, so neither is here: an audit log that quoted the
+// documents would be a second copy of the corpus, kept for years, in a file that
+// is deliberately easier to ship off the machine than the index is.
+//
+// Group names are left out for the same reason with a different edge to it. The
+// rule that admitted somebody is recorded, because "they own it" and "the
+// document is public to the tenant" are different facts about an access, but the
+// group that matched is not, because a log of access decisions that named groups
+// would describe the shape of an organisation to anybody who can read it.
+//
+// # What it costs
+//
+// Records are handed to a writer that runs on its own goroutine, so a request
+// pays a channel send rather than a write to disk. The queue is bounded and a
+// full one blocks the request rather than dropping the record, which is the
+// deliberate choice: an audit log with a hole in it exactly where the busiest
+// minute of the day was is worse than a slow request, because nobody can tell
+// afterwards which of the two it was.
+//
+// # Where they go
+//
+// [Logging] writes them to the process log, which is the default and is why
+// there is no way to switch this off: a deployment that configures nothing still
+// has its records in whatever it already collects. [Open] writes JSON Lines to a
+// directory, one file per day, which is the shape an existing system can ingest
+// without anybody writing a parser. See docs/audit.md.
+package audit
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Action is what somebody did, in the vocabulary of the product rather than of
+// HTTP. A person who reads an audit log is looking for "who downloaded that",
+// and GET is not the answer to it.
+type Action string
+
+// The actions. They are constants because an export is read by something that
+// filters on them, and a typo in a string literal is a filter that silently
+// matches nothing.
+const (
+	// Search is a query against the corpus. The documents on the record are the
+	// page that came back, which is what was actually shown to somebody.
+	Search Action = "search"
+
+	// Suggest is the typeahead. It is separate from a search because it runs on
+	// every keystroke and its records are the noisiest thing in the log, and
+	// somebody reading a person's activity needs to be able to tell the two
+	// apart at a glance.
+	Suggest Action = "suggest"
+
+	// List is a surface that returns documents without a query: what somebody
+	// opened recently, what has been reported as out of date.
+	List Action = "list"
+
+	// Read is one document opened, which is the record most questions are
+	// really about.
+	Read Action = "read"
+
+	// Content is the bytes themselves leaving the system, which is the one
+	// somebody investigating an incident looks for first.
+	Content Action = "content"
+
+	// Thumbnail is a rendering of those bytes. It is not the document and it is
+	// enough of it to read a page over somebody's shoulder, so it is audited
+	// like the content it comes from.
+	Thumbnail Action = "thumbnail"
+)
+
+// Outcome is what happened.
+type Outcome string
+
+const (
+	// Served means content came back.
+	Served Outcome = "served"
+
+	// Refused means the request was answered without content: no such document,
+	// nothing this person may read, or a role they do not have. The three are
+	// deliberately one outcome here, for the same reason the API answers all
+	// three with a 404. An audit log that separated them would be a way of
+	// proving a document exists to somebody who cannot read it, and it would be
+	// read by more people than the API is.
+	Refused Outcome = "refused"
+
+	// Failed means the request could not be answered. It is not a refusal and it
+	// is not an access, and an investigation that counted it as either would be
+	// counting outages as behaviour.
+	Failed Outcome = "failed"
+)
+
+// Item is one document on a record.
+//
+// It is an id and where it came from, and never a title. The id is what an
+// investigation follows back into the source, and the source is what turns a
+// list of ids into a sentence somebody can act on: eleven documents out of the
+// shared drive rather than eleven documents.
+type Item struct {
+	ID     string `json:"id"`
+	Source string `json:"source,omitempty"`
+}
+
+// Record is one access.
+type Record struct {
+	// At is when the request was answered, in UTC. It is stamped by the log
+	// rather than by the caller, so that two records cannot disagree about
+	// order because two handlers read the clock differently.
+	At time.Time `json:"at"`
+
+	// Tenant and Subject are who asked. Subject is the identity the deployment
+	// authenticated, which is what an investigation has to be able to join
+	// against a directory months later.
+	Tenant  string `json:"tenant"`
+	Subject string `json:"subject"`
+
+	// Kind is what sort of principal it was, a person or a service account.
+	// Every deployment eventually has an integration reading documents on a
+	// schedule, and an audit log where those are indistinguishable from people
+	// is one where the interesting rows are buried.
+	Kind string `json:"kind,omitempty"`
+
+	// Surface is the route pattern the access came through, so a record says
+	// through which door rather than only which document. The pattern rather
+	// than the path, because a path carries document ids and they are already
+	// on the record in a field something can filter on.
+	Surface string `json:"surface"`
+
+	// Action is what they did and Outcome is what happened.
+	Action  Action  `json:"action"`
+	Outcome Outcome `json:"outcome"`
+
+	// Query is what somebody typed, on the surfaces where they typed something.
+	//
+	// It is their own words rather than anybody's document, which is why it is
+	// allowed here at all, and it is the field that makes the log answer the
+	// question people actually ask: not which documents were opened but what
+	// somebody was looking for.
+	Query string `json:"query,omitempty"`
+
+	// Documents is what came back, and Count is how many. Count is not
+	// len(Documents), because a surface that returns a page of a large result
+	// set records the page it showed and the size of what it matched.
+	Documents []Item `json:"documents,omitempty"`
+	Count     int    `json:"count"`
+
+	// Rule is the clause of the access control list that admitted them, where
+	// one document was read and the answer is known. It is the rule and never
+	// the group that matched it. See the package documentation.
+	Rule string `json:"rule,omitempty"`
+
+	// Bytes is how much content left the system, for the surfaces that serve
+	// bytes. It is zero everywhere else rather than an estimate of a JSON body,
+	// because the number is here to answer "how much of it did they take" and a
+	// response size does not answer that.
+	Bytes int64 `json:"bytes,omitempty"`
+}
+
+// QueueSize is how many records may be waiting to be written.
+//
+// It is large enough to absorb a burst from every handler on a busy process and
+// small enough that a sink which has stopped accepting writes is felt as
+// backpressure within a second rather than as a gigabyte of retained records.
+const QueueSize = 4096
+
+// Sink is where records are kept.
+//
+// Append is called from one goroutine, which is what lets a file sink hold a
+// buffered writer without a lock on the write path. Flush is called when the
+// queue is empty, so batching falls out of the arrival rate rather than out of a
+// timer somebody has to tune.
+type Sink interface {
+	Append(Record) error
+	Flush() error
+	Close() error
+}
+
+// Stats is what the log has done, for the metrics that say whether it is
+// keeping up.
+type Stats struct {
+	// Written is records the sink accepted.
+	Written int64
+
+	// Failed is records the sink refused. A record that could not be written is
+	// reported and dropped: the alternative is a search endpoint that returns a
+	// 500 because a disk is full, which turns a logging problem into an outage.
+	Failed int64
+
+	// Queued is how many are waiting. A number that is consistently near
+	// [QueueSize] means the sink cannot keep up and requests are being made to
+	// wait for it.
+	Queued int
+}
+
+// Log is the append only audit log.
+type Log struct {
+	sink Sink
+	log  *slog.Logger
+	now  func() time.Time
+
+	queue chan Record
+	sync  chan chan error
+
+	// quit is closed by Close and closed is how the writer says it has
+	// finished. Two channels rather than one, because the writer has to be able
+	// to report what the sink said on the way out.
+	quit   chan struct{}
+	closed chan error
+
+	written atomic.Int64
+	failed  atomic.Int64
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Option configures a [Log].
+type Option func(*Log)
+
+// WithLogger sets where a sink failure is reported. It is not where the records
+// go: for that, pass [Logging] as the sink.
+func WithLogger(l *slog.Logger) Option {
+	return func(a *Log) {
+		if l != nil {
+			a.log = l
+		}
+	}
+}
+
+// WithClock sets the clock that stamps records.
+func WithClock(now func() time.Time) Option {
+	return func(a *Log) {
+		if now != nil {
+			a.now = now
+		}
+	}
+}
+
+// WithQueue sets how many records may be waiting.
+func WithQueue(n int) Option {
+	return func(a *Log) {
+		if n > 0 {
+			a.queue = make(chan Record, n)
+		}
+	}
+}
+
+// New returns a log writing to a sink.
+//
+// A nil sink is [Logging] over the logger, which is what makes this impossible
+// to turn off by leaving something out of a configuration file. There is no
+// option here that stops records being written, and that is on purpose: a
+// deployment that could be configured into not auditing is one that will be, by
+// somebody who is trying to make a disk fit.
+func New(sink Sink, opts ...Option) *Log {
+	a := &Log{
+		log:    slog.Default(),
+		now:    time.Now,
+		queue:  make(chan Record, QueueSize),
+		sync:   make(chan chan error),
+		quit:   make(chan struct{}),
+		closed: make(chan error, 1),
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	if sink == nil {
+		sink = Logging(a.log)
+	}
+	a.sink = sink
+	go a.run()
+	return a
+}
+
+// Write records one access.
+//
+// It blocks if the queue is full, which is the whole design in one line. See the
+// package documentation.
+func (a *Log) Write(rec Record) {
+	if rec.At.IsZero() {
+		rec.At = a.now()
+	}
+	rec.At = rec.At.UTC()
+	select {
+	case a.queue <- rec:
+	case <-a.quit:
+		// The process is shutting down and this record arrived after the log
+		// was closed. Reported rather than swallowed, because a handler still
+		// serving content after the audit log has been closed is a shutdown
+		// ordering bug and this is the only place it is visible.
+		a.log.Error("an access was not audited because the log is closed",
+			"tenant", rec.Tenant, "subject", rec.Subject, "surface", rec.Surface)
+	}
+}
+
+// Sync waits for everything written so far to reach the sink, and flushes it.
+//
+// It is here for two callers: a test that has just made a request and wants to
+// read the record back, and a process that is shutting down. Nothing on a
+// request path should call it.
+func (a *Log) Sync() error {
+	reply := make(chan error, 1)
+	select {
+	case a.sync <- reply:
+		return <-reply
+	case <-a.quit:
+		return nil
+	}
+}
+
+// Stats reports what the log has done.
+func (a *Log) Stats() Stats {
+	return Stats{
+		Written: a.written.Load(),
+		Failed:  a.failed.Load(),
+		Queued:  len(a.queue),
+	}
+}
+
+// Close drains what is waiting, flushes the sink and closes it.
+//
+// A process that exits without calling this loses whatever had not reached the
+// sink yet, which is the price of not paying for a write to disk on the request
+// path. It is why this is called from the shutdown path of the command rather
+// than left to a finaliser.
+func (a *Log) Close() error {
+	a.closeOnce.Do(func() {
+		close(a.quit)
+		a.closeErr = <-a.closed
+	})
+	return a.closeErr
+}
+
+// run is the writer. It is the only goroutine that touches the sink, which is
+// what lets a sink hold a buffer without a lock on it.
+func (a *Log) run() {
+	for {
+		select {
+		case rec := <-a.queue:
+			a.append(rec)
+			// Flushed when nothing else is waiting, so a burst costs one write
+			// to disk and a quiet process has its last record on disk
+			// immediately rather than at the end of an interval.
+			if len(a.queue) == 0 {
+				a.flush()
+			}
+		case reply := <-a.sync:
+			a.drain()
+			reply <- a.flush()
+		case <-a.quit:
+			a.drain()
+			err := a.flush()
+			if cerr := a.sink.Close(); cerr != nil && err == nil {
+				err = cerr
+			}
+			a.closed <- err
+			return
+		}
+	}
+}
+
+// drain writes what is already queued and returns as soon as nothing is.
+func (a *Log) drain() {
+	for {
+		select {
+		case rec := <-a.queue:
+			a.append(rec)
+		default:
+			return
+		}
+	}
+}
+
+// append writes one record.
+//
+// A sink that refuses is reported and the record is lost, because the caller is
+// a request that has already been answered. Failing the request instead would
+// mean a full disk answering a search with a 500, which is a logging problem
+// escalated into an outage, and the count is on [Stats] so that a deployment can
+// alert on it.
+func (a *Log) append(rec Record) {
+	if err := a.sink.Append(rec); err != nil {
+		a.failed.Add(1)
+		a.log.Error("an audit record could not be written",
+			"error", err, "tenant", rec.Tenant, "subject", rec.Subject, "surface", rec.Surface)
+		return
+	}
+	a.written.Add(1)
+}
+
+// flush pushes the sink's buffer, reporting a failure the same way.
+func (a *Log) flush() error {
+	err := a.sink.Flush()
+	if err != nil {
+		a.log.Error("audit records could not be flushed", "error", err)
+	}
+	return err
+}

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -1,0 +1,256 @@
+package audit_test
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/audit"
+)
+
+// noon is the clock these tests run at, because a record carries a timestamp
+// and a test that reads the wall clock is a test that cannot assert on one.
+var noon = time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+
+// memory is a sink that keeps what it was given.
+type memory struct {
+	mu      sync.Mutex
+	records []audit.Record
+	flushes int
+	closed  bool
+	err     error
+}
+
+func (m *memory) Append(rec audit.Record) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+	m.records = append(m.records, rec)
+	return nil
+}
+
+func (m *memory) Flush() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.flushes++
+	return nil
+}
+
+func (m *memory) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+func (m *memory) held() []audit.Record {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]audit.Record(nil), m.records...)
+}
+
+// read is one document access, which is the record most of these tests write.
+func read(subject, id string) audit.Record {
+	return audit.Record{
+		Tenant: "acme", Subject: subject, Kind: "user",
+		Surface: "GET /api/v1/documents/{id}",
+		Action:  audit.Read, Outcome: audit.Served,
+		Documents: []audit.Item{{ID: id, Source: "gdrive"}},
+		Count:     1,
+		Rule:      "group",
+	}
+}
+
+func logging(t *testing.T, sink audit.Sink) *audit.Log {
+	t.Helper()
+	a := audit.New(sink, audit.WithClock(func() time.Time { return noon }))
+	t.Cleanup(func() { _ = a.Close() })
+	return a
+}
+
+// TestARecordReachesTheSink is the whole of the write path, and the timestamp
+// assertion is the part worth having: it is stamped by the log rather than by
+// the caller, so two handlers cannot disagree about the order of two accesses
+// because they read the clock differently.
+func TestARecordReachesTheSink(t *testing.T) {
+	sink := &memory{}
+	a := logging(t, sink)
+
+	a.Write(read("u_mei", "d1"))
+	if err := a.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	held := sink.held()
+	if len(held) != 1 {
+		t.Fatalf("the sink holds %d records, want 1", len(held))
+	}
+	if held[0].At != noon {
+		t.Errorf("the record is stamped %v, want the log's clock", held[0].At)
+	}
+	if held[0].Subject != "u_mei" || held[0].Documents[0].ID != "d1" {
+		t.Errorf("the record came through as %+v", held[0])
+	}
+	if sink.flushes == 0 {
+		t.Error("nothing was flushed, so a quiet process would hold its last record in a buffer")
+	}
+}
+
+// TestClosingWritesWhatIsStillWaiting. The queue is the reason a search does not
+// wait for a disk, and it is also the reason a process that exits without
+// draining loses the last records it served.
+func TestClosingWritesWhatIsStillWaiting(t *testing.T) {
+	sink := &memory{}
+	a := audit.New(sink, audit.WithClock(func() time.Time { return noon }))
+
+	for i := range 200 {
+		a.Write(read("u_mei", string(rune('a'+i%26))))
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if got := len(sink.held()); got != 200 {
+		t.Errorf("%d records reached the sink, want 200", got)
+	}
+	if !sink.closed {
+		t.Error("the sink was left open, so a file would be left unflushed")
+	}
+}
+
+// TestClosingTwiceIsAllowed, because shutdown paths run twice more often than
+// anybody plans for and the second one should not panic on a closed channel.
+func TestClosingTwiceIsAllowed(t *testing.T) {
+	a := audit.New(&memory{})
+	if err := a.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("the second close returned %v", err)
+	}
+}
+
+// TestASinkThatRefusesIsCountedRatherThanFatal. The caller is a request that has
+// already been answered, so failing it is not on the table, and a search
+// endpoint returning 500 because a disk filled up is a logging problem promoted
+// into an outage.
+func TestASinkThatRefusesIsCountedRatherThanFatal(t *testing.T) {
+	sink := &memory{err: errors.New("the disk is full")}
+	var logged bytes.Buffer
+	a := audit.New(sink,
+		audit.WithClock(func() time.Time { return noon }),
+		audit.WithLogger(slog.New(slog.NewTextHandler(&logged, nil))))
+	t.Cleanup(func() { _ = a.Close() })
+
+	a.Write(read("u_mei", "d1"))
+	if err := a.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	st := a.Stats()
+	if st.Failed != 1 || st.Written != 0 {
+		t.Errorf("the log reports %d failed and %d written, want 1 and 0", st.Failed, st.Written)
+	}
+	if !strings.Contains(logged.String(), "could not be written") {
+		t.Errorf("a record that was lost was not reported:\n%s", logged.String())
+	}
+}
+
+// TestTheDefaultSinkIsTheProcessLog is why there is no way to turn this off. A
+// deployment that configures nothing still has its records in whatever collects
+// the process log.
+func TestTheDefaultSinkIsTheProcessLog(t *testing.T) {
+	var logged bytes.Buffer
+	a := audit.New(nil,
+		audit.WithClock(func() time.Time { return noon }),
+		audit.WithLogger(slog.New(slog.NewTextHandler(&logged, nil))))
+
+	a.Write(read("u_mei", "d1"))
+	if err := a.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	line := logged.String()
+	if !strings.Contains(line, audit.Message) {
+		t.Fatalf("the record is not in the log:\n%s", line)
+	}
+	for _, want := range []string{"subject=u_mei", "tenant=acme", "action=read", "documents=d1", "sources=gdrive", "rule=group"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("the logged record is missing %q:\n%s", want, line)
+		}
+	}
+}
+
+// TestOneLinePerAccess, whatever the size of the page. A log where one search
+// becomes eleven lines is one where the number of accesses is whatever the page
+// size happened to be.
+func TestOneLinePerAccess(t *testing.T) {
+	var logged bytes.Buffer
+	a := audit.New(audit.Logging(slog.New(slog.NewTextHandler(&logged, nil))),
+		audit.WithClock(func() time.Time { return noon }))
+
+	a.Write(audit.Record{
+		Tenant: "acme", Subject: "u_mei", Surface: "GET /api/v1/search",
+		Action: audit.Search, Outcome: audit.Served, Query: "payments failover",
+		Documents: []audit.Item{
+			{ID: "d1", Source: "gdrive"},
+			{ID: "d2", Source: "gdrive"},
+			{ID: "d3", Source: "slack"},
+		},
+		Count: 3,
+	})
+	if err := a.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	got := strings.TrimSpace(logged.String())
+	if lines := strings.Count(got, "\n") + 1; lines != 1 {
+		t.Fatalf("one search wrote %d lines:\n%s", lines, got)
+	}
+	if !strings.Contains(got, "documents=d1,d2,d3") {
+		t.Errorf("the page is not on the record:\n%s", got)
+	}
+	if !strings.Contains(got, "sources=gdrive,slack") {
+		t.Errorf("the sources are not deduplicated:\n%s", got)
+	}
+}
+
+// TestEveryRecordIsWrittenUnderLoad is the guarantee the queue exists to make.
+// Nothing is sampled and nothing is dropped, however many goroutines are
+// serving requests.
+func TestEveryRecordIsWrittenUnderLoad(t *testing.T) {
+	sink := &memory{}
+	a := audit.New(sink,
+		audit.WithClock(func() time.Time { return noon }),
+		// Far smaller than the number written, so the writers have to be made
+		// to wait rather than allowed to drop anything.
+		audit.WithQueue(4))
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 250 {
+				a.Write(read("u_mei", "d1"))
+			}
+		}()
+	}
+	wg.Wait()
+	if err := a.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if got := len(sink.held()); got != 2000 {
+		t.Errorf("%d records of 2000 were written", got)
+	}
+	if st := a.Stats(); st.Written != 2000 {
+		t.Errorf("the log reports %d written, want 2000", st.Written)
+	}
+}

--- a/audit/file.go
+++ b/audit/file.go
@@ -1,0 +1,248 @@
+package audit
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Prefix and Extension are how an audit file is named. A day's records are in
+// audit-2026-08-25.jsonl, in UTC.
+//
+// The name carries the date rather than a sequence number, because everything
+// anybody does with these files is by date: ship yesterday's, keep ninety days,
+// find the week of the incident. A rotation scheme with numbers in it makes all
+// three of those a script.
+const (
+	Prefix    = "audit-"
+	Extension = ".jsonl"
+
+	// Layout is the date in a file name, which is the same order the name sorts
+	// in, which is why it is this one.
+	Layout = "2006-01-02"
+)
+
+// DirMode and FileMode are what the directory and the files are created with.
+//
+// They are narrow because of what is in them. A record says which documents a
+// named person read, and a directory of those is worth reading for somebody who
+// wanted to know what a company is working on, so it is not group readable and
+// it is certainly not world readable.
+const (
+	DirMode  fs.FileMode = 0o700
+	FileMode fs.FileMode = 0o600
+)
+
+// File is a sink writing JSON Lines to one file per day.
+//
+// One record per line, one file per UTC day, no header and no framing. That is
+// the format because it is the one every log shipper, every warehouse loader and
+// every command line already reads: an export is cp, and an ingest is whatever
+// the company already runs. A format of ours would need a tool of ours, and the
+// team that has to answer for this in an audit does not want a tool of ours.
+type File struct {
+	dir       string
+	retention time.Duration
+	now       func() time.Time
+
+	mu   sync.Mutex
+	day  string
+	file *os.File
+	buf  *bufio.Writer
+}
+
+// FileOption configures a [File].
+type FileOption func(*File)
+
+// WithRetention deletes files older than d when the day rolls over.
+//
+// Zero keeps everything, which is the default, because a deployment that has
+// not said how long it keeps its audit trail has not decided, and deleting
+// somebody's compliance record on a guess is not a default this gets to pick.
+func WithRetention(d time.Duration) FileOption {
+	return func(f *File) {
+		if d > 0 {
+			f.retention = d
+		}
+	}
+}
+
+// WithFileClock sets the clock used to decide what is old enough to delete.
+func WithFileClock(now func() time.Time) FileOption {
+	return func(f *File) {
+		if now != nil {
+			f.now = now
+		}
+	}
+}
+
+// Open returns a sink writing into a directory, creating it if it is not there.
+func Open(dir string, opts ...FileOption) (*File, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, errors.New("audit: no directory")
+	}
+	f := &File{dir: dir, now: time.Now}
+	for _, opt := range opts {
+		opt(f)
+	}
+	if err := os.MkdirAll(dir, DirMode); err != nil {
+		return nil, fmt.Errorf("audit: %w", err)
+	}
+	// Opened now rather than on the first record, so that a directory nobody can
+	// write to is a startup failure rather than a discovery made by the first
+	// person to search for something.
+	if err := f.open(f.now().UTC().Format(Layout)); err != nil {
+		return nil, err
+	}
+	f.prune()
+	return f, nil
+}
+
+// Append writes one record.
+func (f *File) Append(rec Record) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if day := rec.At.UTC().Format(Layout); day != f.day {
+		if err := f.roll(day); err != nil {
+			return err
+		}
+	}
+	raw, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("audit: %w", err)
+	}
+	// One write of one line. A record split across two writes is a line a reader
+	// cannot parse if the process dies between them, and the whole value of this
+	// format is that a truncated file is still readable up to the truncation.
+	raw = append(raw, '\n')
+	if _, err := f.buf.Write(raw); err != nil {
+		return fmt.Errorf("audit: %w", err)
+	}
+	return nil
+}
+
+// Flush pushes the buffer to the file.
+//
+// It does not fsync. A record is durable against the process dying, which is
+// what the log is for, and not against the machine losing power in the same
+// second, which would cost a disk write per search. See docs/audit.md.
+func (f *File) Flush() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.flush()
+}
+
+// Close flushes and closes the current file.
+func (f *File) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.file == nil {
+		return nil
+	}
+	err := f.flush()
+	if cerr := f.file.Close(); cerr != nil && err == nil {
+		err = fmt.Errorf("audit: %w", cerr)
+	}
+	f.file, f.buf = nil, nil
+	return err
+}
+
+// Path is the file being written, which is what a startup line says so that
+// nobody has to guess where the records went.
+func (f *File) Path() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return filepath.Join(f.dir, Prefix+f.day+Extension)
+}
+
+// roll moves to another day's file and prunes what has aged out.
+func (f *File) roll(day string) error {
+	if f.file != nil {
+		if err := f.flush(); err != nil {
+			return err
+		}
+		if err := f.file.Close(); err != nil {
+			return fmt.Errorf("audit: %w", err)
+		}
+		f.file, f.buf = nil, nil
+	}
+	if err := f.open(day); err != nil {
+		return err
+	}
+	f.prune()
+	return nil
+}
+
+// open appends to one day's file, creating it if this is the first record of
+// the day and reopening it if the process was restarted during it.
+func (f *File) open(day string) error {
+	file, err := os.OpenFile(filepath.Join(f.dir, Prefix+day+Extension),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, FileMode)
+	if err != nil {
+		return fmt.Errorf("audit: %w", err)
+	}
+	f.day, f.file, f.buf = day, file, bufio.NewWriter(file)
+	return nil
+}
+
+func (f *File) flush() error {
+	if f.buf == nil {
+		return nil
+	}
+	if err := f.buf.Flush(); err != nil {
+		return fmt.Errorf("audit: %w", err)
+	}
+	return nil
+}
+
+// prune deletes what has aged out of the retention window.
+//
+// Failures are ignored on purpose. This runs on the writer, once a day, and a
+// file that could not be deleted is a disk that will fill up eventually, which
+// is a slower and more visible problem than an audit log that stopped writing
+// because a stale file was in the way.
+func (f *File) prune() {
+	if f.retention <= 0 {
+		return
+	}
+	cutoff := f.now().UTC().Add(-f.retention)
+	entries, err := os.ReadDir(f.dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		day, ok := dayOf(entry.Name())
+		if !ok || entry.IsDir() {
+			continue
+		}
+		// The end of the day rather than the start, so a retention of a day
+		// keeps today and yesterday whole rather than deleting records written
+		// this morning.
+		if day.Add(24 * time.Hour).After(cutoff) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(f.dir, entry.Name()))
+	}
+}
+
+// dayOf reads the date out of an audit file name, and says no to anything else
+// in the directory. A deployment that pointed this at a directory with other
+// things in it should lose nothing but its own old records.
+func dayOf(name string) (time.Time, bool) {
+	if !strings.HasPrefix(name, Prefix) || !strings.HasSuffix(name, Extension) {
+		return time.Time{}, false
+	}
+	day, err := time.Parse(Layout, strings.TrimSuffix(strings.TrimPrefix(name, Prefix), Extension))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return day, true
+}

--- a/audit/file_test.go
+++ b/audit/file_test.go
@@ -1,0 +1,253 @@
+package audit_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/audit"
+)
+
+// at is a record stamped for a given moment, which is what decides the file it
+// lands in.
+func at(when time.Time, id string) audit.Record {
+	rec := read("u_mei", id)
+	rec.At = when
+	return rec
+}
+
+func day(y int, m time.Month, d int) time.Time {
+	return time.Date(y, m, d, 9, 30, 0, 0, time.UTC)
+}
+
+// TestADayIsAFile. Everything anybody does with these files is by date, so the
+// day is in the name and a day's records are all in one place.
+func TestADayIsAFile(t *testing.T) {
+	dir := t.TempDir()
+	f, err := audit.Open(dir, audit.WithFileClock(func() time.Time { return day(2026, 8, 25) }))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	for _, rec := range []audit.Record{
+		at(day(2026, 8, 25), "d1"),
+		at(day(2026, 8, 25).Add(2*time.Hour), "d2"),
+		at(day(2026, 8, 26), "d3"),
+	} {
+		if err := f.Append(rec); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if got := lines(t, filepath.Join(dir, "audit-2026-08-25.jsonl")); len(got) != 2 {
+		t.Errorf("the first day holds %d records, want 2", len(got))
+	}
+	second := lines(t, filepath.Join(dir, "audit-2026-08-26.jsonl"))
+	if len(second) != 1 {
+		t.Fatalf("the second day holds %d records, want 1", len(second))
+	}
+	var rec audit.Record
+	if err := json.Unmarshal([]byte(second[0]), &rec); err != nil {
+		t.Fatalf("the line is not a record: %v", err)
+	}
+	if rec.Documents[0].ID != "d3" {
+		t.Errorf("the record after the roll is %+v", rec)
+	}
+}
+
+// TestNobodyElseCanReadTheTrail. A record says which documents a named person
+// read, and a directory of those is worth reading for somebody who wanted to
+// know what a company is working on.
+func TestNobodyElseCanReadTheTrail(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "audit")
+	f, err := audit.Open(dir)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != audit.DirMode {
+		t.Errorf("the directory is %v, want %v", perm, audit.DirMode)
+	}
+	file, err := os.Stat(f.Path())
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := file.Mode().Perm(); perm != audit.FileMode {
+		t.Errorf("the file is %v, want %v", perm, audit.FileMode)
+	}
+}
+
+// TestARestartAppendsToTheDay rather than starting it again. A process that is
+// restarted twice in an afternoon should not lose the morning.
+func TestARestartAppendsToTheDay(t *testing.T) {
+	dir := t.TempDir()
+	clock := func() time.Time { return day(2026, 8, 25) }
+
+	for _, id := range []string{"d1", "d2"} {
+		f, err := audit.Open(dir, audit.WithFileClock(clock))
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		if err := f.Append(at(day(2026, 8, 25), id)); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	}
+
+	if got := lines(t, filepath.Join(dir, "audit-2026-08-25.jsonl")); len(got) != 2 {
+		t.Errorf("the day holds %d records after a restart, want 2", len(got))
+	}
+}
+
+// TestADirectoryThatCannotBeWrittenIsAStartupFailure, rather than something the
+// first person to search for anything discovers.
+func TestADirectoryThatCannotBeWrittenIsAStartupFailure(t *testing.T) {
+	if _, err := audit.Open(" "); err == nil {
+		t.Error("an empty directory opened without complaint")
+	}
+	if os.Geteuid() == 0 {
+		// Permissions do not apply to root, and a container that runs its tests
+		// as root would fail this for a reason that has nothing to do with us.
+		t.Skip("running as root")
+	}
+	dir := filepath.Join(t.TempDir(), "closed")
+	if err := os.Mkdir(dir, 0o500); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := audit.Open(filepath.Join(dir, "audit")); err == nil {
+		t.Error("a directory nobody can write to opened without complaint")
+	}
+}
+
+// TestRetentionDeletesWhatAgedOutAndNothingElse. A file is deleted only once
+// the whole day it holds is outside the window, so two days of retention at
+// half past nine keeps the day before yesterday rather than deleting records
+// that are thirty hours old, and a file in the directory that is not ours is
+// left where it is.
+func TestRetentionDeletesWhatAgedOutAndNothingElse(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{
+		"audit-2026-08-20.jsonl",
+		"audit-2026-08-23.jsonl",
+		"audit-2026-08-24.jsonl",
+		"audit-2026-08-25.jsonl",
+		"README.md",
+		"audit-not-a-date.jsonl",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	f, err := audit.Open(dir,
+		audit.WithFileClock(func() time.Time { return day(2026, 8, 25) }),
+		audit.WithRetention(48*time.Hour))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	want := []string{
+		"README.md",
+		"audit-2026-08-23.jsonl",
+		"audit-2026-08-24.jsonl",
+		"audit-2026-08-25.jsonl",
+		"audit-not-a-date.jsonl",
+	}
+	if got := names(t, dir); strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("the directory holds %v, want %v", got, want)
+	}
+}
+
+// TestNothingIsDeletedWithoutARetention. A deployment that has not said how long
+// it keeps its audit trail has not decided, and deleting somebody's compliance
+// record on a guess is not a default this gets to pick.
+func TestNothingIsDeletedWithoutARetention(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "audit-2019-01-01.jsonl"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	f, err := audit.Open(dir, audit.WithFileClock(func() time.Time { return day(2026, 8, 25) }))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if got := names(t, dir); len(got) != 2 {
+		t.Errorf("the directory holds %v, want the old file kept", got)
+	}
+}
+
+// TestTheDayIsRolledIntoRetention. Pruning runs when the file rolls, which is
+// the only moment a long lived process has to notice that another day has aged
+// out of the window.
+func TestTheDayIsRolledIntoRetention(t *testing.T) {
+	dir := t.TempDir()
+	now := day(2026, 8, 25)
+	f, err := audit.Open(dir,
+		audit.WithFileClock(func() time.Time { return now }),
+		audit.WithRetention(24*time.Hour))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := f.Append(at(day(2026, 8, 25), "d1")); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	now = day(2026, 8, 27)
+	if err := f.Append(at(now, "d2")); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	want := []string{"audit-2026-08-27.jsonl"}
+	if got := names(t, dir); strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("the directory holds %v after the roll, want %v", got, want)
+	}
+}
+
+func lines(t *testing.T, path string) []string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	body := strings.TrimSuffix(string(raw), "\n")
+	if body == "" {
+		return nil
+	}
+	return strings.Split(body, "\n")
+}
+
+func names(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var out []string
+	for _, entry := range entries {
+		out = append(out, entry.Name())
+	}
+	return out
+}

--- a/audit/logging.go
+++ b/audit/logging.go
@@ -1,0 +1,94 @@
+package audit
+
+import (
+	"log/slog"
+	"slices"
+	"strings"
+)
+
+// Logging returns a sink that writes records to a structured logger.
+//
+// It is the default, and it is what makes auditing impossible to leave out
+// rather than merely on by default. A deployment that has configured nothing has
+// its records in whatever already collects the process log, which is not the
+// retention story a compliance team wants but is a great deal better than the
+// alternative, and the alternative is the reason so many systems cannot answer
+// the question at all.
+//
+// The message is fixed and every field is a key, so the records can be filtered
+// out of a mixed log by message rather than by parsing text. The document ids
+// are one comma separated value: an audit record is one line, and a log where
+// one access becomes eleven lines is one where the count of accesses is
+// whatever the page size happened to be.
+func Logging(l *slog.Logger) Sink {
+	if l == nil {
+		l = slog.Default()
+	}
+	return logging{l}
+}
+
+// Message is the message every record is logged under, so that a mixed process
+// log can be filtered down to the audit trail with a string match.
+const Message = "content access"
+
+type logging struct{ log *slog.Logger }
+
+func (s logging) Append(rec Record) error {
+	attrs := []any{
+		"at", rec.At,
+		"tenant", rec.Tenant,
+		"subject", rec.Subject,
+		"surface", rec.Surface,
+		"action", string(rec.Action),
+		"outcome", string(rec.Outcome),
+		"count", rec.Count,
+	}
+	if rec.Kind != "" {
+		attrs = append(attrs, "kind", rec.Kind)
+	}
+	if rec.Query != "" {
+		attrs = append(attrs, "query", rec.Query)
+	}
+	if len(rec.Documents) > 0 {
+		attrs = append(attrs, "documents", ids(rec.Documents), "sources", sources(rec.Documents))
+	}
+	if rec.Rule != "" {
+		attrs = append(attrs, "rule", rec.Rule)
+	}
+	if rec.Bytes > 0 {
+		attrs = append(attrs, "bytes", rec.Bytes)
+	}
+	s.log.Info(Message, attrs...)
+	return nil
+}
+
+// Flush and Close do nothing. A logger owns its own writer and its own
+// lifetime, and a sink that closed somebody else's log on shutdown would take
+// the rest of the shutdown's logging with it.
+func (s logging) Flush() error { return nil }
+func (s logging) Close() error { return nil }
+
+// ids is the document ids of a record, in order.
+func ids(items []Item) string {
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = it.ID
+	}
+	return strings.Join(out, ",")
+}
+
+// sources is which connectors they came from, deduplicated and in the order
+// they first appeared. A page of eleven results from one source says "gdrive"
+// rather than saying it eleven times.
+func sources(items []Item) string {
+	var out []string
+	for _, it := range items {
+		if it.Source == "" {
+			continue
+		}
+		if !slices.Contains(out, it.Source) {
+			out = append(out, it.Source)
+		}
+	}
+	return strings.Join(out, ",")
+}

--- a/audit/read.go
+++ b/audit/read.go
@@ -1,0 +1,158 @@
+package audit
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+)
+
+// LineLimit is the longest line a reader will accept.
+//
+// A record is a few hundred bytes and a search record with a full page of
+// results on it is a few thousand, so this is far above anything this package
+// writes. It is here because a reader is pointed at a directory of files, and a
+// file in that directory that is not one of ours should be refused rather than
+// read into memory.
+const LineLimit = 1 << 20
+
+// Records calls fn for every record written between from and to, oldest first.
+//
+// Both bounds are inclusive and a zero bound is open, so Records with two zero
+// times is the whole directory. Files are read in date order and records within
+// a file are in the order they were written, which is the order somebody
+// reconstructing an afternoon needs them in.
+//
+// A record that fn refuses stops the read and the error comes back unchanged,
+// which is how a caller streaming to a network writer stops without reading the
+// rest of a year.
+func Records(dir string, from, to time.Time, fn func(Record) error) error {
+	files, err := files(dir, from, to)
+	if err != nil {
+		return err
+	}
+	for _, path := range files {
+		if err := readFile(path, from, to, fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Export writes the records in a window to w, in the format they are stored in.
+//
+// It is JSON Lines in and JSON Lines out, because the point of the export is to
+// hand somebody a file their existing system can load, and a second format
+// invented on the way out would be a second thing to explain. What it adds over
+// copying the files is the window and the ordering.
+func Export(dir string, from, to time.Time, w io.Writer) (int, error) {
+	out := bufio.NewWriter(w)
+	n := 0
+	err := Records(dir, from, to, func(rec Record) error {
+		raw, err := json.Marshal(rec)
+		if err != nil {
+			return fmt.Errorf("audit: %w", err)
+		}
+		if _, err := out.Write(append(raw, '\n')); err != nil {
+			return fmt.Errorf("audit: %w", err)
+		}
+		n++
+		return nil
+	})
+	if err != nil {
+		return n, err
+	}
+	if err := out.Flush(); err != nil {
+		return n, fmt.Errorf("audit: %w", err)
+	}
+	return n, nil
+}
+
+// files is the audit files of a directory whose day could hold a record in the
+// window, in date order.
+func files(dir string, from, to time.Time) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("audit: %w", err)
+	}
+	var out []string
+	for _, entry := range entries {
+		day, ok := dayOf(entry.Name())
+		if !ok || entry.IsDir() {
+			continue
+		}
+		// A whole day is skipped only when the window cannot reach into it at
+		// all. The record timestamps are checked again below, because a file is
+		// a day and a window is not.
+		if !from.IsZero() && day.Add(24*time.Hour).Before(from.UTC()) {
+			continue
+		}
+		if !to.IsZero() && day.After(to.UTC()) {
+			continue
+		}
+		out = append(out, filepath.Join(dir, entry.Name()))
+	}
+	slices.Sort(out)
+	return out, nil
+}
+
+// readFile streams one day.
+func readFile(path string, from, to time.Time, fn func(Record) error) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("audit: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), LineLimit)
+
+	// A line that will not parse is held rather than reported, and reported only
+	// once the next line proves it was not the last one. The last line of a file
+	// a process died in the middle of is half a record, which is not corruption
+	// worth refusing a year of history over, and a bad line anywhere else is.
+	var (
+		bad    string
+		badAt  int
+		number int
+	)
+	for scanner.Scan() {
+		number++
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if bad != "" {
+			return fmt.Errorf("audit: %s line %d is not a record", path, badAt)
+		}
+		var rec Record
+		if err := json.Unmarshal(line, &rec); err != nil {
+			bad, badAt = string(line), number
+			continue
+		}
+		if !from.IsZero() && rec.At.Before(from) {
+			continue
+		}
+		if !to.IsZero() && rec.At.After(to) {
+			continue
+		}
+		if err := fn(rec); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		// A line too long to scan is the same class of problem as a line that
+		// will not parse, and it is not the last line of a file the process
+		// died in.
+		if errors.Is(err, bufio.ErrTooLong) {
+			return fmt.Errorf("audit: %s line %d is too long to be a record", path, number+1)
+		}
+		return fmt.Errorf("audit: %w", err)
+	}
+	return nil
+}

--- a/audit/read_test.go
+++ b/audit/read_test.go
@@ -1,0 +1,277 @@
+package audit_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/audit"
+)
+
+// trail is a directory holding one record per id, on the days given.
+func trail(t *testing.T, days ...time.Time) string {
+	t.Helper()
+	dir := t.TempDir()
+	for i, when := range days {
+		f, err := audit.Open(dir, audit.WithFileClock(func() time.Time { return when }))
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		if err := f.Append(at(when, "d"+string(rune('1'+i)))); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close: %v", err)
+		}
+	}
+	return dir
+}
+
+func collect(t *testing.T, dir string, from, to time.Time) []audit.Record {
+	t.Helper()
+	var out []audit.Record
+	if err := audit.Records(dir, from, to, func(rec audit.Record) error {
+		out = append(out, rec)
+		return nil
+	}); err != nil {
+		t.Fatalf("records: %v", err)
+	}
+	return out
+}
+
+// TestRecordsComeBackOldestFirst, because the person reading them is
+// reconstructing an afternoon and an afternoon has an order.
+func TestRecordsComeBackOldestFirst(t *testing.T) {
+	dir := trail(t, day(2026, 8, 26), day(2026, 8, 24), day(2026, 8, 25))
+
+	got := collect(t, dir, time.Time{}, time.Time{})
+	if len(got) != 3 {
+		t.Fatalf("%d records came back, want 3", len(got))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].At.Before(got[i-1].At) {
+			t.Fatalf("record %d is stamped before the one ahead of it: %v then %v", i, got[i-1].At, got[i].At)
+		}
+	}
+}
+
+// TestTheWindowIsInclusiveAtBothEnds. Somebody asked for the twenty fifth, and
+// a report that quietly drops the last record of the day is worse than one that
+// refuses.
+func TestTheWindowIsInclusiveAtBothEnds(t *testing.T) {
+	dir := t.TempDir()
+	f, err := audit.Open(dir, audit.WithFileClock(func() time.Time { return day(2026, 8, 25) }))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	start := time.Date(2026, 8, 25, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 8, 25, 23, 59, 59, 0, time.UTC)
+	for i, when := range []time.Time{
+		start.Add(-time.Second),
+		start,
+		start.Add(12 * time.Hour),
+		end,
+		end.Add(time.Second),
+	} {
+		if err := f.Append(at(when, "d"+string(rune('1'+i)))); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	got := collect(t, dir, start, end)
+	var ids []string
+	for _, rec := range got {
+		ids = append(ids, rec.Documents[0].ID)
+	}
+	if want := "d2 d3 d4"; strings.Join(ids, " ") != want {
+		t.Errorf("the day came back as %v, want %s", ids, want)
+	}
+}
+
+// TestAHalfWrittenLastLineIsTolerated. A process killed in the middle of a write
+// leaves half a record at the end of the file, and refusing to read a year of
+// history over it would make the trail useless exactly when somebody needs it.
+func TestAHalfWrittenLastLineIsTolerated(t *testing.T) {
+	dir := trail(t, day(2026, 8, 25))
+	path := filepath.Join(dir, "audit-2026-08-25.jsonl")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if err := os.WriteFile(path, slices.Concat(raw, []byte(`{"at":"2026-08-25T09:31`)), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got := collect(t, dir, time.Time{}, time.Time{}); len(got) != 1 {
+		t.Errorf("%d records came back, want the whole one before the truncation", len(got))
+	}
+}
+
+// TestABadLineInTheMiddleIsRefused, which is the other half of the same rule. A
+// line with a whole record written after it is not a crash, it is corruption,
+// and reading past it would report a trail with a hole in it as complete.
+func TestABadLineInTheMiddleIsRefused(t *testing.T) {
+	dir := trail(t, day(2026, 8, 25))
+	path := filepath.Join(dir, "audit-2026-08-25.jsonl")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	body := slices.Concat(raw, []byte("half a record\n"), raw)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	err = audit.Records(dir, time.Time{}, time.Time{}, func(audit.Record) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "line 2 is not a record") {
+		t.Errorf("a corrupt line in the middle came back as %v", err)
+	}
+}
+
+// TestALineTooLongIsRefused rather than read into memory. The reader is pointed
+// at a directory, and a file in it that is not one of ours should not be able to
+// decide how much memory an export takes.
+func TestALineTooLongIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	line := append(bytes.Repeat([]byte("x"), audit.LineLimit+1), '\n')
+	if err := os.WriteFile(filepath.Join(dir, "audit-2026-08-25.jsonl"), line, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	err := audit.Records(dir, time.Time{}, time.Time{}, func(audit.Record) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "too long") {
+		t.Errorf("a line of %d bytes came back as %v", len(line), err)
+	}
+}
+
+// TestAnythingElseInTheDirectoryIsLeftAlone. A deployment that pointed this at a
+// directory with other things in it should not have its export fail on a README.
+func TestAnythingElseInTheDirectoryIsLeftAlone(t *testing.T) {
+	dir := trail(t, day(2026, 8, 25))
+	for name, body := range map[string]string{
+		"README.md":             "not a record\n",
+		"audit-yesterday.jsonl": "not a record either\n",
+		"audit-2026-08-24.txt":  "nor this\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	if got := collect(t, dir, time.Time{}, time.Time{}); len(got) != 1 {
+		t.Errorf("%d records came back, want only ours", len(got))
+	}
+}
+
+// TestACallerCanStopEarly, which is how something streaming a window to a
+// network writer gives up without reading the rest of a year.
+func TestACallerCanStopEarly(t *testing.T) {
+	dir := trail(t, day(2026, 8, 24), day(2026, 8, 25), day(2026, 8, 26))
+
+	stop := errors.New("enough")
+	seen := 0
+	err := audit.Records(dir, time.Time{}, time.Time{}, func(audit.Record) error {
+		seen++
+		return stop
+	})
+	if !errors.Is(err, stop) {
+		t.Errorf("the read came back with %v, want the caller's error unchanged", err)
+	}
+	if seen != 1 {
+		t.Errorf("the read carried on for %d records after being told to stop", seen)
+	}
+}
+
+// TestAMissingDirectoryIsAnError rather than an empty export, because an export
+// that says nothing happened is the wrong answer to a mistyped path.
+func TestAMissingDirectoryIsAnError(t *testing.T) {
+	err := audit.Records(filepath.Join(t.TempDir(), "nope"), time.Time{}, time.Time{}, func(audit.Record) error {
+		return nil
+	})
+	if err == nil {
+		t.Error("a directory that is not there exported without complaint")
+	}
+}
+
+// TestExportIsTheFormatItIsStoredIn. It is JSON Lines in and JSON Lines out, so
+// what a compliance team is handed loads into whatever they already run.
+func TestExportIsTheFormatItIsStoredIn(t *testing.T) {
+	dir := trail(t, day(2026, 8, 24), day(2026, 8, 25), day(2026, 8, 26))
+
+	var out bytes.Buffer
+	n, err := audit.Export(dir, day(2026, 8, 25).Add(-9*time.Hour), time.Time{}, &out)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("the export wrote %d records, want 2", n)
+	}
+
+	body := strings.Split(strings.TrimSuffix(out.String(), "\n"), "\n")
+	if len(body) != n {
+		t.Fatalf("%d records came out as %d lines", n, len(body))
+	}
+	var first audit.Record
+	if err := json.Unmarshal([]byte(body[0]), &first); err != nil {
+		t.Fatalf("the exported line is not a record: %v", err)
+	}
+	if first.Documents[0].ID != "d2" || first.Subject != "u_mei" {
+		t.Errorf("the first exported record is %+v", first)
+	}
+}
+
+// TestARecordCarriesNoContent is the promise the shape of the record makes. What
+// is stored is who read what and under which rule, never a title, a snippet or a
+// group name, because an audit trail readable by more people than the documents
+// are is a way of leaking the documents.
+func TestARecordCarriesNoContent(t *testing.T) {
+	raw, err := json.Marshal(audit.Record{
+		At: noon, Tenant: "acme", Subject: "u_mei", Kind: "user",
+		Surface: "GET /api/v1/search", Action: audit.Search, Outcome: audit.Served,
+		Query:     "payments failover",
+		Documents: []audit.Item{{ID: "d1", Source: "gdrive"}},
+		Count:     1, Rule: "group",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := map[string]bool{
+		"at": true, "tenant": true, "subject": true, "kind": true, "surface": true,
+		"action": true, "outcome": true, "query": true, "documents": true,
+		"count": true, "rule": true,
+	}
+	for name := range fields {
+		if !want[name] {
+			t.Errorf("a record carries a %q field, which is not one of the ones we can defend keeping", name)
+		}
+	}
+	documents, ok := fields["documents"].([]any)
+	if !ok {
+		t.Fatalf("the documents came back as %T", fields["documents"])
+	}
+	for _, item := range documents {
+		document, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("a document came back as %T", item)
+		}
+		for name := range document {
+			if name != "id" && name != "source" {
+				t.Errorf("a document on a record carries %q, which is more than an identifier", name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Part of #21.
This is the `audit` package on its own, with no callers yet, so that the wiring change that follows is only wiring.

## What a record is

Who asked, what they asked, which documents came back, through which surface, and what happened.
Never what was in them.
A title is content and a snippet is more of it, so an audit log that quoted the documents would be a second copy of the corpus, kept for years, in a file that is deliberately easier to ship off the machine than the index is.

Group names are left out for a related reason.
The rule that admitted somebody is on the record, because owning a document and a document being public to the tenant are different facts about an access, but the group that matched is not.
A log of access decisions that named groups would describe the shape of an organisation to anybody who can read it, and an audit trail is read by more people than the documents are.

Refused and failed are separate outcomes, and a refusal does not say why.
No such document, nothing this person may read, and a role they do not have are one outcome here for the same reason the API answers all three with a 404: separating them in the trail would be a way of proving a document exists to somebody who cannot read it.

## What it costs a request

A record is handed to a writer on its own goroutine, so a handler pays a channel send rather than a write to disk.
The queue is bounded and a full one blocks the request rather than dropping the record.
That is the deliberate choice: an audit log with a hole in it exactly where the busiest minute of the day was is worse than a slow request, because nobody can tell afterwards which of the two it was.

A sink that refuses a write is the other case.
The request has already been answered by then, so the record is counted on `Stats.Failed`, reported on the process log and dropped.
A search endpoint returning 500 because a disk filled up is a logging problem promoted into an outage.

## Where records go

The default sink is the process logger, which is what makes auditing impossible to leave out rather than merely on by default.
A deployment that configures nothing still has its records in whatever already collects the process log.

`audit.Open` writes JSON Lines to a directory, one file per UTC day, `audit-2026-08-25.jsonl`, mode 0600 in a 0700 directory.
The name carries the date because everything anybody does with these files is by date: ship yesterday's, keep ninety days, find the week of the incident.
An export is a copy and retention is a date comparison, and a format of ours would need a tool of ours, which the team that has to answer for this in an audit does not want.

Retention defaults to keeping everything.
A deployment that has not said how long it keeps its audit trail has not decided, and deleting somebody's compliance record on a guess is not a default this gets to pick.
A file is deleted only once the whole day it holds is outside the window, so a retention of two days at half past nine keeps the day before yesterday rather than deleting records that are thirty hours old.

## Reading them back

`audit.Records` streams a window oldest first and `audit.Export` writes it back out in the format it is stored in.
A line that will not parse is held rather than reported, and reported only once a following line proves it was not the last one.
Half a record at the end of a file is what a process killed in the middle of a write leaves behind, and refusing a year of history over it would make the trail useless exactly when somebody needs it.
A bad line with a whole record after it is corruption, and reading past it would report a trail with a hole in it as complete.

Anything in the directory that is not one of our files is ignored rather than read, including for retention, so a deployment that pointed this at a directory with other things in it loses nothing but its own old records.

## Tests

Covered here: a record reaching the sink with the log's own timestamp on it, close draining what is queued, two thousand records from eight goroutines through a queue of four with none dropped, a sink that errors being counted rather than fatal, the default sink being the process log, one line per access whatever the page size, a day being a file, rotation across a day boundary, a restart appending to the day rather than starting it again, the file modes, retention deleting only what aged out, the window being inclusive at both ends, the truncated last line, the bad line in the middle, a line too long to be one of ours, and the export round trip.

The last two boxes on #21, the surface walk and the configuration, come with the wiring change.
