### PR TITLE
Write an audit record from every surface that serves content

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ func main() {
 | `connector/recorded` | HTTP exchanges captured from a real service and replayed from a directory, so tests need no account |
 | `extract` | text and structure out of PDF, Word, PowerPoint, Excel, HTML and Markdown, [docs/extraction.md](docs/extraction.md) |
 | `ingest` | the pipeline that runs a connector into a store |
+| `audit` | the record of every content access, kept on disk or written to the log, [docs/audit.md](docs/audit.md) |
 | `config` | runtime configuration and the rules for loading it |
 | `api` | the HTTP surface |
 | `web` | the browser interface, compiled into the binary |
@@ -619,6 +620,13 @@ A directory that cannot be reached refuses the request rather than resolving som
 Expanding on every request is not affordable, so there is a cache, and there is exactly one layer of it: caching the group edges as well would mean an answer built out of edges that were themselves already old, and a worst case age that is the sum of two lifetimes is a number nobody can state without drawing a diagram.
 One layer means the maximum staleness of any group set is the lifetime, which is configured in one place and published as a metric.
 [docs/identity.md](docs/identity.md) is the whole of it.
+
+The other half of a permission is being able to say afterwards what it let through.
+Every request that puts a document in front of somebody writes a record, and so does every request that was refused one, because a trail holding only the successes answers the easy half of every question anybody asks it.
+That is enforced by a test that walks the route table rather than by a convention: a route that serves content and writes no record fails the build, and a new endpoint that has said nothing about which it is fails it too.
+The record carries who, when, through which route, which document ids and how many bytes left, and it deliberately carries no title, no body and no group name, because an audit trail is kept for years and read by more people than the corpus is.
+There is no setting that turns it off, only one that says where it goes, and a deployment that points it at a directory gets one file per day, a retention it can state, and an export in the format it is stored in.
+[docs/audit.md](docs/audit.md) has the record shape, the reading and the retention rule.
 
 A connector hands the pipeline a body, and for the PDF attached to a ticket or the deck a quarter was reviewed from, the bytes are not it.
 `extract` turns those into text using the standard library and nothing else: no office suite, no headless browser and nothing to install alongside the binary.

--- a/api/api.go
+++ b/api/api.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/tamnd/genba"
 	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/audit"
 	"github.com/tamnd/genba/cache"
 	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/index"
@@ -105,6 +106,13 @@ type Server struct {
 	// recorded, because a histogram nobody scrapes costs a lock and nine
 	// comparisons, and it is only served where a caller mounts [Server.Metrics].
 	metrics *metrics
+
+	// audit is where the record of every content access goes. It is never nil,
+	// because a deployment chooses where its records are kept and not whether
+	// any are written, and ownAudit is whether this server built it and should
+	// therefore shut it down. See [WithAudit].
+	audit    *audit.Log
+	ownAudit bool
 
 	// thumbs holds the rendered thumbnails. It lives on the server rather than
 	// in the store because it is derived data with a cost that is measured in
@@ -201,6 +209,13 @@ func New(st store.Store, searcher *index.Searcher, auth Authenticator, opts ...O
 	for _, opt := range opts {
 		opt(s)
 	}
+	// After the options, because the default sink is this server's logger and
+	// an embedder may have replaced it. There is no branch here where the log
+	// ends up nil: a caller says where the records go, never whether there are
+	// any.
+	if s.audit == nil {
+		s.audit, s.ownAudit = audit.New(audit.Logging(s.log)), true
+	}
 	// After the options, because the cache layers and the storage driver are
 	// what the counters read and both arrive with the server rather than with
 	// the registry.
@@ -215,40 +230,74 @@ func New(st store.Store, searcher *index.Searcher, auth Authenticator, opts ...O
 	return s
 }
 
+// route is one entry in the router.
+//
+// The surface is a table rather than a sequence of calls to mux.Handle because
+// something other than the router has to be able to read it. Content is the
+// field that matters: it says this route can put a document in front of
+// somebody, and every route with it set has to write an audit record on every
+// path that answers. A test walks this table and holds each of those to it, so
+// a route added without a record fails the build rather than being noticed a
+// year later by somebody who needed the trail.
+type route struct {
+	Method  string
+	Pattern string
+	Handler http.Handler
+
+	// Content is whether the route can return a document, part of one, a
+	// rendering of one, or the fact that one exists.
+	Content bool
+}
+
+// routes is the whole HTTP surface.
+func (s *Server) routes() []route {
+	content := func(method, pattern string, h http.Handler) route {
+		return route{Method: method, Pattern: pattern, Handler: h, Content: true}
+	}
+	at := func(method, pattern string, h http.Handler) route {
+		return route{Method: method, Pattern: pattern, Handler: h}
+	}
+	return []route{
+		at("GET", "/healthz", http.HandlerFunc(s.handleHealth)),
+		at("GET", "/readyz", http.HandlerFunc(s.handleReady)),
+		at("GET", "/api/v1/me", s.authenticated(s.handleMe)),
+		content("GET", "/api/v1/search", s.authenticated(s.handleSearch)),
+		content("GET", "/api/v1/suggest", s.authenticated(s.handleSuggest)),
+		content("GET", "/api/v1/documents", s.authenticated(s.handleDocuments)),
+		content("GET", "/api/v1/documents/{id}", s.authenticated(s.handleDocument)),
+		at("POST", "/api/v1/documents/{id}/verify", s.authenticated(s.handleVerify)),
+		at("DELETE", "/api/v1/documents/{id}/verify", s.authenticated(s.handleUnverify)),
+		at("PUT", "/api/v1/documents/{id}/owner", s.authenticated(s.handleSetOwner)),
+		at("DELETE", "/api/v1/documents/{id}/owner", s.authenticated(s.handleClearOwner)),
+		at("POST", "/api/v1/documents/{id}/stale", s.authenticated(s.handleReport)),
+		at("DELETE", "/api/v1/documents/{id}/stale", s.authenticated(s.handleResolve)),
+		at("DELETE", "/api/v1/documents/{id}/stale/mine", s.authenticated(s.handleWithdraw)),
+		content("GET", "/api/v1/documents/{id}/content", s.authenticated(s.handleContent)),
+		content("GET", "/api/v1/documents/{id}/thumbnail", s.authenticated(s.handleThumbnail)),
+		content("GET", "/api/v1/reported", s.authenticated(s.handleReported)),
+		content("GET", "/api/v1/recent", s.authenticated(s.handleRecent)),
+		at("POST", "/api/v1/recent", s.authenticated(s.handleRecordOpen)),
+		at("GET", "/api/v1/stats", s.authenticated(s.handleStats)),
+		at("GET", "/api/v1/events", s.authenticated(s.handleEvents)),
+		at("GET", "/api/v1/admin/answers", s.admin(s.handleAnswers)),
+		at("PUT", "/api/v1/admin/answers/{id}", s.admin(s.handleCurate)),
+		at("DELETE", "/api/v1/admin/answers/{id}", s.admin(s.handleRetract)),
+		at("GET", "/api/v1/admin/operations", s.admin(s.handleAdmin)),
+		at("GET", "/api/v1/admin/access", s.admin(s.handleAccess)),
+		at("POST", "/api/v1/admin/connectors", s.admin(s.handleAddConnector)),
+		at("DELETE", "/api/v1/admin/connectors/{source}", s.admin(s.handleDropConnector)),
+		at("POST", "/api/v1/admin/connectors/{source}/start", s.admin(s.handleStartConnector)),
+		at("POST", "/api/v1/admin/connectors/{source}/stop", s.admin(s.handleStopConnector)),
+		at("POST", "/api/v1/admin/connectors/{source}/sync", s.admin(s.handleSyncConnector)),
+	}
+}
+
 // Handler returns the router.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /healthz", s.handleHealth)
-	mux.HandleFunc("GET /readyz", s.handleReady)
-	mux.Handle("GET /api/v1/me", s.authenticated(s.handleMe))
-	mux.Handle("GET /api/v1/search", s.authenticated(s.handleSearch))
-	mux.Handle("GET /api/v1/suggest", s.authenticated(s.handleSuggest))
-	mux.Handle("GET /api/v1/documents", s.authenticated(s.handleDocuments))
-	mux.Handle("GET /api/v1/documents/{id}", s.authenticated(s.handleDocument))
-	mux.Handle("POST /api/v1/documents/{id}/verify", s.authenticated(s.handleVerify))
-	mux.Handle("DELETE /api/v1/documents/{id}/verify", s.authenticated(s.handleUnverify))
-	mux.Handle("PUT /api/v1/documents/{id}/owner", s.authenticated(s.handleSetOwner))
-	mux.Handle("DELETE /api/v1/documents/{id}/owner", s.authenticated(s.handleClearOwner))
-	mux.Handle("POST /api/v1/documents/{id}/stale", s.authenticated(s.handleReport))
-	mux.Handle("DELETE /api/v1/documents/{id}/stale", s.authenticated(s.handleResolve))
-	mux.Handle("DELETE /api/v1/documents/{id}/stale/mine", s.authenticated(s.handleWithdraw))
-	mux.Handle("GET /api/v1/documents/{id}/content", s.authenticated(s.handleContent))
-	mux.Handle("GET /api/v1/documents/{id}/thumbnail", s.authenticated(s.handleThumbnail))
-	mux.Handle("GET /api/v1/reported", s.authenticated(s.handleReported))
-	mux.Handle("GET /api/v1/recent", s.authenticated(s.handleRecent))
-	mux.Handle("POST /api/v1/recent", s.authenticated(s.handleRecordOpen))
-	mux.Handle("GET /api/v1/stats", s.authenticated(s.handleStats))
-	mux.Handle("GET /api/v1/events", s.authenticated(s.handleEvents))
-	mux.Handle("GET /api/v1/admin/answers", s.admin(s.handleAnswers))
-	mux.Handle("PUT /api/v1/admin/answers/{id}", s.admin(s.handleCurate))
-	mux.Handle("DELETE /api/v1/admin/answers/{id}", s.admin(s.handleRetract))
-	mux.Handle("GET /api/v1/admin/operations", s.admin(s.handleAdmin))
-	mux.Handle("GET /api/v1/admin/access", s.admin(s.handleAccess))
-	mux.Handle("POST /api/v1/admin/connectors", s.admin(s.handleAddConnector))
-	mux.Handle("DELETE /api/v1/admin/connectors/{source}", s.admin(s.handleDropConnector))
-	mux.Handle("POST /api/v1/admin/connectors/{source}/start", s.admin(s.handleStartConnector))
-	mux.Handle("POST /api/v1/admin/connectors/{source}/stop", s.admin(s.handleStopConnector))
-	mux.Handle("POST /api/v1/admin/connectors/{source}/sync", s.admin(s.handleSyncConnector))
+	for _, rt := range s.routes() {
+		mux.Handle(rt.Method+" "+rt.Pattern, rt.Handler)
+	}
 	if s.assets != nil {
 		mux.Handle("GET /", s.assets)
 	}
@@ -497,6 +546,15 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 	res, err := s.searcher.Search(r.Context(), p, query)
 	if err != nil {
 		s.log.Error("search failed", "error", err, "tenant", p.Tenant)
+		// A search that could not be run is on the trail as well as in the log.
+		// It is not an access and it is not a refusal, and an investigation
+		// reconstructing an afternoon needs to see the gap rather than infer it
+		// from a silence.
+		s.accessed(r, p, audit.Record{
+			Action:  audit.Search,
+			Outcome: audit.Failed,
+			Query:   r.URL.Query().Get("q"),
+		})
 		writeError(w, http.StatusInternalServerError, "internal", "the search could not be run")
 		return
 	}
@@ -538,6 +596,16 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 		hit.Verified = verifiedOf(vouched[h.Document.ID], now)
 		out.Hits = append(out.Hits, hit)
 	}
+	// The page that was shown and the size of what it matched, which are two
+	// different numbers and both belong on the record: what somebody saw, and
+	// how much there was to see.
+	s.accessed(r, p, audit.Record{
+		Action:    audit.Search,
+		Outcome:   audit.Served,
+		Query:     out.Query,
+		Documents: hitItems(res.Hits),
+		Count:     res.Total,
+	})
 	writeConditional(w, r, http.StatusOK, out, out.identity())
 }
 
@@ -750,9 +818,11 @@ func (s *Server) handleSuggest(w http.ResponseWriter, r *http.Request, p *acl.Pr
 	res, err := s.searcher.Search(r.Context(), p, q)
 	if err != nil {
 		s.log.Warn("suggest failed", "error", err, "tenant", p.Tenant)
+		s.accessed(r, p, audit.Record{Action: audit.Suggest, Outcome: audit.Failed, Query: raw})
 		writeConditional(w, r, http.StatusOK, out, out.identity())
 		return
 	}
+	var shown []audit.Item
 	for _, h := range res.Hits {
 		if len(out.Suggestions) >= SuggestLimit {
 			break
@@ -764,7 +834,19 @@ func (s *Server) handleSuggest(w http.ResponseWriter, r *http.Request, p *acl.Pr
 			ID:   h.Document.ID,
 			URL:  h.Document.URL,
 		})
+		shown = append(shown, item(h.Document))
 	}
+	// The titles of these went in front of somebody, which is the whole reason
+	// the typeahead is audited like a search rather than treated as a keystroke.
+	// The operator completions are left off the record: they are the same six
+	// words for everybody and say nothing about the corpus.
+	s.accessed(r, p, audit.Record{
+		Action:    audit.Suggest,
+		Outcome:   audit.Served,
+		Query:     raw,
+		Documents: shown,
+		Count:     len(shown),
+	})
 	out.TookMS = float64(time.Since(start).Microseconds()) / 1000
 	writeConditional(w, r, http.StatusOK, out, out.identity())
 }
@@ -816,18 +898,39 @@ func facetValues(in []index.Facet) []facet {
 }
 
 func (s *Server) handleDocument(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
-	d, err := s.store.Get(r.Context(), p, r.PathValue("id"))
+	id := r.PathValue("id")
+	d, err := s.store.Get(r.Context(), p, id)
 	switch {
 	case errors.Is(err, genba.ErrNotFound):
 		// A document the caller may not read and a document that does not exist
-		// produce the same response, all the way out to the status code.
+		// produce the same response, all the way out to the status code, and
+		// they are one outcome on the record for the same reason.
+		s.accessed(r, p, audit.Record{
+			Action:    audit.Read,
+			Outcome:   audit.Refused,
+			Documents: []audit.Item{{ID: id}},
+		})
 		writeError(w, http.StatusNotFound, "not_found", "no such document")
 		return
 	case err != nil:
 		s.log.Error("document lookup failed", "error", err)
+		s.accessed(r, p, audit.Record{
+			Action:    audit.Read,
+			Outcome:   audit.Failed,
+			Documents: []audit.Item{{ID: id}},
+		})
 		writeError(w, http.StatusInternalServerError, "internal", "the document could not be read")
 		return
 	}
+	// One document, so the clause that admitted them is known and worth keeping.
+	// It is the clause and never the reference it matched. See [ruleOf].
+	s.accessed(r, p, audit.Record{
+		Action:    audit.Read,
+		Outcome:   audit.Served,
+		Documents: []audit.Item{item(d)},
+		Count:     1,
+		Rule:      ruleOf(p, d),
+	})
 	body := documentResponse(d)
 	// The preview is where somebody decides whether to trust what they are
 	// reading, so it carries the claim and whether this reader is one of the
@@ -941,15 +1044,20 @@ var inlineTypes = map[string]bool{
 }
 
 func (s *Server) handleContent(w http.ResponseWriter, r *http.Request, p *acl.Principal) {
+	id := r.PathValue("id")
 	cs, ok := s.store.(store.ContentStore)
 	if !ok {
 		// A deployment on a driver that holds no bytes has no content to serve,
 		// and says so the same way it would for a document that is not there.
+		s.accessed(r, p, audit.Record{
+			Action:    audit.Content,
+			Outcome:   audit.Refused,
+			Documents: []audit.Item{{ID: id}},
+		})
 		writeError(w, http.StatusNotFound, "not_found", "no such document")
 		return
 	}
 
-	id := r.PathValue("id")
 	// The document is read first because it is where the permission decision and
 	// the media type both come from. The driver applies the principal again on
 	// the content read, so this is a lookup rather than the check itself.
@@ -958,15 +1066,37 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request, p *acl.Pr
 		var c doc.Content
 		c, err = cs.Content(r.Context(), p, id)
 		if err == nil {
+			// The bytes are counted before they are written, and a conditional
+			// request that comes back 304 still records the access. What is being
+			// recorded is that this person was given this document, and a browser
+			// that already had a copy was given it earlier.
+			s.accessed(r, p, audit.Record{
+				Action:    audit.Content,
+				Outcome:   audit.Served,
+				Documents: []audit.Item{item(d)},
+				Count:     1,
+				Rule:      ruleOf(p, d),
+				Bytes:     int64(len(c.Bytes)),
+			})
 			s.writeContent(w, r, d, c)
 			return
 		}
 	}
 	switch {
 	case errors.Is(err, genba.ErrNotFound):
+		s.accessed(r, p, audit.Record{
+			Action:    audit.Content,
+			Outcome:   audit.Refused,
+			Documents: []audit.Item{{ID: id}},
+		})
 		writeError(w, http.StatusNotFound, "not_found", "no such document")
 	default:
 		s.log.Error("content lookup failed", "error", err)
+		s.accessed(r, p, audit.Record{
+			Action:    audit.Content,
+			Outcome:   audit.Failed,
+			Documents: []audit.Item{{ID: id}},
+		})
 		writeError(w, http.StatusInternalServerError, "internal", "the document could not be read")
 	}
 }

--- a/api/audit.go
+++ b/api/audit.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/audit"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+)
+
+// WithAudit sets where the record of every content access is written.
+//
+// There is no option that switches auditing off, and there is not going to be
+// one. A server built without this one still writes its records, to the process
+// log, because a deployment that can quietly stop recording who read what is a
+// deployment whose audit trail is worth nothing: the answer to "was this on at
+// the time" has to be yes by construction rather than by a configuration file
+// somebody would have to go and read.
+//
+// What a deployment chooses here is where the records go and how long they are
+// kept. See [audit.Open] for the file sink and docs/audit.md for the shape of
+// what it writes.
+func WithAudit(a *audit.Log) Option {
+	return func(s *Server) {
+		if a != nil {
+			s.audit = a
+		}
+	}
+}
+
+// Close releases what the server owns, which is the audit log it built for
+// itself and nothing else.
+//
+// A store, a searcher and an audit log that were passed in belong to whoever
+// passed them, and a server that closed them would be shutting down half of
+// somebody else's process. An embedder that never calls this loses at most the
+// records still queued when the process exits.
+func (s *Server) Close() error {
+	if !s.ownAudit {
+		return nil
+	}
+	return s.audit.Close()
+}
+
+// accessed writes one record for a request that has been answered.
+//
+// The caller fills in what happened and this fills in who and where, so that a
+// handler cannot get the identity fields subtly wrong and no handler has to
+// know how a principal maps onto a record.
+func (s *Server) accessed(r *http.Request, p *acl.Principal, rec audit.Record) {
+	if p != nil {
+		rec.Tenant, rec.Subject, rec.Kind = p.Tenant, p.Subject, kindOf(p.Kind)
+	}
+	rec.Surface = surfaceOf(r)
+	s.audit.Write(rec)
+}
+
+// kindOf is the principal kind as the record spells it.
+//
+// It is written out here rather than taken from a String method, because these
+// strings are filtered on by whatever reads an export and they must not change
+// when somebody renames a constant.
+func kindOf(k acl.Kind) string {
+	switch k {
+	case acl.KindService:
+		return "service"
+	case acl.KindAgent:
+		return "agent"
+	default:
+		return "user"
+	}
+}
+
+// surfaceOf is the route the access came through.
+//
+// The registered pattern rather than the path, because a path carries document
+// ids and they are already on the record in a field something can filter on. A
+// handler called directly, which is a test rather than a deployment, has no
+// pattern and gets the path.
+func surfaceOf(r *http.Request) string {
+	if r.Pattern != "" {
+		return r.Pattern
+	}
+	return r.Method + " " + r.URL.Path
+}
+
+// item is one document on a record: an identifier and where it came from, never
+// a title.
+func item(d doc.Document) audit.Item {
+	return audit.Item{ID: d.ID, Source: d.Source}
+}
+
+// items is the same for a list of documents.
+func items(docs []doc.Document) []audit.Item {
+	out := make([]audit.Item, 0, len(docs))
+	for _, d := range docs {
+		out = append(out, item(d))
+	}
+	return out
+}
+
+// hitItems is the same for a page of results.
+func hitItems(hits []index.Result) []audit.Item {
+	out := make([]audit.Item, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, item(h.Document))
+	}
+	return out
+}
+
+// ruleOf is the clause of the access control list that admitted somebody to one
+// document.
+//
+// Only the clause. The reference it matched is deliberately dropped, because
+// that is a group name and a trail of access decisions that named groups would
+// describe the shape of an organisation to everybody who can read the trail.
+func ruleOf(p *acl.Principal, d doc.Document) string {
+	return string(d.Permissions.Decide(p).Rule)
+}

