### PR TITLE
Check the corpus permissions again at query time

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,17 @@ The one exception is the object storage credentials, which are read from the env
 | `-corpus-acl` | `tenant` | who may read it: `tenant` for everybody in the tenant, `owners` to read OWNERS files, `os` to read the file system's own permissions |
 | `-corpus-identity` | `unix` | identity source the account names in the tree belong to, for `-corpus-acl os` |
 | `-corpus-domain` | empty | domain the accounts on this host belong to, for `-corpus-acl os`, empty to grant nothing on the world bit |
+| `-corpus-recheck` | `false` | read the rule again on every request, so a revocation lands before the next sync does |
 | `-corpus-refresh` | `0` | how often to sync again, zero for once at startup |
 | `-corpus-watch` | `false` | ask the operating system what changed instead of walking the tree, needs `-corpus-refresh` |
 | `-corpus-reconcile` | `0` | how often to sweep the index against the tree, zero for after every sync |
 | `-corpus-rate` | `0` | files a second the read keeps itself under, zero for as fast as the disk allows |
+
+`-corpus-recheck` is for a tree with a real access control list over it.
+The permissions in the index are the ones the last sync read, so an OWNERS file edited at nine takes effect at ten on a server that syncs hourly, and the hour in between is served out of the old list.
+With it the rule is read again while the response is being written, for the handful of documents about to go on somebody's screen, and a file that has been deleted leaves the results before the sweep notices.
+It only takes rows away: somebody added to a document still waits for the sync, because the index decides which documents are candidates at all.
+[docs/permissions.md](docs/permissions.md) has what the check costs and what happens when it cannot answer.
 
 `-corpus-watch` is what makes a short refresh interval affordable on a large tree.
 Without it every refresh walks, which is a stat of every file to find the four that moved, and with it the cost of a refresh is a function of how much changed rather than of how large the corpus is.

--- a/api/api.go
+++ b/api/api.go
@@ -571,10 +571,16 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 	// The page is checked against the sources before anything is built out of
 	// it, so a document somebody lost access to since the last sync is gone from
 	// the response, from the record of the response and from the count of what
-	// was shown. The total is left as the index reported it: it is a statement
-	// about how much matched rather than about this page, and correcting it by
-	// the rows this page dropped would be arithmetic on two different sets.
-	res.Hits = s.stillMatching(r, p, res.Hits)
+	// was shown.
+	//
+	// The total comes down with it. Leaving it alone would tell somebody that
+	// something they may not read matched what they typed, and on a query
+	// specific enough to match one document the count is the answer. Only this
+	// page can be corrected, so what is left is a floor rather than a recount,
+	// which is the direction to be wrong in.
+	kept := s.stillMatching(r, p, res.Hits)
+	res.Total -= len(res.Hits) - len(kept)
+	res.Hits = kept
 	res.Answer = onlyQuoting(res.Answer, res.Hits)
 
 	out := searchResponse{

--- a/api/recheck_test.go
+++ b/api/recheck_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -170,6 +171,39 @@ func TestADocumentTheSourceWithdrewLooksLikeOneThatIsNotThere(t *testing.T) {
 	if withdrawn != missing || body != other {
 		t.Errorf("a withdrawn document answers %d %q and a missing one answers %d %q",
 			withdrawn, body, missing, other)
+	}
+}
+
+// TestTheTotalComesDownWithThePage, because a count is an answer.
+//
+// A query specific enough to match one document says everything a title would
+// have said: there is a document about this, and you may not read it. So the
+// rows this page dropped come off the total, which leaves a floor rather than a
+// recount and is the direction to be wrong in.
+func TestTheTotalComesDownWithThePage(t *testing.T) {
+	set := recheck.New()
+	set.Add("gdrive", denying())
+
+	st := corpus(t)
+	s := New(st, index.New(st), HeaderAuth{Tenant: "acme"}, WithRecheck(set))
+	t.Cleanup(func() { _ = s.Close() })
+
+	code, body := ask(t, s.Handler(), http.MethodGet, "/api/v1/search?q=payments")
+	if code != http.StatusOK {
+		t.Fatalf("the search answered %d:\n%s", code, body)
+	}
+	var out struct {
+		Total int                   `json:"total"`
+		Hits  []struct{ ID string } `json:"hits"`
+	}
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Hits) != 0 {
+		t.Fatalf("the source withdrew everything and the page has %d rows:\n%s", len(out.Hits), body)
+	}
+	if out.Total != 0 {
+		t.Errorf("the page is empty and the total says %d, which says a document exists:\n%s", out.Total, body)
 	}
 }
 

