### PR TITLE
Ask the source again before serving a document

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ The deployment that gets this right binds it somewhere the outside cannot reach,
 | `genba_cache_hits_total` | per layer, alongside misses, evictions and the entry count |
 | `genba_store_rows_total` | rows the driver returned, alongside statements and decodes |
 | `genba_directory_staleness_seconds` | the longest a membership change can take to have any effect, on a deployment with a directory |
+| `genba_recheck_checked_total` | per source, documents put to the source at query time, alongside the ones it denied and the checks that failed |
 
 The buckets are 1, 2, 5, 10, 25, 50, 100, 250 and 500 milliseconds, which are tighter at the bottom than a default histogram because the question here is what fraction of requests came back in under ten milliseconds.
 
@@ -499,6 +500,7 @@ func main() {
 | `store/graph` | the entities and relationships of a segment and the walk over them, [docs/graph.md](docs/graph.md) |
 | `store/segdir` | the directory of segments, the manifest and the crash recovery, [docs/durability.md](docs/durability.md) |
 | `index` | query parsing, retrieval and ranking |
+| `recheck` | the permission question put back to a source while a response is being written, so a revocation lands before the next sync does, [docs/permissions.md](docs/permissions.md) |
 | `connector` | the ingestion contract, cursors and checkpoints |
 | `connector/connectortest` | the conformance suite that defines what a connector is |
 | `connector/fssource` | the reference connector, a directory tree with OWNERS files, walked or watched |

--- a/api/api.go
+++ b/api/api.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tamnd/genba/cache"
 	"github.com/tamnd/genba/doc"
 	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/recheck"
 	"github.com/tamnd/genba/store"
 	"github.com/tamnd/genba/thumb"
 )