--- a/api/audit_test.go
+++ b/api/audit_test.go
@@ -1,0 +1,235 @@
+package api_test
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/audit"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// kept is a sink that holds what it was given, which is the only way to assert
+// on a record without going through a file.
+type kept struct {
+	mu      sync.Mutex
+	records []audit.Record
+}
+
+func (k *kept) Append(rec audit.Record) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.records = append(k.records, rec)
+	return nil
+}
+
+func (k *kept) Flush() error { return nil }
+func (k *kept) Close() error { return nil }
+
+// trailed is a server over a small corpus, with its audit records readable.
+func trailed(t *testing.T) (*kept, *audit.Log, http.Handler) {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	perm := acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "gdrive",
+		AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}},
+		Version:     1,
+	}
+	docs := []doc.Document{
+		{
+			ID: "d1", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Payments failover runbook", Body: "Fail the payments queue over.",
+			Permissions: perm,
+		},
+		{
+			ID: "secret", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Board pack", Body: "Numbers.",
+			Permissions: acl.Permissions{
+				Mode:        acl.ModeACL,
+				Source:      "gdrive",
+				AllowGroups: []acl.Ref{{Source: "gdrive", Value: "board@acme.com"}},
+				Version:     1,
+			},
+		},
+		{
+			ID: "img", Tenant: "acme", Source: "gdrive", Kind: doc.KindImage,
+			Title: "diagram.png", Permissions: perm,
+			Properties: map[string]string{doc.MediaType: "image/png"},
+			Content:    &doc.Content{Bytes: square(t), Width: 8, Height: 8},
+		},
+	}
+	if err := st.Put(t.Context(), docs...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	sink := &kept{}
+	log := audit.New(sink)
+	t.Cleanup(func() { _ = log.Close() })
+
+	s := api.New(st, index.New(st), api.HeaderAuth{Tenant: "acme"}, api.WithAudit(log))
+	t.Cleanup(func() { _ = s.Close() })
+	return sink, log, s.Handler()
+}
+
+// written is the records one request produced.
+func written(t *testing.T, sink *kept, log *audit.Log, h http.Handler, target string) []audit.Record {
+	t.Helper()
+	request(t, h, http.MethodGet, target, engineer())
+	if err := log.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	return append([]audit.Record(nil), sink.records...)
+}
+
+// TestADocumentSomebodyMayNotReadIsOnTheTrailAsARefusal, which is the record an
+// investigation is most often actually looking for.
+//
+// It is the one a system that only logged successes would not have. The id is
+// on it because that is what was asked for, and nothing else is, because the
+// answer to the request was that there is nothing to say.
+func TestADocumentSomebodyMayNotReadIsOnTheTrailAsARefusal(t *testing.T) {
+	sink, log, h := trailed(t)
+
+	got := written(t, sink, log, h, "/api/v1/documents/secret")
+	if len(got) != 1 {
+		t.Fatalf("%d records, want 1", len(got))
+	}
+	rec := got[0]
+	if rec.Outcome != audit.Refused || rec.Action != audit.Read {
+		t.Errorf("the record is a %q %q", rec.Outcome, rec.Action)
+	}
+	if len(rec.Documents) != 1 || rec.Documents[0].ID != "secret" {
+		t.Errorf("the record names %v", rec.Documents)
+	}
+	if rec.Rule != "" {
+		t.Errorf("a refusal carries the rule %q, and the trail does not say why somebody was turned away", rec.Rule)
+	}
+}
+
+// TestADocumentThatIsNotThereLooksTheSameOnTheTrail as one somebody may not
+// read.
+//
+// The API answers a missing document and a forbidden one identically, and so
+// does the record. A trail that separated them would prove a document exists to
+// anybody who can read the trail, which is more people than can read the
+// document.
+func TestADocumentThatIsNotThereLooksTheSameOnTheTrail(t *testing.T) {
+	sink, log, h := trailed(t)
+
+	missing := written(t, sink, log, h, "/api/v1/documents/nope")
+	if len(missing) != 1 {
+		t.Fatalf("%d records, want 1", len(missing))
+	}
+	if missing[0].Outcome != audit.Refused {
+		t.Fatalf("a document that does not exist is a %q", missing[0].Outcome)
+	}
+	if missing[0].Rule != "" || missing[0].Documents[0].Source != "" {
+		t.Errorf("the record says more about a document nobody may see than a refusal does: %+v", missing[0])
+	}
+}
+
+// TestTheRuleThatAdmittedSomebodyIsOnTheRecord, because "they own it" and "it is
+// public to the tenant" are different facts about an access and an investigation
+// has to be able to tell them apart. The reference that matched is not, because
+// it is a group name.
+func TestTheRuleThatAdmittedSomebodyIsOnTheRecord(t *testing.T) {
+	sink, log, h := trailed(t)
+
+	got := written(t, sink, log, h, "/api/v1/documents/d1")
+	if len(got) != 1 {
+		t.Fatalf("%d records, want 1", len(got))
+	}
+	if got[0].Rule != string(acl.RuleListed) {
+		t.Errorf("the record says the rule was %q, want %q", got[0].Rule, acl.RuleListed)
+	}
+	if got[0].Documents[0].Source != "gdrive" {
+		t.Errorf("the record does not say where the document came from: %+v", got[0].Documents)
+	}
+}
+
+// TestHowMuchContentLeftIsOnTheRecord. The question after an incident is not
+// only which documents somebody opened but how much of the corpus they took,
+// and a response size does not answer that.
+func TestHowMuchContentLeftIsOnTheRecord(t *testing.T) {
+	sink, log, h := trailed(t)
+
+	got := written(t, sink, log, h, "/api/v1/documents/img/content")
+	if len(got) != 1 {
+		t.Fatalf("%d records, want 1", len(got))
+	}
+	if got[0].Action != audit.Content || got[0].Outcome != audit.Served {
+		t.Fatalf("the record is a %q %q", got[0].Outcome, got[0].Action)
+	}
+	if want := int64(len(square(t))); got[0].Bytes != want {
+		t.Errorf("the record says %d bytes left, want %d", got[0].Bytes, want)
+	}
+}
+
+// TestASearchRecordsThePageAndTheSizeOfWhatMatched, which are two different
+// numbers: what somebody saw, and how much there was to see.
+func TestASearchRecordsThePageAndTheSizeOfWhatMatched(t *testing.T) {
+	sink, log, h := trailed(t)
+
+	got := written(t, sink, log, h, "/api/v1/search?q=payments&limit=1")
+	if len(got) != 1 {
+		t.Fatalf("%d records, want 1", len(got))
+	}
+	rec := got[0]
+	if rec.Action != audit.Search || rec.Query != "payments" {
+		t.Errorf("the record is a %q for %q", rec.Action, rec.Query)
+	}
+	if len(rec.Documents) != 1 || rec.Documents[0].ID != "d1" {
+		t.Errorf("the page on the record is %v", rec.Documents)
+	}
+	if rec.Count < 1 {
+		t.Errorf("the record says %d documents matched", rec.Count)
+	}
+}
+
+// TestSomebodyElsesResultsAreNotOnSomebodyElsesTrail. The search is filtered by
+// the driver and the record is built from what came back, so a document the
+// caller may not read cannot appear on their record. This is the test that
+// would fail if the record were ever built from the query rather than from the
+// answer.
+func TestSomebodyElsesResultsAreNotOnSomebodyElsesTrail(t *testing.T) {
+	sink, log, h := trailed(t)
+
+	got := written(t, sink, log, h, "/api/v1/search?q=numbers")
+	if len(got) != 1 {
+		t.Fatalf("%d records, want 1", len(got))
+	}
+	for _, item := range got[0].Documents {
+		if item.ID == "secret" {
+			t.Fatalf("a document this caller may not read is on their record: %v", got[0].Documents)
+		}
+	}
+}
+
+// square is a real PNG, small enough to be cheap and large enough to be one.
+func square(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewNRGBA(image.Rect(0, 0, 8, 8))
+	for x := range 8 {
+		for y := range 8 {
+			img.Set(x, y, color.NRGBA{R: 0x20, G: 0x80, B: 0xd0, A: 0xff})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encoding a test image: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/api/documents.go
+++ b/api/documents.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/audit"
 )
 
 // DocumentsMax is how many documents one lookup may name.
@@ -58,8 +59,19 @@ func (s *Server) handleDocuments(w http.ResponseWriter, r *http.Request, p *acl.
 	}
 
 	out := documentsResponse{Documents: []searchHit{}}
-	for _, d := range s.documents(r, p, ids) {
+	found := s.documents(r, p, ids)
+	for _, d := range found {
 		out.Documents = append(out.Documents, hitOf(d))
 	}
+	// What came back rather than what was asked for. An id the caller may not
+	// read is not on the record as a refusal, because this endpoint is handed a
+	// list somebody already holds and half of it not resolving is the normal
+	// case rather than an event.
+	s.accessed(r, p, audit.Record{
+		Action:    audit.List,
+		Outcome:   audit.Served,
+		Documents: items(found),
+		Count:     len(found),
+	})
 	writeConditional(w, r, http.StatusOK, out, nil)
 }

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tamnd/genba/audit"
 	"github.com/tamnd/genba/metric"
 	"github.com/tamnd/genba/store"
 )
@@ -33,6 +34,9 @@ const (
 	MetricCacheEntries    = "genba_cache_entries"
 	MetricGroupStaleness  = "genba_directory_staleness_seconds"
 	MetricQuarantined     = "genba_quarantined_documents"
+	MetricAuditRecords    = "genba_audit_records_total"
+	MetricAuditFailed     = "genba_audit_failed_total"
+	MetricAuditQueued     = "genba_audit_queued_records"
 	MetricStoreRows       = "genba_store_rows_total"
 	MetricStoreStatements = "genba_store_statements_total"
 	MetricStoreDecodes    = "genba_store_decodes_total"
@@ -141,6 +145,26 @@ func newMetrics(s *Server) *metrics {
 			}
 			return map[string]float64{"": float64(st.Quarantined)}
 		})