--- a/arch_test.go
+++ b/arch_test.go
@@ -263,7 +263,7 @@ var allowed = map[string][]string{
 	"benchcorpus/gen": {"benchcorpus", "store/sqlitestore"},
 
 	"cmd/genba":  {""},
-	"cmd/genbad": {"", "api", "audit", "config", "connector", "connector/aclmap", "connector/fssource", "connector/limit", "connector/objectsource", "directory", "directory/provider", "index", "ingest", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
+	"cmd/genbad": {"", "api", "audit", "config", "connector", "connector/aclmap", "connector/fssource", "connector/limit", "connector/objectsource", "directory", "directory/provider", "index", "ingest", "recheck", "store", "store/memstore", "store/pgstore", "store/sqlitestore", "web"},
 }
 
 func TestDependencyDirection(t *testing.T) {

--- a/cmd/genbad/corpus.go
+++ b/cmd/genbad/corpus.go
@@ -39,6 +39,21 @@ type corpusOptions struct {
 	// leaves the world bit granting nothing, which is the safe reading.
 	Domain string
 
+	// Recheck asks the tree again, while a response is being written, whether
+	// the person reading it may still read what is about to go on the screen.
+	//
+	// What it buys is the window between a revocation and the next sync. An
+	// OWNERS file is edited at nine and the crawler comes past at ten, and
+	// without this the hour in between is served out of the index, which still
+	// says the old thing. What it costs is a read of the rules governing the
+	// documents on one page, on the same machine, inside the request.
+	//
+	// It is off because it is not free and because the deployments it matters
+	// for are the ones with a real access control list over the tree. A corpus
+	// everybody in the tenant may read has nothing to recheck except whether
+	// the file is still there.
+	Recheck bool
+
 	// Refresh is how often to sync again. Zero syncs once at startup.
 	Refresh time.Duration
 
@@ -87,6 +102,12 @@ const (
 
 func (o corpusOptions) validate() error {
 	if o.Dir == "" {
+		if o.Recheck {
+			// A permission check over a corpus this server is not reading is a
+			// flag that does nothing, and the shape of that mistake is a
+			// deployment believing revocations are landing in seconds.
+			return errors.New("corpus recheck needs a corpus to check")
+		}
 		return nil
 	}
 	if o.Name == "" {
@@ -158,6 +179,24 @@ func policyFor(o corpusOptions) (fssource.Policy, error) {
 	default:
 		return nil, fmt.Errorf("unknown corpus acl %q", o.ACL)
 	}
+}
+
+// corpusChecker builds the query time permission check for the corpus.
+//
+// The policy it is given is a second one, built here and held by nobody else,
+// which is deliberate rather than wasteful. [fssource.OwnersPolicy] keeps its
+// answers for the length of a walk and drops them when the sync starts the next
+// one, and a check sharing that cache would be answering out of the same
+// snapshot the index already holds, which is the thing it exists to go around.
+// Reloading the sync's copy instead would cost the sync its cache, on a tree
+// where that cache is the difference between one read per OWNERS file and one
+// per document.
+func corpusChecker(cfg corpusOptions) (*fssource.Checker, error) {
+	policy, err := policyFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return fssource.NewChecker(cfg.Dir, cfg.Name, policy)
 }
 
 // ingestCorpus syncs the configured directory into the store.

--- a/cmd/genbad/corpus_test.go
+++ b/cmd/genbad/corpus_test.go
@@ -53,6 +53,8 @@ func TestCorpusFlagsAreChecked(t *testing.T) {
 		{"watching with nothing to watch for", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclTenant, Watch: true}, "refresh"},
 		{"watching between refreshes", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclTenant, Watch: true, Refresh: time.Second}, ""},
 		{"a usable set", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOwners}, ""},
+		{"a recheck with nothing to check", corpusOptions{Recheck: true}, "recheck"},
+		{"a recheck over a corpus", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOwners, Recheck: true}, ""},
 		{"the os policy with nobody to name accounts", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOS}, "identity source"},
 		{"the os policy told where the names come from", corpusOptions{Dir: "/tmp", Name: "files", ACL: aclOS, Identity: "unix"}, ""},
 	}

