### PR TITLE
Attack every content surface with two corpora

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,56 @@ jobs:
       - name: test without the interface
         run: go test -tags noassets -count=1 ./...
 
+  # The permission suite, over a hundred corpora instead of the eight a laptop
+  # run uses.
+  #
+  # These tests build two servers over the same random corpus, one holding all of
+  # it and one holding only the documents the reader may open, and require every
+  # surface to answer identically. A leak is a difference between them, and the
+  # differences that are left are rare shapes: a word that appears in one
+  # document, a container with a single member, a facet with one hit behind it.
+  # Eight corpora almost never hit those, which is the whole reason for running a
+  # hundred here rather than folding the wider sweep into the test job.
+  #
+  # It runs without the race detector on purpose. The test job already runs this
+  # package under -race on two operating systems, and the detector costs enough
+  # per corpus to turn a hundred of them into an hour.
+  #
+  # The last step is there for the same reason the Postgres one is. These tests
+  # take their seeds from the environment, and a typo in the run filter would
+  # match nothing and pass, which is a green tick over a suite that never ran.
+  adversary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+      - name: attack a hundred corpora
+        shell: bash
+        env:
+          GENBA_PERMISSION_SEEDS: 100
+        run: |
+          go test -count=1 -v -timeout 40m ./api/ \
+            -run 'TestASearchIsWhatItWouldBeIfTheHiddenDocumentsWereNotThere|TestAForbiddenDocumentAnswersLikeAMissingOne|TestTheSameSurfacesAnswerForADocumentTheReaderMayRead|TestTheAnswerQuotesOnlyWhatTheReaderCouldHaveOpened|TestNoSurfaceNamesADocumentTheReaderCannotRead' \
+            | tee /tmp/adversary.log
+      - name: check the suite was not skipped
+        shell: bash
+        run: |
+          for name in TestASearchIsWhatItWouldBeIfTheHiddenDocumentsWereNotThere \
+                      TestAForbiddenDocumentAnswersLikeAMissingOne \
+                      TestTheSameSurfacesAnswerForADocumentTheReaderMayRead \
+                      TestTheAnswerQuotesOnlyWhatTheReaderCouldHaveOpened \
+                      TestNoSurfaceNamesADocumentTheReaderCannotRead; do
+            if ! grep -q -- "--- PASS: $name" /tmp/adversary.log; then
+              echo "$name did not run, so this job proved nothing."
+              exit 1
+            fi
+          done
+
   # The performance gate, in two halves.
   #
   # The counters assert work rather than wall clock: rows read, statements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ make race
 make lint
 ```
 
-CI runs the same commands on Linux and macOS, plus a cross compile for Windows and FreeBSD, a build without the browser interface, `govulncheck`, a `go mod tidy` check and a license check.
+CI runs the same commands on Linux and macOS, plus a cross compile for Windows and FreeBSD, a build without the browser interface, the permission suite over a hundred corpora, `govulncheck`, a `go mod tidy` check and a license check.
 Running them locally is faster than finding out from a red badge.
 
 ## If you touched the query path or the interface
@@ -48,6 +48,12 @@ Two more that follow from it:
 - A permission that failed to resolve is not a permission.
   Hold the document back rather than guessing.
 - A forbidden document and a missing one must be indistinguishable to the caller, down to the response body.
+
+`api/adversary_test.go` is what holds every surface to that.
+It builds two servers over the same random corpus, one holding all of it and one holding only the documents the reader may open, and it requires the two to answer identically on every route that can return content.
+A difference between them is a channel, whatever it is made of: a facet count, a total, a suggested spelling, a silence where there was an answer.
+It runs over eight corpora on a laptop and over a hundred in CI, and `GENBA_PERMISSION_SEEDS=100 go test ./api/` is how you run the wider sweep before you push.
+A failure names the seed it happened on, which is all anyone needs to reproduce it.
 
 ## Style
 

--- a/api/adversary_test.go
+++ b/api/adversary_test.go
@@ -1,0 +1,763 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tamnd/genba/acl"
+	"github.com/tamnd/genba/doc"
+	"github.com/tamnd/genba/index"
+	"github.com/tamnd/genba/store/memstore"
+)
+
+// This file is the adversarial half of the permission tests, and it is inside
+// the package for the reason surface_test.go is: it walks the route table, so a
+// surface added next year is attacked without anybody remembering to come back
+// here.
+//
+// The tests elsewhere are written from the product's side. This document is
+// readable by this person, therefore it comes back. These are written from the
+// other side, by somebody who has the corpus and wants to know what is in the
+// part of it they were not given. The corpus is random, the permissions on it
+// are random, and what is asserted is not that the right documents came back
+// but that nothing in the response depended on the ones that did not.
+//
+// The oracle is a second server over a second store holding only what the
+// reader may read. If the rest of the corpus has no effect, the two servers
+// answer the same bytes, and every difference between them is a channel: a
+// total, a facet count, a spelling correction, an ordering that moved because a
+// document nobody may read was scored against.
+//
+// # What this deliberately does not assert
+//
+// Response timing. A test that measures a millisecond on a shared runner
+// measures the runner. The work based counters under benchcorpus are where a
+// permission path that walks the corpus for one reader and not another shows
+// up, and they fail on the count rather than on the clock.
+//
+// The size of the corpus. GET /api/v1/stats reports how many documents the
+// deployment holds, and it reports the same number to everybody. That is a
+// decision rather than a leak this suite missed: the number names no document,
+// no title, no source and no container, and an operator needs it to tell a
+// finished sync from a stalled one.
+
+// worlds is how many corpora the property tests run over by default.
+//
+// The seeds are fixed rather than drawn from a clock. A suite that fails on
+// Tuesday and passes on Wednesday teaches people to run it again instead of
+// reading it, and a failure here is a leak that somebody has to be able to
+// reproduce on their own machine from the seed in the message.
+const worlds = 8
+
+// deeperSweep names the environment variable that widens the sweep, which is
+// what CI sets. Eight corpora on a laptop keeps the package fast, and a
+// hundred on every change is what turns a rare shape into a caught one.
+const deeperSweep = "GENBA_PERMISSION_SEEDS"
+
+// The reader every attack below is made as.
+const (
+	readerTenant  = "acme"
+	readerSubject = "u_mei"
+)
+
+// readerHeaders is that reader on the wire.
+func readerHeaders() map[string]string {
+	return map[string]string{
+		HeaderTenant:     readerTenant,
+		HeaderSubject:    readerSubject,
+		HeaderGroups:     "gdrive:eng@acme.com,slack:eng,jira:eng",
+		HeaderIdentities: "gdrive:mei@acme.com,slack:U04MEI,jira:mei",
+	}
+}
+
+// theReader is the same principal the server will build, built by the same
+// code.
+//
+// It matters that this is not written out by hand. The list of who may read
+// what is worked out here and compared against what the server served, so a
+// second reading of the headers would be a second definition of who is asking,
+// and the two would agree right up until one of them was wrong.
+func theReader(t *testing.T) *acl.Principal {
+	t.Helper()
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	for k, v := range readerHeaders() {
+		r.Header.Set(k, v)
+	}
+	p, err := HeaderAuth{Tenant: readerTenant}.Authenticate(r)
+	if err != nil {
+		t.Fatalf("building the reader: %v", err)
+	}
+	return p
+}
+
+// world is a random corpus split into what the reader may read and what they
+// may not.
+type world struct {
+	seed    uint64
+	all     []doc.Document
+	visible []doc.Document
+	hidden  []doc.Document
+}
+
+// newWorld generates one corpus and works out, independently of the server,
+// which of it the reader may read.
+func newWorld(t *testing.T, seed uint64) *world {
+	t.Helper()
+	rnd := rand.New(rand.NewPCG(seed, 0x9e3779b97f4a7c15))
+	p, png := theReader(t), pixels(t)
+
+	w := &world{seed: seed}
+	for i := range 14 + rnd.IntN(18) {
+		d := document(rnd, i, png)
+		w.all = append(w.all, d)
+		if d.Permissions.Allows(p) {
+			w.visible = append(w.visible, d)
+			continue
+		}
+		w.hidden = append(w.hidden, d)
+	}
+	if len(w.visible) == 0 || len(w.hidden) == 0 {
+		t.Fatalf("seed %d made %d readable and %d unreadable documents, and a corpus with none of either proves nothing",
+			seed, len(w.visible), len(w.hidden))
+	}
+	return w
+}
+
+// The words the corpus is written out of. They are shared on purpose: every
+// document is about the same handful of subjects, so a query matches across the
+// permission boundary rather than neatly on one side of it.
+var (
+	worldSources    = []string{"gdrive", "slack", "jira"}
+	worldKinds      = []doc.Kind{doc.KindPage, doc.KindMessage, doc.KindTicket, doc.KindFile, doc.KindCode}
+	worldContainers = []string{"handbook", "platform", "payments", "hiring"}
+	worldPeople     = []doc.Person{
+		{Subject: "u_mei", Name: "Mei", Email: "mei@acme.com"},
+		{Subject: "u_ravi", Name: "Ravi", Email: "ravi@acme.com"},
+		{Subject: "u_juno", Name: "Juno", Email: "juno@acme.com"},
+	}
+)
+
+// worldStart is when the corpus was written, so that a recency prior is the
+// same number on both servers.
+var worldStart = time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+
+// document is one random document, marked with two words that appear nowhere
+// else in the corpus.
+//
+// One of them is in the title and is the word an attacker searches for. The
+// other is only ever in the body, and it is what the responses are scanned for,
+// because a response that echoes the query back is not leaking anything and a
+// test that could not tell those apart would be reporting the echo.
+func document(rnd *rand.Rand, i int, png []byte) doc.Document {
+	nonce := fmt.Sprintf("kx%04d", i)
+	source := worldSources[rnd.IntN(len(worldSources))]
+	container := worldContainers[rnd.IntN(len(worldContainers))]
+	author := worldPeople[rnd.IntN(len(worldPeople))]
+
+	d := doc.Document{
+		ID:        "doc-" + nonce,
+		Tenant:    readerTenant,
+		Source:    source,
+		Kind:      worldKinds[rnd.IntN(len(worldKinds))],
+		Title:     "Runbook " + nonce + " for " + container,
+		Author:    author,
+		Owner:     author,
+		Container: container,
+		URL:       "https://example.com/d/" + nonce,
+		Body: "The " + nonce + " runbook covers the " + container + " rotation. " +
+			"Escalate to the " + container + " on call when the queue backs up. " +
+			"The change window is recorded under " + "zzq" + fmt.Sprintf("%04d", i) + " every quarter.",
+		ModifiedAt:  worldStart.Add(-time.Duration(i) * time.Hour),
+		CreatedAt:   worldStart.Add(-time.Duration(i+100) * time.Hour),
+		Permissions: permissionsFor(rnd, i, source, author),
+	}
+	// Every fifth document is an image with real bytes behind it, so that the
+	// two surfaces that answer with something other than JSON are attacked with
+	// a document they would otherwise have served.
+	if i%5 == 1 {
+		d.Kind = doc.KindImage
+		d.Properties = map[string]string{doc.MediaType: "image/png"}
+		d.Content = &doc.Content{Bytes: png, Width: 8, Height: 8}
+	}
+	return d
+}
+
+// permissionsFor is a random rule, drawn from the shapes real sources produce.
+//
+// The first three documents are fixed rather than drawn, because every seed has
+// to give the suite something readable, something unreadable, and one of each
+// with bytes behind it. Everything after them is the draw.
+func permissionsFor(rnd *rand.Rand, i int, source string, author doc.Person) acl.Permissions {
+	perm := acl.Permissions{Mode: acl.ModeACL, Source: source, Version: 1}
+	perm.Owner = acl.Ref{Source: source, Value: identityIn(source, author)}
+
+	shape := rnd.IntN(10)
+	switch i {
+	case 0:
+		shape = 0 // readable by everyone in the tenant
+	case 1:
+		shape = 8 // an image only its owner may read, and the owner is not the reader
+	case 2:
+		shape = 9 // a rule that never resolved
+	}
+
+	mine := acl.Ref{Source: source, Value: readerIdentity(source)}
+	theirs := acl.Ref{Source: source, Value: "ravi@acme.com"}
+	myGroup := acl.Ref{Source: source, Value: readerGroup(source)}
+	theirGroup := acl.Ref{Source: source, Value: "finance@acme.com"}
+
+	switch shape {
+	case 0:
+		perm.Mode = acl.ModePublicToTenant
+	case 1, 2:
+		perm.AllowGroups = []acl.Ref{myGroup, theirGroup}
+	case 3:
+		perm.AllowGroups = []acl.Ref{theirGroup}
+	case 4:
+		perm.AllowUsers = []acl.Ref{mine}
+	case 5:
+		perm.AllowUsers = []acl.Ref{theirs}
+	case 6:
+		// Named on the allow list and denied by name, which is the case that
+		// tells a rule that reads its clauses in order from one that does not.
+		perm.AllowGroups = []acl.Ref{myGroup}
+		perm.AllowUsers = []acl.Ref{mine}
+		perm.DenyUsers = []acl.Ref{mine}
+	case 7:
+		perm.Mode = acl.ModeOwnerOnly
+		perm.Owner = mine
+	case 8:
+		perm.Mode = acl.ModeOwnerOnly
+		perm.Owner = theirs
+	case 9:
+		perm.Mode = acl.ModeUnknown
+		perm.Reason = "the group " + theirGroup.GroupKey() + " is not in the directory"
+	}
+	return perm
+}
+
+// readerIdentity and readerGroup are how the reader is named by each source,
+// which is what a rule from that source compares against.
+func readerIdentity(source string) string {
+	switch source {
+	case "slack":
+		return "U04MEI"
+	case "jira":
+		return "mei"
+	default:
+		return "mei@acme.com"
+	}
+}
+
+func readerGroup(source string) string {
+	if source == "gdrive" {
+		return "eng@acme.com"
+	}
+	return "eng"
+}
+
+// identityIn is how one of the made up people is named by a source.
+func identityIn(source string, p doc.Person) string {
+	if p.Subject == readerSubject {
+		return readerIdentity(source)
+	}
+	return p.Email
+}
+
+// nonceOf is the word in a document's title that nothing else in the corpus
+// has, and secretOf is the one in its body.
+func nonceOf(d doc.Document) string  { return strings.TrimPrefix(d.ID, "doc-") }
+func secretOf(d doc.Document) string { return "zzq" + strings.TrimPrefix(nonceOf(d), "kx") }
+
+// serving is a server over the given documents.
+func (w *world) serving(t *testing.T, docs []doc.Document) http.Handler {
+	t.Helper()
+	st := memstore.New()
+	t.Cleanup(func() { _ = st.Close() })
+	if len(docs) > 0 {
+		if err := st.Put(t.Context(), docs...); err != nil {
+			t.Fatalf("seeding the corpus: %v", err)
+		}
+	}
+	s := New(st, index.New(st), HeaderAuth{Tenant: readerTenant})
+	t.Cleanup(func() { _ = s.Close() })
+	return s.Handler()
+}
+
+// full is the deployment, and readable is the same deployment in a universe
+// where the documents this reader may not read were never indexed.
+func (w *world) full(t *testing.T) http.Handler     { return w.serving(t, w.all) }
+func (w *world) readable(t *testing.T) http.Handler { return w.serving(t, w.visible) }
+
+// queries is what somebody who has seen the corpus would type to find the part
+// of it they were not given.
+//
+// Every one of them is aimed at a document the reader may not read: its own
+// rare word, its title, a sentence out of its body, and each of the operators
+// that narrow to the source, the space, the type and the author it has.
+func (w *world) queries() []string {
+	out := []string{"runbook", "runbook rotation", "escalate queue", "sort:recent runbook"}
+	for _, d := range w.hidden {
+		out = append(out,
+			nonceOf(d),
+			d.Title,
+			"escalate to the "+d.Container+" on call",
+			"app:"+d.Source+" runbook",
+			"in:"+d.Container+" runbook",
+			"type:"+string(d.Kind)+" runbook",
+			"from:"+d.Author.Name+" runbook",
+			"owner:"+d.Owner.Email+" runbook",
+		)
+	}
+	return out
+}
+
+// TestASearchIsWhatItWouldBeIfTheHiddenDocumentsWereNotThere compares a search
+// against the whole corpus with the same search against only the part of it the
+// reader may read.
+//
+// This is the one that catches the counting. A facet count, a total, a spelling
+// correction and an ordering are all numbers the reader is allowed to see, and
+// each of them is derived from a set of documents, so each of them is a way of
+// asking how many there are and roughly what they say. Comparing whole
+// responses rather than any one of those fields means the next number added to
+// this endpoint is covered on the day it is added.
+func TestASearchIsWhatItWouldBeIfTheHiddenDocumentsWereNotThere(t *testing.T) {
+	for _, seed := range seeds(t) {
+		w := newWorld(t, seed)
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			full, readable := w.full(t), w.readable(t)
+			for _, q := range w.queries() {
+				target := "/api/v1/search?q=" + url.QueryEscape(q)
+				_, got := askAs(t, full, http.MethodGet, target)
+				_, want := askAs(t, readable, http.MethodGet, target)
+				if diff := differs(t, got, want); diff != "" {
+					t.Errorf("searching %q over the whole corpus is not what it is over the readable part of it, which is a channel:\n%s", q, diff)
+				}
+			}
+		})
+	}
+}
+
+// TestAForbiddenDocumentAnswersLikeAMissingOne holds every surface that takes
+// an id to the same answer for a document the reader may not read and for one
+// that was never there.
+//
+// A 403 beside a 404 is a lookup service for document ids: paste in the id from
+// a link somebody forwarded, and the difference between the two tells you
+// whether it exists. The bodies are compared as bytes rather than as statuses
+// because the sentence inside is the other half of the same tell.
+func TestAForbiddenDocumentAnswersLikeAMissingOne(t *testing.T) {
+	for _, seed := range seeds(t) {
+		w := newWorld(t, seed)
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			h := w.full(t)
+			for _, probe := range idProbes() {
+				missing := probe.at(t, h, "doc-kx9999")
+				for _, d := range w.hidden {
+					if forbidden := probe.at(t, h, d.ID); forbidden != missing {
+						t.Errorf("%s answers one way for %s, which is there and may not be read, and another for a document that is not there:\n%s\n%s",
+							probe.name, d.ID, forbidden, missing)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestTheSameSurfacesAnswerForADocumentTheReaderMayRead is what stops the test
+// above from passing on a server that answers 404 to everything.
+func TestTheSameSurfacesAnswerForADocumentTheReaderMayRead(t *testing.T) {
+	w := newWorld(t, 1)
+	h := w.full(t)
+	for _, probe := range idProbes() {
+		missing := probe.at(t, h, "doc-kx9999")
+		var answered bool
+		for _, d := range w.visible {
+			if probe.at(t, h, d.ID) != missing {
+				answered = true
+				break
+			}
+		}
+		if !answered {
+			t.Errorf("%s answers the same for every readable document as it does for one that is not there, so the test above says nothing about it", probe.name)
+		}
+	}
+}
+
+// TestTheAnswerQuotesOnlyWhatTheReaderCouldHaveOpened attacks the passages
+// above the results with the documents they are drawn from.
+//
+// The quotes are the one place in the product where text from a document is
+// shown outside the row that names it, and the query is somebody else's
+// sentence, so this is the surface most likely to be got wrong by a change that
+// looks like an improvement to the answer.
+func TestTheAnswerQuotesOnlyWhatTheReaderCouldHaveOpened(t *testing.T) {
+	for _, seed := range seeds(t) {
+		w := newWorld(t, seed)
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			h := w.full(t)
+			readable := make(map[string]bool, len(w.visible))
+			for _, d := range w.visible {
+				readable[d.ID] = true
+			}
+
+			for _, d := range w.hidden {
+				for _, q := range []string{d.Title, d.Body, nonceOf(d), "escalate to the " + d.Container + " on call"} {
+					_, body := askAs(t, h, http.MethodGet, "/api/v1/search?q="+url.QueryEscape(q))
+					var out struct {
+						Answer *struct {
+							Quotes []struct {
+								ID   string `json:"id"`
+								Text string `json:"text"`
+							} `json:"quotes"`
+						} `json:"answer"`
+					}
+					if err := json.Unmarshal([]byte(body), &out); err != nil {
+						t.Fatalf("decoding the search: %v\n%s", err, body)
+					}
+					if out.Answer == nil {
+						continue
+					}
+					for _, quoted := range out.Answer.Quotes {
+						if !readable[quoted.ID] {
+							t.Errorf("asking %q quoted %s, which this reader cannot open: %q", q, quoted.ID, quoted.Text)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// raids is how each surface that can serve content is aimed at the documents
+// the reader may not read.
+//
+// One entry per content route. A route without one fails the walk rather than
+// being skipped, which is the rule the other two walks over this table use: a
+// surface added to the API has to say how somebody would attack it, in the
+// change that adds it rather than in a review a year later.
+var raids = map[string]func(w *world) []string{
+	"GET /api/v1/search": func(w *world) []string {
+		var out []string
+		for _, q := range w.queries() {
+			out = append(out, "/api/v1/search?q="+url.QueryEscape(q))
+		}
+		return out
+	},
+	"GET /api/v1/suggest": func(w *world) []string {
+		var out []string
+		for _, d := range w.hidden {
+			nonce := nonceOf(d)
+			out = append(out,
+				"/api/v1/suggest?q="+url.QueryEscape(nonce),
+				"/api/v1/suggest?q="+url.QueryEscape(nonce[:4]),
+				"/api/v1/suggest?q="+url.QueryEscape(d.Title),
+				"/api/v1/suggest?q="+url.QueryEscape("runbook"),
+			)
+		}
+		return out
+	},
+	"GET /api/v1/documents": func(w *world) []string {
+		query := make(url.Values)
+		for _, d := range w.hidden {
+			query.Add("id", d.ID)
+		}
+		return []string{"/api/v1/documents?" + query.Encode()}
+	},
+	"GET /api/v1/documents/{id}": func(w *world) []string {
+		return targets(w, "/api/v1/documents/%s")
+	},
+	"GET /api/v1/documents/{id}/content": func(w *world) []string {
+		return targets(w, "/api/v1/documents/%s/content")
+	},
+	"GET /api/v1/documents/{id}/thumbnail": func(w *world) []string {
+		return targets(w, "/api/v1/documents/%s/thumbnail?size=96")
+	},
+	"GET /api/v1/reported": func(*world) []string {
+		return []string{"/api/v1/reported", "/api/v1/reported?limit=100"}
+	},
+	"GET /api/v1/recent": func(*world) []string {
+		return []string{"/api/v1/recent", "/api/v1/recent?limit=100"}
+	},
+}
+
+// targets is one request per unreadable document.
+func targets(w *world, pattern string) []string {
+	out := make([]string, 0, len(w.hidden))
+	for _, d := range w.hidden {
+		out = append(out, fmt.Sprintf(pattern, url.PathEscape(d.ID)))
+	}
+	return out
+}
+
+// TestNoSurfaceNamesADocumentTheReaderCannotRead is the walk.
+//
+// It goes through the router the way a browser does, over a random corpus, and
+// reads every response looking for the word that only one document has. What it
+// is looking for is not a bug anybody would write on purpose. It is the second
+// list on a screen, the preview that was added to a panel, the field somebody
+// widened, and the way those get found is by attacking every surface with the
+// same corpus rather than by reviewing each one when it lands.
+func TestNoSurfaceNamesADocumentTheReaderCannotRead(t *testing.T) {
+	for _, seed := range seeds(t) {
+		w := newWorld(t, seed)
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			h := w.full(t)
+			poison(t, h, w)
+
+			for _, rt := range served(t) {
+				pattern := rt.Method + " " + rt.Pattern
+				build, ok := raids[pattern]
+				if !ok {
+					t.Errorf("%s can serve content and this walk does not know how to attack it, add it to raids in adversary_test.go", pattern)
+					continue
+				}
+				for _, target := range build(w) {
+					_, body := askAs(t, h, rt.Method, target)
+					if named := leaked(w, body); len(named) != 0 {
+						t.Errorf("%s served %v of a corpus this reader may not read:\n%s\n%s",
+							pattern, named, target, body)
+					}
+				}
+			}
+		})
+	}
+}
+
+// poison is the attacker putting the documents they may not read into the two
+// screens that are built out of their own history.
+//
+// Recording an open and reporting a document are both writes that take an id
+// and no permission of their own, which is right: refusing them would answer
+// the question of whether the id exists. So the check has to be on the way out,
+// on the screens that read the history back, and the way to find out whether it
+// is there is to fill the history with ids that must never come back.
+func poison(t *testing.T, h http.Handler, w *world) {
+	t.Helper()
+	for _, d := range w.hidden {
+		sendAs(t, h, http.MethodPost, "/api/v1/recent", `{"id":`+strconv.Quote(d.ID)+`}`)
+		sendAs(t, h, http.MethodPost, "/api/v1/documents/"+url.PathEscape(d.ID)+"/stale",
+			`{"note":"this is a note about a document I cannot read"}`)
+		sendAs(t, h, http.MethodPost, "/api/v1/documents/"+url.PathEscape(d.ID)+"/verify", `{}`)
+	}
+}
+
+// leaked is which unreadable documents a response names.
+//
+// It looks for the id and for the word that is only in that document's body,
+// and not for the word in its title, because the title word is what the query
+// was made of and a response that echoes the query back is not telling anybody
+// anything they did not type.
+func leaked(w *world, body string) []string {
+	var named []string
+	for _, d := range w.hidden {
+		if strings.Contains(body, d.ID) || strings.Contains(body, secretOf(d)) {
+			named = append(named, d.ID)
+		}
+	}
+	return named
+}
+
+// idProbe is one surface that takes a document id.
+type idProbe struct {
+	name   string
+	method string
+	path   string
+	body   string
+}
+
+// idProbes is every surface that takes an id in its path, including the ones
+// that write.
+//
+// The writes are here because a refusal is an answer too. Reporting a document
+// that does not exist and reporting one that exists and is not yours have to
+// come back the same, or the report button becomes the lookup service the read
+// path was careful not to be.
+func idProbes() []idProbe {
+	return []idProbe{
+		{name: "GET the document", method: http.MethodGet, path: "/api/v1/documents/%s"},
+		{name: "GET the content", method: http.MethodGet, path: "/api/v1/documents/%s/content"},
+		{name: "GET the thumbnail", method: http.MethodGet, path: "/api/v1/documents/%s/thumbnail?size=96"},
+		{name: "report it as stale", method: http.MethodPost, path: "/api/v1/documents/%s/stale", body: `{"note":"the failover section is out of date"}`},
+		{name: "withdraw that report", method: http.MethodDelete, path: "/api/v1/documents/%s/stale/mine"},
+		{name: "vouch for it", method: http.MethodPost, path: "/api/v1/documents/%s/verify", body: `{}`},
+		{name: "withdraw that", method: http.MethodDelete, path: "/api/v1/documents/%s/verify"},
+		// A body the endpoint accepts, because a body it rejects is answered
+		// before the id is looked at and would make this probe assert nothing.
+		{name: "correct its owner", method: http.MethodPut, path: "/api/v1/documents/%s/owner", body: `{"email":"mei@acme.com","name":"Mei"}`},
+		{name: "withdraw that correction", method: http.MethodDelete, path: "/api/v1/documents/%s/owner"},
+	}
+}
+
+// reply is what one probe came back with, and it is comparable on purpose:
+// what this file asserts about two of them is that they are the same value.
+type reply struct {
+	code        int
+	contentType string
+	body        string
+}
+
+func (r reply) String() string {
+	return fmt.Sprintf("%d %s %s", r.code, r.contentType, strings.TrimSpace(r.body))
+}
+
+// at asks this probe about one id.
+func (p idProbe) at(t *testing.T, h http.Handler, id string) reply {
+	t.Helper()
+	w := record(t, h, p.method, fmt.Sprintf(p.path, url.PathEscape(id)), p.body)
+	return reply{code: w.Code, contentType: w.Header().Get("Content-Type"), body: w.Body.String()}
+}
+
+// seeds is which corpora to attack.
+func seeds(t *testing.T) []uint64 {
+	t.Helper()
+	n := worlds
+	if raw := strings.TrimSpace(os.Getenv(deeperSweep)); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 {
+			t.Fatalf("%s is %q, which is not a number of corpora", deeperSweep, raw)
+		}
+		n = parsed
+	}
+	out := make([]uint64, 0, n)
+	for i := range n {
+		out = append(out, uint64(i)+1)
+	}
+	return out
+}
+
+// askAs makes one request as the reader.
+func askAs(t *testing.T, h http.Handler, method, target string) (code int, body string) {
+	t.Helper()
+	w := record(t, h, method, target, "")
+	return w.Code, w.Body.String()
+}
+
+// sendAs is askAs with a body, for the writes.
+func sendAs(t *testing.T, h http.Handler, method, target, body string) (code int, out string) {
+	t.Helper()
+	w := record(t, h, method, target, body)
+	return w.Code, w.Body.String()
+}
+
+func record(t *testing.T, h http.Handler, method, target, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequestWithContext(t.Context(), method, target, nil)
+	} else {
+		r = httptest.NewRequestWithContext(t.Context(), method, target, strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range readerHeaders() {
+		r.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+// differs compares two responses field by field and says where they part,
+// ignoring how long each one took.
+//
+// Field by field rather than as two blocks of JSON, because these responses run
+// to a few hundred lines and a failure that prints both of them in full is a
+// failure somebody diffs by hand at the point where they most want to be told
+// the answer. What a leak looks like here is one number.
+func differs(t *testing.T, got, want string) string {
+	t.Helper()
+	found := apart("", decodeJSON(t, got), decodeJSON(t, want))
+	if len(found) == 0 {
+		return ""
+	}
+	return strings.Join(found, "\n")
+}
+
+// apart walks two decoded responses together and returns every field they
+// disagree on, named by its path.
+func apart(path string, got, want any) []string {
+	switch a := got.(type) {
+	case map[string]any:
+		b, ok := want.(map[string]any)
+		if !ok {
+			break
+		}
+		var found []string
+		for _, key := range union(a, b) {
+			if path == "" && key == "took_ms" {
+				continue
+			}
+			left, inLeft := a[key]
+			right, inRight := b[key]
+			switch {
+			case !inLeft:
+				found = append(found, at(path, key)+" is only there over the readable part of the corpus")
+			case !inRight:
+				found = append(found, at(path, key)+" is only there over the whole corpus")
+			default:
+				found = append(found, apart(at(path, key), left, right)...)
+			}
+		}
+		return found
+	case []any:
+		b, ok := want.([]any)
+		if !ok {
+			break
+		}
+		if len(a) != len(b) {
+			return []string{fmt.Sprintf("%s has %d over the whole corpus and %d over the readable part of it", path, len(a), len(b))}
+		}
+		var found []string
+		for i := range a {
+			found = append(found, apart(fmt.Sprintf("%s[%d]", path, i), a[i], b[i])...)
+		}
+		return found
+	}
+	if reflect.DeepEqual(got, want) {
+		return nil
+	}
+	return []string{fmt.Sprintf("%s is %v over the whole corpus and %v over the readable part of it", path, got, want)}
+}
+
+// union is every key in either response, in a stable order.
+func union(a, b map[string]any) []string {
+	keys := make([]string, 0, len(a)+len(b))
+	for k := range a {
+		keys = append(keys, k)
+	}
+	for k := range b {
+		if _, ok := a[k]; !ok {
+			keys = append(keys, k)
+		}
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func at(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}
+
+func decodeJSON(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decoding a response: %v\n%s", err, body)
+	}
+	return out
+}

--- a/api/api.go
+++ b/api/api.go
@@ -501,7 +501,26 @@ type searchHit struct {
 	// marks exactly what the index matched rather than running a substring
 	// search of its own and highlighting the wrong halves of words.
 	Passages []passage `json:"passages,omitempty"`
-	Score    float64   `json:"score"`
+
+	// There is no ranking score here, and there was one until the adversarial
+	// suite in adversary_test.go went looking for numbers on this wire that
+	// depend on documents the reader cannot read.
+	//
+	// BM25 is a function of statistics over the corpus: how many documents
+	// there are, how long they are on average, and how many of them carry each
+	// term of the query. Those are counted per tenant rather than per reader,
+	// because counting them per reader is a pass over the corpus on every
+	// keystroke. So the score of a document somebody may read is partly a
+	// measurement of the documents they may not, and printing it to seventeen
+	// digits makes that an equation anybody can solve: put a rare word in a
+	// document of your own, search for it, and the score says roughly how many
+	// other documents in the company carry that word.
+	//
+	// The order is still decided that way, which is a channel too and a much
+	// narrower one, and it is what issue #199 is about. This was the wide one,
+	// and nothing outside the server was reading it: the interface draws the
+	// results in the order they arrive and the entity tag already hashed the
+	// response with the score taken out.
 
 	// Verified is who vouched for this document and until when, and is absent
 	// when nobody has. It is on the row rather than only in the preview because
@@ -614,7 +633,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 	vouched, now := s.verifications(r, p, ids), s.now()
 	for _, h := range res.Hits {
 		hit := hitOf(h.Document)
-		hit.Snippet, hit.Passages, hit.Score = h.Snippet, passages(h.Passages), h.Score
+		hit.Snippet, hit.Passages = h.Snippet, passages(h.Passages)
 		hit.Verified = verifiedOf(vouched[h.Document.ID], now)
 		out.Hits = append(out.Hits, hit)
 	}
@@ -631,23 +650,17 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request, p *acl.Pri
 	writeConditional(w, r, http.StatusOK, out, out.identity())
 }
 
-// identity is the response without the numbers that change on every request.
+// identity is the response without the number that changes on every request,
+// which is how long the search took.
 //
-// Two of them do. How long the search took is the obvious one. The other is the
-// score, which carries a recency prior that decays against the wall clock, so
-// it is a slightly different number every time the same query is run and it
-// would make an entity tag that never matches, which is a revalidation that can
-// never succeed. What the tag has to mean is that the same documents came back
-// in the same order with the same content, and it still means exactly that:
-// scores that moved enough to matter moved the order too.
+// It used to take the score out as well, because the score carries a recency
+// prior that decays against the wall clock and is therefore a slightly
+// different number every time the same query is run, which would make an entity
+// tag that never matches. The score is no longer on the wire at all, for the
+// reason written on [searchHit], and what the tag means is unchanged: the same
+// documents in the same order with the same content.
 func (r searchResponse) identity() any {
 	r.TookMS = 0
-	hits := make([]searchHit, len(r.Hits))
-	copy(hits, r.Hits)
-	for i := range hits {
-		hits[i].Score = 0
-	}
-	r.Hits = hits
 	return r
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -107,10 +107,9 @@ type searchBody struct {
 	Total      int    `json:"total"`
 	Correction string `json:"correction"`
 	Hits       []struct {
-		ID      string  `json:"id"`
-		Title   string  `json:"title"`
-		Snippet string  `json:"snippet"`
-		Score   float64 `json:"score"`
+		ID      string `json:"id"`
+		Title   string `json:"title"`
+		Snippet string `json:"snippet"`
 	} `json:"hits"`
 	Facets map[string][]struct {
 		Value    string `json:"value"`

--- a/api/recent.go
+++ b/api/recent.go
@@ -59,17 +59,6 @@ type openedHit struct {
 // is a fact about the past.
 func (r recentResponse) identity() any {
 	r.At = time.Time{}
-	opened := make([]openedHit, len(r.Opened))
-	copy(opened, r.Opened)
-	for i := range opened {
-		opened[i].Score = 0
-	}
-	changed := make([]searchHit, len(r.Changed))
-	copy(changed, r.Changed)
-	for i := range changed {
-		changed[i].Score = 0
-	}
-	r.Opened, r.Changed = opened, changed
 	return r
 }
 

--- a/api/recheck_test.go
+++ b/api/recheck_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tamnd/genba/acl"
 	"github.com/tamnd/genba/audit"
@@ -56,7 +57,7 @@ func TestEverySurfaceThatServesContentRunsTheRecheck(t *testing.T) {
 				t.Fatalf("%s serves content and this walk does not know how to make it serve some, add it to probes in recheck_test.go", pattern)
 			}
 
-			set := recheck.New()
+			set := patient()
 			set.Add("gdrive", denying())
 			_, body := ask(t, checking(t, set), rt.Method, target)
 
@@ -84,7 +85,7 @@ func TestTheSameSurfacesServeTheCorpusWhenTheSourceSaysYes(t *testing.T) {
 		t.Run(pattern, func(t *testing.T) {
 			target := probes[pattern]
 
-			set := recheck.New()
+			set := patient()
 			set.Add("gdrive", allowing())
 			code, body := ask(t, checking(t, set), rt.Method, target)
 
@@ -121,7 +122,7 @@ func corpusIn(body string) []string {
 // behaviour it had before this existed, and so does a source its neighbour is
 // checking.
 func TestASourceWithNoCheckerIsServedFromTheIndex(t *testing.T) {
-	set := recheck.New()
+	set := patient()
 	set.Add("slack", denying())
 
 	code, body := ask(t, checking(t, set), http.MethodGet, "/api/v1/documents/d1")
@@ -159,7 +160,7 @@ func TestNoRecheckIsNoQuestion(t *testing.T) {
 // Telling somebody their access was withdrawn tells them the document exists
 // and roughly what it is about, which is most of what the withdrawal was for.
 func TestADocumentTheSourceWithdrewLooksLikeOneThatIsNotThere(t *testing.T) {
-	set := recheck.New()
+	set := patient()
 	set.Add("gdrive", denying())
 	h := checking(t, set)
 
@@ -181,7 +182,7 @@ func TestADocumentTheSourceWithdrewLooksLikeOneThatIsNotThere(t *testing.T) {
 // rows this page dropped come off the total, which leaves a floor rather than a
 // recount and is the direction to be wrong in.
 func TestTheTotalComesDownWithThePage(t *testing.T) {
-	set := recheck.New()
+	set := patient()
 	set.Add("gdrive", denying())
 
 	st := corpus(t)
@@ -212,7 +213,7 @@ func TestTheTotalComesDownWithThePage(t *testing.T) {
 // nobody was shown, so the number of them has to be somewhere an operator
 // already looks.
 func TestACheckThatFailsRemovesTheRowAndSaysSoInTheMetrics(t *testing.T) {
-	set := recheck.New()
+	set := patient()
 	set.Add("gdrive", recheck.Func(func(context.Context, *acl.Principal, []string) (map[string]bool, error) {
 		return nil, errors.New("the drive is not answering")
 	}))
@@ -246,7 +247,7 @@ func TestACheckThatFailsRemovesTheRowAndSaysSoInTheMetrics(t *testing.T) {
 // somebody a result, and an operator who cannot tell them apart has one number
 // that means either.
 func TestADeniedDocumentIsCountedApartFromAFailedOne(t *testing.T) {
-	set := recheck.New()
+	set := patient()
 	set.Add("gdrive", denying())
 
 	st := corpus(t)
@@ -274,7 +275,7 @@ func TestADeniedDocumentIsCountedApartFromAFailedOne(t *testing.T) {
 // access to it had just gone, and a surface that silently answered 404 without
 // one would lose that.
 func TestAWithdrawnDocumentIsARefusalOnTheTrail(t *testing.T) {
-	set := recheck.New()
+	set := patient()
 	set.Add("gdrive", denying())
 
 	sink := &recorder{}
@@ -367,6 +368,19 @@ func scrape(t *testing.T, s *Server) string {
 	w := httptest.NewRecorder()
 	s.Metrics().ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
 	return w.Body.String()
+}
+
+// patient is a recheck set whose deadline cannot run out.
+//
+// The default is twenty milliseconds, which is the right number to hold a real
+// source to and the wrong one to write a test against. Every checker in this
+// file answers out of a map and cannot be slow, so a check that misses that
+// deadline means the runner was busy, and the row it drops turns a walk over
+// the route table into a coin toss that fails once a fortnight with a message
+// about permissions. The deadline itself is covered in recheck, where a source
+// can be made slow on purpose.
+func patient() *recheck.Set {
+	return recheck.New(recheck.WithTimeout(time.Minute))
 }
 
 // denying is a source that has withdrawn everything, which is the state this

--- a/api/reported.go
+++ b/api/reported.go
@@ -58,12 +58,6 @@ type reportedHit struct {
 // the past.
 func (r reportedResponse) identity() any {
 	r.At = time.Time{}
-	docs := make([]reportedHit, len(r.Documents))
-	copy(docs, r.Documents)
-	for i := range docs {
-		docs[i].Score = 0
-	}
-	r.Documents = docs
 	return r
 }
 

--- a/cmd/genba/main.go
+++ b/cmd/genba/main.go
@@ -153,13 +153,12 @@ func (c *client) get(ctx context.Context, path string, query url.Values, out any
 type searchResponse struct {
 	Total int `json:"total"`
 	Hits  []struct {
-		ID      string  `json:"id"`
-		Title   string  `json:"title"`
-		URL     string  `json:"url"`
-		Source  string  `json:"source"`
-		Kind    string  `json:"kind"`
-		Snippet string  `json:"snippet"`
-		Score   float64 `json:"score"`
+		ID      string `json:"id"`
+		Title   string `json:"title"`
+		URL     string `json:"url"`
+		Source  string `json:"source"`
+		Kind    string `json:"kind"`
+		Snippet string `json:"snippet"`
 	} `json:"hits"`
 }
 

--- a/cmd/genbad/main_test.go
+++ b/cmd/genbad/main_test.go
@@ -75,7 +75,11 @@ func TestMetricsAreOnTheirOwnAddress(t *testing.T) {
 
 	waitForHealth(t, "http://"+addr+"/healthz")
 
-	if body := get(t, "http://"+metricsAddr+"/metrics"); !strings.Contains(body, "genba_request_duration_milliseconds") {
+	// The health check is on the API address, and the two listeners bind
+	// independently, so a healthy API says nothing about whether the metrics
+	// port is open yet. Asking once and reading a refused connection as an empty
+	// body made this a test of how busy the machine is.
+	if body := waitForMetrics(t, "http://"+metricsAddr+"/metrics"); !strings.Contains(body, "genba_request_duration_milliseconds") {
 		t.Errorf("the metrics listener served:\n%s", body)
 	}
 	if body := get(t, "http://"+addr+"/metrics"); strings.Contains(body, "genba_request_duration_milliseconds") {
@@ -111,6 +115,21 @@ func TestMetricsAreOffByDefault(t *testing.T) {
 	if err == nil {
 		_ = conn.Close()
 		t.Errorf("something is listening on %s with no metrics address configured", metricsAddr)
+	}
+}
+
+// waitForMetrics reads the metrics endpoint once it is up, and returns whatever
+// it read last when it never is, so the caller reports what it got rather than
+// a timeout with nothing in it.
+func waitForMetrics(t *testing.T, url string) string {
+	t.Helper()
+	deadline := time.Now().Add(time.Minute)
+	for {
+		body := get(t, url)
+		if body != "" || !time.Now().Before(deadline) {
+			return body
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }
 

--- a/index/cache_test.go
+++ b/index/cache_test.go
@@ -248,8 +248,12 @@ func TestCacheNeverCrossesVisibility(t *testing.T) {
 	if slices.Contains(theirs, "d1") || slices.Contains(theirs, "d2") {
 		t.Fatalf("the seller was handed the engineer's documents: %v", theirs)
 	}
-	if ranks, _, _ := st.counts(); ranks != 2 {
-		t.Errorf("the driver ranked %d times for two different askers, want 2", ranks)
+	// Three rather than two. The seller found nothing, and a search that found
+	// nothing asks whether the words in it are words the asker has a document
+	// for, which is one more cut of a single row. It is what keeps the "did you
+	// mean" from being decided by a count over the whole tenant.
+	if ranks, _, _ := st.counts(); ranks != 3 {
+		t.Errorf("the driver ranked %d times for two different askers, want 3", ranks)
 	}
 
 	// And going back to the first asker still gets the first answer, rather than
@@ -326,8 +330,11 @@ func TestGroupChangeMakesPreviousEntriesUnreachable(t *testing.T) {
 	if got := ids(search(t, s, after, index.Query{Text: "payments"})); len(got) != 0 {
 		t.Fatalf("a principal whose group was taken away still saw %v", got)
 	}
-	if ranks, _, _ := st.counts(); ranks != 2 {
-		t.Errorf("the driver ranked %d times either side of a group change, want 2", ranks)
+	// Three rather than two, for the reason in TestCacheNeverCrossesVisibility:
+	// the search after the change found nothing, and the correction asks what
+	// this person's own documents carry before it offers anything.
+	if ranks, _, _ := st.counts(); ranks != 3 {
+		t.Errorf("the driver ranked %d times either side of a group change, want 3", ranks)
 	}
 }
 

--- a/index/counters_test.go
+++ b/index/counters_test.go
@@ -46,6 +46,23 @@ const counterCorpus = 4_000
 // is the regression this number is here to catch.
 const maxStatements = 9
 
+// correctionStatements is what a search that found nothing may spend on top of
+// that, looking for a spelling that would have found something.
+//
+// One window read of the term table per word the corpus does not have, one read
+// asking which of the words that were typed this person has a document for, one
+// asking the same of every spelling that came back, and the confirmation of the
+// corrected query. The two carriage reads are one statement each however many
+// words they are about, which is what makes it affordable to be sure rather
+// than to guess from the nearest spelling.
+//
+// It is written per term rather than as one number because that is the shape of
+// the cost, and because a correction that started running a statement per
+// spelling would otherwise hide inside a round number.
+func correctionStatements(terms int) int64 {
+	return int64(terms + 3)
+}
+
 // countRows is the rows the counting returns for a request that constrains the
 // given number of facet fields: the total, then one pool per expression the
 // statement declares and one capped group of values per field it counts.
@@ -92,11 +109,19 @@ func rowBudget(pool, terms, hits, constrained int) int64 {
 	// The corpus row and one row per term of statistics.
 	rows += 1 + terms
 	// A search that found nothing looks for a spelling that would have found
-	// something, which reads four windows of the term table per word it does
-	// not recognise and then confirms the corrected query as the asker. That
-	// confirmation is a candidate cut for a single row.
+	// something, and that is four reads on top of the search.
+	//
+	// Four windows of the term table per word it does not recognise. Two
+	// carriage reads, one for the words that were typed and one for the
+	// spellings offered back, each a pool of documents and the counts for the
+	// words they hold. And the confirmation of the corrected query, which is a
+	// cut for a single row.
 	if hits == 0 {
-		rows += terms*4*sqlitestore.NearWindow + 1
+		spellings := terms * index.CorrectionOffers
+		rows += terms * 4 * sqlitestore.NearWindow
+		rows += index.CarriagePool * (1 + terms)
+		rows += index.CarriagePool * (1 + spellings)
+		rows += 1 + terms
 	}
 	// And the page that is actually returned.
 	return int64(rows + hits)
@@ -157,8 +182,12 @@ func TestSearchCounters(t *testing.T) {
 				if want := int64(len(res.Hits)); c.Decodes > want {
 					t.Errorf("Search(%q) decoded %d documents to return %d", q.Text, c.Decodes, want)
 				}
-				if c.Statements > maxStatements {
-					t.Errorf("Search(%q) ran %d statements, at most %d", q.Text, c.Statements, maxStatements)
+				statements := int64(maxStatements)
+				if len(res.Hits) == 0 {
+					statements += correctionStatements(len(query.Request().Terms))
+				}
+				if c.Statements > statements {
+					t.Errorf("Search(%q) ran %d statements, at most %d", q.Text, c.Statements, statements)
 				}
 
 				// The ranker sees the pool, never the match set, so a query

--- a/index/spell.go
+++ b/index/spell.go
@@ -24,13 +24,54 @@ const correctionWords = 4
 // a guess rather than a correction.
 const correctionShortest = 3
 
+// CorrectionOffers is how many spellings of one word are considered.
+//
+// It is exported for the same reason the driver's near window is: the counter
+// test spends it, and a budget written as a number in two places is a budget
+// that stops agreeing with itself.
+//
+// Asking the vocabulary for the single nearest word and stopping there makes
+// the offer depend on who owns the document that word came from: the nearest
+// spelling of a mistyped word can sit in a document the asker may not open, and
+// then there is no correction at all, while the same query from a colleague who
+// can open it gets one. Silence that moves with somebody else's permissions is
+// a channel, so a list is taken and the first spelling this person has a
+// document for wins.
+//
+// A dozen, because the list is sorted by edit distance and the word somebody
+// meant is near the top of it or nowhere, and because a dozen costs what one
+// costs. The scan that finds them is the same scan whatever the limit is, and
+// the words that come back are all asked about in a single read. What the extra
+// eleven buy is not a better correction, it is the same correction for everybody
+// who can read the document it leads to.
+//
+// A dozen is also where this stops. A word whose twelve nearest spellings all
+// sit in documents the asker cannot open gets no offer, where somebody who can
+// open one of them would get one. That, the order the vocabulary comes back in,
+// which is by how many documents in the tenant carry each word, and the window
+// the driver reads to find it at all, are what is left of a correction drawn
+// from a vocabulary with no permission filter on it. See #199.
+const CorrectionOffers = 12
+
+// CarriagePool is how many documents the carriage read looks at. It is
+// exported, like the rest of the numbers a search spends, because the counter
+// test spends it.
+//
+// It is asking which of a handful of words this person has a document for, and
+// the answer is in the candidates it gets back: each one carries the counts for
+// the words it holds. A word is carried when a document that holds it comes
+// back, so the pool has to be deep enough that one document per word fits in
+// it, which the candidate floor is by a wide margin. The cut is ordered by the
+// match, and the words at issue here are rare ones, so the document that
+// answers for a word is at the top of the pool rather than at the bottom.
+const CarriagePool = CandidateFloor
+
 // correct is the "did you mean" on a search that found nothing.
 //
 // It runs only on the empty result, only on a short query, and only for terms
-// the corpus does not have at all, which is what keeps it from second guessing a
-// query that is spelled fine and simply matched nothing this week. The document
-// frequencies it reads for that were already fetched to score the query, so
-// deciding whether to try costs no reads.
+// the person asking has no document carrying, which is what keeps it from
+// second guessing a query that is spelled fine and simply matched nothing this
+// week.
 //
 // The security rule is the interesting part, and it belongs to this function
 // rather than to the driver. A vocabulary is a fact about the tenant, and the
@@ -41,23 +82,81 @@ const correctionShortest = 3
 // for a single row, and it is dropped unless it found one. What is shown is
 // then a query that person can run and get results from, which is the only
 // thing a correction was ever supposed to be.
+//
+// Whether an offer is made at all is the same question one step earlier, and it
+// is the one this used to get wrong. Deciding to stay quiet because the corpus
+// already has the word makes the silence itself an answer: type a word nobody
+// has and you are offered a correction, type a word that appears only in a
+// document you may not open and you are offered nothing, so the two replies
+// read the tenant's vocabulary out one word per search. The document
+// frequencies are counted over the tenant, which is what makes them stable
+// enough to rank with, and that is exactly what makes them the wrong thing to
+// branch on here. So a term the corpus has is checked against what this person
+// can read before it is passed over, and the spelling that gets offered is the
+// nearest one they have a document for rather than the nearest one that exists.
+// See [Searcher.carried] and [CorrectionOffers].
 func (s *Searcher) correct(ctx context.Context, p *acl.Principal, q Query, terms []string, corpus store.Corpus) (string, error) {
 	sp, ok := s.store.(store.Speller)
 	if !ok || q.Text == "" || len(terms) == 0 || len(terms) > correctionWords {
 		return "", nil
 	}
 
-	swap := make(map[string]string, len(terms))
+	// The words long enough to be worth correcting, and among those the ones the
+	// corpus has at all. A frequency of zero over the tenant is zero over
+	// anything inside it, so a word nobody has costs nothing to be sure about
+	// and a query of nothing but typos does not read anything here.
+	var words, known []string
 	for _, t := range terms {
-		if corpus.DocFreq[t] > 0 || utf8.RuneCountInString(t) < correctionShortest {
+		if utf8.RuneCountInString(t) < correctionShortest {
 			continue
 		}
-		near, err := sp.Near(ctx, p, t, 1)
+		words = append(words, t)
+		if corpus.DocFreq[t] > 0 {
+			known = append(known, t)
+		}
+	}
+	if len(words) == 0 {
+		return "", nil
+	}
+	has, err := s.carried(ctx, p, known)
+	if err != nil {
+		return "", err
+	}
+
+	offers := make(map[string][]string, len(words))
+	var spellings []string
+	for _, t := range words {
+		if has[t] {
+			continue
+		}
+		near, err := sp.Near(ctx, p, t, CorrectionOffers)
 		if err != nil {
 			return "", err
 		}
 		if len(near) > 0 {
-			swap[t] = near[0]
+			offers[t] = near
+			spellings = append(spellings, near...)
+		}
+	}
+	if len(offers) == 0 {
+		return "", nil
+	}
+
+	// Every spelling of every word in one read, and then the nearest one this
+	// person has a document for. Asking about them one at a time would be a
+	// statement each, and asking about none of them is what used to leave the
+	// choice to whoever owns the nearest document.
+	held, err := s.carried(ctx, p, spellings)
+	if err != nil {
+		return "", err
+	}
+	swap := make(map[string]string, len(offers))
+	for t, near := range offers {
+		for _, n := range near {
+			if held[n] {
+				swap[t] = n
+				break
+			}
 		}
 	}
 	if len(swap) == 0 {
@@ -71,7 +170,9 @@ func (s *Searcher) correct(ctx context.Context, p *acl.Principal, q Query, terms
 
 	// The confirmation. Same filters, because the offer has to lead to the page
 	// the person is looking at, and one row, because whether there is a result
-	// is the whole question.
+	// is the whole question. The words are all carried, and a query made of them
+	// can still find nothing: they may be carried by different documents, or by
+	// documents outside the filters this search is under.
 	confirm := q
 	confirm.Text = text
 	found, err := s.collect(ctx, p, confirm.Request(), store.Selection{Limit: 1})
@@ -82,6 +183,59 @@ func (s *Searcher) correct(ctx context.Context, p *acl.Principal, q Query, terms
 		return "", nil
 	}
 	return text, nil
+}
+
+// carried is which of these words the person asking has a document for.
+//
+// It is the whole list in one read rather than a read per word, which is what
+// makes it affordable to be sure about a dozen spellings instead of guessing
+// from the nearest one. The candidates come back with the counts for the words
+// they hold, so which words are carried is in the answer rather than in a
+// second question.
+//
+// There are no filters on it, because the question is whether a word is spelled
+// the way this corpus spells it rather than whether it appears in the four
+// sources somebody has ticked. A word that only exists in a source they
+// filtered out is still a word, and offering to respell it would be the wrong
+// offer.
+//
+// It goes through the same path a search takes, so it obeys the permission rule
+// the driver applies and lands in the same cache a repeat of the query would
+// hit, and it happens only on a query that matched nothing.
+func (s *Searcher) carried(ctx context.Context, p *acl.Principal, words []string) (map[string]bool, error) {
+	if len(words) == 0 {
+		return nil, nil
+	}
+	found, err := s.collect(ctx, p, store.Request{Terms: unique(words)}, store.Selection{Limit: CarriagePool})
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(words))
+	for _, c := range found.cands {
+		for t, n := range c.Terms {
+			if n.Title+n.Body > 0 {
+				out[t] = true
+			}
+		}
+	}
+	return out, nil
+}
+
+// unique is the words in the order they were first asked about, with the
+// repeats dropped. Two misspelled words in one query can suggest the same
+// spelling, and asking the driver about it twice would be a term in the
+// statement twice.
+func unique(words []string) []string {
+	out := make([]string, 0, len(words))
+	seen := make(map[string]bool, len(words))
+	for _, w := range words {
+		if seen[w] {
+			continue
+		}
+		seen[w] = true
+		out = append(out, w)
+	}
+	return out
 }
 
 // replaceTerms rewrites the words of a query that were corrected and leaves

--- a/store/spell.go
+++ b/store/spell.go
@@ -31,6 +31,11 @@ import (
 // is what keeps a correction from telling somebody that a word appears in a
 // document they cannot read. [index.Searcher] does exactly this, and a caller
 // that skips it has built an oracle for the contents of the corpus.
+//
+// Deciding not to call Near is the same rule with the answers swapped, and it
+// is easier to get wrong because nothing is shown. A caller that stays quiet
+// because a count over the tenant says the word exists has told the asker that
+// the word exists, once per search, for a word at a time.
 type Speller interface {
 	// Near returns terms in the principal's tenant that are close to the given
 	// term, nearest first and commonest among equals, and at most limit of


### PR DESCRIPTION
Closes #23.

## What this is

`api/adversary_test.go` builds two servers over the same random corpus.
One holds all of it, the other holds only the documents the reader may open.
Every route that can return content is then asked the same question of both, and the answers have to be identical.
A difference between them is a channel, whatever it happens to be made of: a facet count, a total, a suggested spelling, a silence where there was an answer.

The suite walks the unexported route table rather than a list of paths, so a new content route fails it until somebody says how to call it.
Eight corpora run on a laptop, a hundred run in CI, and a failure names the seed so anybody can reproduce it from the message.

## The two leaks it found

**The search score.** BM25 is a function of statistics counted over the tenant, because counting them per reader would be a pass over the corpus on every keystroke.
That makes the score of a document you may read partly a measurement of the documents you may not.
Printed to seventeen digits it is an equation anybody can solve: put a rare word in a document of your own, search for it, and the score tells you roughly how many other documents in the company carry that word.
The score is off the wire now.
Nothing outside the server was reading it, the interface draws results in the order they arrive, and the entity tag already hashed the response with the score taken out.
Ordering is still decided that way, which is a much narrower channel, and that one is #199.

**The spelling offer.** A correction was skipped when the tenant wide document frequency said the corpus already had the word.
So typing a word nobody has got you a correction, and typing a word that appears only in a document you may not open got you nothing.
Two different replies, one word per search, over the whole tenant vocabulary.
The gate runs as the asker now.
The words in the query are checked against what this person actually carries in a single read, and the spelling that gets offered is the nearest one they have a document for rather than the nearest one that exists.
Twelve spellings are considered instead of one, because a dozen costs what one costs when they are all asked about in the same read, and because the nearest spelling of a mistyped word can easily sit in a document the asker cannot open.

What is left of that path is written down in `index/spell.go` and pointed at #199: the twelve deep cap, the tie break inside the vocabulary that orders by how many documents in the tenant carry each word, and the window the driver reads to find candidates at all.

## Cost

The correction only runs on a query that found nothing, and it now costs that query two extra reads plus the confirmation.
`index/counters_test.go` states that as a budget of its own rather than loosening the bound on every query, so a regression in the common path still fails.
Searches that found something are unchanged, and there is one less float on the wire.

## CI

A job of its own runs the five tests over a hundred corpora.
It runs without the race detector on purpose, since the test job already runs this package under it on Linux and macOS, and the detector would turn a hundred corpora into an hour.
The last step greps the log for each test name, because a run filter that matches nothing passes quietly.

## Also here

Two flakes that were making the suite a report on how busy the runner was.
`api/recheck_test.go` gives its checkers a minute instead of the twenty milliseconds a real source is held to, because every checker in that file answers out of a map.
`cmd/genbad` waits for the metrics listener rather than assuming it is up because the API address is healthy, since the two bind independently and a refused connection was being read as an empty body.

## Checks

- `gofmt -s -l .` and `go vet ./...` clean
- `go test -race ./...` green
- `golangci-lint run ./...` reports 0 issues
- the five permission tests over 120 corpora, green, 762s on an eight core box