+
+	// What the audit trail has done with itself.
+	//
+	// Failed is the one to alert on and it should be flat at zero: a record that
+	// could not be written is an access that happened and cannot be proved, and
+	// the deployment finding that out at the end of a quarter is the failure
+	// this metric exists to prevent. Queued is the other half of the story,
+	// because a queue that is not draining is a sink that is about to start
+	// making a request wait.
+	audited := func(pick func(audit.Stats) float64) func(context.Context) map[string]float64 {
+		return func(context.Context) map[string]float64 {
+			return map[string]float64{"": pick(s.audit.Stats())}
+		}
+	}
+	r.Counters(MetricAuditRecords, "Content access records written.", "", "counter",
+		audited(func(st audit.Stats) float64 { return float64(st.Written) }))
+	r.Counters(MetricAuditFailed, "Content access records that could not be written, which should be zero.", "", "counter",
+		audited(func(st audit.Stats) float64 { return float64(st.Failed) }))
+	r.Counters(MetricAuditQueued, "Content access records waiting to be written.", "", "gauge",
+		audited(func(st audit.Stats) float64 { return float64(st.Queued) }))
 
 	// A driver is not obliged to be measurable. One that is publishes the same
 	// numbers the CI gate asserts on, so a slow deployment can be compared with

--- a/api/recent.go
+++ b/api/recent.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/audit"
 	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/store"
 )