--- a/cmd/genbad/main.go
+++ b/cmd/genbad/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tamnd/genba/config"
 	"github.com/tamnd/genba/connector/limit"
 	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/recheck"
 	"github.com/tamnd/genba/store"
 	"github.com/tamnd/genba/store/memstore"
 	"github.com/tamnd/genba/store/pgstore"
@@ -100,6 +101,7 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	fs.StringVar(&corpus.ACL, "corpus-acl", aclTenant, "who may read the corpus: tenant, owners or os")
 	fs.StringVar(&corpus.Identity, "corpus-identity", "unix", "identity source the account names in the tree belong to, for -corpus-acl os")
 	fs.StringVar(&corpus.Domain, "corpus-domain", "", "domain the accounts on this host belong to, for -corpus-acl os, empty for none")
+	fs.BoolVar(&corpus.Recheck, "corpus-recheck", false, "ask the tree again on every request whether the reader may still read what is about to be shown, which closes the window between a revocation and the next sync")
 	fs.DurationVar(&corpus.Refresh, "corpus-refresh", 0, "how often to reindex the directory, zero for once")
 	fs.BoolVar(&corpus.Watch, "corpus-watch", false, "ask the operating system what changed instead of walking the tree, needs -corpus-refresh")
 	fs.DurationVar(&corpus.Reconcile, "corpus-reconcile", 0, "how often to sweep the index against the directory, zero for after every sync")
@@ -213,6 +215,23 @@ func run(ctx context.Context, args []string, getenv func(string) string, stdout,
 	}
 	if h := web.Handler(); h != nil {
 		opts = append(opts, api.WithAssets(h))
+	}
+
+	// The permission question put back to the source while a response is being
+	// written, for the one source that can answer it inside a request. It is one
+	// set with one checker in it today, and the set is what the rest of the
+	// sources join when they can answer as cheaply.
+	if corpus.Recheck {
+		checker, err := corpusChecker(corpus)
+		if err != nil {
+			return err
+		}
+		set := recheck.New()
+		set.Add(corpus.Name, checker)
+		opts = append(opts, api.WithRecheck(set))
+		log.Info("checking corpus permissions again at query time",
+			"source", corpus.Name, "dir", corpus.Dir, "acl", corpus.ACL,
+			"timeout", recheck.DefaultTimeout, "ttl", recheck.DefaultTTL)
 	}
 
 	// The searcher subscribes the cache to the store's writes, so it is closed