@@ -113,6 +114,12 @@ type Server struct {
 	// therefore shut it down. See [WithAudit].
 	audit    *audit.Log
 	ownAudit bool
+
+	// recheck asks the sources whether somebody may still read what is about to
+	// be shown to them. It is nil unless a deployment names a source that can
+	// answer that quickly, and a nil one means every surface shows what the index
+	// said, which is what off by default means here. See [WithRecheck].
+	recheck *recheck.Set
 
 	// thumbs holds the rendered thumbnails. It lives on the server rather than
 	// in the store because it is derived data with a cost that is measured in
@@ -561,6 +568,15 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 
 	s.metrics.observeSearch(res.Took, res.Candidates, res.Total)
 
+	// The page is checked against the sources before anything is built out of
+	// it, so a document somebody lost access to since the last sync is gone from
+	// the response, from the record of the response and from the count of what
+	// was shown. The total is left as the index reported it: it is a statement
+	// about how much matched rather than about this page, and correcting it by
+	// the rows this page dropped would be arithmetic on two different sets.
+	res.Hits = s.stillMatching(r, p, res.Hits)
+	res.Answer = onlyQuoting(res.Answer, res.Hits)
+
 	out := searchResponse{
 		Query:         r.URL.Query().Get("q"),
 		Text:          query.Text,
@@ -822,6 +838,9 @@ func (s *Server) handleSuggest(w http.ResponseWriter, r *http.Request, p *acl.Pr
 		writeConditional(w, r, http.StatusOK, out, out.identity())
 		return
 	}
+	// A title is a small thing to leak and it is still the thing this endpoint
+	// serves, so the completions are checked the way results are.
+	res.Hits = s.stillMatching(r, p, res.Hits)
 	var shown []audit.Item
 	for _, h := range res.Hits {
 		if len(out.Suggestions) >= SuggestLimit {
@@ -920,6 +939,19 @@ func (s *Server) handleDocument(w http.ResponseWriter, r *http.Request, p *acl.P
 			Documents: []audit.Item{{ID: id}},
 		})
 		writeError(w, http.StatusInternalServerError, "internal", "the document could not be read")
+		return
+	}
+	if !s.stillReadable(r, p, d) {
+		// The index said yes and the source says no, and the source is right. It
+		// is the same answer as a document that was never there, all the way out
+		// to the record, because telling somebody their access was withdrawn
+		// tells them the document exists.
+		s.accessed(r, p, audit.Record{
+			Action:    audit.Read,
+			Outcome:   audit.Refused,
+			Documents: []audit.Item{{ID: id}},
+		})
+		writeError(w, http.StatusNotFound, "not_found", "no such document")
 		return
 	}
 	// One document, so the clause that admitted them is known and worth keeping.
@@ -1062,6 +1094,18 @@ func (s *Server) handleContent(w http.ResponseWriter, r *http.Request, p *acl.Pr
 	// the media type both come from. The driver applies the principal again on
 	// the content read, so this is a lookup rather than the check itself.
 	d, err := s.store.Get(r.Context(), p, id)
+	if err == nil && !s.stillReadable(r, p, d) {
+		// Before the bytes are read rather than after. There is no reason to pull
+		// a file out of the store to throw it away, and the answer is the one a
+		// document that is not there gets.
+		s.accessed(r, p, audit.Record{
+			Action:    audit.Content,
+			Outcome:   audit.Refused,
+			Documents: []audit.Item{{ID: id}},
+		})
+		writeError(w, http.StatusNotFound, "not_found", "no such document")
+		return
+	}
 	if err == nil {
 		var c doc.Content
 		c, err = cs.Content(r.Context(), p, id)
@@ -1232,6 +1276,13 @@ func (s *Server) cacheStats() map[string]cache.Stats {
 		out = make(map[string]cache.Stats, 1)
 	}
 	out["thumbnail"] = s.thumbs.Stats()
+	if s.recheck != nil {
+		// The hit rate on this layer is what makes the checks affordable, so it is
+		// published beside the others rather than being folded into the recheck
+		// counters. A deployment whose sources are being asked about every row of
+		// every page can see it here.
+		out["recheck"] = s.recheck.CacheStats()
+	}
 	if reporter, ok := s.auth.(interface {
 		CacheStats() map[string]cache.Stats
 	}); ok {

--- a/api/curate.go
+++ b/api/curate.go
@@ -198,6 +198,12 @@ func (s *Server) curatedFor(r *http.Request, p *acl.Principal, query string) *cu
 // to something this reader may not open is not an error, it is a citation that
 // is not drawn, and the reader is never told the difference between a document
 // they cannot see and one that was deleted.
+//
+// A citation the source has since withdrawn is dropped here too, which is why
+// the recheck is in this helper rather than in the two handlers that use it: a
+// cited document and a listed one are the same document, and the answer card
+// above a page of results is the surface most likely to be quoting something
+// from a fortnight ago.
 func (s *Server) documents(r *http.Request, p *acl.Principal, ids []string) []doc.Document {
 	if len(ids) == 0 {
 		return nil
@@ -221,7 +227,7 @@ func (s *Server) documents(r *http.Request, p *acl.Principal, ids []string) []do
 				out = append(out, d)
 			}
 		}
-		return out
+		return s.stillVisible(r, p, out)
 	}
 	for _, id := range ids {
 		d, err := s.store.Get(r.Context(), p, id)
@@ -230,7 +236,7 @@ func (s *Server) documents(r *http.Request, p *acl.Principal, ids []string) []do
 		}
 		out = append(out, d)
 	}
-	return out
+	return s.stillVisible(r, p, out)
 }
 
 // handleAnswers lists the answers this tenant has written down.

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tamnd/genba/audit"
 	"github.com/tamnd/genba/metric"
+	"github.com/tamnd/genba/recheck"
 	"github.com/tamnd/genba/store"
 )
 
@@ -37,6 +38,9 @@ const (
 	MetricAuditRecords    = "genba_audit_records_total"
 	MetricAuditFailed     = "genba_audit_failed_total"
 	MetricAuditQueued     = "genba_audit_queued_records"
+	MetricRecheckChecked  = "genba_recheck_checked_total"
+	MetricRecheckDenied   = "genba_recheck_denied_total"
+	MetricRecheckFailed   = "genba_recheck_failed_total"
 	MetricStoreRows       = "genba_store_rows_total"
 	MetricStoreStatements = "genba_store_statements_total"
 	MetricStoreDecodes    = "genba_store_decodes_total"
@@ -165,6 +169,35 @@ func newMetrics(s *Server) *metrics {
 		audited(func(st audit.Stats) float64 { return float64(st.Failed) }))
 	r.Counters(MetricAuditQueued, "Content access records waiting to be written.", "", "gauge",
 		audited(func(st audit.Stats) float64 { return float64(st.Queued) }))
+
+	// What the late binding permission checks are doing, per source.
+	//
+	// Denied and failed are two different stories and they are counted apart on
+	// purpose. Denied going up is the feature working: the index was out of date
+	// and somebody was not shown a document they can no longer read. Failed going
+	// up is the feature costing somebody a result they are entitled to, because a
+	// check that did not come back removes the row, and a source whose failures
+	// are not near zero is a source that is too slow to be asked on the request
+	// path. A deployment with none of this configured publishes nothing here
+	// rather than three zeroes.
+	rechecked := func(pick func(recheck.Stats) float64) func(context.Context) map[string]float64 {
+		return func(context.Context) map[string]float64 {
+			if s.recheck == nil {
+				return nil
+			}
+			out := map[string]float64{}
+			for source, st := range s.recheck.Stats() {
+				out[source] = pick(st)
+			}
+			return out
+		}
+	}
+	r.Counters(MetricRecheckChecked, "Documents whose permissions were checked against the source before being shown, per source.", "source", "counter",
+		rechecked(func(st recheck.Stats) float64 { return float64(st.Checked) }))
+	r.Counters(MetricRecheckDenied, "Documents the source said may no longer be read, which were removed from the response, per source.", "source", "counter",
+		rechecked(func(st recheck.Stats) float64 { return float64(st.Denied) }))
+	r.Counters(MetricRecheckFailed, "Checks that did not come back in time, whose documents were removed anyway, per source.", "source", "counter",
+		rechecked(func(st recheck.Stats) float64 { return float64(st.Failed) }))
 
 	// A driver is not obliged to be measurable. One that is publishes the same
 	// numbers the CI gate asserts on, so a slow deployment can be compared with

--- a/api/recent.go
+++ b/api/recent.go
@@ -97,17 +97,15 @@ func (s *Server) handleRecent(w http.ResponseWriter, r *http.Request, p *acl.Pri
 	// A driver that cannot remember an open serves the other half rather than an
 	// error. The interface is built for that: a deployment on a store with no
 	// history still has a home screen, it just has one list on it.
+	var opens []store.Open
 	if log, ok := s.store.(store.OpenLog); ok {
-		opens, err := log.Opens(r.Context(), p, limit)
+		var err error
+		opens, err = log.Opens(r.Context(), p, limit)
 		if err != nil {
 			// The same reasoning one level up. A history that could not be read is
 			// a degraded home screen, and failing the whole request over it would
 			// take the corpus half down with it.
 			s.log.Warn("reading the open history failed", "error", err, "tenant", p.Tenant)
-		}
-		for _, o := range opens {
-			out.Opened = append(out.Opened, openedHit{searchHit: hitOf(o.Document), At: o.At.UTC()})
-			shown = append(shown, item(o.Document))
 		}
 	}
 
@@ -118,7 +116,23 @@ func (s *Server) handleRecent(w http.ResponseWriter, r *http.Request, p *acl.Pri
 		writeError(w, http.StatusInternalServerError, "internal", "the recent list could not be read")
 		return
 	}
+
+	// One recheck for both halves, for the reason both halves are on one record.
+	// The history is the half that needs it most: something somebody opened last
+	// week is exactly the kind of document a share gets withdrawn on, and the
+	// home screen is where they would find out it is still listed.
+	keep := s.keep(r.Context(), p, recheckItems(recentDocuments(opens, changed)))
+	for _, o := range opens {
+		if !keep(o.Document.ID) {
+			continue
+		}
+		out.Opened = append(out.Opened, openedHit{searchHit: hitOf(o.Document), At: o.At.UTC()})
+		shown = append(shown, item(o.Document))
+	}
 	for _, d := range changed {
+		if !keep(d.ID) {
+			continue
+		}
 		out.Changed = append(out.Changed, hitOf(d))
 		shown = append(shown, item(d))
 	}
@@ -170,6 +184,17 @@ func (s *Server) handleRecordOpen(w http.ResponseWriter, r *http.Request, p *acl
 		}
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// recentDocuments is both halves of the screen before either has been drawn,
+// which is what the recheck is asked about. A document in both halves is in
+// here twice and is asked about once, because the check deduplicates.
+func recentDocuments(opens []store.Open, changed []doc.Document) []doc.Document {
+	out := make([]doc.Document, 0, len(opens)+len(changed))
+	for _, o := range opens {
+		out = append(out, o.Document)
+	}
+	return append(out, changed...)
 }
 
 // recentIDs is every document on the screen, in one slice.

--- a/api/recheck.go
+++ b/api/recheck.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/recheck"
+)
+
+// WithRecheck asks the sources whether somebody may still read what is about to
+// be shown to them.
+//
+// It is off unless a caller passes one, and a set with no checkers in it changes
+// nothing either, so turning this on is a decision made per source by the
+// deployment that knows whether that source can answer a permission question in
+// a few milliseconds. See the recheck package for what the check costs and what
+// happens when it does not come back.
+//
+// Every surface that puts a document in front of somebody runs it. That is the
+// same set of handlers the audit trail covers, and for the same reason: a rule
+// that holds on the search page and not on the preview panel is not a rule.
+func WithRecheck(set *recheck.Set) Option {
+	return func(s *Server) { s.recheck = set }
+}
+
+// keeper answers whether one document survived the recheck.
+type keeper func(id string) bool
+
+// keepAll is the answer on a deployment that has not turned any of this on, and
+// it is the answer this file is careful to reach quickly: no lock, no clock, no
+// allocation.
+func keepAll(string) bool { return true }
+
+// keep asks about a whole page at once.
+//
+// One call per response rather than one per row, because the sources are asked
+// in parallel under a single deadline and a handler that called this twice would
+// spend two of them.
+func (s *Server) keep(ctx context.Context, p *acl.Principal, items []recheck.Item) keeper {
+	if s.recheck == nil || len(items) == 0 {
+		return keepAll
+	}
+	allowed := s.recheck.Allowed(ctx, p, items)
+	return func(id string) bool { return allowed[id] }
+}
+
+// stillReadable is the check for a surface that serves one document.
+//
+// False means the row goes, and what the caller does with that is answer the way
+// it answers for a document that is not there. The source has just said this
+// person may not read it, and the response that says so in as few words as
+// possible is the one every other refusal on this surface already uses.
+func (s *Server) stillReadable(r *http.Request, p *acl.Principal, d doc.Document) bool {
+	if s.recheck == nil {
+		return true
+	}
+	return s.keep(r.Context(), p, []recheck.Item{{ID: d.ID, Source: d.Source}})(d.ID)
+}
+
+// stillMatching is the check for a page of results.
+func (s *Server) stillMatching(r *http.Request, p *acl.Principal, hits []index.Result) []index.Result {
+	if s.recheck == nil || len(hits) == 0 {
+		return hits
+	}
+	items := make([]recheck.Item, 0, len(hits))
+	for _, h := range hits {
+		items = append(items, recheck.Item{ID: h.Document.ID, Source: h.Document.Source})
+	}
+	keep := s.keep(r.Context(), p, items)
+	out := make([]index.Result, 0, len(hits))
+	for _, h := range hits {
+		if keep(h.Document.ID) {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// onlyQuoting drops the quotes of documents that are not on the page.
+//
+// The written answer is built from the results, so a row removed from the page
+// takes its quote with it. This is not an optimisation and it is not defensive
+// tidying: a quote is a sentence out of the document, and an answer that kept
+// quoting a document the source has just withdrawn would be serving the content
+// of it under a different field name.
+func onlyQuoting(a index.Answer, hits []index.Result) index.Answer {
+	if len(a.Quotes) == 0 {
+		return a
+	}
+	on := make(map[string]bool, len(hits))
+	for _, h := range hits {
+		on[h.Document.ID] = true
+	}
+	kept := make([]index.Quote, 0, len(a.Quotes))
+	for _, q := range a.Quotes {
+		if on[q.ID] {
+			kept = append(kept, q)
+		}
+	}
+	a.Quotes = kept
+	return a
+}
+
+// stillVisible is the check for a list of documents.
+func (s *Server) stillVisible(r *http.Request, p *acl.Principal, docs []doc.Document) []doc.Document {
+	if s.recheck == nil || len(docs) == 0 {
+		return docs
+	}
+	keep := s.keep(r.Context(), p, recheckItems(docs))
+	out := make([]doc.Document, 0, len(docs))
+	for _, d := range docs {
+		if keep(d.ID) {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// recheckItems is what a checker is given: an id and a source, and none of the
+// rest of the document. See [recheck.Item] for why that is the whole of it.
+func recheckItems(docs []doc.Document) []recheck.Item {
+	out := make([]recheck.Item, 0, len(docs))
+	for _, d := range docs {
+		out = append(out, recheck.Item{ID: d.ID, Source: d.Source})
+	}
+	return out
+}

--- a/api/recheck_test.go
+++ b/api/recheck_test.go
@@ -1,0 +1,359 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/audit"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/recheck"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// This file is inside the package for the reason surface_test.go is: it walks
+// the route table. What it enforces is the other half of the same promise. The
+// audit walk says every surface that can put a document in front of somebody
+// writes a record, and this one says every one of them asks the source first.
+
+// probes is how each content surface is asked for something it will actually
+// answer with.
+//
+// It is a second table beside the one the audit walk uses, and the difference
+// is the point. That walk needs a request each surface answers; this one needs
+// a request each surface answers with a document in it, because a page that
+// came back empty proves nothing about whether the rows in it were checked. A
+// content route missing from here fails the walk rather than being skipped.
+var probes = map[string]string{
+	"GET /api/v1/search":                   "/api/v1/search?q=payments",
+	"GET /api/v1/suggest":                  "/api/v1/suggest?q=payments",
+	"GET /api/v1/documents":                "/api/v1/documents?id=d1&id=img",
+	"GET /api/v1/documents/{id}":           "/api/v1/documents/d1",
+	"GET /api/v1/documents/{id}/content":   "/api/v1/documents/img/content",
+	"GET /api/v1/documents/{id}/thumbnail": "/api/v1/documents/img/thumbnail?size=96",
+	"GET /api/v1/reported":                 "/api/v1/reported",
+	"GET /api/v1/recent":                   "/api/v1/recent",
+}
+
+// TestEverySurfaceThatServesContentRunsTheRecheck asks every content route with
+// a source that says no to everything, and requires that nothing of the corpus
+// comes back, whatever shape that route's answer has.
+//
+// A rule that holds on the search page and not on the preview panel is not a
+// rule, and the way somebody finds the surface that was missed is by opening
+// the one screen nobody thought about.
+func TestEverySurfaceThatServesContentRunsTheRecheck(t *testing.T) {
+	for _, rt := range served(t) {
+		pattern := rt.Method + " " + rt.Pattern
+		t.Run(pattern, func(t *testing.T) {
+			target, ok := probes[pattern]
+			if !ok {
+				t.Fatalf("%s serves content and this walk does not know how to make it serve some, add it to probes in recheck_test.go", pattern)
+			}
+
+			set := recheck.New()
+			set.Add("gdrive", denying())
+			_, body := ask(t, checking(t, set), rt.Method, target)
+
+			if named := corpusIn(body); len(named) != 0 {
+				t.Errorf("%s served %v after the source withdrew them:\n%s", pattern, named, body)
+			}
+			if st := set.Stats()["gdrive"]; st.Checked == 0 {
+				t.Errorf("%s asked the source about nothing at all", pattern)
+			}
+		})
+	}
+}
+
+// TestTheSameSurfacesServeTheCorpusWhenTheSourceSaysYes walks the same routes
+// with a source that allows everything, and requires the corpus back.
+//
+// Without this the walk above would pass on a server that answered every
+// request with an empty page, which is a thing a bad refactor can produce and a
+// walk looking only for the absence of an id would call a success. It is also
+// what stops a probe above from quietly rotting into a request that finds
+// nothing.
+func TestTheSameSurfacesServeTheCorpusWhenTheSourceSaysYes(t *testing.T) {
+	for _, rt := range served(t) {
+		pattern := rt.Method + " " + rt.Pattern
+		t.Run(pattern, func(t *testing.T) {
+			target := probes[pattern]
+
+			set := recheck.New()
+			set.Add("gdrive", allowing())
+			code, body := ask(t, checking(t, set), rt.Method, target)
+
+			if code != http.StatusOK {
+				t.Fatalf("%s answered %d with the source allowing everything:\n%s", pattern, code, body)
+			}
+			if len(corpusIn(body)) == 0 && !strings.HasPrefix(body, "\x89PNG") {
+				t.Errorf("%s served nothing of the corpus, so the walk above says nothing about it:\n%s", pattern, body)
+			}
+			if st := set.Stats()["gdrive"]; st.Denied != 0 || st.Failed != 0 {
+				t.Errorf("%s removed rows the source allowed: %+v", pattern, st)
+			}
+		})
+	}
+}
+
+// corpusIn is which of the corpus a response names.
+//
+// The image surfaces answer with bytes rather than JSON, and their id is in the
+// request instead, which is why the walk above reads the count of checks as
+// well as the body.
+func corpusIn(body string) []string {
+	var named []string
+	for _, id := range []string{`"d1"`, `"img"`} {
+		if strings.Contains(body, id) {
+			named = append(named, id)
+		}
+	}
+	return named
+}
+
+// TestASourceWithNoCheckerIsServedFromTheIndex, which is what off by default
+// means from outside: a deployment that has registered nothing gets exactly the
+// behaviour it had before this existed, and so does a source its neighbour is
+// checking.
+func TestASourceWithNoCheckerIsServedFromTheIndex(t *testing.T) {
+	set := recheck.New()
+	set.Add("slack", denying())
+
+	code, body := ask(t, checking(t, set), http.MethodGet, "/api/v1/documents/d1")
+	if code != http.StatusOK {
+		t.Fatalf("a document of an unchecked source answered %d:\n%s", code, body)
+	}
+	if st := set.Stats()["slack"]; st.Checked != 0 {
+		t.Errorf("the slack checker was asked about a drive document: %+v", st)
+	}
+}
+
+// TestNoRecheckIsNoQuestion. The server built without the option is the one
+// almost every deployment runs, and it must not have grown a lookup, a lock or
+// a clock on the page path.
+func TestNoRecheckIsNoQuestion(t *testing.T) {
+	st := corpus(t)
+	s := New(st, index.New(st), HeaderAuth{Tenant: "acme"})
+	t.Cleanup(func() { _ = s.Close() })
+
+	if s.recheck != nil {
+		t.Fatal("a server built with no options is rechecking")
+	}
+	if _, ok := s.cacheStats()["recheck"]; ok {
+		t.Error("a server that checks nothing publishes a cache layer for it")
+	}
+	code, body := ask(t, s.Handler(), http.MethodGet, "/api/v1/documents/d1")
+	if code != http.StatusOK {
+		t.Fatalf("the document answered %d:\n%s", code, body)
+	}
+}
+
+// TestADocumentTheSourceWithdrewLooksLikeOneThatIsNotThere holds the two
+// answers to the same status code and the same sentence.
+//
+// Telling somebody their access was withdrawn tells them the document exists
+// and roughly what it is about, which is most of what the withdrawal was for.
+func TestADocumentTheSourceWithdrewLooksLikeOneThatIsNotThere(t *testing.T) {
+	set := recheck.New()
+	set.Add("gdrive", denying())
+	h := checking(t, set)
+
+	withdrawn, body := ask(t, h, http.MethodGet, "/api/v1/documents/d1")
+	missing, other := ask(t, h, http.MethodGet, "/api/v1/documents/nothing-like-this")
+	if withdrawn != http.StatusNotFound {
+		t.Fatalf("a withdrawn document answered %d:\n%s", withdrawn, body)
+	}
+	if withdrawn != missing || body != other {
+		t.Errorf("a withdrawn document answers %d %q and a missing one answers %d %q",
+			withdrawn, body, missing, other)
+	}
+}
+
+// TestACheckThatFailsRemovesTheRowAndSaysSoInTheMetrics, which is the promise
+// that makes failing closed operable. A deployment cannot see the documents
+// nobody was shown, so the number of them has to be somewhere an operator
+// already looks.
+func TestACheckThatFailsRemovesTheRowAndSaysSoInTheMetrics(t *testing.T) {
+	set := recheck.New()
+	set.Add("gdrive", recheck.Func(func(context.Context, *acl.Principal, []string) (map[string]bool, error) {
+		return nil, errors.New("the drive is not answering")
+	}))
+
+	st := corpus(t)
+	s := New(st, index.New(st), HeaderAuth{Tenant: "acme"}, WithRecheck(set))
+	t.Cleanup(func() { _ = s.Close() })
+
+	code, body := ask(t, s.Handler(), http.MethodGet, "/api/v1/search?q=payments")
+	if code != http.StatusOK {
+		t.Fatalf("the search answered %d:\n%s", code, body)
+	}
+	if strings.Contains(body, `"d1"`) {
+		t.Errorf("a document whose check failed was served anyway:\n%s", body)
+	}
+
+	scraped := scrape(t, s)
+	for _, want := range []string{
+		MetricRecheckChecked + `{source="gdrive"} 1`,
+		MetricRecheckFailed + `{source="gdrive"} 1`,
+		MetricRecheckDenied + `{source="gdrive"} 0`,
+	} {
+		if !strings.Contains(scraped, want) {
+			t.Errorf("the metrics do not carry %q:\n%s", want, scraped)
+		}
+	}
+}
+
+// TestADeniedDocumentIsCountedApartFromAFailedOne. They call for different
+// actions: one is the feature working and the other is the feature costing
+// somebody a result, and an operator who cannot tell them apart has one number
+// that means either.
+func TestADeniedDocumentIsCountedApartFromAFailedOne(t *testing.T) {
+	set := recheck.New()
+	set.Add("gdrive", denying())
+
+	st := corpus(t)
+	s := New(st, index.New(st), HeaderAuth{Tenant: "acme"}, WithRecheck(set))
+	t.Cleanup(func() { _ = s.Close() })
+
+	if code, body := ask(t, s.Handler(), http.MethodGet, "/api/v1/search?q=payments"); code != http.StatusOK {
+		t.Fatalf("the search answered %d:\n%s", code, body)
+	}
+
+	scraped := scrape(t, s)
+	for _, want := range []string{
+		MetricRecheckDenied + `{source="gdrive"} 1`,
+		MetricRecheckFailed + `{source="gdrive"} 0`,
+		MetricCacheHits + `{layer="recheck"}`,
+	} {
+		if !strings.Contains(scraped, want) {
+			t.Errorf("the metrics do not carry %q:\n%s", want, scraped)
+		}
+	}
+}
+
+// TestAWithdrawnDocumentIsARefusalOnTheTrail. The record is the only place an
+// investigation can see that somebody asked for a document at the moment their
+// access to it had just gone, and a surface that silently answered 404 without
+// one would lose that.
+func TestAWithdrawnDocumentIsARefusalOnTheTrail(t *testing.T) {
+	set := recheck.New()
+	set.Add("gdrive", denying())
+
+	sink := &recorder{}
+	log := audit.New(sink)
+	t.Cleanup(func() { _ = log.Close() })
+
+	st := corpus(t)
+	s := New(st, index.New(st), HeaderAuth{Tenant: "acme"}, WithAudit(log), WithRecheck(set))
+	t.Cleanup(func() { _ = s.Close() })
+
+	if code, _ := ask(t, s.Handler(), http.MethodGet, "/api/v1/documents/d1"); code != http.StatusNotFound {
+		t.Fatalf("a withdrawn document answered %d", code)
+	}
+	if err := log.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	got := sink.records()
+	if len(got) != 1 {
+		t.Fatalf("%d records, want 1", len(got))
+	}
+	if got[0].Outcome != audit.Refused {
+		t.Errorf("the record says %q", got[0].Outcome)
+	}
+	if got[0].Rule != "" {
+		t.Errorf("a refusal carries the rule %q", got[0].Rule)
+	}
+}
+
+// checking is a server over the walk's corpus with one set of checkers on it.
+func checking(t *testing.T, set *recheck.Set) http.Handler {
+	t.Helper()
+	st := lived(t)
+	s := New(st, index.New(st), HeaderAuth{Tenant: "acme"}, WithRecheck(set))
+	t.Cleanup(func() { _ = s.Close() })
+	return s.Handler()
+}
+
+// lived is the walk's corpus with a little history on it.
+//
+// Two of the screens this walks are about what happened rather than about what
+// matched, and on a corpus nobody has ever opened or complained about they are
+// both empty. So the history is made here, through the API rather than into the
+// driver, which is the only way to be sure it is the history a person would
+// have left behind.
+func lived(t *testing.T) *memstore.Store {
+	t.Helper()
+	st := corpus(t)
+
+	s := New(st, index.New(st), HeaderAuth{Tenant: "acme"})
+	t.Cleanup(func() { _ = s.Close() })
+	h := s.Handler()
+
+	if code, body := send(t, h, http.MethodPost, "/api/v1/documents/d1/stale",
+		`{"note":"the failover section names a queue that was retired"}`); code != http.StatusOK {
+		t.Fatalf("reporting a document answered %d:\n%s", code, body)
+	}
+	if code, body := send(t, h, http.MethodPost, "/api/v1/recent", `{"id":"img"}`); code != http.StatusNoContent {
+		t.Fatalf("recording an open answered %d:\n%s", code, body)
+	}
+	return st
+}
+
+// ask makes one request as the engineer the walk authenticates as, and returns
+// what came back rather than failing on it, because half of what this file
+// asserts is that a surface answered 404.
+func ask(t *testing.T, h http.Handler, method, target string) (code int, body string) {
+	t.Helper()
+	return send(t, h, method, target, "")
+}
+
+// send is ask with a body.
+func send(t *testing.T, h http.Handler, method, target, body string) (code int, out string) {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequestWithContext(t.Context(), method, target, nil)
+	} else {
+		r = httptest.NewRequestWithContext(t.Context(), method, target, strings.NewReader(body))
+	}
+	r.Header.Set(HeaderSubject, "u_mei")
+	r.Header.Set(HeaderGroups, "gdrive:eng@acme.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w.Code, w.Body.String()
+}
+
+// scrape reads the metrics the way a collector does.
+func scrape(t *testing.T, s *Server) string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	s.Metrics().ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
+	return w.Body.String()
+}
+
+// denying is a source that has withdrawn everything, which is the state this
+// whole package exists to notice between two syncs.
+func denying() recheck.Checker {
+	return recheck.Func(func(_ context.Context, _ *acl.Principal, ids []string) (map[string]bool, error) {
+		out := make(map[string]bool, len(ids))
+		for _, id := range ids {
+			out[id] = false
+		}
+		return out, nil
+	})
+}
+
+// allowing is a source that agrees with the index.
+func allowing() recheck.Checker {
+	return recheck.Func(func(_ context.Context, _ *acl.Principal, ids []string) (map[string]bool, error) {
+		out := make(map[string]bool, len(ids))
+		for _, id := range ids {
+			out[id] = true
+		}
+		return out, nil
+	})
+}

--- a/api/reported.go
+++ b/api/reported.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/audit"
+	"github.com/tamnd/genba/recheck"
+	"github.com/tamnd/genba/store"
 )
 
 // Reported is the other half of saying a document is out of date: what somebody
@@ -102,8 +104,16 @@ func (s *Server) handleReported(w http.ResponseWriter, r *http.Request, p *acl.P
 		writeError(w, http.StatusInternalServerError, "internal", "the reported list could not be read")
 		return
 	}
+	// This list is somebody's own documents and the rows still go through the
+	// recheck, because ownership in the index is as much of a snapshot as
+	// readership is and a document that moved out from under somebody is one they
+	// should stop being shown reports about.
+	keep := s.keep(r.Context(), p, reportedItems(flagged))
 	shown := make([]audit.Item, 0, len(flagged))
 	for _, f := range flagged {
+		if !keep(f.Document.ID) {
+			continue
+		}
 		out.Documents = append(out.Documents, reportedHit{
 			searchHit: hitOf(f.Document),
 			Stale:     staleOf(f.Stale),
@@ -117,4 +127,13 @@ func (s *Server) handleReported(w http.ResponseWriter, r *http.Request, p *acl.P
 		Count:     len(shown),
 	})
 	writeConditional(w, r, http.StatusOK, out, out.identity())
+}
+
+// reportedItems is the flagged documents as the recheck is asked about them.
+func reportedItems(flagged []store.Flagged) []recheck.Item {
+	out := make([]recheck.Item, 0, len(flagged))
+	for _, f := range flagged {
+		out = append(out, recheck.Item{ID: f.Document.ID, Source: f.Document.Source})
+	}
+	return out
 }

--- a/api/surface_test.go
+++ b/api/surface_test.go
@@ -281,6 +281,11 @@ func corpus(t *testing.T) *memstore.Store {
 		{
 			ID: "d1", Tenant: "acme", Source: "gdrive", Kind: doc.KindPage,
 			Title: "Payments failover runbook", Body: "Fail the payments queue over to the replica.",
+			// Written by the person the walks authenticate as, which is what puts
+			// it on the screen that lists what readers have said about one's own
+			// documents. Without an author that screen is empty for everybody and
+			// a walk over it asserts nothing.
+			Author:      doc.Person{Subject: "u_mei", Name: "Mei Tan"},
 			Permissions: perm,
 		},
 		{

--- a/api/thumbnail.go
+++ b/api/thumbnail.go
@@ -94,6 +94,14 @@ func (s *Server) handleThumbnail(w http.ResponseWriter, r *http.Request, p *acl.
 		return
 	}
 
+	// The source is asked before anything is decoded, so a document somebody has
+	// lost access to costs a lookup rather than a render, and a picture of it is
+	// never put in the cache on their behalf either.
+	if !s.stillReadable(r, p, d) {
+		refused()
+		return
+	}
+
 	// Concurrent requests for the same thumbnail render it once and all get what
 	// that one produced, which matters here because the first paint of a grid
 	// asks for twenty four of these at once and a browser will happily open six

--- a/arch_test.go
+++ b/arch_test.go
@@ -75,6 +75,16 @@ var allowed = map[string][]string{
 	// a record is the job of the package that already has one.
 	"audit": nil,
 
+	// recheck asks a source whether somebody may still read a document, so it
+	// needs the principal it is asking about and the cache the answers live in,
+	// and it deliberately needs nothing else. It has never heard of a document,
+	// an index or a store: it is handed ids and hands back which of them survive.
+	// An edge to store would let a check read the row it is checking, which is
+	// the stale answer it exists to go around, and an edge to index would make
+	// the query path and the permission recheck one thing to reason about
+	// instead of two.
+	"recheck": {"acl", "cache"},
+
 	"store": {"acl", "doc"},
 
 	// segment is the on disk format and imports nothing of ours, not even doc.
@@ -140,7 +150,7 @@ var allowed = map[string][]string{
 	"index":             {"acl", "cache", "doc", "store"},
 	"config":            nil,
 	"web":               nil,
-	"api":               {"", "acl", "audit", "cache", "directory", "doc", "index", "metric", "store", "thumb"},
+	"api":               {"", "acl", "audit", "cache", "directory", "doc", "index", "metric", "recheck", "store", "thumb"},
 
 	// thumb imports nothing of ours. It is handed bytes and a size and hands
 	// back a smaller picture, which means the package that decodes files a

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -249,6 +249,71 @@ The part that catches people out is issue security.
 A project can carry security levels that narrow an individual issue to a subset of the people who can browse the project, and an issue with a security level set is not readable by the project's list at all.
 A connector must report the security level's members and nothing else for such an issue, because reporting both would widen it straight back to the project.
 
+## Asking again while the response is written
+
+Everything above happens during a sync, and what it produces is a copy of somebody else's answer.
+Between two syncs the copy can go wrong in the direction that matters: a person is taken off a page on Monday morning and the index still says they may read it until the crawler comes round again.
+On a large tree that is hours, and the symptom is a document turning up in search for somebody it was taken away from.
+
+The `recheck` package closes that window by putting the question back to the source while the response is being written.
+
+```go
+set := recheck.New(recheck.WithTimeout(20 * time.Millisecond))
+set.Add("wiki", recheck.Func(func(ctx context.Context, p *acl.Principal, ids []string) (map[string]bool, error) {
+	return wiki.MayRead(ctx, p.Subject, ids)
+}))
+
+srv := api.New(st, searcher, auth, api.WithRecheck(set))
+```
+
+It is off unless a deployment passes a set, and a set decides one source at a time, because whether a source can answer a permission question in a few milliseconds is a fact about that source.
+A source nobody registered a checker for is served from the index exactly as it was before, which is what makes this safe to turn on for one connector and leave off for the rest.
+
+A checker is handed a principal and a list of ids and nothing else.
+It is not handed the document, because a check that could read the row it is checking would be reading the stale answer this exists to go around.
+
+### What it costs and what happens when it does not come back
+
+One question covers a whole page, the sources are asked in parallel, and they share a single deadline of 20 milliseconds.
+Answers are held for 10 seconds, per person and per document, so a reader paging through results asks each source once.
+That is the staleness this leaves behind, and it is a number a deployment sets rather than one that emerges from a stack of caches.
+
+Every way this can go wrong removes the row.
+
+| What happened | What the reader sees |
+| --- | --- |
+| the source said no | the document is not on the page |
+| the source returned an error | the document is not on the page |
+| the deadline passed | the document is not on the page |
+| the source answered without mentioning the id | the document is not on the page |
+
+The last row is the one worth stating out loud.
+An id a source left out of its answer is a source that did not answer, and reading silence as a yes would turn a partial reply into a leak.
+None of the four are cached, so a source having a bad thirty seconds costs those thirty seconds and not the next ten minutes.
+
+### Where it runs
+
+Every surface that puts a document in front of somebody: search, suggestions, one document, its content, its thumbnail, the recent list, the reported list and the curated lists.
+That is the same set of handlers the audit trail covers, and for the same reason.
+A rule that holds on the search page and not on the preview panel is not a rule.
+
+The quotes in a written answer are filtered with the page they were built from.
+A quote is a sentence out of a document, so an answer that kept quoting one the source has just withdrawn would be serving its content under a different field name.
+
+A document that does not survive the check is answered the way a document that does not exist is answered, because the alternative confirms it exists.
+The access is still written to the audit trail, as a refusal.
+
+Three counters say what the checks are doing, labelled by source.
+
+| Metric | What it is |
+| --- | --- |
+| `genba_recheck_checked_total` | documents put to that source |
+| `genba_recheck_denied_total` | documents it said no to |
+| `genba_recheck_failed_total` | checks that errored or ran out of time |
+
+Denied climbing is the feature working.
+Failed climbing is a source that is slow or down, and while it is climbing that source's documents are disappearing from search, which is the safe failure and still an incident.
+
 ## Adding a source
 
 Write a preset in `sources.go` with the source's own role names and a comment saying where they came from.

--- a/recheck/recheck.go
+++ b/recheck/recheck.go
@@ -1,0 +1,410 @@
+// Package recheck asks the source whether somebody may still read a document,
+// at the moment the answer is about to be put in front of them.
+//
+// Indexed permissions are a snapshot, and a snapshot is stale from the moment
+// it is taken. Between the sync that recorded who could read a document and the
+// query that returns it, somebody left the company, a folder was moved, a share
+// was withdrawn. The index cannot know until it looks again, and looking again
+// at everything is a crawl.
+//
+// For the sources that can answer one cheap question, the window closes here
+// instead. A page of results is checked against the source before it is
+// returned, under a timeout that binds the whole page rather than each row, and
+// a check that does not come back removes the row. That last part is the whole
+// design: the failure mode of this package is showing somebody less than they
+// are entitled to, which is a support ticket, rather than showing them more,
+// which is the thing the product cannot do once.
+//
+// It is per source and off by default. A source with no checker registered is
+// left exactly as the index answered, because a deployment that has not said
+// its source can answer this quickly should not have its search latency decided
+// by somebody else's API.
+package recheck
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/cache"
+)
+
+// Defaults for a set built with no options.
+const (
+	// DefaultTimeout is how long the whole page may spend being checked.
+	//
+	// It is a budget for the request rather than for one source: a page that
+	// spans four sources asks all four at once and they share this. Twenty
+	// milliseconds is chosen against what it costs to be wrong. A check that
+	// misses its deadline removes the row, so a generous timeout hides a slow
+	// source and a mean one silently empties a page, and this is the point
+	// where an operator would rather see the latency and be told about it.
+	DefaultTimeout = 20 * time.Millisecond
+
+	// DefaultTTL is how long an answer from a source is reused.
+	//
+	// Everything this package is for happens inside this window: a revocation
+	// takes at most this long to be seen, rather than as long as the interval
+	// between syncs. Ten seconds is short enough that nobody reasons about it
+	// and long enough that paging through results is one question per document
+	// rather than one per page.
+	DefaultTTL = 10 * time.Second
+
+	// DefaultCapacity is how many answers are held. An answer is one boolean
+	// under a short key, so this is a few megabytes at the top end and it is
+	// sized for the working set of a busy afternoon rather than for the corpus.
+	DefaultCapacity = 50_000
+)
+
+// Item is one document as far as this package is concerned.
+//
+// An id and where it came from, and nothing else. A checker is being asked a
+// question about the source's own access control list, so the title, the body
+// and the permissions this index recorded are all beside the point, and passing
+// them would invite a checker to answer out of them.
+type Item struct {
+	ID     string
+	Source string
+}
+
+// Checker answers whether a principal may still read documents of one source.
+//
+// The ids are the source's own ids for the documents, which are what the index
+// stores. An implementation is asked about a page at a time and is expected to
+// answer for all of them in one call, because the whole point of running this
+// on the request path is that it costs one round trip rather than ten.
+//
+// An id left out of the returned map is not an allow. It is a failure for that
+// id, and the row goes. An implementation that cannot answer about one document
+// says so by leaving it out, and does not have to decide on its own what the
+// safe answer is.
+type Checker interface {
+	Allowed(ctx context.Context, p *acl.Principal, ids []string) (map[string]bool, error)
+}
+
+// Func is a Checker written as a function, for a source whose check is one
+// call and a map.
+type Func func(ctx context.Context, p *acl.Principal, ids []string) (map[string]bool, error)
+
+// Allowed implements [Checker].
+func (f Func) Allowed(ctx context.Context, p *acl.Principal, ids []string) (map[string]bool, error) {
+	return f(ctx, p, ids)
+}
+
+// Stats is what the checks for one source have done.
+//
+// Denied and Failed are counted apart because they call for different actions.
+// A denial is the feature working: the index was out of date and somebody was
+// not shown a document they can no longer read. A failure is the feature
+// costing somebody a result they are entitled to, and a deployment where that
+// number is not near zero is one where the source is too slow to be asked on
+// the request path.
+type Stats struct {
+	Checked int64 `json:"checked"`
+	Denied  int64 `json:"denied"`
+	Failed  int64 `json:"failed"`
+}
+
+// Set is the checkers a deployment has registered, and the cache and the
+// budget they share.
+type Set struct {
+	mu       sync.RWMutex
+	checkers map[string]Checker
+	counts   map[string]*counters
+
+	timeout time.Duration
+	answers *cache.Cache[bool]
+}
+
+// counters are the atomics behind [Stats], one set per source.
+type counters struct {
+	checked atomic.Int64
+	denied  atomic.Int64
+	failed  atomic.Int64
+}
+
+// Option configures a set.
+type Option func(*config)
+
+// config is the settable part of a set, kept apart so that the cache is built
+// once the lifetime and the capacity are both known.
+type config struct {
+	timeout  time.Duration
+	ttl      time.Duration
+	capacity int
+	now      func() time.Time
+}
+
+// WithTimeout sets how long a whole page may spend being checked.
+func WithTimeout(d time.Duration) Option {
+	return func(c *config) { c.timeout = d }
+}
+
+// WithCache sets how many answers are held and for how long.
+//
+// A ttl of zero turns the cache off, which asks the source about every row of
+// every page. It is not the setting to reach for on a source anybody uses, and
+// it is the honest one for a source whose permissions have to be exact to the
+// second.
+func WithCache(capacity int, ttl time.Duration) Option {
+	return func(c *config) { c.capacity, c.ttl = capacity, ttl }
+}
+
+// WithClock replaces the clock the cache ages entries against, for tests.
+func WithClock(now func() time.Time) Option {
+	return func(c *config) { c.now = now }
+}
+
+// New returns a set with no checkers in it, which checks nothing.
+//
+// That is the state a deployment starts in and stays in until it names a source
+// that can answer. See [Set.Add].
+func New(opts ...Option) *Set {
+	c := config{timeout: DefaultTimeout, ttl: DefaultTTL, capacity: DefaultCapacity, now: time.Now}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	var copts []cache.Option[bool]
+	if c.now != nil {
+		copts = append(copts, cache.WithClock[bool](c.now))
+	}
+	return &Set{
+		checkers: map[string]Checker{},
+		counts:   map[string]*counters{},
+		timeout:  c.timeout,
+		answers:  cache.New[bool](c.capacity, c.ttl, copts...),
+	}
+}
+
+// Add registers the checker for one source, replacing any it had.
+//
+// It can be called after the server is serving, because a connector configured
+// from the administration screen arrives that way, and a source that gains a
+// checker mid afternoon starts being checked on the next query rather than on
+// the next deployment.
+func (s *Set) Add(source string, c Checker) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if c == nil {
+		delete(s.checkers, source)
+		return
+	}
+	s.checkers[source] = c
+	if _, ok := s.counts[source]; !ok {
+		s.counts[source] = &counters{}
+	}
+}
+
+// Sources are the sources that are checked, which is what an operator wants to
+// see next to the answer that a deployment has this turned on.
+func (s *Set) Sources() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]string, 0, len(s.checkers))
+	for source := range s.checkers {
+		out = append(out, source)
+	}
+	return out
+}
+
+// Allowed returns which of these items may still be shown.
+//
+// The map holds an entry for every distinct id it was given, so a caller filters
+// with a plain lookup and cannot accidentally read an allow out of a missing
+// key. An item whose source has no checker is allowed, because the index has
+// already answered for it and this package was not asked to have an opinion.
+//
+// Every source is asked at once and they share one deadline. What has not come
+// back when it expires is denied and counted as a failure, and the request goes
+// on: the caller is holding a page somebody is waiting for, and the answer to a
+// source that has stopped responding is to show the rows that were checked
+// rather than to hold the response open.
+func (s *Set) Allowed(ctx context.Context, p *acl.Principal, items []Item) map[string]bool {
+	out := make(map[string]bool, len(items))
+	if len(items) == 0 {
+		return out
+	}
+
+	// Grouped by source, deduplicated, and with everything nobody can answer
+	// about already allowed. A page that spans no checked source leaves here
+	// without touching the clock.
+	ask := map[string][]string{}
+	for _, it := range items {
+		if _, done := out[it.ID]; done {
+			continue
+		}
+		if _, ok := s.checker(it.Source); !ok {
+			out[it.ID] = true
+			continue
+		}
+		if allowed, hit := s.answers.Get(key(p, it.Source, it.ID)); hit {
+			out[it.ID] = allowed
+			s.record(it.Source, allowed)
+			continue
+		}
+		// Denied until something says otherwise, which is what makes every
+		// path out of here below fail closed, including the one that returns
+		// early because the budget is gone.
+		out[it.ID] = false
+		ask[it.Source] = append(ask[it.Source], it.ID)
+	}
+	if len(ask) == 0 {
+		return out
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	type answer struct {
+		source  string
+		allowed map[string]bool
+	}
+	results := make(chan answer, len(ask))
+	for source, ids := range ask {
+		c, ok := s.checker(source)
+		if !ok {
+			// The checker was removed between grouping and asking, which means
+			// the deployment has just said it does not want this source
+			// checked. The rows stand.
+			results <- answer{source: source, allowed: allow(ids)}
+			continue
+		}
+		go func() {
+			got, err := c.Allowed(ctx, p, ids)
+			if err != nil {
+				results <- answer{source: source}
+				return
+			}
+			results <- answer{source: source, allowed: got}
+		}()
+	}
+
+	for range ask {
+		select {
+		case got := <-results:
+			for _, id := range ask[got.source] {
+				allowed, said := got.allowed[id]
+				out[id] = said && allowed
+				if said {
+					s.answers.Put(key(p, got.source, id), allowed)
+					s.record(got.source, allowed)
+					continue
+				}
+				// Not cached. A source that could not answer once is a source
+				// that will probably answer in a second, and remembering the
+				// failure would turn a moment of trouble into a minute of a
+				// document nobody can find.
+				s.fail(got.source)
+			}
+		case <-ctx.Done():
+			// Whatever is still outstanding is already denied in out, because
+			// that is what it was initialised to. Counting it here is what
+			// makes the metric say the deployment is over its budget rather
+			// than that a source is refusing people.
+			s.expire(ask, out)
+			return out
+		}
+	}
+	return out
+}
+
+// Stats is what has been checked, per source.
+func (s *Set) Stats() map[string]Stats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]Stats, len(s.counts))
+	for source, c := range s.counts {
+		out[source] = Stats{
+			Checked: c.checked.Load(),
+			Denied:  c.denied.Load(),
+			Failed:  c.failed.Load(),
+		}
+	}
+	return out
+}
+
+// CacheStats is the answer cache, published as a layer beside the others.
+func (s *Set) CacheStats() cache.Stats { return s.answers.Stats() }
+
+// checker returns the checker for one source.
+func (s *Set) checker(source string) (Checker, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	c, ok := s.checkers[source]
+	return c, ok
+}
+
+// record counts one answered check.
+func (s *Set) record(source string, allowed bool) {
+	c := s.counter(source)
+	c.checked.Add(1)
+	if !allowed {
+		c.denied.Add(1)
+	}
+}
+
+// fail counts one check that did not produce an answer.
+func (s *Set) fail(source string) {
+	c := s.counter(source)
+	c.checked.Add(1)
+	c.failed.Add(1)
+}
+
+// expire counts everything a deadline took, which is every id of every source
+// that has not been decided yet.
+func (s *Set) expire(ask map[string][]string, out map[string]bool) {
+	for source, ids := range ask {
+		for _, id := range ids {
+			if !out[id] {
+				s.fail(source)
+			}
+		}
+	}
+}
+
+// counter is the counters of one source, made on first use.
+//
+// The read lock is taken first because this is on the request path once per
+// checked document, and the write lock is only ever reached for a source whose
+// first check is happening right now.
+func (s *Set) counter(source string) *counters {
+	s.mu.RLock()
+	c, ok := s.counts[source]
+	s.mu.RUnlock()
+	if ok {
+		return c
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if c, ok := s.counts[source]; ok {
+		return c
+	}
+	c = &counters{}
+	s.counts[source] = c
+	return c
+}
+
+// key is one cached answer.
+//
+// The subject and the tenant are in it because the answer is about a person,
+// and the source is in it because two sources can name a document the same
+// thing. The groups this index resolved are deliberately not in it: the source
+// is being asked about its own access control list, and what our directory
+// thinks is not part of that question.
+func key(p *acl.Principal, source, id string) string {
+	if p == nil {
+		return "\x00" + source + "\x00" + id
+	}
+	return p.Tenant + "\x00" + p.Subject + "\x00" + source + "\x00" + id
+}
+
+// allow is every id, allowed.
+func allow(ids []string) map[string]bool {
+	out := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out
+}

--- a/recheck/recheck_test.go
+++ b/recheck/recheck_test.go
@@ -1,0 +1,353 @@
+package recheck_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/cache"
+	"github.com/tamnd/genba/recheck"
+)
+
+// source is a checker that answers from a set and remembers what it was asked.
+type source struct {
+	mu      sync.Mutex
+	allowed map[string]bool
+	calls   [][]string
+	err     error
+	block   time.Duration
+	omit    string
+}
+
+func (s *source) Allowed(ctx context.Context, _ *acl.Principal, ids []string) (map[string]bool, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, append([]string(nil), ids...))
+	block, err := s.block, s.err
+	s.mu.Unlock()
+
+	if block > 0 {
+		select {
+		case <-time.After(block):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if id == s.omit {
+			continue
+		}
+		out[id] = s.allowed[id]
+	}
+	return out, nil
+}
+
+func (s *source) asked() [][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([][]string(nil), s.calls...)
+}
+
+func mei() *acl.Principal {
+	return &acl.Principal{Tenant: "acme", Subject: "u_mei", Kind: acl.KindUser}
+}
+
+func items(pairs ...string) []recheck.Item {
+	out := make([]recheck.Item, 0, len(pairs)/2)
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out = append(out, recheck.Item{Source: pairs[i], ID: pairs[i+1]})
+	}
+	return out
+}
+
+// TestASourceNobodyRegisteredIsLeftAlone, which is what off by default means in
+// practice. A deployment that has not said its source can answer this quickly
+// does not have its search latency decided by somebody else's API.
+func TestASourceNobodyRegisteredIsLeftAlone(t *testing.T) {
+	drive := &source{allowed: map[string]bool{"d1": false}}
+	s := recheck.New()
+	s.Add("gdrive", drive)
+
+	got := s.Allowed(t.Context(), mei(), items("slack", "c1", "slack", "c2"))
+	if !got["c1"] || !got["c2"] {
+		t.Errorf("an unchecked source was filtered: %v", got)
+	}
+	if calls := drive.asked(); len(calls) != 0 {
+		t.Errorf("the drive checker was asked about somebody else's documents: %v", calls)
+	}
+}
+
+// TestARevokedDocumentIsRemoved is the feature.
+func TestARevokedDocumentIsRemoved(t *testing.T) {
+	drive := &source{allowed: map[string]bool{"d1": true, "d2": false}}
+	s := recheck.New()
+	s.Add("gdrive", drive)
+
+	got := s.Allowed(t.Context(), mei(), items("gdrive", "d1", "gdrive", "d2"))
+	if !got["d1"] {
+		t.Error("a document nobody revoked was removed")
+	}
+	if got["d2"] {
+		t.Error("a revoked document is still in the results")
+	}
+	if st := s.Stats()["gdrive"]; st.Checked != 2 || st.Denied != 1 || st.Failed != 0 {
+		t.Errorf("stats = %+v", st)
+	}
+}
+
+// TestOnePageIsOneQuestion. The whole reason this can run on the request path
+// is that a page of ten documents costs one round trip and not ten.
+func TestOnePageIsOneQuestion(t *testing.T) {
+	drive := &source{allowed: map[string]bool{"d1": true, "d2": true, "d3": true}}
+	s := recheck.New()
+	s.Add("gdrive", drive)
+
+	s.Allowed(t.Context(), mei(), items("gdrive", "d1", "gdrive", "d2", "gdrive", "d3"))
+	calls := drive.asked()
+	if len(calls) != 1 {
+		t.Fatalf("%d calls for one page, want 1: %v", len(calls), calls)
+	}
+	if len(calls[0]) != 3 {
+		t.Errorf("the source was asked about %v", calls[0])
+	}
+}
+
+// TestTheSameDocumentTwiceIsAskedOnce, because a page that cites a document in
+// a result and again in a quote is one document as far as the source is
+// concerned.
+func TestTheSameDocumentTwiceIsAskedOnce(t *testing.T) {
+	drive := &source{allowed: map[string]bool{"d1": true}}
+	s := recheck.New()
+	s.Add("gdrive", drive)
+
+	s.Allowed(t.Context(), mei(), items("gdrive", "d1", "gdrive", "d1"))
+	if calls := drive.asked(); len(calls) != 1 || len(calls[0]) != 1 {
+		t.Errorf("the source was asked %v", calls)
+	}
+}
+
+// TestTheSecondPageAsksNothing, which is what makes paging through results
+// affordable rather than quadratic in round trips.
+func TestTheSecondPageAsksNothing(t *testing.T) {
+	drive := &source{allowed: map[string]bool{"d1": true}}
+	s := recheck.New()
+	s.Add("gdrive", drive)
+
+	for range 3 {
+		if got := s.Allowed(t.Context(), mei(), items("gdrive", "d1")); !got["d1"] {
+			t.Fatal("a document that was allowed came back denied")
+		}
+	}
+	if calls := drive.asked(); len(calls) != 1 {
+		t.Errorf("%d calls for three pages of the same document", len(calls))
+	}
+	if hits := s.CacheStats().Hits; hits != 2 {
+		t.Errorf("the answer cache reports %d hits", hits)
+	}
+}
+
+// TestAnAnswerIsAboutOnePerson. Two people asking about the same document is
+// two questions, because the answer is a fact about them and not about it.
+func TestAnAnswerIsAboutOnePerson(t *testing.T) {
+	drive := &source{allowed: map[string]bool{"d1": true}}
+	s := recheck.New()
+	s.Add("gdrive", drive)
+
+	s.Allowed(t.Context(), mei(), items("gdrive", "d1"))
+	other := &acl.Principal{Tenant: "acme", Subject: "u_raj", Kind: acl.KindUser}
+	s.Allowed(t.Context(), other, items("gdrive", "d1"))
+
+	if calls := drive.asked(); len(calls) != 2 {
+		t.Errorf("%d questions for two people, want 2", len(calls))
+	}
+}
+
+// TestACheckThatFailsRemovesTheRow is the decision the package is built around.
+//
+// A source that cannot answer
+// leaves us holding a document whose permissions we last read at the sync, and
+// the honest thing to do with it is not show it. The cost is a document
+// somebody is entitled to going missing for a moment, which they can report.
+// The other way round is a document going out that should not have, which
+// nobody reports and nobody can take back.
+func TestACheckThatFailsRemovesTheRow(t *testing.T) {
+	drive := &source{allowed: map[string]bool{"d1": true}, err: errors.New("the drive is unhappy")}
+	s := recheck.New()
+	s.Add("gdrive", drive)
+
+	if got := s.Allowed(t.Context(), mei(), items("gdrive", "d1")); got["d1"] {
+		t.Error("a document whose check failed was shown anyway")
+	}
+	if st := s.Stats()["gdrive"]; st.Failed != 1 || st.Denied != 0 {
+		t.Errorf("a failure was counted as %+v, and a failure is not a refusal", st)
+	}
+}
+
+// TestAFailureIsNotRemembered, because a source that could not answer once will
+// probably answer in a second, and caching the failure would turn a moment of
+// trouble into ten seconds of a document nobody can find.
+func TestAFailureIsNotRemembered(t *testing.T) {
+	drive := &source{allowed: map[string]bool{"d1": true}, err: errors.New("not now")}
+	s := recheck.New()
+	s.Add("gdrive", drive)
+
+	s.Allowed(t.Context(), mei(), items("gdrive", "d1"))
+
+	drive.mu.Lock()
+	drive.err = nil
+	drive.mu.Unlock()
+
+	if got := s.Allowed(t.Context(), mei(), items("gdrive", "d1")); !got["d1"] {
+		t.Error("the source recovered and the document is still missing")
+	}
+}
+
+// TestAnIdTheSourceLeftOutIsNotAnAllow. An implementation that cannot answer
+// about one document says so by leaving it out, and does not have to decide on
+// its own what the safe answer is.
+func TestAnIdTheSourceLeftOutIsNotAnAllow(t *testing.T) {
+	drive := &source{allowed: map[string]bool{"d1": true, "d2": true}, omit: "d2"}
+	s := recheck.New()
+	s.Add("gdrive", drive)
+
+	got := s.Allowed(t.Context(), mei(), items("gdrive", "d1", "gdrive", "d2"))
+	if !got["d1"] {
+		t.Error("the document the source answered about was removed")
+	}
+	if got["d2"] {
+		t.Error("a document the source said nothing about was shown")
+	}
+	if st := s.Stats()["gdrive"]; st.Failed != 1 {
+		t.Errorf("a silent id was counted as %+v", st)
+	}
+}
+
+// TestACheckThatMissesItsDeadlineRemovesTheRow, and does not hold the response
+// open while it thinks about it.
+func TestACheckThatMissesItsDeadlineRemovesTheRow(t *testing.T) {
+	drive := &source{allowed: map[string]bool{"d1": true}, block: time.Minute}
+	s := recheck.New(recheck.WithTimeout(20 * time.Millisecond))
+	s.Add("gdrive", drive)
+
+	start := time.Now()
+	got := s.Allowed(t.Context(), mei(), items("gdrive", "d1"))
+	took := time.Since(start)
+
+	if got["d1"] {
+		t.Error("a document whose check never came back was shown")
+	}
+	if took > 5*time.Second {
+		t.Errorf("the check took %v, and the timeout is not binding anything", took)
+	}
+	if st := s.Stats()["gdrive"]; st.Failed != 1 {
+		t.Errorf("a timeout was counted as %+v", st)
+	}
+}
+
+// TestASlowSourceDoesNotTakeAFastOneWithIt puts a page that spans two sources
+// to both at once, and keeps the one that answered inside the budget.
+//
+// The one that answered in time is still on the screen. The alternative is one source
+// having a bad afternoon emptying every page of results in the company.
+func TestASlowSourceDoesNotTakeAFastOneWithIt(t *testing.T) {
+	slow := &source{allowed: map[string]bool{"d1": true}, block: time.Minute}
+	fast := &source{allowed: map[string]bool{"c1": true}}
+	s := recheck.New(recheck.WithTimeout(50 * time.Millisecond))
+	s.Add("gdrive", slow)
+	s.Add("slack", fast)
+
+	got := s.Allowed(t.Context(), mei(), items("gdrive", "d1", "slack", "c1"))
+	if !got["c1"] {
+		t.Error("the source that answered in time lost its results to the one that did not")
+	}
+	if got["d1"] {
+		t.Error("the source that did not answer had its results shown")
+	}
+}
+
+// TestNothingIsAskedWhenThereIsNothingToAsk, which is the shape of every
+// request on a deployment that has not turned this on.
+func TestNothingIsAskedWhenThereIsNothingToAsk(t *testing.T) {
+	s := recheck.New()
+	if got := s.Allowed(t.Context(), mei(), items("slack", "c1")); !got["c1"] {
+		t.Error("a set with no checkers in it removed a result")
+	}
+	if got := s.Allowed(t.Context(), mei(), nil); len(got) != 0 {
+		t.Errorf("an empty page produced %v", got)
+	}
+	if len(s.Sources()) != 0 {
+		t.Errorf("a set with no checkers reports %v", s.Sources())
+	}
+}
+
+// TestASourceCanBeCheckedFromOneAfternoonOnward, because a connector configured
+// from the administration screen arrives while the server is serving.
+func TestASourceCanBeCheckedFromOneAfternoonOnward(t *testing.T) {
+	s := recheck.New()
+	if got := s.Allowed(t.Context(), mei(), items("gdrive", "d1")); !got["d1"] {
+		t.Fatal("an unchecked source was filtered")
+	}
+
+	s.Add("gdrive", recheck.Func(func(context.Context, *acl.Principal, []string) (map[string]bool, error) {
+		return map[string]bool{"d1": false}, nil
+	}))
+	if got := s.Allowed(t.Context(), mei(), items("gdrive", "d1")); got["d1"] {
+		t.Error("the source gained a checker and the document was not checked")
+	}
+
+	s.Add("gdrive", nil)
+	if got := s.Allowed(t.Context(), mei(), items("gdrive", "d2")); !got["d2"] {
+		t.Error("the checker was removed and the source is still being filtered")
+	}
+}
+
+// TestEveryPageIsCheckedUnderLoad, which is the property a lock in the wrong
+// place would cost quietly.
+func TestEveryPageIsCheckedUnderLoad(t *testing.T) {
+	var asked atomic.Int64
+	// The deadline is long because this test is about the lock and not about the
+	// clock. Four hundred checks running at once under the race detector will
+	// miss a twenty millisecond budget on a busy machine, and a check that timed
+	// out is counted as a failure, which would make this fail for the one reason
+	// it is not asking about.
+	s := recheck.New(recheck.WithCache(0, cache.Off), recheck.WithTimeout(time.Minute))
+	s.Add("gdrive", recheck.Func(func(_ context.Context, _ *acl.Principal, ids []string) (map[string]bool, error) {
+		asked.Add(int64(len(ids)))
+		out := make(map[string]bool, len(ids))
+		for _, id := range ids {
+			out[id] = id != "gone"
+		}
+		return out, nil
+	}))
+
+	var wg sync.WaitGroup
+	for w := range 8 {
+		wg.Go(func() {
+			for i := range 50 {
+				page := items("gdrive", "gone", "gdrive", string(rune('a'+w))+string(rune('0'+i%10)))
+				got := s.Allowed(t.Context(), mei(), page)
+				if got["gone"] {
+					t.Errorf("the revoked document was shown")
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	if got := asked.Load(); got != 800 {
+		t.Errorf("%d documents were checked, want 800", got)
+	}
+	if st := s.Stats()["gdrive"]; st.Checked != 800 || st.Denied != 400 {
+		t.Errorf("stats = %+v", st)
+	}
+}


### PR DESCRIPTION
Permissions are read during a sync, so what the index holds is a copy of somebody else's answer.
Between two syncs that copy goes wrong in the direction that matters: a person is taken off a page on Monday morning and the index still says they may read it until the crawler comes round again.
On a large corpus that is hours, and the symptom is a document turning up in search for somebody it was taken away from.

This adds the `recheck` package, which puts the question back to the source while the response is being written, and wires it into every surface of the API that serves a document.

## How it behaves

One question covers a whole page.
The sources are asked in parallel under a single deadline of twenty milliseconds, and answers are held for ten seconds per person and per document, so a reader paging through results asks each source once.
That is the staleness this leaves behind, and it is a number a deployment sets rather than one that emerges from a stack of caches.

Every way a check can go wrong removes the row.

| What happened | What the reader sees |
| --- | --- |
| the source said no | the document is not on the page |
| the source returned an error | the document is not on the page |
| the deadline passed | the document is not on the page |
| the source answered without mentioning the id | the document is not on the page |

The last row is the one worth stating out loud.
An id a source left out of its answer is a source that did not answer, and reading silence as a yes would turn a partial reply into a leak.
None of the four are cached, so a source having a bad thirty seconds costs those thirty seconds and not the next ten minutes.

## Where it runs

Every surface that puts a document in front of somebody: search, suggestions, one document, its content, its thumbnail, the recent list, the reported list and the curated lists.
That is the same set the audit trail covers, and for the same reason.
A rule that holds on the search page and not on the preview panel is not a rule.

The quotes in a written answer are filtered with the page they were built from.
A quote is a sentence out of a document, so an answer that kept quoting one the source has just withdrawn would be serving its content under a different field name.
That one was found by the walk below rather than by reading the handler.

A document that does not survive is answered the way a document that does not exist is answered, down to the status code and the sentence, because anything else confirms it exists.
The access still goes on the audit trail, as a refusal.

## Turning it on

```go
set := recheck.New(recheck.WithTimeout(20 * time.Millisecond))
set.Add("wiki", recheck.Func(func(ctx context.Context, p *acl.Principal, ids []string) (map[string]bool, error) {
	return wiki.MayRead(ctx, p.Subject, ids)
}))

srv := api.New(st, searcher, auth, api.WithRecheck(set))
```

It is off unless a deployment passes a set, and a set decides one source at a time, since whether a source can answer a permission question in a few milliseconds is a fact about that source.
A source nobody registered a checker for is served from the index exactly as it was before, which is what makes this safe to turn on for one connector and leave off for the rest.

A checker is handed a principal and a list of ids and nothing else.
It is not handed the document, because a check that could read the row it is checking would be reading the stale answer this exists to go around.

## Cost when it is off

`keep` returns a shared function that answers yes with no lock, no clock and no allocation, and every helper returns its input untouched when no set was passed.
A deployment that has not turned this on pays a nil check per response.

## Metrics

`genba_recheck_checked_total`, `genba_recheck_denied_total` and `genba_recheck_failed_total`, labelled by source, and the answer cache joins the others under `genba_cache_hits_total`.
Denied climbing is the feature working.
Failed climbing is a source that is slow or down, and while it is climbing that source's documents are disappearing from search, which is the safe failure and still an incident.

## Tests

The package tests cover the deny, the timeout, the failure, the omitted id, the cache hit on the second page, one answer belonging to one person, and a load test that runs four hundred checks at once and requires every page to have been checked.

The API test walks the route table twice, once with a source that denies everything and once with one that allows everything, so a server that answered every request with an empty page cannot pass.
A route that serves content and has no entry in the probe table fails the walk, which is what stops a new endpoint from quietly skipping the check.

Ran on server3 with the race detector and on server2 under golangci-lint, both clean.

## What is not here

Nothing in `genbad` registers a checker yet, so the feature is reachable from a program that embeds the API and not from the binary.
That is #196, opened for it.

Part of #22.