@@ -88,6 +89,10 @@ func (s *Server) handleRecent(w http.ResponseWriter, r *http.Request, p *acl.Pri
 		Changed: []searchHit{},
 		At:      s.now().UTC(),
 	}
+	// Both halves land on one record, because they are one screen and a trail
+	// that split them would say somebody looked at two things when they looked
+	// at a home page once.
+	var shown []audit.Item
 
 	// A driver that cannot remember an open serves the other half rather than an
 	// error. The interface is built for that: a deployment on a store with no
@@ -102,18 +107,27 @@ func (s *Server) handleRecent(w http.ResponseWriter, r *http.Request, p *acl.Pri
 		}
 		for _, o := range opens {
 			out.Opened = append(out.Opened, openedHit{searchHit: hitOf(o.Document), At: o.At.UTC()})
+			shown = append(shown, item(o.Document))
 		}
 	}
 
 	changed, err := s.searcher.Recent(r.Context(), p, limit)
 	if err != nil {
 		s.log.Error("recent failed", "error", err, "tenant", p.Tenant)
+		s.accessed(r, p, audit.Record{Action: audit.List, Outcome: audit.Failed})
 		writeError(w, http.StatusInternalServerError, "internal", "the recent list could not be read")
 		return
 	}
 	for _, d := range changed {
 		out.Changed = append(out.Changed, hitOf(d))
+		shown = append(shown, item(d))
 	}
+	s.accessed(r, p, audit.Record{
+		Action:    audit.List,
+		Outcome:   audit.Served,
+		Documents: shown,
+		Count:     len(shown),
+	})
 
 	// One question for both halves, because they are one screen. A badge that
 	// showed up in results and not here would read as a bug in the badge rather

--- a/api/reported.go
+++ b/api/reported.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/audit"
 )
 
 // Reported is the other half of saying a document is out of date: what somebody