--- a/cmd/genbad/recheck_test.go
+++ b/cmd/genbad/recheck_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// recheckTree is the corpus tree with two approvers on the guides directory, so
+// that one of them can be taken off it while the server is running.
+func recheckTree(t *testing.T) string {
+	t.Helper()
+	root := corpusTree(t)
+	writeOwners(t, root, "approvers:\n  - bob\n  - dave\n")
+	return root
+}
+
+func writeOwners(t *testing.T, root, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, "guides", "OWNERS"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// serveCorpus starts a server on the tree and returns its address.
+//
+// There is no refresh interval on purpose. Every sync this process will ever do
+// has happened by the time the queries below run, so anything that changes
+// after that is a change only a check at query time can see.
+func serveCorpus(t *testing.T, root string, extra ...string) string {
+	t.Helper()
+	addr := freeAddr(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	args := append([]string{
+		"-addr", addr,
+		"-tenant", "acme",
+		"-corpus", root,
+		"-corpus-name", "handbook",
+		"-corpus-acl", aclOwners,
+		"-log-level", "error",
+	}, extra...)
+	go func() {
+		var out, errOut bytes.Buffer
+		done <- run(ctx, args, env(nil), &out, &errOut)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("the server did not shut down")
+		}
+	})
+
+	waitForIndex(t, "http://"+addr)
+	return addr
+}
+
+// The window this closes: the OWNERS file is edited, the crawler is not due for
+// another hour, and the person who was taken off the directory asks for it.
+func TestATakenAwayFileIsGoneBeforeTheNextSync(t *testing.T) {
+	root := recheckTree(t)
+	addr := serveCorpus(t, root, "-corpus-recheck")
+
+	// bob is the control, and he is asked first on purpose. An answer is held
+	// for ten seconds per person and per document, so asking about dave here as
+	// well would mean the query after the edit was answered by that cache rather
+	// than by the tree, and the test would be waiting out a timer to prove
+	// something the timer is not about. dave has never been asked, so his first
+	// question below is a real one.
+	if got := searchAs(t, addr, "bob", "legacy"); len(got.Hits) == 0 {
+		t.Fatal("bob approves the guides directory and cannot see a file in it")
+	}
+
+	// dave is taken off the directory. Nothing about the document changed, so a
+	// walk would find nothing to do even if one were due, and the index still
+	// carries the list that named him.
+	writeOwners(t, root, "approvers:\n  - bob\n")
+
+	if got := searchAs(t, addr, "dave", "legacy"); len(got.Hits) != 0 {
+		t.Errorf("dave was taken off the directory and still gets results: %v", got.Hits)
+	}
+	if got := searchAs(t, addr, "bob", "legacy"); len(got.Hits) == 0 {
+		t.Error("bob is still an approver and the check took his results away")
+	}
+	// The check only ever takes rows away, and this is where that shows. erin was
+	// added to the file a moment ago and still cannot find the document, because
+	// the index decides which rows are candidates and the index has not been told
+	// yet. A grant waits for the sync. A revocation does not, and that asymmetry
+	// is the whole shape of the feature.
+	writeOwners(t, root, "approvers:\n  - bob\n  - erin\n")
+	if got := searchAs(t, addr, "erin", "legacy"); len(got.Hits) != 0 {
+		t.Error("erin was let in by a check that is only able to take rows away")
+	}
+}
+
+// The other half, and the reason the flag exists rather than the behaviour
+// being on for everybody. Without it the server answers out of the index, which
+// is the whole point of an index and is also a stale list until the next sync.
+func TestWithoutTheFlagTheIndexIsWhatAnswers(t *testing.T) {
+	root := recheckTree(t)
+	addr := serveCorpus(t, root)
+
+	if got := searchAs(t, addr, "dave", "legacy"); len(got.Hits) == 0 {
+		t.Fatal("dave approves the guides directory and cannot see a file in it")
+	}
+	writeOwners(t, root, "approvers:\n  - bob\n")
+	if got := searchAs(t, addr, "dave", "legacy"); len(got.Hits) == 0 {
+		t.Error("the results changed without a sync and without the flag that reads the tree again")
+	}
+}
+
+// A file somebody removed leaves the results at once rather than waiting for
+// the sweep, because a file that is not there is nobody's to read.
+func TestADeletedFileIsGoneBeforeTheSweep(t *testing.T) {
+	root := recheckTree(t)
+	addr := serveCorpus(t, root, "-corpus-recheck")
+
+	if got := searchAs(t, addr, "dave", "legacy"); len(got.Hits) == 0 {
+		t.Fatal("the file was not indexed in the first place")
+	}
+	if err := os.Remove(filepath.Join(root, "guides", "legacy.md")); err != nil {
+		t.Fatal(err)
+	}
+	if got := searchAs(t, addr, "bob", "legacy"); len(got.Hits) != 0 {
+		t.Errorf("a file that is no longer in the tree came back: %v", got.Hits)
+	}
+	if got := searchAs(t, addr, "bob", "deploying"); len(got.Hits) == 0 {
+		t.Error("the check took away a document the tree still holds")
+	}
+}
+
+// A flag that quietly does nothing is worse than one that is refused, because
+// what it looks like from outside is a deployment where revocations land in
+// seconds.
+func TestARecheckWithNoCorpusIsRefused(t *testing.T) {
+	var out, errOut bytes.Buffer
+	err := run(t.Context(), []string{"-corpus-recheck", "-log-level", "error"}, env(nil), &out, &errOut)
+	if err == nil {
+		t.Fatal("a server started with a permission check over nothing")
+	}
+}