@@ -86,6 +87,10 @@ func (s *Server) handleReported(w http.ResponseWriter, r *http.Request, p *acl.P
 	out := reportedResponse{Documents: []reportedHit{}, At: s.now().UTC()}
 	rep, ok := s.reporter()
 	if !ok {
+		// An empty list is still an answer about the corpus, and a deployment
+		// whose driver remembers no reports should not have a hole in its trail
+		// where this screen is.
+		s.accessed(r, p, audit.Record{Action: audit.List, Outcome: audit.Served})
 		writeConditional(w, r, http.StatusOK, out, out.identity())
 		return
 	}
@@ -93,14 +98,23 @@ func (s *Server) handleReported(w http.ResponseWriter, r *http.Request, p *acl.P
 	flagged, err := rep.Reported(r.Context(), p, limit)
 	if err != nil {
 		s.log.Error("the reported list could not be read", "error", err, "tenant", p.Tenant)
+		s.accessed(r, p, audit.Record{Action: audit.List, Outcome: audit.Failed})
 		writeError(w, http.StatusInternalServerError, "internal", "the reported list could not be read")
 		return
 	}
+	shown := make([]audit.Item, 0, len(flagged))
 	for _, f := range flagged {
 		out.Documents = append(out.Documents, reportedHit{
 			searchHit: hitOf(f.Document),
 			Stale:     staleOf(f.Stale),
 		})
+		shown = append(shown, item(f.Document))
 	}
+	s.accessed(r, p, audit.Record{
+		Action:    audit.List,
+		Outcome:   audit.Served,
+		Documents: shown,
+		Count:     len(shown),
+	})
 	writeConditional(w, r, http.StatusOK, out, out.identity())
 }

--- a/api/surface_test.go
+++ b/api/surface_test.go
@@ -1,0 +1,314 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/audit"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// This file is inside the package because it walks the route table, which is
+// not exported and should not be. What it enforces is the promise the product
+// makes about its audit trail: that the set of surfaces which can put a
+// document in front of somebody and the set which write a record are the same
+// set, and that they stay the same set as the API grows.
+
+// requests is how to exercise each surface that serves content.
+//
+// Every route the table marks as content needs one, and a route without one
+// fails the walk rather than being skipped. That is the point: adding an
+// endpoint that returns documents means answering the question of what its
+// audit record looks like, in the same change rather than a year later.
+var requests = map[string]string{
+	"GET /api/v1/search":                   "/api/v1/search?q=payments",
+	"GET /api/v1/suggest":                  "/api/v1/suggest?q=pay",
+	"GET /api/v1/documents":                "/api/v1/documents?id=img",
+	"GET /api/v1/documents/{id}":           "/api/v1/documents/img",
+	"GET /api/v1/documents/{id}/content":   "/api/v1/documents/img/content",
+	"GET /api/v1/documents/{id}/thumbnail": "/api/v1/documents/img/thumbnail?size=96",
+	"GET /api/v1/reported":                 "/api/v1/reported",
+	"GET /api/v1/recent":                   "/api/v1/recent",
+}
+
+// quiet is every other route, with the reason it serves no content.
+//
+// It is spelled out one route at a time on purpose. A new endpoint is in
+// neither list, so somebody has to decide which it is, and writing "it returns
+// no documents" next to a route that returns documents is a thing a reviewer
+// can see.
+var quiet = map[string]string{
+	"GET /healthz":                                 "liveness, and it takes no principal",
+	"GET /readyz":                                  "readiness, and it takes no principal",
+	"GET /api/v1/me":                               "who the caller is, which they already know",
+	"POST /api/v1/documents/{id}/verify":           "a claim about a document, not the document",
+	"DELETE /api/v1/documents/{id}/verify":         "withdrawing a claim",
+	"PUT /api/v1/documents/{id}/owner":             "a correction to who is accountable",
+	"DELETE /api/v1/documents/{id}/owner":          "withdrawing that correction",
+	"POST /api/v1/documents/{id}/stale":            "a report about a document, not the document",
+	"DELETE /api/v1/documents/{id}/stale":          "clearing a report",
+	"DELETE /api/v1/documents/{id}/stale/mine":     "withdrawing one's own report",
+	"POST /api/v1/recent":                          "recording that something was opened, and it answers 204",
+	"GET /api/v1/stats":                            "counts of the corpus, with nothing of any document in them",
+	"GET /api/v1/events":                           "index events, which carry no document",
+	"GET /api/v1/admin/answers":                    "curated answers, which are written here rather than read from the corpus",
+	"PUT /api/v1/admin/answers/{id}":               "writing one",
+	"DELETE /api/v1/admin/answers/{id}":            "retracting one",
+	"GET /api/v1/admin/operations":                 "what the connectors are doing",
+	"GET /api/v1/admin/access":                     "why one principal can see one document, which is a decision rather than content",
+	"POST /api/v1/admin/connectors":                "configuration",
+	"DELETE /api/v1/admin/connectors/{source}":     "configuration",
+	"POST /api/v1/admin/connectors/{source}/start": "configuration",
+	"POST /api/v1/admin/connectors/{source}/stop":  "configuration",
+	"POST /api/v1/admin/connectors/{source}/sync":  "configuration",
+}
+
+// TestEverySurfaceThatServesContentWritesARecord is the walk.
+//
+// It goes through the router the way a browser does, so what it proves is not
+// that a handler calls a function but that a request arriving at this server
+// leaves a record behind, with the caller on it and the route it came through.
+func TestEverySurfaceThatServesContentWritesARecord(t *testing.T) {
+	for _, rt := range served(t) {
+		pattern := rt.Method + " " + rt.Pattern
+		t.Run(pattern, func(t *testing.T) {
+			target, ok := requests[pattern]
+			if !ok {
+				t.Fatalf("%s serves content and this test does not know how to call it, add it to requests in surface_test.go", pattern)
+			}
+
+			wk := auditing(t)
+			wk.ask(t, rt.Method, target)
+
+			got := wk.records()
+			if len(got) != 1 {
+				t.Fatalf("%s wrote %d records, want exactly one", pattern, len(got))
+			}
+			rec := got[0]
+			switch {
+			case rec.Outcome != audit.Served:
+				t.Errorf("the record says %q, want a served access", rec.Outcome)
+			case rec.Surface != pattern:
+				t.Errorf("the record came through %q, want %q", rec.Surface, pattern)
+			case rec.Subject != "u_mei" || rec.Tenant != "acme":
+				t.Errorf("the record names %q of %q", rec.Subject, rec.Tenant)
+			case rec.Kind != "user":
+				t.Errorf("the record calls the caller a %q", rec.Kind)
+			case rec.At.IsZero():
+				t.Error("the record is not stamped")
+			}
+		})
+	}
+}
+
+// TestARecordNamesNoContentAndNoGroup walks the same surfaces and reads what
+// was written.
+//
+// An audit trail is kept for years and is read by more people than the corpus
+// is, so a title in it is a leak with a long tail and a group name in it
+// describes the shape of the organisation to everybody holding the export.
+func TestARecordNamesNoContentAndNoGroup(t *testing.T) {
+	wk := auditing(t)
+	for _, rt := range served(t) {
+		if target, ok := requests[rt.Method+" "+rt.Pattern]; ok {
+			wk.ask(t, rt.Method, target)
+		}
+	}
+
+	// The title of a document in the corpus, the body of one, and the group that
+	// admitted the caller to both.
+	secrets := []string{"Payments failover runbook", "Fail the payments queue", "architecture.png", "eng@acme.com"}
+	for _, rec := range wk.records() {
+		raw, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		for _, secret := range secrets {
+			if bytes.Contains(raw, []byte(secret)) {
+				t.Errorf("a record of %s carries %q:\n%s", rec.Surface, secret, raw)
+			}
+		}
+	}
+}
+
+// TestEveryRouteHasSaidWhetherItServesContent is the other half of the walk.
+//
+// The walk above can only hold routes to a promise they have made, so this is
+// what stops a new endpoint from quietly making none.
+func TestEveryRouteHasSaidWhetherItServesContent(t *testing.T) {
+	s := New(corpus(t), nil, HeaderAuth{Tenant: "acme"})
+	t.Cleanup(func() { _ = s.Close() })
+
+	for _, rt := range s.routes() {
+		pattern := rt.Method + " " + rt.Pattern
+		if rt.Content {
+			if _, ok := quiet[pattern]; ok {
+				t.Errorf("%s is marked as serving content and is also listed as serving none", pattern)
+			}
+			continue
+		}
+		if _, ok := quiet[pattern]; !ok {
+			t.Errorf("%s serves no content according to the route table, say why in quiet in surface_test.go, or mark the route as content", pattern)
+		}
+	}
+}
+
+// TestAuditingIsOnWithoutBeingConfigured. There is no option that turns this
+// off, and the way that is proved is that a server built with nothing but its
+// dependencies still writes to something.
+func TestAuditingIsOnWithoutBeingConfigured(t *testing.T) {
+	s := New(corpus(t), nil, HeaderAuth{Tenant: "acme"})
+	t.Cleanup(func() { _ = s.Close() })
+
+	if s.audit == nil {
+		t.Fatal("a server built with no options has nowhere to write its audit records")
+	}
+	s.audit.Write(audit.Record{Action: audit.Read, Outcome: audit.Served})
+	if err := s.audit.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if st := s.audit.Stats(); st.Written != 1 {
+		t.Errorf("the default log wrote %d records, want 1", st.Written)
+	}
+}
+
+// served is the routes that can put a document in front of somebody.
+func served(t *testing.T) []route {
+	t.Helper()
+	s := New(corpus(t), nil, HeaderAuth{Tenant: "acme"})
+	t.Cleanup(func() { _ = s.Close() })
+
+	var out []route
+	for _, rt := range s.routes() {
+		if rt.Content {
+			out = append(out, rt)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no route says it serves content, which cannot be right")
+	}
+	return out
+}
+
+// walker is a server over the corpus with somewhere to read its records back
+// from.
+type walker struct {
+	sink    *recorder
+	log     *audit.Log
+	handler http.Handler
+}
+
+func auditing(t *testing.T) *walker {
+	t.Helper()
+	sink := &recorder{}
+	log := audit.New(sink)
+	t.Cleanup(func() { _ = log.Close() })
+
+	st := corpus(t)
+	s := New(st, index.New(st), HeaderAuth{Tenant: "acme"}, WithAudit(log))
+	t.Cleanup(func() { _ = s.Close() })
+	return &walker{sink: sink, log: log, handler: s.Handler()}
+}
+
+// ask makes one request as somebody who may read the corpus, and waits for the
+// records it produced to reach the sink.
+func (wk *walker) ask(t *testing.T, method, target string) {
+	t.Helper()
+	r := httptest.NewRequestWithContext(t.Context(), method, target, nil)
+	r.Header.Set(HeaderSubject, "u_mei")
+	r.Header.Set(HeaderGroups, "gdrive:eng@acme.com")
+	w := httptest.NewRecorder()
+	wk.handler.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("%s %s answered %d, and this walk is about the paths that answer with content:\n%s",
+			method, target, w.Code, w.Body.String())
+	}
+	// The write path is a queue, so a test that read the sink without this would
+	// be asserting on how fast a goroutine was scheduled.
+	if err := wk.log.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+}
+
+func (wk *walker) records() []audit.Record { return wk.sink.records() }
+
+// recorder is a sink that keeps what it was given.
+type recorder struct {
+	mu   sync.Mutex
+	held []audit.Record
+}
+
+func (s *recorder) Append(rec audit.Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.held = append(s.held, rec)
+	return nil
+}
+
+func (s *recorder) Flush() error { return nil }
+func (s *recorder) Close() error { return nil }
+
+func (s *recorder) records() []audit.Record {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]audit.Record(nil), s.held...)
+}
+
+// corpus is one page and one image, both readable by the engineer the walk
+// authenticates as.
+func corpus(t *testing.T) *memstore.Store {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+
+	perm := acl.Permissions{
+		Mode:        acl.ModeACL,
+		Source:      "gdrive",
+		AllowGroups: []acl.Ref{{Source: "gdrive", Value: "eng@acme.com"}},
+		Version:     1,
+	}
+	docs := []doc.Document{
+		{
+			ID: "d1", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
+			Title: "Payments failover runbook", Body: "Fail the payments queue over to the replica.",
+			Permissions: perm,
+		},
+		{
+			ID: "img", Tenant: "acme", Source: "gdrive", Kind: doc.KindImage,
+			Title: "architecture.png", Permissions: perm,
+			Properties: map[string]string{doc.MediaType: "image/png"},
+			Content:    &doc.Content{Bytes: pixels(t), Width: 8, Height: 8},
+		},
+	}
+	if err := st.Put(t.Context(), docs...); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	return st
+}
+
+// pixels is a real PNG, because the thumbnail endpoint decodes what it is
+// given and a fake one would take that surface off the walk.
+func pixels(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewNRGBA(image.Rect(0, 0, 8, 8))
+	for x := range 8 {
+		for y := range 8 {
+			img.Set(x, y, color.NRGBA{R: 0x20, G: 0x80, B: 0xd0, A: 0xff})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encoding a test image: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/api/thumbnail.go
+++ b/api/thumbnail.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tamnd/genba"
 	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/audit"
 	"github.com/tamnd/genba/cache"
 	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/store"
@@ -58,21 +59,38 @@ func (s *Server) handleThumbnail(w http.ResponseWriter, r *http.Request, p *acl.
 		return
 	}
 
+	id := r.PathValue("id")
+	// A thumbnail is a rendering of the document and it is enough of one to read
+	// a page over somebody's shoulder, so every answer this endpoint gives is on
+	// the trail, including the ones that give nothing.
+	refused := func() {
+		s.accessed(r, p, audit.Record{
+			Action:    audit.Thumbnail,
+			Outcome:   audit.Refused,
+			Documents: []audit.Item{{ID: id}},
+		})
+		notThere(w)
+	}
+
 	cs, ok := s.store.(store.ContentStore)
 	if !ok {
-		notThere(w)
+		refused()
 		return
 	}
 
-	id := r.PathValue("id")
 	d, err := s.store.Get(r.Context(), p, id)
 	if err != nil {
 		if !errors.Is(err, genba.ErrNotFound) {
 			s.log.Error("thumbnail lookup failed", "error", err)
+			s.accessed(r, p, audit.Record{
+				Action:    audit.Thumbnail,
+				Outcome:   audit.Failed,
+				Documents: []audit.Item{{ID: id}},
+			})
 			writeError(w, http.StatusInternalServerError, "internal", "the document could not be read")
 			return
 		}
-		notThere(w)
+		refused()
 		return
 	}
 
@@ -93,9 +111,18 @@ func (s *Server) handleThumbnail(w http.ResponseWriter, r *http.Request, p *acl.
 		// file that is not an image at all are the same answer, and it is the
 		// same answer a document that does not exist gets. The interface falls
 		// back to the icon for the kind, which is what it draws anyway.
-		notThere(w)
+		refused()
 		return
 	}
+
+	s.accessed(r, p, audit.Record{
+		Action:    audit.Thumbnail,
+		Outcome:   audit.Served,
+		Documents: []audit.Item{item(d)},
+		Count:     1,
+		Rule:      ruleOf(p, d),
+		Bytes:     int64(len(got.Bytes)),
+	})
 
 	sum := sha256.Sum256(got.Bytes)
 	h := w.Header()

--- a/arch_test.go
+++ b/arch_test.go
@@ -140,7 +140,7 @@ var allowed = map[string][]string{
 	"index":             {"acl", "cache", "doc", "store"},
 	"config":            nil,
 	"web":               nil,
-	"api":               {"", "acl", "cache", "directory", "doc", "index", "metric", "store", "thumb"},
+	"api":               {"", "acl", "audit", "cache", "directory", "doc", "index", "metric", "store", "thumb"},
 
 	// thumb imports nothing of ours. It is handed bytes and a size and hands
 	// back a smaller picture, which means the package that decodes files a
@@ -253,7 +253,7 @@ var allowed = map[string][]string{
 	"benchcorpus/gen": {"benchcorpus", "store/sqlitestore"},
 
 	"cmd/genba":  {""},
-	"cmd/genbad": {"", "api", "config", "connector", "connector/aclmap", "connector/fssource", "connector/limit", "connector/objectsource", "directory", "directory/provider", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
+	"cmd/genbad": {"", "api", "audit", "config", "connector", "connector/aclmap", "connector/fssource", "connector/limit", "connector/objectsource", "directory", "directory/provider", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
 }
 
 func TestDependencyDirection(t *testing.T) {

--- a/cmd/genbad/audit.go
+++ b/cmd/genbad/audit.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/tamnd/genba/audit"
+	"github.com/tamnd/genba/config"
+)
+
+// openAudit builds the log every content access is written to.
+//
+// There is no branch in here that returns nothing. A deployment says where its
+// records are kept, and the answer when it has not said anything is the process
+// log rather than silence, because a trail that can be switched off in a
+// configuration file is a trail nobody can rely on having.
+//
+// A directory that cannot be written is a startup failure. Coming up anyway and
+// falling back to the log would be the same server serving the same content
+// with a different promise about it, and the difference would be one line in a
+// log nobody reads until they need the records that were never written.
+func openAudit(cfg config.Config, log *slog.Logger) (*audit.Log, error) {
+	if cfg.AuditDir == "" {
+		return audit.New(audit.Logging(log)), nil
+	}
+	f, err := audit.Open(cfg.AuditDir, audit.WithRetention(cfg.AuditRetention))
+	if err != nil {
+		return nil, fmt.Errorf("opening the audit trail: %w", err)
+	}
+	return audit.New(f, audit.WithLogger(log)), nil
+}
+
+// auditDestination is what the startup line says about where the trail goes,
+// which is the one thing an operator wants to read back after a deployment.
+func auditDestination(cfg config.Config) string {
+	if cfg.AuditDir == "" {
+		return "log"
+	}
+	return cfg.AuditDir
+}

--- a/cmd/genbad/audit_test.go
+++ b/cmd/genbad/audit_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/api"
+	"github.com/tamnd/genba/audit"
+)
+
+// TestASearchOnARunningServerIsOnTheTrail is the whole feature seen from
+// outside.
+//
+// Everything below this is a unit test of a part of it. This one starts the
+// binary the way a unit file does, asks it a question the way a person does,
+// stops it the way a deployment does, and then reads the directory the way
+// somebody answering a question about last quarter does. If any of the wiring
+// is missing, the directory is empty and this is the test that says so.
+func TestASearchOnARunningServerIsOnTheTrail(t *testing.T) {
+	dir := t.TempDir()
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, []string{
+			"-addr", addr,
+			"-tenant", "acme",
+			"-audit-dir", dir,
+			"-log-level", "error",
+		}, env(nil), &out, &errOut)
+	}()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+	askAs(t, "http://"+addr+"/api/v1/search?q=payments", "u_mei")
+
+	// The records are written behind the request, so the trail is read after the
+	// process has stopped rather than racing it. That is also the shape of the
+	// promise: a shutdown does not lose what was already served.
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run returned %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the server did not shut down after its context was cancelled")
+	}
+
+	var got []audit.Record
+	err := audit.Records(dir, time.Time{}, time.Now().Add(time.Hour), func(rec audit.Record) error {
+		got = append(got, rec)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reading the trail: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("the server served a search and left no record of it")
+	}
+	found := false
+	for _, rec := range got {
+		if rec.Action == audit.Search && rec.Subject == "u_mei" && rec.Tenant == "acme" && rec.Query == "payments" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the search is not on the trail: %+v", got)
+	}
+}
+
+// TestADirectoryThatCannotBeOpenedStopsTheProcess rather than being worked
+// around.
+//
+// A server that came up anyway and wrote to the log instead would be serving
+// the same content under a promise it is not keeping, and the only sign of it
+// would be a line in a log nobody looks at until they need the records.
+func TestADirectoryThatCannotBeOpenedStopsTheProcess(t *testing.T) {
+	// A file where the directory was meant to be, which is what a bad path in a
+	// unit file usually turns out to be.
+	blocked := filepath.Join(t.TempDir(), "audit")
+	if err := os.WriteFile(blocked, []byte("not a directory\n"), 0o600); err != nil {
+		t.Fatalf("writing the blocking file: %v", err)
+	}
+
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), []string{"-addr", freeAddr(t), "-audit-dir", blocked}, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("the server started with nowhere to write its audit trail")
+	}
+	if !strings.Contains(err.Error(), "audit") {
+		t.Fatalf("error %q does not say what could not be opened", err)
+	}
+}
+
+// TestARetentionWithNowhereToApplyItIsRefused. Setting one and no directory is
+// somebody believing they have said how long their trail is kept while the
+// records go to the process log and this setting deletes nothing.
+func TestARetentionWithNowhereToApplyItIsRefused(t *testing.T) {
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), []string{"-addr", freeAddr(t), "-audit-retention", "720h"}, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("the server accepted a retention with no files to delete")
+	}
+	if !strings.Contains(err.Error(), "retention") {
+		t.Fatalf("error %q does not mention the retention", err)
+	}
+}
+
+// TestTheTrailIsWrittenToTheLogWhenNoDirectoryIsConfigured, because the default
+// is a different destination and not a missing one. This is the laptop case and
+// the collector case, and it is still a trail.
+func TestTheTrailIsWrittenToTheLogWhenNoDirectoryIsConfigured(t *testing.T) {
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	// Read after run has returned, which is after every deferred close has run,
+	// so nothing is still writing to it while this reads.
+	var out, errOut bytes.Buffer
+	go func() {
+		done <- run(ctx, []string{"-addr", addr, "-tenant", "acme"}, env(nil), &out, &errOut)
+	}()
+
+	waitForHealth(t, "http://"+addr+"/healthz")
+	askAs(t, "http://"+addr+"/api/v1/search?q=payments", "u_mei")
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run returned %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the server did not shut down after its context was cancelled")
+	}
+
+	logged := errOut.String()
+	if !strings.Contains(logged, audit.Message) || !strings.Contains(logged, "u_mei") {
+		t.Errorf("the search is not in the log:\n%s", logged)
+	}
+}
+
+// askAs makes one request as somebody, and fails on anything but a 200 so that
+// a test about records is never quietly a test about a 404.
+func askAs(t *testing.T, url, subject string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+	if err != nil {
+		t.Fatalf("building the request: %v", err)
+	}
+	req.Header.Set(api.HeaderSubject, subject)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("asking %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s answered %d", url, resp.StatusCode)
+	}
+}

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -86,6 +86,13 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	// administrator, which is the right default for a deployment that has not
 	// said who operates it.
 	admins := fs.String("admins", strings.Join(cfg.Admins, ","), "subjects that hold the administrator role, comma separated")
+	// Where the record of every content access is kept. There is no flag that
+	// turns this off: the choice is a directory or the process log, and both of
+	// them are a trail. A deployment that has to answer who read what puts it on
+	// a disk, because a log line lives as long as whatever is collecting the log
+	// and that is usually days rather than years.
+	fs.StringVar(&cfg.AuditDir, "audit-dir", cfg.AuditDir, "directory to keep the content access records in, one file per day, empty to write them to the log")
+	fs.DurationVar(&cfg.AuditRetention, "audit-retention", cfg.AuditRetention, "how long a day of records is kept, zero to keep them forever")
 
 	var corpus corpusOptions
 	fs.StringVar(&corpus.Dir, "corpus", "", "directory to index at startup")
@@ -146,6 +153,22 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 
 	log := newLogger(stderr, cfg.LogLevel)
 
+	// Before the store, because a process that cannot write its audit trail
+	// should fail before it has opened a database and started answering
+	// questions about the corpus in it.
+	trail, err := openAudit(cfg, log)
+	if err != nil {
+		return err
+	}
+	// Deferred first and therefore closed last, after the listeners have stopped
+	// and after the store has, so the last record a request produced is on the
+	// disk before the process leaves.
+	defer func() {
+		if err := trail.Close(); err != nil {
+			log.Error("closing the audit trail", "error", err)
+		}
+	}()
+
 	st, err := openStore(ctx, cfg)
 	if err != nil {
 		return err
@@ -171,6 +194,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		api.WithDriver(string(cfg.Store)),
 		api.WithIndexing(track.State),
 		api.WithOperations(ops.State),
+		api.WithAudit(trail),
 	}
 
 	// A connector can be added from the interface only where the driver can