--- a/connector/fssource/check.go
+++ b/connector/fssource/check.go
@@ -1,0 +1,148 @@
+package fssource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tamnd/genba/acl"
+)
+
+// Checker answers whether somebody may still read a file, while a response is
+// being written rather than at the next sync.
+//
+// The permissions in the index were read when the crawler last came past. On a
+// tree people are working in, that copy goes wrong in the direction that
+// matters: an OWNERS file is edited on Monday morning, a mode bit is taken away
+// at lunchtime, and until the next walk the index still says the old thing. A
+// checker closes that window by reading the rule again, per request, for the
+// handful of documents that are about to go on somebody's screen.
+//
+// It is cheap here and that is why the filesystem is the first source to have
+// one. The answer is on the same machine: the id carries the path, the rule is
+// a file a few directories up, and both are almost always in the page cache. A
+// source reached over somebody else's API is a different conversation about
+// what fits inside a query, and it is not this type.
+//
+// The shape is what the recheck package asks for, so a [Checker] can be
+// registered under a source name without either package importing the other.
+//
+// # The policy has to be its own
+//
+// A checker must not be given the same [Policy] the running source holds.
+// [OwnersPolicy] caches its answers for the length of a walk, which is right
+// for a sync and wrong here: a check reading that cache would be answering out
+// of the snapshot it exists to go around, and would agree with the stale index
+// every time. So a checker reloads its policy before every batch, and a policy
+// being reloaded underneath a sync would cost that sync its cache.
+//
+// Build a second one. They are cheap, and the two have different lifetimes for
+// a reason.
+type Checker struct {
+	root   string
+	name   string
+	policy Policy
+}
+
+// NewChecker returns a checker for the tree under root.
+//
+// name is the source name the documents carry, which is what the ids are
+// prefixed with and what the checker is registered under.
+//
+// A nil policy is refused rather than treated as permissive. A checker without
+// one would answer no to everything, which is safe and is also a server that
+// serves nothing, and the difference between the two is worth finding at
+// startup rather than in a support conversation.
+func NewChecker(root, name string, policy Policy) (*Checker, error) {
+	if name == "" {
+		return nil, errors.New("fssource: checker: the source has no name, and the ids to check are prefixed with it")
+	}
+	if policy == nil {
+		return nil, errors.New("fssource: checker: no permission policy, which would refuse every document in the tree")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("fssource: checker: %w", err)
+	}
+	return &Checker{root: abs, name: name, policy: policy}, nil
+}
+
+// Source returns the name of the source this checker answers for.
+func (c *Checker) Source() string { return c.name }
+
+// Allowed reports which of the ids the principal may still read.
+//
+// An id left out of the answer is not an allow. The caller reads a missing id
+// as a check that did not happen and removes the document, so everything this
+// method cannot answer for is simply not in the map: an id from another source,
+// a path that tried to leave the tree, a file it could not stat, and a rule
+// that stopped resolving. What is in the map with a false is the ordinary
+// answer, that the file is gone or that this person is no longer on it.
+//
+// The policy is reloaded once per call, not once per id, which is what keeps a
+// page of results at one read of each OWNERS file rather than one per document.
+func (c *Checker) Allowed(ctx context.Context, p *acl.Principal, ids []string) (map[string]bool, error) {
+	if r, ok := c.policy.(Reloader); ok {
+		r.Reload()
+	}
+
+	out := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if err := ctx.Err(); err != nil {
+			// Whatever has been decided so far is returned with it. The ids that
+			// were not reached are missing from the map, which is exactly how a
+			// caller reads a check that ran out of time.
+			return out, err
+		}
+		rel, ok := relOf(c.name, id)
+		if !ok {
+			continue
+		}
+		full := filepath.Join(c.root, filepath.FromSlash(rel))
+		if !c.inside(full) {
+			continue
+		}
+
+		info, err := os.Lstat(full)
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			// A deleted file is an answer rather than a failure, and it is the
+			// one this catches soonest: the row leaves the results the moment
+			// somebody removes the file, and the reconciliation that takes it out
+			// of the index can happen in its own time.
+			out[id] = false
+			continue
+		case err != nil:
+			continue
+		case !info.Mode().IsRegular():
+			// A directory or a device with a document's id is not a document
+			// anybody is reading, and the policies below are written about files.
+			out[id] = false
+			continue
+		}
+
+		perms, err := permissionsOf(ctx, c.policy, c.name, rel, info)
+		if err != nil {
+			continue
+		}
+		// A path whose rule no longer resolves comes back quarantined, which
+		// allows nobody, so it is denied here for the same reason the sync
+		// quarantines it: nobody can currently say who may read it.
+		out[id] = perms.Allows(p)
+	}
+	return out, nil
+}
+
+// inside reports whether a path is under the root.
+//
+// [relOf] has already collapsed the obvious ways out, and this is the one that
+// does not depend on reading the string correctly. It is here because the ids
+// arrive from the index, and an id is a string a connector wrote that turns
+// into a file path.
+func (c *Checker) inside(full string) bool {
+	return strings.HasPrefix(full, c.root+string(filepath.Separator))
+}