@@ -276,6 +300,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 		"interface", web.Enabled(),
 		"cache", cfg.Cache,
 		"directories", len(cfg.Directories),
+		"audit", auditDestination(cfg),
 	)
 
 	errc := make(chan error, len(servers))

--- a/cmd/genbad/main_test.go
+++ b/cmd/genbad/main_test.go
@@ -174,9 +174,16 @@ func waitForIndex(t *testing.T, base string) {
 	t.Fatal("the server was still indexing after thirty seconds")
 }
 
+// waitForHealth waits for the listener to answer.
+//
+// The deadline is long because the interface is compressed before the listener
+// binds, once per process, and both encoders are asked for their best. That is
+// a fraction of a second in an ordinary build and it is over a minute in a race
+// build on a small machine, so a shorter deadline here fails on the slowest
+// machine anybody runs the suite on rather than on a server that is broken.
 func waitForHealth(t *testing.T, url string) {
 	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(2 * time.Minute)
 	for time.Now().Before(deadline) {
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,22 @@ type Config struct {
 	// a write alone, which is what a deployment that cannot tolerate a stale
 	// ordering asks for.
 	CacheResultExpiry time.Duration
+
+	// AuditDir is where the record of every content access is kept, one file per
+	// day. Empty writes the records to the process log instead, which is where
+	// they go on a laptop and behind a collector that is shipping the log
+	// somewhere already.
+	//
+	// What empty does not do is turn the trail off. There is no setting for
+	// that, because a deployment chooses where its records are kept and not
+	// whether any are written.
+	AuditDir string
+
+	// AuditRetention is how long a day of records is kept before its file is
+	// deleted, and zero keeps them forever. A day is deleted once the whole day
+	// it holds is outside the window, so a retention of a week never deletes a
+	// record that is six days old.
+	AuditRetention time.Duration
 }
 
 // Default returns the configuration a server starts with when nothing is set.
@@ -151,6 +167,7 @@ func Load(getenv func(string) string) (Config, error) {
 	str(getenv, "GENBA_DSN", &c.DSN)
 	str(getenv, "GENBA_TENANT", &c.Tenant)
 	str(getenv, "GENBA_LOG_LEVEL", &c.LogLevel)
+	str(getenv, "GENBA_AUDIT_DIR", &c.AuditDir)
 	if v := getenv("GENBA_DIRECTORY"); v != "" {
 		c.Directories = list(v)
 	}
@@ -168,6 +185,7 @@ func Load(getenv func(string) string) (Config, error) {
 		dur(getenv, "GENBA_CACHE_RESULT_EXPIRY", &c.CacheResultExpiry),
 		dur(getenv, "GENBA_DIRECTORY_TTL", &c.DirectoryTTL),
 		dur(getenv, "GENBA_DIRECTORY_REFRESH", &c.DirectoryRefresh),
+		dur(getenv, "GENBA_AUDIT_RETENTION", &c.AuditRetention),
 		boolean(getenv, "GENBA_CACHE", &c.Cache),
 	)
 	if err != nil {
@@ -206,6 +224,14 @@ func (c Config) Validate() error {
 	default:
 		errs = append(errs, fmt.Errorf("config: unknown log level %q", c.LogLevel))
 	}
+	// A retention with nowhere to apply it is somebody believing they have said
+	// how long their audit trail is kept. The records are going to the process
+	// log, whatever is holding that log decides how long it lives, and this
+	// setting deletes nothing. It is worth failing at startup rather than
+	// discovering at an audit.
+	if c.AuditRetention != 0 && c.AuditDir == "" {
+		errs = append(errs, errors.New("config: audit retention is set and audit dir is not, so there are no files to delete"))
+	}
 	for _, d := range []struct {
 		name  string
 		value time.Duration
@@ -216,6 +242,7 @@ func (c Config) Validate() error {
 		{"cache result expiry", c.CacheResultExpiry},
 		{"directory ttl", c.DirectoryTTL},
 		{"directory refresh", c.DirectoryRefresh},
+		{"audit retention", c.AuditRetention},
 	} {
 		if d.value < 0 {
 			errs = append(errs, fmt.Errorf("config: %s is negative", d.name))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,6 +69,28 @@ func TestSeveralDirectoriesComeFromOneVariable(t *testing.T) {
 	}
 }
 
+// TestTheAuditTrailIsConfiguredByWhereItGoes, not by whether it happens. The
+// default has no directory and that is a destination rather than an off switch,
+// which is the one property of this setting worth a test.
+func TestTheAuditTrailIsConfiguredByWhereItGoes(t *testing.T) {
+	c, err := config.Load(env(map[string]string{
+		"GENBA_AUDIT_DIR":       "/var/lib/genba/audit",
+		"GENBA_AUDIT_RETENTION": "720h",
+	}))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.AuditDir != "/var/lib/genba/audit" {
+		t.Errorf("AuditDir = %q", c.AuditDir)
+	}
+	if c.AuditRetention != 720*time.Hour {
+		t.Errorf("AuditRetention = %v", c.AuditRetention)
+	}
+	if d := config.Default(); d.AuditDir != "" || d.AuditRetention != 0 {
+		t.Errorf("the default keeps records at %q for %v, and it should say nothing", d.AuditDir, d.AuditRetention)
+	}
+}
+
 func TestLoadRejectsBadValues(t *testing.T) {
 	tests := []struct {
 		name string
@@ -81,6 +103,7 @@ func TestLoadRejectsBadValues(t *testing.T) {
 		{"unknown log level", map[string]string{"GENBA_LOG_LEVEL": "trace"}, "unknown log level"},
 		{"duration without a unit", map[string]string{"GENBA_READ_TIMEOUT": "30"}, "needs a unit"},
 		{"unparseable duration", map[string]string{"GENBA_READ_TIMEOUT": "soon"}, "GENBA_READ_TIMEOUT"},
+		{"retention with no files", map[string]string{"GENBA_AUDIT_RETENTION": "168h"}, "audit retention"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/alerts.yml
+++ b/docs/alerts.yml
@@ -1,6 +1,6 @@
 # Prometheus alerting rules for genba.
 #
-# There is one alert in here, and that is on purpose.
+# There are two alerts in here, and that is on purpose.
 # An alert that nobody acts on trains everybody to ignore the ones that matter, so a rule earns its place by naming something a person would get out of bed for.
 # Everything else worth watching is on a dashboard, where a number that is drifting can be looked at during working hours.
 #
@@ -31,6 +31,23 @@ groups:
             The 95th percentile of search latency has been above 25ms for five minutes.
             Check genba_search_candidates first: a candidate count that has moved with the match count means the first phase of retrieval has stopped cutting.
             Check genba_cache_hits_total against genba_cache_misses_total next: a hit rate that has collapsed usually means something is writing to the corpus continuously and dropping the cached orderings as fast as they are built.
+
+      # A record that could not be written is an access that happened and cannot be proved.
+      # It earns the second alert because it is the only failure genba has that cannot be recovered by looking again later.
+      # A slow query can be measured again tomorrow and a held document comes back after a sweep, but the request that served a document while the disk was full is over, and nothing in the process still knows about it.
+      #
+      # The threshold is any of them at all, because the trail is either complete or it is not, and a deployment that decides a few missing records a day is acceptable has decided its trail is not evidence.
+      # Fifteen minutes, because the usual cause is a full disk or a directory that lost its permissions in a deployment, and both of those are still true fifteen minutes later.
+      - alert: AuditRecordsAreBeingLost
+        expr: increase(genba_audit_failed_total[15m]) > 0
+        for: 15m
+        labels:
+          severity: page
+        annotations:
+          summary: Content access records are not being written
+          description: >-
+            The server served content it could not record. Check the disk the audit directory is on first, then its ownership, which is the usual pair of causes.
+            Check genba_audit_queued_records next: a queue that is not draining is a sink that has started making requests wait rather than one that is dropping records, and it is the same underlying problem one step earlier.
 
 # What is deliberately not alerted on, and why.
 #

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,120 @@
+# The record of who read what
+
+Every request that puts a document in front of somebody leaves a record behind.
+That includes the ones that did not: a document somebody was refused, a document that was not there, and a request that failed while it was being served.
+A trail that only holds the successes answers the easy half of every question anybody asks it.
+
+The rule is written down as a test rather than as a convention.
+`api/surface_test.go` walks the server's route table, and a route that says it serves content and has no way to be exercised fails the walk.
+A route that says nothing at all fails it too, so a new endpoint cannot avoid the question by not answering it.
+The second half of the same test reads back what was written and fails if a document title, a document body or a group name appears anywhere in it.
+
+## What is on a record
+
+```json
+{
+  "at": "2026-08-19T09:14:22.104Z",
+  "tenant": "acme",
+  "subject": "u_mei",
+  "kind": "user",
+  "surface": "GET /api/v1/documents/{id}/content",
+  "action": "content",
+  "outcome": "served",
+  "documents": [{"id": "d_4194", "source": "gdrive"}],
+  "count": 1,
+  "rule": "listed",
+  "bytes": 184320
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `at` | when the server answered, in UTC |
+| `tenant` | the tenant the request was made in |
+| `subject` | the stable identifier of the caller, not their address |
+| `kind` | `user`, `service` or `agent` |
+| `surface` | the route pattern, so the record says how the document was reached |
+| `action` | `search`, `suggest`, `list`, `read`, `content` or `thumbnail` |
+| `outcome` | `served`, `refused` or `failed` |
+| `query` | what was typed, on the search and suggest surfaces only |
+| `documents` | the ids and sources of what was actually returned |
+| `count` | how many matched, which is larger than `documents` on a paged search |
+| `rule` | the rule that admitted the caller, on a served single document |
+| `bytes` | how much content left the process |
+
+What is deliberately not on a record is the content.
+No title, no body, no snippet, no filename.
+An audit trail is kept for years, is copied into ticketing systems and is read by more people than the corpus is, so a title in it is a leak with a long tail.
+Group names are left off for the same reason one step further out: the list of groups that admitted somebody describes the shape of the organisation to everybody holding the export.
+The `rule` is on the record because "they own it" and "it is public to the tenant" are different facts about an access and an investigation has to be able to tell them apart, and the reference that matched is not, because that reference is a group name.
+
+The documents on a record are the ones that came back, never the ones that were asked for.
+A search is filtered by the storage driver before the handler sees it, so a document the caller may not read cannot reach their record.
+The exception is a refusal, where the id that was asked for is the only thing there is to say.
+
+A refusal and a document that does not exist look identical on the trail, in the same way they look identical to the caller.
+Separating them would prove a document exists to everybody who can read the trail, which is more people than can read the document.
+
+## Where the records go
+
+```
+genbad -audit-dir /var/lib/genba/audit -audit-retention 2160h
+```
+
+| Setting | Variable | Default |
+| --- | --- | --- |
+| `-audit-dir` | `GENBA_AUDIT_DIR` | empty, which writes to the process log |
+| `-audit-retention` | `GENBA_AUDIT_RETENTION` | zero, which keeps every day forever |
+
+There is no setting that turns the trail off.
+A deployment chooses where its records are kept and not whether any are written, so a server built with no options at all still writes to something, and `api.New` has no option that takes it away.
+The default destination is the process log, under the message `content access`, which is the right answer on a laptop and behind a collector that is already shipping the log somewhere.
+
+A directory is one file per UTC day, named `audit-2026-08-19.jsonl`, one JSON object per line.
+The directory is created with mode 0700 and the files with mode 0600, and a directory that cannot be written is a startup failure rather than a fallback to the log.
+Coming up anyway would be the same server serving the same content under a promise it is not keeping.
+
+A retention with no directory is refused at startup for the same reason.
+It reads like a statement about how long the trail is kept while the records are going to the log, whatever holds that log decides how long they live, and the setting deletes nothing.
+
+## What a busy server does
+
+Writes go through a queue so that a slow disk does not sit on the request path.
+Two things about that queue are worth knowing.
+
+A full queue blocks the request rather than dropping the record.
+The alternative is a server that answers faster by keeping fewer records under exactly the load somebody would later be asked about.
+
+A sink that returns an error drops the record and counts it rather than failing the request.
+That is the one place the trail loses something, which is why the count is published and alerted on.
+
+| Metric | What it is |
+| --- | --- |
+| `genba_audit_records_total` | records written |
+| `genba_audit_failed_total` | records that could not be written, which should be flat at zero |
+| `genba_audit_queued_records` | records waiting, which should be near zero |
+
+`AuditRecordsAreBeingLost` in `docs/alerts.yml` fires on any of the second one.
+It is one of the two alerts in the file because it is the only failure here that cannot be recovered by looking again later.
+
+## Reading it back
+
+```go
+err := audit.Records(dir, from, to, func(rec audit.Record) error {
+	fmt.Println(rec.Subject, rec.Action, rec.Documents)
+	return nil
+})
+```
+
+`Records` walks the days that overlap the window, oldest first, and calls the function for each record inside it.
+The window is inclusive at both ends.
+Returning an error from the function stops the walk and is returned, which is how a caller reads the first page of a large window without holding the rest of it.
+
+`Export` is the same walk written to an `io.Writer`, in the format it is stored in, which means an export is concatenation and not a translation.
+The reason it is not CSV is that the next question is always one the columns did not anticipate, and a JSON Lines file is something a person can grep and a spreadsheet can still import.
+
+A half written last line is tolerated, because a process that was killed mid write leaves one and the records before it are still evidence.
+A bad line anywhere else is an error naming the line number, because a corrupt file in the middle of a window is a different problem and quietly skipping it would produce an export that looks complete.
+
+Files that are not part of the trail are left alone, both by the reader and by the retention sweep.
+A day is deleted only once the whole day it holds is outside the window, so a retention of a week never deletes a record that is six days old.


### PR DESCRIPTION
Follows #194, which added the `audit` package with nothing calling it. This is the wiring, and it closes the remaining boxes on #21.

The part worth reviewing is not the record writes. It is the thing that stops the next endpoint from forgetting them.

## The surface is a table now

`Handler` was thirty calls to `mux.Handle`, so the set of routes existed only inside a function that had already finished building a router by the time anything could ask it a question. It is a table now, and every entry says whether it can put a document in front of somebody.

`api/surface_test.go` walks that table. It calls each content route through the router the way a browser does and fails if the request left no record. A content route it does not know how to call fails as well, so adding an endpoint that returns documents means answering the question of what its audit record looks like in the same change rather than a year later. A route in neither list fails too, which is what stops a new endpoint from quietly making no promise.

The second half of the same walk marshals every record and fails if a document title, a document body or a group name appears anywhere in it. That is the property the record shape was designed around and the one that would rot first.

## What is on a record

Records are built from what came back, never from what was asked for. A search is filtered by the storage driver before the handler sees it, so a document the caller may not read cannot reach their record, and `TestSomebodyElsesResultsAreNotOnSomebodyElsesTrail` fails if that is ever inverted.

A refusal carries the id that was asked for and nothing else. A document that does not exist looks identical on the trail to one somebody may not read, because separating them would prove a document exists to everybody who can read the trail, which is more people than can read the document.

A served single document carries the rule that admitted the caller, because "they own it" and "it is public to the tenant" are different facts about an access. The reference that matched is not on the record, because that reference is a group name.

## Configuration

```
genbad -audit-dir /var/lib/genba/audit -audit-retention 2160h
```

`GENBA_AUDIT_DIR` and `GENBA_AUDIT_RETENTION`, with flags to match. There is no setting that turns the trail off, only one that says where it goes, and the default destination is the process log.

A directory that cannot be written is a startup failure rather than a fallback to the log. Coming up anyway would be the same server serving the same content under a promise it is not keeping, and the only sign of it would be a line in a log nobody looks at until they need the records that were never written.

A retention with no directory is refused for the same reason. It reads like a statement about how long the trail is kept while the records are going to the log and this setting deletes nothing.

## Metrics and the alert

`genba_audit_records_total`, `genba_audit_failed_total` and `genba_audit_queued_records`.

The failure count gets an alert, which makes two in `docs/alerts.yml`. It earns the second one because it is the only failure genba has that cannot be recovered by looking again later. A slow query can be measured again tomorrow and a held document comes back after a sweep, but the request that served a document while the disk was full is over and nothing in the process still knows about it.

## One test change that is not about auditing

`waitForHealth` in the daemon tests waited ten seconds. That is not enough on a small machine: the interface is compressed before the listener binds, both encoders at their best, and a race build on a six core box spends over a minute on it. The deadline is two minutes now. The test that was failing on it was `TestServerServesAndShutsDown`, which is older than this branch.

## Checked

`gofmt`, `go vet`, `go test -race ./...` and `golangci-lint run ./...` on a Linux box. `docs/audit.md` has the record shape, the reading, the retention rule and the two behaviours under load that went the way that costs latency.