--- a/connector/fssource/check_test.go
+++ b/connector/fssource/check_test.go
@@ -1,0 +1,202 @@
+package fssource_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/connector/fssource"
+)
+
+// checkTree is a repository with one rule at the root and one below it, which
+// is the arrangement every question here is about: who the rule names now,
+// rather than who it named when the crawler went past.
+func checkTree(t *testing.T) string {
+	t.Helper()
+	return tree(t, map[string]string{
+		"OWNERS":        "approvers:\n  - alice\nreviewers:\n  - bob\n",
+		"README.md":     "# top\n",
+		"net/OWNERS":    "approvers:\n  - erin\n",
+		"net/design.md": "# networking\n",
+	})
+}
+
+func checker(t *testing.T, root string) *fssource.Checker {
+	t.Helper()
+	c, err := fssource.NewChecker(root, "repo", policyFor(t, root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func github(name string) *acl.Principal {
+	return &acl.Principal{Tenant: "acme", Subject: "u_" + name, Kind: acl.KindUser,
+		Identities: []acl.Identity{{Source: "github", Value: name}}}
+}
+
+// rewrite replaces a file in the tree, which is what somebody taking an access
+// away looks like on a filesystem.
+func rewrite(t *testing.T, root, rel, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(rel)), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTheRuleIsReadAgainRatherThanRemembered(t *testing.T) {
+	root := checkTree(t)
+	c := checker(t, root)
+	erin := github("erin")
+
+	got, err := c.Allowed(t.Context(), erin, []string{"repo:net/design.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got["repo:net/design.md"] {
+		t.Fatal("erin is an approver of net and was refused it")
+	}
+
+	// The edit a sync would not see for another hour. Nothing about the document
+	// changed, only the rule above it.
+	rewrite(t, root, "net/OWNERS", "approvers:\n  - frank\n")
+
+	got, err = c.Allowed(t.Context(), erin, []string{"repo:net/design.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["repo:net/design.md"] {
+		t.Error("erin was taken off the file and the check still says yes, which is the cached answer this exists to go around")
+	}
+	got, err = c.Allowed(t.Context(), github("frank"), []string{"repo:net/design.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got["repo:net/design.md"] {
+		t.Error("frank was put on the file and cannot read it")
+	}
+}
+
+func TestAFileThatIsGoneIsRefused(t *testing.T) {
+	root := checkTree(t)
+	c := checker(t, root)
+
+	if err := os.Remove(filepath.Join(root, "net", "design.md")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.Allowed(t.Context(), github("erin"), []string{"repo:net/design.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed, ok := got["repo:net/design.md"]; !ok || allowed {
+		t.Errorf("a deleted file answered %v, %v, want a plain refusal", allowed, ok)
+	}
+}
+
+func TestADirectoryIsNotADocument(t *testing.T) {
+	root := checkTree(t)
+	c := checker(t, root)
+
+	got, err := c.Allowed(t.Context(), github("alice"), []string{"repo:net"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["repo:net"] {
+		t.Error("a directory was served as a document")
+	}
+}
+
+// An id this checker did not mint is not this checker's to answer for, and the
+// caller reads the silence as a check that did not happen.
+func TestAnIdFromAnotherSourceIsLeftAlone(t *testing.T) {
+	root := checkTree(t)
+	c := checker(t, root)
+
+	got, err := c.Allowed(t.Context(), github("alice"), []string{"wiki:README.md", "README.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("answered %v for ids belonging to somebody else", got)
+	}
+}
+
+// The ids come out of the index, the index was written by a connector, and a
+// connector is a lot of code to trust with a string that turns into a path.
+func TestAPathThatTriesToLeaveTheTreeGetsNothing(t *testing.T) {
+	root := checkTree(t)
+	c := checker(t, root)
+
+	outside := filepath.Join(filepath.Dir(root), "elsewhere.md")
+	if err := os.WriteFile(outside, []byte("# not in the corpus\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(outside) })
+
+	for _, id := range []string{
+		"repo:../elsewhere.md",
+		"repo:net/../../elsewhere.md",
+		"repo:/etc/passwd",
+	} {
+		got, err := c.Allowed(t.Context(), github("alice"), []string{id})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got[id] {
+			t.Errorf("%s was allowed, which is a path that left the tree", id)
+		}
+	}
+}
+
+func TestOnePageIsOneReadOfTheRules(t *testing.T) {
+	root := checkTree(t)
+	c := checker(t, root)
+
+	got, err := c.Allowed(t.Context(), github("alice"), []string{
+		"repo:README.md", "repo:net/design.md", "repo:missing.md",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got["repo:README.md"] {
+		t.Error("alice is an approver at the root and was refused a file there")
+	}
+	if got["repo:net/design.md"] {
+		t.Error("alice was allowed a subtree whose own rule replaced her")
+	}
+	if allowed, ok := got["repo:missing.md"]; !ok || allowed {
+		t.Errorf("a file that is not there answered %v, %v", allowed, ok)
+	}
+}
+
+// A check that ran out of time hands back what it decided and says why. The ids
+// it did not reach are missing rather than allowed, which is how the caller
+// tells the two apart.
+func TestACheckThatIsCancelledAnswersForNobodyElse(t *testing.T) {
+	root := checkTree(t)
+	c := checker(t, root)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	got, err := c.Allowed(ctx, github("alice"), []string{"repo:README.md", "repo:net/design.md"})
+	if err == nil {
+		t.Fatal("a cancelled check reported no error")
+	}
+	if len(got) != 0 {
+		t.Errorf("answered %v after being cancelled", got)
+	}
+}
+
+func TestACheckerWithoutAPolicyIsRefusedAtTheDoor(t *testing.T) {
+	root := checkTree(t)
+
+	if _, err := fssource.NewChecker(root, "repo", nil); err == nil {
+		t.Error("a checker with no policy was built, and it would refuse every document in the tree")
+	}
+	if _, err := fssource.NewChecker(root, "", policyFor(t, root)); err == nil {
+		t.Error("a checker with no source name was built, and no id would ever match it")
+	}
+}

--- a/connector/fssource/fssource.go
+++ b/connector/fssource/fssource.go
@@ -740,13 +740,20 @@ func (s *Source) refresh(ctx context.Context, rel string, info fs.FileInfo, sinc
 // built without one is in, and the answer is that nothing resolved, which
 // quarantines every document rather than publishing the tree.
 func (s *Source) permissions(ctx context.Context, rel string, info fs.FileInfo) (acl.Permissions, error) {
-	if s.policy == nil {
-		return connector.Unresolved(s.name, "this source was built without a permission policy, so nothing in the tree resolves"), nil
+	return permissionsOf(ctx, s.policy, s.name, rel, info)
+}
+
+// permissionsOf is the question itself, without a source to ask it, so that a
+// [Checker] over the same tree asks it the same way, including the shortcut for
+// a policy that would otherwise stat a file the caller is already holding.
+func permissionsOf(ctx context.Context, policy Policy, source, rel string, info fs.FileInfo) (acl.Permissions, error) {
+	if policy == nil {
+		return connector.Unresolved(source, "this source was built without a permission policy, so nothing in the tree resolves"), nil
 	}
-	if p, ok := s.policy.(statPolicy); ok {
+	if p, ok := policy.(statPolicy); ok {
 		return p.permissionsFor(ctx, rel, info)
 	}
-	return s.policy.Permissions(ctx, rel)
+	return policy.Permissions(ctx, rel)
 }
 
 // changedAt asks the policy when the rule governing a file last changed, and

--- a/connector/fssource/maintain.go
+++ b/connector/fssource/maintain.go
@@ -105,8 +105,15 @@ func (s *Source) id(rel string) string { return s.name + ":" + rel }
 // stripping the leading separator means a "../../etc/passwd" collapses to
 // "etc/passwd" inside the root rather than escaping it, and the stat that
 // follows simply finds nothing.
-func (s *Source) rel(id string) (string, bool) {
-	rel, ok := strings.CutPrefix(id, s.name+":")
+func (s *Source) rel(id string) (string, bool) { return relOf(s.name, id) }
+
+// relOf is [Source.rel] without a source, so that a [Checker] built over the
+// same tree reads an id exactly the way the connector that minted it does.
+//
+// Two readings of the same string is how a path that one of them stops gets
+// through the other.
+func relOf(name, id string) (rel string, ok bool) {
+	rel, ok = strings.CutPrefix(id, name+":")
 	if !ok || rel == "" {
 		return "", false
 	}

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -272,6 +272,10 @@ A source nobody registered a checker for is served from the index exactly as it 
 A checker is handed a principal and a list of ids and nothing else.
 It is not handed the document, because a check that could read the row it is checking would be reading the stale answer this exists to go around.
 
+It only ever takes rows away.
+Somebody added to a document since the last sync still waits for the crawler, because the index is what decides which documents are candidates for a query in the first place and it has not been told about them yet.
+A revocation does not wait, and that asymmetry is the shape of the whole feature: the direction that costs a company its private documents is the one that is closed in seconds.
+
 ### What it costs and what happens when it does not come back
 
 One question covers a whole page, the sources are asked in parallel, and they share a single deadline of 20 milliseconds.
@@ -302,6 +306,24 @@ A quote is a sentence out of a document, so an answer that kept quoting one the 
 
 A document that does not survive the check is answered the way a document that does not exist is answered, because the alternative confirms it exists.
 The access is still written to the audit trail, as a refusal.
+
+The total on a search comes down with the page.
+A count is an answer, and on a query specific enough to match one document a total of one says everything the title would have said.
+Only the page that was checked can be corrected, so what is left is a floor rather than a recount.
+
+### Turning it on for a directory
+
+`genbad` can check a corpus it is indexing, which is the one source whose permissions are cheap enough to read inside a request.
+
+```
+genbad -corpus /srv/handbook -corpus-acl owners -corpus-recheck
+```
+
+The check reads the rule again and stats the file, so an OWNERS file edited at nine takes effect at nine rather than at the next walk, and a file somebody deleted leaves the results before the sweep notices it is gone.
+It holds its own policy, deliberately not the one the sync holds: an OWNERS policy keeps its answers for the length of a walk, and a check reading that cache would be answering out of the same snapshot the index already has.
+
+It is worth having wherever the tree has a real access control list over it.
+On `-corpus-acl tenant`, where everybody in the deployment may read everything, the only thing left to notice is a file that is no longer there.
 
 Three counters say what the checks are doing, labelled by source.
 


### PR DESCRIPTION
#197 landed the query time recheck as a library feature: build a set, register a checker per source, hand it to `api.New`.
Nothing in `genbad` did that, so it was reachable from a program that embeds the API and not from the binary a deployment runs.
This is the other half of #22, tracked as #196.

## A checker for the filesystem

The filesystem is the source to start with because the answer is on the same machine.
`fssource.Checker` reads the path out of the id, stats the file and asks the policy who may read it now.

| What it finds | What it answers |
| --- | --- |
| the rule still names this person | yes |
| the rule no longer names them | no |
| the file has been deleted | no |
| the path is a directory | no |
| the id belongs to another source | nothing, which the caller reads as a check that did not happen |
| the path tried to leave the tree | nothing |
| the stat failed for any other reason | nothing |
| the rule stopped resolving | no, for the same reason a sync quarantines it |

A deleted file is the case worth calling out.
It leaves the results the moment somebody removes it, rather than waiting for the sweep that walks the tree to find out.

## The policy is its own

The checker holds a second policy instance and reloads it before every batch.
`OwnersPolicy` keeps its answers for the length of a walk and drops them when the next one starts, which is right for a sync and wrong here: a check sharing that cache would be answering out of the same snapshot the index already holds, which is the thing it exists to go around.
Reloading the sync's copy instead would cost that sync its cache, on a tree where the cache is the difference between one read per OWNERS file and one read per document.

One reload per call rather than per id, so a page of results is one read of each rule.

## The flag

```
genbad -corpus /srv/handbook -corpus-acl owners -corpus-recheck
```

Off by default.
Setting it with no corpus is refused at startup, because a flag that quietly does nothing looks from outside like a deployment where revocations land in seconds.

## Two corrections to #197

The total on a search now comes down with the page.
Leaving it as the index reported it told somebody that something they may not read matched what they typed, and on a query specific enough to match one document the count is the answer.
Only the page that was checked can be corrected, so what is left is a floor rather than a recount, which is the direction to be wrong in.

The check only ever takes rows away, and that is now written down rather than implied.
Somebody added to a document since the last sync still waits for the crawler, because the index decides which documents are candidates for a query in the first place.
A revocation does not wait, and that asymmetry is the shape of the whole feature.

## Tests

`connector/fssource` covers the rule being read again rather than remembered, the deleted file, the directory, the foreign id, three ways of trying to leave the tree, a page of mixed answers and a cancelled check.

`cmd/genbad` starts a real server on a tree with no refresh interval, so every sync it will ever do has happened before the queries run.
An approver is taken out of the OWNERS file and stops getting results, the one left in still gets them, and with the flag off the same edit changes nothing.
The person who is taken away is asked for the first time after the edit on purpose: an answer is held for ten seconds per person and per document, so asking before and after inside that window would be asking the cache rather than the tree.

Ran on server3 with the race detector and on server2 under golangci-lint, both clean.

## Not here

A connector added from the interface does not get a checker, only the one on the command line.
The sources reached over somebody else's API need a request per check, which is a different conversation about what fits inside a twenty millisecond budget.

Closes #196.
